### PR TITLE
[DON'T MERGE YET] Limit individual contributor zip input to 5 digits

### DIFF
--- a/fec/data/templates/partials/individual-contributions-filter.jinja
+++ b/fec/data/templates/partials/individual-contributions-filter.jinja
@@ -22,7 +22,7 @@ Filter individual contributions
   <div class="accordion__content">
     {{ text.field('contributor_city', 'City') }}
     {{ states.field('contributor_state') }}
-    {{ text.field('contributor_zip', 'ZIP code')}}
+    {{ text.field('contributor_zip', 'ZIP code', {'maxlength':5}) }}
     {{ text.field('contributor_employer', 'Employer') }}
     {{ text.field('contributor_occupation', 'Occupation') }}
   </div>


### PR DESCRIPTION
## Summary

- Addresses #1391 
Limits zip code input to 5 digits for the individual contributor search http://localhost:8000/data/receipts/individual-contributions/

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Individual contributor search