### PR TITLE
Corrects style on feed pagination component

### DIFF
--- a/fec/fec/static/scss/components/_pagination.scss
+++ b/fec/fec/static/scss/components/_pagination.scss
@@ -3,18 +3,23 @@
 // Based on the datatables.js markup and classes
 //
 // <div class="dataTables_paginate paging_simple_numbers" id="results_paginate">
-//   <a class="paginate_button previous">Previous</a>
-//   <span>
-//     <a class="paginate_button">1</a>
-//     <a class="paginate_button">2</a>
-//     <a class="paginate_button current">3</a>
-//     <a class="paginate_button">4</a>
-//     <a class="paginate_button">5</a>
-//     <span class="ellipsis">…</span>
-//     <a class="paginate_button">162</a>
-//   </span>
-//   <a class="paginate_button next">Next</a>
-// </div>
+//    <div class="results-info">
+//      <a class="paginate_button previous">Previous</a>
+//      <span>
+//        <a class="paginate_button">1</a>
+//        <a class="paginate_button">2</a>
+//        <a class="paginate_button current">3</a>
+//        <a class="paginate_button">4</a>
+//        <a class="paginate_button">5</a>
+//        <span class="ellipsis">…</span>
+//        <a class="paginate_button">24</a>
+//      </span>
+//      <a class="paginate_button next">Next</a>
+//      <div class="u-float-right t-sans">Showing
+//        <span class="js-page-info">1-10 of 240</span> entries
+//      </div>
+//    </div>
+//  </div>
 //
 
 .paginate_button {

--- a/fec/fec/static/scss/components/_pagination.scss
+++ b/fec/fec/static/scss/components/_pagination.scss
@@ -46,6 +46,7 @@
   }
 
   &.current {
+    font-weight: 700;
     color: $inverse;
     background-color: $gray-dark;
   }

--- a/fec/fec/static/scss/components/_pagination.scss
+++ b/fec/fec/static/scss/components/_pagination.scss
@@ -41,6 +41,7 @@
   }
 
   &.current {
-    background-color: $gray;
+    color: $inverse;
+    background-color: $gray-dark;
   }
 }


### PR DESCRIPTION
## Summary

Discovered in the audit of the components in the pattern library https://github.com/fecgov/fec-pattern-library/issues/67

- Corrects styling of the current page nav button to distinguish it from the other possible page buttons through changing the button background color and font weight.
- Adds additional framing elements to the component's canonical example code, such as border lines and total item count

## Impacted areas of the application
This PR _should_ only impact the code in the pattern library. This component isn't currently used, but is built and ready to be transitioned into layouts.

## Screenshots

**Before**
![screen shot 2018-03-07 at 9 10 07 pm](https://user-images.githubusercontent.com/11636908/37129429-f4066f92-224c-11e8-8501-202dce3f8e41.png)

**After**
![screen shot 2018-03-07 at 9 14 59 pm](https://user-images.githubusercontent.com/11636908/37129434-f7716bfa-224c-11e8-83cd-0d5c9dd5ca03.png)


## Related PRs

branch | PR
------ | ------
update-pagination | [Patter library 86, Update and add pagination component](https://github.com/fecgov/fec-pattern-library/pull/86)

