### PR TITLE
fixed robots.txt file in our dev, stage, and feature environments

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -18,7 +18,9 @@ FEC_API_URL = env.get_credential('FEC_API_URL', 'http://localhost:5000')
 FEC_API_KEY = env.get_credential('FEC_WEB_API_KEY')
 FEC_API_VERSION = env.get_credential('FEC_API_VERSION', 'v1')
 FEC_API_KEY_PUBLIC = env.get_credential('FEC_WEB_API_KEY_PUBLIC', '')
-FEC_CMS_ROBOTS = env.get_credential('FEC_CMS_ROBOTS')
+
+# Disables crawling for all of our environments except for production
+FEC_CMS_ROBOTS = True
 
 FEC_GITHUB_TOKEN = env.get_credential('FEC_GITHUB_TOKEN')
 

--- a/fec/fec/settings/production.py
+++ b/fec/fec/settings/production.py
@@ -6,6 +6,9 @@ SECRET_KEY = env.get_credential('DJANGO_SECRET_KEY')
 DEBUG = False
 TEMPLATE_DEBUG = False
 
+# Allows search crawling in production only
+FEC_CMS_ROBOTS = False
+
 SESSION_COOKIE_SECURE = True
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_SECURE = True

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -36,7 +36,7 @@ if settings.FEC_CMS_ENVIRONMENT != 'LOCAL':
     urlpatterns.insert(0,url(r'^admin/login', uaa_views.login, name='login'))
 
 if settings.FEC_CMS_ROBOTS:
-    url(
+    urlpatterns += url(
         r'^robots\.txt$',
         TemplateView.as_view(
             template_name='robots.txt',


### PR DESCRIPTION
## Summary

The robots.txt file was not showing up for all of our non-production environments (dev, stage, and feature). This fixes the robots file so that all search engines will be disallowed from crawling them. Production is explicitly set to not have a robots.txt file to allow for search engine crawling.

## Impacted areas of the application
List general components of the application that this PR will affect:

- Dev
- Stage
- Feature