### PR TITLE
Makes POV consistent, Augments contact info

### DIFF
--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -77,7 +77,7 @@
           </ul>
           <ul>
             <li>
-              <a href="{{ cms_url }}/contact-us/">Contact</a>
+              <a href="{{ cms_url }}/contact/">Contact</a>
             </li>
             <li>
               <a href="{{ cms_url }}/about/">About</a>

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -77,7 +77,7 @@
           </ul>
           <ul>
             <li>
-              <a href="{{ cms_url }}/contact-us/">Contact us</a>
+              <a href="{{ cms_url }}/contact-us/">Contact</a>
             </li>
             <li>
               <a href="{{ cms_url }}/about/">About</a>

--- a/fec/home/templates/home/contact.html
+++ b/fec/home/templates/home/contact.html
@@ -72,21 +72,28 @@
           <h5 class="contact-item__title">Electronic Filing Office</h5>
           <span class="t-block">Including password assistance and technical support</span>
           <span class="contact-item__phone">202-694-1307</span>
+          <span class="contact-item__phone">1-800-424-9530, menu option 4</span>
+
         </li>
         <li class="contact-item contact-item--half">
           <h5 class="contact-item__title">Press Office</h5>
-          <span class="t-block">Including media inquiries and speaker requests</span>
+          <span class="t-block">Including media inquiries</span>
           <span class="contact-item__phone">202-694-1220</span>
+          <span class="contact-item__phone">1-800-424-9530, menu option 1</span>
           <span class="t-block"><a href="mailto:press@fec.gov">press@fec.gov</a></span>
         </li>
         <li class="contact-item contact-item--half">
           <h5 class="contact-item__title">Information Division</h5>
-          <span class="t-block">Including help with educational materials, registering a committee, ordering a reporting form or campaign finance law</span>
+          <span class="t-block">Including speaker requests and help with educational materials, registering a committee, or campaign finance law</span>
           <span class="contact-item__phone">202-694-1100</span>
+          <span class="contact-item__phone">1-800-424-9530, menu option 6</span>
+          <span class="t-block"><a href="mailto:info@fec.gov">info@fec.gov</a></span>
+
         </li>
         <li class="contact-item contact-item--half">
           <h5 class="contact-item__title">Public Records Division</h5>
           <span class="t-block">Including help accessing reports and other public documents</span>
+          <span class="contact-item__phone">202-694-1120</span>
           <span class="contact-item__phone">1-800-424-9530, menu option 2</span>
           <span class="t-block"><a href="mailto:pubrec@fec.gov">pubrec@fec.gov</a></span>
         </li>
@@ -94,6 +101,7 @@
           <h5 class="contact-item__title">Reports Analysis Division</h5>
           <span class="t-block">Including help with report creation, transactions and amendments </span>
           <span class="contact-item__phone">202-694-1130</span>
+          <span class="contact-item__phone">1-800-424-9530, menu option 5</span>
         </li>
       </ul>
     </div>

--- a/fec/home/templates/home/registration-and-reporting/checklist_page.html
+++ b/fec/home/templates/home/registration-and-reporting/checklist_page.html
@@ -120,7 +120,7 @@
               <li><a href="/registration-and-reporting/missed-deadline/">Missed deadlines</a></li>
               <li>Responding to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
               <li><a href="/registration-and-reporting/administrative-fines/">Administrative fines</a></li>
-              <li><a href="/contact-us/">Contact us</a></li>
+              <li><a href="/contact-us/">Contact</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/registration-and-reporting/checklist_page.html
+++ b/fec/home/templates/home/registration-and-reporting/checklist_page.html
@@ -120,7 +120,7 @@
               <li><a href="/registration-and-reporting/missed-deadline/">Missed deadlines</a></li>
               <li>Responding to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
               <li><a href="/registration-and-reporting/administrative-fines/">Administrative fines</a></li>
-              <li><a href="/contact-us/">Contact</a></li>
+              <li><a href="/contact/">Contact</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/registration-and-reporting/nonconnected_checklist_page.html
+++ b/fec/home/templates/home/registration-and-reporting/nonconnected_checklist_page.html
@@ -123,7 +123,7 @@
               <li><a href="/registration-and-reporting/missed-deadline/">Missed deadlines</a></li>
               <li>Responding to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
               <li><a href="/registration-and-reporting/administrative-fines/">Administrative fines</a></li>
-              <li><a href="/contact-us/">Contact us</a></li>
+              <li><a href="/contact-us/">Contact</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/registration-and-reporting/nonconnected_checklist_page.html
+++ b/fec/home/templates/home/registration-and-reporting/nonconnected_checklist_page.html
@@ -123,7 +123,7 @@
               <li><a href="/registration-and-reporting/missed-deadline/">Missed deadlines</a></li>
               <li>Responding to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
               <li><a href="/registration-and-reporting/administrative-fines/">Administrative fines</a></li>
-              <li><a href="/contact-us/">Contact</a></li>
+              <li><a href="/contact/">Contact</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/registration-and-reporting/party_checklist_page.html
+++ b/fec/home/templates/home/registration-and-reporting/party_checklist_page.html
@@ -123,7 +123,7 @@
               <li><a href="/registration-and-reporting/missed-deadline/">Missed deadlines</a></li>
               <li>Responding to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
               <li><a href="/registration-and-reporting/administrative-fines/">Administrative fines</a></li>
-              <li><a href="/contact-us/">Contact us</a></li>
+              <li><a href="/contact-us/">Contact</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/registration-and-reporting/party_checklist_page.html
+++ b/fec/home/templates/home/registration-and-reporting/party_checklist_page.html
@@ -123,7 +123,7 @@
               <li><a href="/registration-and-reporting/missed-deadline/">Missed deadlines</a></li>
               <li>Responding to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
               <li><a href="/registration-and-reporting/administrative-fines/">Administrative fines</a></li>
-              <li><a href="/contact-us/">Contact</a></li>
+              <li><a href="/contact/">Contact</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/registration-and-reporting/ssf_checklist_page.html
+++ b/fec/home/templates/home/registration-and-reporting/ssf_checklist_page.html
@@ -131,7 +131,7 @@
               <li><a href="/registration-and-reporting/missed-deadline/">Missed deadlines</a></li>
               <li>Responding to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
               <li><a href="/registration-and-reporting/administrative-fines/">Administrative fines</a></li>
-              <li><a href="/contact-us/">Contact</a></li>
+              <li><a href="/contact/">Contact</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/registration-and-reporting/ssf_checklist_page.html
+++ b/fec/home/templates/home/registration-and-reporting/ssf_checklist_page.html
@@ -131,7 +131,7 @@
               <li><a href="/registration-and-reporting/missed-deadline/">Missed deadlines</a></li>
               <li>Responding to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
               <li><a href="/registration-and-reporting/administrative-fines/">Administrative fines</a></li>
-              <li><a href="/contact-us/">Contact us</a></li>
+              <li><a href="/contact-us/">Contact</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
We're moving away from the first-person POV on this site. This PR removes the "us" from "Contact us" for consistency.

Additionally adds office contact information, based on feedback from Greg Scott.

Content only change. Anyone can review!