### PR TITLE
Fix datatable checkbox dropdown bug in IE

### DIFF
--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -90,6 +90,7 @@ Dropdown.prototype.handleFocusAway = function(e) {
       !this.$panel.is($target) && !$target.is(this.$button)) {
     this.hide();
   }
+  e.stopImmediatePropagation()
 };
 
 Dropdown.prototype.handleKeyup = function(e) {


### PR DESCRIPTION
**Addresses:**
Committee filing filters not working on Internet Explorer #1521
**Areas of application affected:** 
all datatables
This is actually a bug across AA datatables where ,in Internet Explorer (IE), clicking on a dropdown item causes the dropdown to close and no item to be chosen. This is a bug that is caused by the javascript event created to close the menu when the user tabs (focuses) away from the dropdown and into the document body.
In order for this event to be fired recognized when tabbing (or focusing) away from the dropdown item, we must use [focusin](https://developer.mozilla.org/en-US/docs/Web/Events/focusin) instead of [focus](https://developer.mozilla.org/en-US/docs/Web/Events/focus) because the former [bubbles](https://developer.mozilla.org/en-US/docs/Web/API/Event/bubbles) and the latter does not.
IE11 handles this bubbling improperly and causes a `focusin` event on the document (outside the dropdown) upon clicking anywhere inside the dropdown. The menu closes and no item is ever chosen. 
**Two ways to fix:**
1) To fix this I have removed bubbling on event handler for this using `stopImmediatePropigation()`.Keyboard actions still work on this item including tabbing, enter and escape. The only caveat is that the dropdown will not close automatically when one tabs past the last item in the list. (enter, excape, or a click outside the dropdown does close it) But is does tab to the next filter item after the dropdown, so users with screenreaders will not be affected.
2) The other way to fix this without this small functionality hit would be to downgrade the meta tage to emulate IE 10. This works. I would like to hear others' thoughts on which of the two seems best, This PR is setup for the first option.
**Also, once this is decided, we may want to  change this to a hotfix because this is a fairly obtrusive bug**