### PR TITLE
Careers page - USAJobs API- Replace WhoMayApply with HiringPath description(s)

### DIFF
--- a/fec/home/templates/partials/jobs.html
+++ b/fec/home/templates/partials/jobs.html
@@ -7,7 +7,7 @@
       <h3><a href="{{ j.position_uri }}">{{ j.position_id }} , {{ j.position_title}}</a></h3>
         <ul class="u-padding--bottom">
           <li class='t-sans'><strong>Open Period:</strong> {{ j.position_start_date }} - {{ j.position_end_date }}</li>
-          <li class='t-sans'><strong>Who May Apply:</strong> {{ j.who_may_apply }}</li>
+          <li class='t-sans'><strong>Open To:</strong> {{ j.open_to }}</li>
           <li class='t-sans'><strong>Grade:</strong> {{ j.job_grade }} - {{ j.low_grade }} - {{ j.high_grade }}</li>
         </ul>
       </li>

--- a/fec/home/templatetags/open_jobs.py
+++ b/fec/home/templatetags/open_jobs.py
@@ -1,43 +1,53 @@
 
 from django import template
 import requests
-from django.conf import settings
-from django.conf import os
 import dateutil.parser
 
 register = template.Library()
 
 @register.inclusion_tag('partials/jobs.html')
 def get_jobs():
+    """query USAJobs for FEC jobs and hiring path code-list to cross reference agianst"""
     url = "https://data.usajobs.gov/api/Search"
+    get_codes_url = "https://data.usajobs.gov/api/codelist/hiringpaths"
 
-    querystring = {"Organization":"LF00","WhoMayApply":"All"}
+    querystring = {"Organization":"LF00", "WhoMayApply":"All"}
     headers = {
-        'authorization-key': settings.USAJOBS_API_KEY,  
+        'authorization-key': 'nPBInwg8jHzg4fjcxznoFxfAyp79RfOHG6s0mhEKU8Q=',
         'user-agent': "jcarroll@fec.gov",
         'host': "data.usajobs.gov",
         'cache-control': "no-cache",
         }
-    
+
     response = requests.request("GET", url, headers=headers, params=querystring)
 
-    responses=response.json()    
+    responses = response.json()
+
+    codes_response = requests.request("GET", get_codes_url, headers=headers, params=querystring)
+
+    codes_responses = codes_response.json()
 
     jobData = []
     for i in responses['SearchResult']['SearchResultItems']:
-        x= {}
-        x = { 
-        "position_title": i["MatchedObjectDescriptor"]["PositionTitle"] , 
-        "position_id": i["MatchedObjectDescriptor"]["PositionID"], 
-        "position_uri": i ["MatchedObjectDescriptor"]["PositionURI"],
+        x = {
+        "position_title": i["MatchedObjectDescriptor"]["PositionTitle"],
+        "position_id": i["MatchedObjectDescriptor"]["PositionID"],
+        "position_uri": i["MatchedObjectDescriptor"]["PositionURI"],
         "position_start_date" : dateutil.parser.parse(i['MatchedObjectDescriptor']['PositionStartDate']),
         "position_end_date" : dateutil.parser.parse(i['MatchedObjectDescriptor']['PositionEndDate']),
-        "who_may_apply" : i['MatchedObjectDescriptor']['UserArea']['Details']['WhoMayApply']['Name'],
         "job_grade" : i['MatchedObjectDescriptor']['JobGrade'][0]['Code'],
         "low_grade" : i['MatchedObjectDescriptor']['UserArea']['Details']['LowGrade'],
-        "high_grade" : i['MatchedObjectDescriptor']['UserArea']['Details']['HighGrade'] }
+        "high_grade" : i['MatchedObjectDescriptor']['UserArea']['Details']['HighGrade']
+        }
+
+        hiring_path_codes = codes_responses['CodeList'][0]['ValidValue']
+        hiring_path = [item for item in i['MatchedObjectDescriptor']['UserArea']['Details']['HiringPath']]
+        hp = []
+        for k in hiring_path:
+            hpa = [item for item in hiring_path_codes if item['Code'] == k.upper()]
+            hp.append(hpa[0]['Value'])
+            hiring_path_list = ', '.join(str(n) for n in hp)
+            open_to = {'open_to':hiring_path_list}
+        x.update(open_to)
         jobData.append(x)
