### PR TITLE
[WIP] Feature/committee totals pages

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -289,9 +289,9 @@ house_senate_types = OrderedDict([
 
 table_columns = OrderedDict([
     ('candidates', ['Name', 'Office', 'Election years', 'Party', 'State', 'District', 'First filing date']),
-    ('candidates-office-president', ['Name', 'Party', 'Receipts', 'Disbursements']),
-    ('candidates-office-senate', ['Name', 'Party', 'State', 'Receipts', 'Disbursements']),
-    ('candidates-office-house', ['Name', 'Party', 'State', 'District', 'Receipts', 'Disbursements']),
+    ('candidates-office-president', ['Name', 'Party', 'Receipts', 'Disbursements', 'Ending cash on hand']),
+    ('candidates-office-senate', ['Name', 'Party', 'State', 'Receipts', 'Disbursements', 'Ending cash on hand']),
+    ('candidates-office-house', ['Name', 'Party', 'State', 'District', 'Receipts', 'Disbursements', 'Ending cash on hand']),
     ('committees', ['Name', 'Treasurer', 'Type', 'Designation', 'First filing date']),
     ('committee-totals-pacs', ['Name', 'Receipts', 'Disbursements', 'Ending cash on hand', 'Ending coverage date']),
     ('committee-totals-party', ['Name', 'Party', 'Receipts', 'Disbursements', 'Ending cash on hand', 'Ending coverage date']),

--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -293,6 +293,8 @@ table_columns = OrderedDict([
     ('candidates-office-senate', ['Name', 'Party', 'State', 'Receipts', 'Disbursements']),
     ('candidates-office-house', ['Name', 'Party', 'State', 'District', 'Receipts', 'Disbursements']),
     ('committees', ['Name', 'Treasurer', 'Type', 'Designation', 'First filing date']),
+    ('committee-totals-pacs', ['Name', 'Receipts', 'Disbursements', 'Ending cash on hand', 'Ending coverage date']),
+    ('committee-totals-party', ['Name', 'Party', 'Receipts', 'Disbursements', 'Ending cash on hand', 'Ending coverage date']),
     ('communication-costs', ['Committee', 'Support/Oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Description', 'Disbursement date', 'Amount']),
     ('electioneering-communications', ['Spender', 'Candidate mentioned','Number of candidates', 'Amount per candidate', 'Date', 'Disbursement amount' ]),

--- a/fec/data/templates/advanced.jinja
+++ b/fec/data/templates/advanced.jinja
@@ -206,6 +206,14 @@
                 <h3><i class="icon i-all-files icon--inline--left"></i><a href="/data/committees">All committees</a></h3>
                 <p>Search for committees by type, years active, political party, location and treasurer.</p>
               </div>
+              <div class="post post--child">
+                <h4><a href="/data/committees/pac/">Political action committees</a></h4>
+                <p>Search political action committee (PAC) data including money raised, money spent, cash on hand and debt.</p>
+              </div>
+              <div class="post post--child">
+                <h4><a href="/data/committees/party/">Political party committees</a></h4>
+                <p>Search political party committee data including money raised, money spent, cash on hand and debt.</p>
+              </div>
               <div class="post">
                 <h3><a href="/data/filings/?form_type=F1">Most recent Statements of Organization (Form 1)</a></h3>
                 <p>Statements of Organization (Form 1) contain basic information about committees, including type, address and treasurer.</p>

--- a/fec/data/templates/partials/committee-totals-filter.jinja
+++ b/fec/data/templates/partials/committee-totals-filter.jinja
@@ -1,0 +1,13 @@
+{% extends 'partials/filters.jinja' %}
+
+{% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
+{% import 'macros/filters/election-filter.jinja' as election_filter %}
+
+{% block filters %}
+<div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
+  <div class="filters__inner">
+    {{ typeahead.field('q', 'Committee name or ID', False, dataset='committees', allow_text=False) }}
+    {{ election_filter.single_cycle('cycle', 'Election cycle') }}
+  </div>
+</div>
+{% endblock %}

--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
         views_datatables.candidates_office),
     url(r'^data/candidates/$', views_datatables.candidates),
     url(r'^data/committees/$', views_datatables.committees),
+    url(r'^data/committees/(?P<committee_type>\w+)/$', views_datatables.committee_totals),
     url(r'^data/communication-costs/$',
         views_datatables.communication_costs),
     url(r'^data/disbursements/$', views_datatables.disbursements),

--- a/fec/data/views_datatables.py
+++ b/fec/data/views_datatables.py
@@ -51,6 +51,20 @@ def committees(request):
     })
 
 
+def committee_totals(request, committee_type):
+    if committee_type.lower() not in ['pacs', 'party']:
+        raise Http404()
+    title = 'Political action committees' if committee_type == 'pacs' else 'Political party committees'
+    return render(request, 'datatable.jinja', {
+        'parent': 'data',
+        'result_type': 'committees',
+        'slug': 'committee-totals',
+        'table_context': OrderedDict([('committee_type', committee_type)]),
+        'title': title,
+        'columns': constants.table_columns['committee-totals-' + committee_type.lower()]
+    })
+
+
 def communication_costs(request):
     return render(request, 'datatable.jinja', {
         'parent': 'data',

--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -152,6 +152,7 @@ var candidateOffice = {
   district: {data: 'district', className: 'min-desktop column--small hide-panel'},
   receipts: currencyColumn({data: 'receipts', className: 'min-tablet hide-panel column--number'}),
   disbursements: currencyColumn({data: 'disbursements', className: 'min-tablet hide-panel column--number'}),
+  cash: currencyColumn({data: 'cash_on_hand_end_period', className: 'min-tablet hide-panel column--number'}),
   trigger: modalTriggerColumn
 };
 

--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -619,6 +619,9 @@ var loans = [
 ];
 
 module.exports = {
+  currencyColumn: currencyColumn,
+  dateColumn: dateColumn,
+  modalTriggerColumn: modalTriggerColumn,
   candidateColumn: candidateColumn,
   committeeColumn: committeeColumn,
   dateColumn: dateColumn,

--- a/fec/fec/static/js/pages/datatable-candidates-office.js
+++ b/fec/fec/static/js/pages/datatable-candidates-office.js
@@ -10,9 +10,9 @@ var columns = require('../modules/columns');
 var tablePanels = require('../modules/table-panels');
 
 var columnGroups = {
-  president: columnHelpers.getColumns(columns.candidateOffice, ['name', 'party', 'receipts', 'disbursements', 'trigger']),
-  senate: columnHelpers.getColumns(columns.candidateOffice, ['name', 'party', 'state', 'receipts', 'disbursements', 'trigger']),
-  house: columnHelpers.getColumns(columns.candidateOffice, ['name', 'party', 'state', 'district', 'receipts', 'disbursements', 'trigger']),
+  president: columnHelpers.getColumns(columns.candidateOffice, ['name', 'party', 'receipts', 'disbursements', 'cash', 'trigger']),
+  senate: columnHelpers.getColumns(columns.candidateOffice, ['name', 'party', 'state', 'receipts', 'disbursements', 'cash', 'trigger']),
+  house: columnHelpers.getColumns(columns.candidateOffice, ['name', 'party', 'state', 'district', 'receipts', 'disbursements', 'cash', 'trigger']),
 };
 
 var defaultSort = {

--- a/fec/fec/static/js/pages/datatable-committee-totals.js
+++ b/fec/fec/static/js/pages/datatable-committee-totals.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/* jslint camelcase: false */
+/* jslint maxlen: false */
+
+var $ = require('jquery');
+var tables = require('../modules/tables');
+var columns = require('../modules/columns');
+var committeeTotalsTemplate = require('../templates/committee-totals.hbs');
+
+var tableColumns = {
+  'pacs': [
+    {
+      data: 'committee_id',
+      className: 'all',
+    },
+    columns.currencyColumn({data: 'receipts', className: 'all column--number'}),
+    columns.currencyColumn({data: 'disbursements', className: 'min-tablet column--number'}),
+    columns.currencyColumn({data: 'last_cash_on_hand_end_period', className: 'min-tablet hide-panel column--number'}),
+    columns.dateColumn({data: 'coverage_end_date', className: 'min-tablet hide-panel column--small'}),
+    columns.modalTriggerColumn
+  ],
+  'party': [
+    {
+      data: 'committee_id',
+      className: 'all',
+    },
+    {
+      data: 'party_full',
+      className: 'min-tablet',
+    },
+    columns.currencyColumn({data: 'receipts', className: 'all column--number'}),
+    columns.currencyColumn({data: 'disbursements', className: 'min-tablet column--number'}),
+    columns.currencyColumn({data: 'last_cash_on_hand_end_period', className: 'min-tablet hide-panel column--number'}),
+    columns.dateColumn({data: 'coverage_end_date', className: 'min-tablet hide-panel column--small'}),
+    columns.modalTriggerColumn
+  ]
+};
+
+// Sort by receipts on pacs and parties.
+var sortColumn = context.committee_type === 'pacs' ? 1 : 2;
+
+var titles = {
+  'pacs': 'Political action committees',
+  'party': 'Political party committees'
+};
+
+$(document).ready(function() {
+  var $table = $('#results');
+  new tables.DataTable($table, {
+    autoWidth: false,
+    title: titles[context.committee_type],
+    path: ['totals', context.committee_type],
+    columns: tableColumns[context.committee_type],
+    useFilters: true,
+    useExport: true,
+    disableExport: true,
+    order: [[sortColumn, 'desc']],
+    rowCallback: tables.modalRenderRow,
+    callbacks: {
+      afterRender: tables.modalRenderFactory(committeeTotalsTemplate)
+    }
+  });
+});

--- a/fec/fec/static/js/templates/candidates.hbs
+++ b/fec/fec/static/js/templates/candidates.hbs
@@ -77,6 +77,9 @@
 <div class="panel__row">
   <h4 class="panel__title">Financial totals for {{time_period}}</h4>
   <table>
+    {{#panelRow "Coverage dates"}}
+      {{datetime coverage_start_date format="pretty"}} to {{datetime coverage_end_date format="pretty"}}
+    {{/panelRow}}
     {{#panelRow "Receipts"}}
       {{{currency receipts}}}
     {{/panelRow}}

--- a/fec/fec/static/js/templates/committee-totals.hbs
+++ b/fec/fec/static/js/templates/committee-totals.hbs
@@ -1,0 +1,37 @@
+<div class="panel__row">
+  <div class="panel__heading">
+    <h4 class="panel__title"><a href="{{basePath}}/committee/{{committee_id}}">{{name}}</a></h4>
+  </div>
+  <table>
+    {{#panelRow "Committee"}}
+      <a href="{{basePath}}/committee/{{committee_id}}">{{ committee_id }}</a>
+    {{/panelRow}}
+    {{#panelRow "Political party"}}
+      {{party_full}}
+    {{/panelRow}}
+    {{#panelRow "Designation"}}
+      {{designation_full}}
+    {{/panelRow}}
+    {{#panelRow "Type"}}
+      {{committee_type_full}}
+    {{/panelRow}}
+    {{#panelRow "Total receipts"}}
+      {{currency receipts}}
+    {{/panelRow}}
+    {{#panelRow "Total disbursements"}}
+      {{currency disbursements}}
+    {{/panelRow}}
+    {{#panelRow "Beginning cash on hand"}}
+      {{currency cash_on_hand_beginning_period}}
+    {{/panelRow}}
+    {{#panelRow "Ending cash on hand"}}
+      {{currency last_cash_on_hand_end_period}}
+    {{/panelRow}}
+    {{#panelRow "Coverage dates"}}
+      {{datetime coverage_start_date format="pretty"}} to {{datetime coverage_end_date format="pretty"}}
+    {{/panelRow}}
+    {{#panelRow "Last report filed"}}
+      {{last_report_type_full}}
+    {{/panelRow}}
+  </table>
+</div>


### PR DESCRIPTION
This adds new data pages for `/committees/pacs/` and `/committees/party/` with the financial totals columns, as well as adding cash on hand columns to `/candidate/[office]/` pages.

This is now blocked by both the `feature/unification` branch being merged in as well as the API work from https://github.com/18F/openFEC/issues/2631 happening.

Once `feature/unification` is merged, this PR should be changed to target `develop`. 

Resolves https://github.com/18F/openFEC-web-app/issues/2274