### PR TITLE
[WIP - Don't merge yet] Fixed RFAIs that reference Form 1

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -570,7 +570,8 @@ $(document).ready(function() {
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
             form_type: ['F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13', 'RFAI'],
-            sort: ['-coverage_end_date', 'report_type_full', '-beginning_image_number']
+            sort: ['-coverage_end_date', 'report_type_full', '-beginning_image_number'],
+            sort_hide_null: ['false']
           }, query),
           callbacks: {
             afterRender: filings.renderModal
@@ -595,8 +596,7 @@ $(document).ready(function() {
           order: [[2, 'desc']],
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
-            form_type: ['F1', 'RFAI']
-            /*request_type: ['1']*/
+            form_type: ['F1']
           }, query),
         }, filingsOpts);
         tables.DataTable.defer($table, opts);

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -595,7 +595,8 @@ $(document).ready(function() {
           order: [[2, 'desc']],
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
-            form_type: ['F1']
+            form_type: ['F1', 'RFAI']
+            /*request_type: ['1']*/
           }, query),
         }, filingsOpts);
         tables.DataTable.defer($table, opts);


### PR DESCRIPTION
## Summary

- Addresses https://github.com/18F/fec-cms/issues/1663
_RFAI's that reference a statement of organization, also known as `RQ2`, was not showing in the filings table. The problem was that nulls were being filtered out from the regularly filed reports. Now that null values are shown, we can now see all the RFAI's within the Regularly filed reports section of the committee's filing tab_

**Note:** It was requested that we group the RFAIs that reference form 1 with the statement of organization. However, after reviewing the code, it is a lot more difficult to implement this given the current abilities of our API. A possible easier solution would be to refactor the RFAIs to their own section that is separate from the Regularly filed reports section.  

## Impacted areas of the application
List general components of the application that this PR will affect:
-  Committee's filing tab

## Screenshots
Below is an example with all the RFAIs shown for committee ID C00637983
![screen shot 2018-01-17 at 3 08 57 pm](https://user-images.githubusercontent.com/12799132/35064532-678e1b1c-fb98-11e7-8d34-433439a48129.png)