-
-    return ({'jobData':jobData})
-
-
+    return {'jobData':jobData}

--- a/fec/home/templatetags/open_jobs.py
+++ b/fec/home/templatetags/open_jobs.py
@@ -2,6 +2,7 @@
 from django import template
 import requests
 import dateutil.parser
+from django.conf import settings
 
 register = template.Library()
 
@@ -9,11 +10,11 @@ register = template.Library()
 def get_jobs():
     """query USAJobs for FEC jobs and hiring path code-list to cross reference agianst"""
     url = "https://data.usajobs.gov/api/Search"
-    get_codes_url = "https://data.usajobs.gov/api/codelist/hiringpaths"
+    get_codes_url = settings.USAJOBS_API_KEY
 
     querystring = {"Organization":"LF00", "WhoMayApply":"All"}
     headers = {
-        'authorization-key': 'nPBInwg8jHzg4fjcxznoFxfAyp79RfOHG6s0mhEKU8Q=',
+        'authorization-key': '',
         'user-agent': "jcarroll@fec.gov",
         'host': "data.usajobs.gov",
         'cache-control': "no-cache",

--- a/fec/home/templatetags/open_jobs.py
+++ b/fec/home/templatetags/open_jobs.py
@@ -10,11 +10,11 @@ register = template.Library()
 def get_jobs():
     """query USAJobs for FEC jobs and hiring path code-list to cross reference agianst"""
     url = "https://data.usajobs.gov/api/Search"
-    get_codes_url = settings.USAJOBS_API_KEY
+    get_codes_url = 'https://data.usajobs.gov/api/codelist/hiringpaths'
 
     querystring = {"Organization":"LF00", "WhoMayApply":"All"}
     headers = {
-        'authorization-key': '',
+        'authorization-key': settings.USAJOBS_API_KEY,
         'user-agent': "jcarroll@fec.gov",
         'host': "data.usajobs.gov",
         'cache-control': "no-cache",


### PR DESCRIPTION
Addresses Issue: [1839 - USAJobs API not returning 'WhoMayApply'](https://github.com/fecgov/fec-cms/issues/1839 )
USAJObs is not longer showing WhoMayApply as an endpoint parameter. Instead, the HiringPath parameter can be used. 
(Note: There will be a followup PR including refactored Python resulting from pairing with @ccostino. But I wanted to get this change in in the meantime.)

The hiring path(s) listed for each job are abbreviations, and not very descriptive or helpful. So in addition to querying the api to search open FEC Jobs, I am also querying the hiring paths endpoint to get a list of codes and their associated descriptive text which I can use to map the hiring path(s) for each job to the associated descriptions.

job item hiring path:
``` 
HiringPath": [
                      "fed-competitive",
                      "fed-excepted",
                       "vet"
                            ] 
```

Sample data returned from https://data.usajobs.gov/api/codelist/hiringpaths:

```CodeList": [
        {
            "ValidValue": [
                {
                    "Code": "DISABILITY",
                    "Value": "Individuals with disabilities",
                    "LastModified": "2017-06-30T08:16:59.55",
                    "IsDisabled": "No"
                },
                {
                    "Code": "FED",
                    "Value": "Federal employees",
                    "LastModified": "2018-03-08T17:02:05.403",
                    "IsDisabled": "Yes"
                },
                {page- Addresses # [_Issue number_]
(. . . etc.)
```

![new_careers](https://user-images.githubusercontent.com/5572856/37301262-7c51d3dc-25fe-11e8-95fb-84e67d933e33.gif)



