### PR TITLE
GovDelivery signup on all-updates page

### DIFF
--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -12,6 +12,22 @@
       <p>FEC Record articles inform candidates and committees about FEC developments and are published as news happens. Tips for Treasurers are published once a week.</p>
     </div>
   </div>
+  <div class="js-accordion accordion--neutral" data-content-prefix="email_signup">
+  <button type="button" class="js-accordion-trigger accordion__button">Sign up for emiail updates
+  </button>
+  <div class="accordion__content">
+    <form id="GD-snippet-form" action="https://public.govdelivery.com/accounts/USFEC/subscriber/qualify?qsp=USFEC_1" accept-charset="UTF-8" method="post" target="_blank">
+      <input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="{{ settings.GOV_DELIVERY_TOKEN }}" />
+        <fieldset>
+          <div class="example--primary">
+            <p class="t-upper u-no-margin">Email</p>
+            <input class="form-element--inline" type="text" name="email" id="email" placeholder="Email address">
+            <button class="button--cta heading__right form-element--inline" type="submit" name="commit" value="Subscribe" class="form_button">Subscribe</button>
+          </div>
+        </fieldset>
+      </form>
+   </div>
+  </div>
 {% endblock %}
 
 {% block filters %}

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -19,15 +19,18 @@
     <form id="GD-snippet-form" action="https://public.govdelivery.com/accounts/USFEC/subscriber/qualify?qsp=USFEC_1" accept-charset="UTF-8" method="post" target="_blank">
       <input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="{{ settings.GOV_DELIVERY_TOKEN }}" />
         <fieldset>
-          <div class="example--primary">
+          <div class="message">
             <label for="submit" class="label">Email</label>
             <input class="form-element--inline" size="40" type="text" name="email" id="email">
             <button class="button--cta form-element--inline" type="submit" name="commit" value="Subscribe" class="form_button">Subscribe</button>
-   On the next page, set your email preferences, then complete your subscription by selecting which latest updates publications types you want to receive by email.
+
             <ul class="list--flat-bordered t-small t-sans u-margin--top">
               <li><a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank">Edit an existing subscription</a></li>
               <li><a href="https://insights.govdelivery.com/Communications/Subscriber_Help_Center/What_information_does_GovDelivery_collect%3F_How_is_it_used%3F" target="_blank">Privacy policy</a></li>
             </ul>
+            <p class="u-margin--top">
+            On the next page, set your email preferences, then complete your subscription by selecting which latest updates publications types you want to receive by email.
+            </p>
           </div>
         </fieldset>
       </form>

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -18,7 +18,7 @@
   <div class="accordion__content">
     <form id="GD-snippet-form" action="https://public.govdelivery.com/accounts/USFEC/subscriber/qualify?qsp=USFEC_1" accept-charset="UTF-8" method="post" target="_blank">
       <input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="{{ settings.GOV_DELIVERY_TOKEN }}" />
-        <fieldset class="u-margin--left">
+        <fieldset class="u-margin--left u-padding--left">
           <label for="submit" class="label">Email</label>
             <input class="form-element--inline" size="40" type="text" name="email" id="email">
             <button class="button--cta form-element--inline" type="submit" name="commit" value="Subscribe" class="form_button">Subscribe</button>
@@ -26,7 +26,7 @@
               <li><a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank">Edit an existing subscription</a></li>
             </ul>
             <div class="message message--info message--small">
-              <p class="u-margin--top">
+              <p>
               On the next page, set your email preferences, then complete your subscription by selecting which latest updates publications types you want to receive by email.
               </p>
             </div>

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -18,20 +18,21 @@
   <div class="accordion__content">
     <form id="GD-snippet-form" action="https://public.govdelivery.com/accounts/USFEC/subscriber/qualify?qsp=USFEC_1" accept-charset="UTF-8" method="post" target="_blank">
       <input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="{{ settings.GOV_DELIVERY_TOKEN }}" />
-        <fieldset>
-          <div class="message">
-            <label for="submit" class="label">Email</label>
+        <fieldset class="u-margin--left">
+          <label for="submit" class="label">Email</label>
             <input class="form-element--inline" size="40" type="text" name="email" id="email">
             <button class="button--cta form-element--inline" type="submit" name="commit" value="Subscribe" class="form_button">Subscribe</button>
-
             <ul class="list--flat-bordered t-small t-sans u-margin--top">
               <li><a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank">Edit an existing subscription</a></li>
+            </ul>
+            <div class="message message--info message--small">
+              <p class="u-margin--top">
+              On the next page, set your email preferences, then complete your subscription by selecting which latest updates publications types you want to receive by email.
+              </p>
+            </div>
+            <ul class="list--flat-bordered t-small t-sans u-margin--top">
               <li><a href="https://insights.govdelivery.com/Communications/Subscriber_Help_Center/What_information_does_GovDelivery_collect%3F_How_is_it_used%3F" target="_blank">Privacy policy</a></li>
             </ul>
