### PR TITLE
[MERGE WITH GIT FLOW] Change `strip_zero_pad` to only remove leading 0's

### DIFF
--- a/fec/data/templatetags/filters.py
+++ b/fec/data/templatetags/filters.py
@@ -97,7 +97,11 @@ def fmt_state_full(value):
 
 @library.filter
 def strip_zero_pad(number):
-    return number.strip("0")
+    '''
+    Removes leading 0's for display purposes
+    Commonly used for congressional districts
+    '''
+    return number.lstrip("0")
 
 
 def date_filter(value, fmt='%m/%d/%Y'):


### PR DESCRIPTION
## Summary (required)

- Addresses https://github.com/18F/fec-cms/issues/1845
Change `strip_zero_pad` function in filters.py to only remove leading 0's - it was removing trailing 0's and turning 10 into 1.
Note: Python has `strip` and `lstrip` - [here are the docs](https://docs.python.org/2/library/string.html#string.lstrip)

## Impacted areas of the application

-  https://www.fec.gov/data/elections/house/[state]/10/2018/ 
`data/templates/elections.jinja`
Example: https://www.fec.gov/data/elections/house/CA/10/2018/

- https://www.fec.gov/data/candidate/[ID]/?tab=about-candidate
`data/templates/partials/candidate/about-candidate.jinja`
Example: https://www.fec.gov/data/candidate/H4VA10089/?tab=about-candidate

## Screenshots - Election Pages
## Before
<img width="571" alt="screen shot 2018-03-09 at 2 45 58 pm" src="https://user-images.githubusercontent.com/31420082/37226916-7d88dfc2-23a9-11e8-82a6-5318a955cd88.png">
## After

<img width="505" alt="screen shot 2018-03-09 at 2 47 04 pm" src="https://user-images.githubusercontent.com/31420082/37226920-7fb279e8-23a9-11e8-80c1-36772ed555a3.png">

## Screenshots - Candidate Pages
## Before
<img width="1062" alt="screen shot 2018-03-09 at 2 47 13 pm" src="https://user-images.githubusercontent.com/31420082/37227037-d9378698-23a9-11e8-93c1-4e7c05389ef3.png">

## After
<img width="1056" alt="screen shot 2018-03-09 at 2 48 06 pm" src="https://user-images.githubusercontent.com/31420082/37227046-df4715bc-23a9-11e8-814e-ac0c06ea679b.png">
