### PR TITLE
Fix build committee_id link in candidate and committee profile pages

### DIFF
--- a/fec/data/templates/macros/tables.jinja
+++ b/fec/data/templates/macros/tables.jinja
@@ -20,21 +20,26 @@
         {% endif %}
       </td>
       <td class="simple-table__cell">
-      {% set committee_id = committee_id|replace("['", "")|replace("']", "") %}
-        {% if item[1]['link'] == "independent-expenditures" or item[1]['link'] == "party-coordinated-expenditures" %}
-          <a href="/data/{{ item[1]['link'] }}/?committee_id={{ committee_id }}&cycle={{ cycle }}">
+{# 
+case 1: this page comes from data/candidate/<candidate_id>/ :
+The committee_id is a tuple list(the count =1 or 2)
+  a)one candidate has only one committee, committee_id=['C00580100'], count=1
+  b)one candidate has two committees, committee_id = ['C00496075','C00462069']
+    count=2
+
+case 2: this page comes from data/committee/<committee_id>/:
+The committee_id is a string, the count=9.
+#}
+        {% if item[1]['type'] and cycle|int > 2006 and committee_id|count < 3 %}
+          <a href="/data/{{ item[1]['type']['link'] }}/?{% for id in committee_id -%}committee_id={{ id }}&{%- endfor %}two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
           </a>
-        {% elif item[1]['link'] %}
-          <a href="/data/{{ item[1]['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}">
-            {{ item[0]|currency }}
-          </a>
-        {% elif item[1]['type'] and cycle|int > 2006 %}
+        {% elif item[1]['type'] and cycle|int > 2006 and committee_id|count == 9 %}
           <a href="/data/{{ item[1]['type']['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
           </a>
         {% else %}
-          {{ item[0]|currency }}
+            {{ item[0]|currency }}
         {% endif %}
       </td>
     </tr>


### PR DESCRIPTION
## Summary (required)
in both candidate and committee profile pages, click the financial-summary section.
some items have link to data table page.

- Addresses # [https://github.com/fecgov/fec-cms/issues/1744](https://github.com/fecgov/fec-cms/issues/1744)

bug analyze:
1) on committee profile page: committee_id data type is a string.
ex: https://www.fec.gov/data/committee/C00586826/?cycle=2016#total-raised
committee_id = ‘C00586826’,  committee_id|count==9 ( 9 chars)

2)on candidate profile page: committee_id data type is a string tuple list [,,,]
  a)one candidate has only one committee:
ex: https://www.fec.gov/data/candidate/P80001571/
committee_id=[‘C00580100’] ,  committee_id|count==1 (one item)

  b)one candidate has two committees:
ex: https://www.fec.gov/data/candidate/S0KY00156/?cycle=2012&election_full=false
committee_id = [‘C00496075’,’ C00462069'],  committee_id|count==2 (two items)
so, the committee_id build wrong url piece: committee_id=C00496075','C00462069
<img width="944" alt="screen shot 2018-03-24 at 3 15 26 pm" src="https://user-images.githubusercontent.com/24395751/37868548-ce037d82-2f7e-11e8-9c13-28812db44b7b.png">

##How to fixed?
templates/macros/tables.jinja is used by both templates/partials/committee/financial-summary.jinja and templates/partials/candidate/financial-summary.jinja files.
so modify tables.jinja to build correct committee_id url using for loop tuple list:
`{% for id in committee_id -%}committee_id={{ id }}&{%- endfor %}`
correct url piece: committee_id=C00496075&committee_id=C00462069&
<img width="945" alt="screen shot 2018-03-24 at 3 11 52 pm" src="https://user-images.githubusercontent.com/24395751/37868589-6f1f664a-2f7f-11e8-8292-cf03ab66542c.png">