-            <p class="u-margin--top">
-            On the next page, set your email preferences, then complete your subscription by selecting which latest updates publications types you want to receive by email.
-            </p>
-          </div>
         </fieldset>
       </form>
     </div>

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -18,7 +18,7 @@
   <div class="accordion__content">
     <form id="GD-snippet-form" action="https://public.govdelivery.com/accounts/USFEC/subscriber/qualify?qsp=USFEC_1" accept-charset="UTF-8" method="post" target="_blank">
       <input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="{{ settings.GOV_DELIVERY_TOKEN }}" />
-        <fieldset class="u-margin--left u-padding--left">
+        <fieldset class="u-margin--left u-padding--left u-padding--right">
           <label for="submit" class="label">Email</label>
             <input class="form-element--inline" size="40" type="text" name="email" id="email">
             <button class="button--cta form-element--inline" type="submit" name="commit" value="Subscribe" class="form_button">Subscribe</button>

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -18,7 +18,7 @@
   <div class="accordion__content">
     <form id="GD-snippet-form" action="https://public.govdelivery.com/accounts/USFEC/subscriber/qualify?qsp=USFEC_1" accept-charset="UTF-8" method="post" target="_blank">
       <input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="{{ settings.GOV_DELIVERY_TOKEN }}" />
-        <fieldset class="u-margin--left u-padding--left u-padding--right">
+        <fieldset class="u-margin--left u-padding--left u-padding--right u-margin--top">
           <label for="submit" class="label">Email</label>
             <input class="form-element--inline" size="40" type="text" name="email" id="email">
             <button class="button--cta form-element--inline" type="submit" name="commit" value="Subscribe" class="form_button">Subscribe</button>
@@ -30,7 +30,7 @@
               On the next page, set your email preferences, then complete your subscription by selecting which latest updates publications types you want to receive by email.
               </p>
             </div>
-            <ul class="list--flat-bordered t-small t-sans u-margin--top">
+            <ul class="list--flat-bordered t-small t-sans u-margin--top u-margin--bottom">
               <li><a href="https://insights.govdelivery.com/Communications/Subscriber_Help_Center/What_information_does_GovDelivery_collect%3F_How_is_it_used%3F" target="_blank">Privacy policy</a></li>
             </ul>
         </fieldset>

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -13,16 +13,20 @@
     </div>
   </div>
   <div class="js-accordion accordion--neutral" data-content-prefix="email_signup">
-  <button type="button" class="js-accordion-trigger accordion__button">Sign up for emiail updates
+  <button type="button" class="js-accordion-trigger accordion__button">Sign up for email updates
   </button>
   <div class="accordion__content">
     <form id="GD-snippet-form" action="https://public.govdelivery.com/accounts/USFEC/subscriber/qualify?qsp=USFEC_1" accept-charset="UTF-8" method="post" target="_blank">
       <input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="{{ settings.GOV_DELIVERY_TOKEN }}" />
         <fieldset>
           <div class="example--primary">
-            <p class="t-upper u-no-margin">Email</p>
-            <input class="form-element--inline" type="text" name="email" id="email" placeholder="Email address">
-            <button class="button--cta heading__right form-element--inline" type="submit" name="commit" value="Subscribe" class="form_button">Subscribe</button>
+            <label for="submit" class="label">Email</label>
+            <input class="form-element--inline" size="40" type="text" name="email" id="email">
+            <button class="button--cta form-element--inline" type="submit" name="commit" value="Subscribe" class="form_button">Subscribe</button>
+            <ul class="list--flat-bordered t-small t-sans u-margin--top">
+              <li><a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank">Edit an existing subscription</a></li>
+              <li><a href="https://insights.govdelivery.com/Communications/Subscriber_Help_Center/What_information_does_GovDelivery_collect%3F_How_is_it_used%3F" target="_blank">Privacy policy</a></li>
+            </ul>
           </div>
         </fieldset>
       </form>


### PR DESCRIPTION
Addresses: 
https://github.com/fecgov/fec-cms/issues/1778
https://github.com/fecgov/fec-cms/issues/1670

Create gov delivery email signup on all-updates page that allows users to signup for all news updates or choose from a list of news/outreach related topics--NOT all gov delivery topics.


- [ ] Add govdelivery token via CUPS (Create User Provided Service) as a sensitive constant
    (GovDelivery token has been removed from code pushed to this repo)

## Live Screenshot:
![gov_del_still](https://user-images.githubusercontent.com/5572856/38062883-551f178e-32c4-11e8-88c1-2809a02ff680.gif)


## Signup:
![gov_del_signup](https://user-images.githubusercontent.com/5572856/38010873-f15c3e70-3228-11e8-95ea-be43f7aeb73d.gif)

