### PR TITLE
[MERGE WITH GIT FLOW] Add `mur_respondents` filter to "next" and "previous" buttons

### DIFF
--- a/fec/legal/templates/partials/legal-pagination.jinja
+++ b/fec/legal/templates/partials/legal-pagination.jinja
@@ -2,12 +2,12 @@
 <div class="dataTables_info">{{ results.offset | int + 1 }}&ndash;{{ results.offset | int + results[result_type + '_returned'] | int }} of about {{ results.total_all }}</div>
 <div class="dataTables_paginate">
 {% if results.offset | int > 0 %}
-<a class="paginate_button previous" href="/data/legal/search/{{ result_type }}/?search={{ query }}&offset={{ results.offset | int - results.limit | int }}#results-{{ result_type }}">Previous</a>
+<a class="paginate_button previous" href="/data/legal/search/{{ result_type }}/?search={{ query }}&mur_respondents={{mur_respondents}}&offset={{ results.offset | int - results.limit | int }}#results-{{ result_type }}">Previous</a>
 {% else %}
 <span class="paginate_button previous is-disabled">Previous</span>
 {% endif %}
 {% if results.offset | int + results.limit | int  < results.total_all | int %}
-<a class="paginate_button next" href="/data/legal/search/{{ result_type }}/?search={{ query }}&offset={{ results.offset | int + results.limit | int }}#results-{{ result_type }}">Next</a>
+<a class="paginate_button next" href="/data/legal/search/{{ result_type }}/?search={{ query }}&mur_respondents={{mur_respondents}}&offset={{ results.offset | int + results.limit | int }}#results-{{ result_type }}">Next</a>
 {% else %}
 <span class="paginate_button next is-disabled">Next</span>
 {% endif %}


### PR DESCRIPTION
## Summary (required)

- Addresses https://github.com/fecgov/fec-cms/issues/1859
- Fix pagination when searching for MUR respondents
- Add `&mur_respondents={{mur_respondents}}` to MUR pagination links

## Impacted areas of the application
- MUR search results

## Screenshots

## Before
Search "Nevada NOW" as MUR Respondent...
https://www.fec.gov/data/legal/search/murs/?search_type=murs&search=&mur_no=&mur_respondents=Nevada+NOW
then try to go to the next page. It resets your results:
<img width="211" alt="screen shot 2018-03-14 at 2 59 23 pm" src="https://user-images.githubusercontent.com/31420082/37425021-5f08d8f2-2798-11e8-8fa0-8f3983dd1f3f.png">


## After
Search "Nevada NOW" as MUR Respondent...
http://localhost:8000/data/legal/search/murs/?search_type=murs&search=&mur_no=&mur_respondents=Nevada+NOW
then try to go to the next page. You actually get to the next page:
<img width="172" alt="screen shot 2018-03-14 at 2 59 41 pm" src="https://user-images.githubusercontent.com/31420082/37425026-632851d8-2798-11e8-87f5-a01116a9cbfd.png">

**Note** I found a display problem but it's already in production. I'll enter a new bug if it's not already there.

https://www.fec.gov/data/legal/search/murs/?search=&mur_respondents=Nevada%20NOW&offset=20#results-murs
http://localhost:8000/data/legal/search/murs/?search=&mur_respondents=Nevada%20NOW&offset=20#results-murs