### PR TITLE
Fix broken committee link in candidate profile page.

### DIFF
--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -19,7 +19,7 @@
       {% endfor %}
       {% for committee in committee_groups['A'] | reverse %}
       <li>
-        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}&cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
1)Related Issue: [https://github.com/fecgov/fec-cms/issues/1877](https://github.com/fecgov/fec-cms/issues/1877)

2)If a candidate has more than one committee listed on his/her candidate profile page. 
The second committee url is broken, due to miss the end '/')
Example: [https://www.fec.gov/data/candidate/H6NV01232/ ](https://www.fec.gov/data/candidate/H6NV01232/ )

3) How to test locally?
a)setup fec-cms repo locally, 
b)pull branch: feature/fix_committee_broken_link
c)export FEC_API_URL=dev api
d)run: [http://localhost:8000/data/candidate/H6NV01232/](http://localhost:8000/data/candidate/H6NV01232/) 
will see the correct second committee url.

 