### PR TITLE
Added copy for latest updates email signup

### DIFF
--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="js-accordion accordion--neutral" data-content-prefix="email_signup">
-  <button type="button" class="js-accordion-trigger accordion__button">Sign up for email updates
+  <button type="button" class="js-accordion-trigger accordion__button">Get latest updates by email
   </button>
   <div class="accordion__content">
     <form id="GD-snippet-form" action="https://public.govdelivery.com/accounts/USFEC/subscriber/qualify?qsp=USFEC_1" accept-charset="UTF-8" method="post" target="_blank">
@@ -23,6 +23,7 @@
             <label for="submit" class="label">Email</label>
             <input class="form-element--inline" size="40" type="text" name="email" id="email">
             <button class="button--cta form-element--inline" type="submit" name="commit" value="Subscribe" class="form_button">Subscribe</button>
+   On the next page, set your email preferences, then complete your subscription by selecting which latest updates publications types you want to receive by email.
             <ul class="list--flat-bordered t-small t-sans u-margin--top">
               <li><a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank">Edit an existing subscription</a></li>
               <li><a href="https://insights.govdelivery.com/Communications/Subscriber_Help_Center/What_information_does_GovDelivery_collect%3F_How_is_it_used%3F" target="_blank">Privacy policy</a></li>
@@ -30,7 +31,7 @@
           </div>
         </fieldset>
       </form>
-   </div>
+    </div>
   </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary (required)
Addresses #1778 (specifically the copy) and makes changes to #1890 

Adds copy to the email signup form on the latest updates page. 
- The interaction is slightly more complex than we'd realized on the GovDelivery end, so I'm adding a sentence to let folks know there's slightly more.
- I also made the title of the accordion refer specifically to `Latest updates`, since that's the scope of the signup page they're going to and it'll help clarify that it's different from the footer signup.

I don't think the GovDelivery privacy policy is strictly necessary, since a new subscriber will see it on the subsequent page, but I don't think it's bad to keep it anyway. It gives some visual balance to the form while also letting someone see it before doing anything else. So that stays.

One other thing @johnnyporkchops: can you make sure the text renders well where it is? I'm not sure if putting it before that `ul` is going to mess up the class for that text. We _can_ put it after, though I like it better before.

## Impacted areas of the application
The new signup accordion @johnnyporkchops has created in #1890 