### PR TITLE
Fix dead link in committee profile page for IE link.

### DIFF
--- a/fec/data/templates/macros/tables.jinja
+++ b/fec/data/templates/macros/tables.jinja
@@ -29,13 +29,21 @@ The committee_id is a tuple list(the count =1 or 2)
 
 case 2: this page comes from data/committee/<committee_id>/:
 The committee_id is a string, the count=9.
+
+case 3: for committe profile page.
+not 'type' object, so use 'link' to check for independent-expenditures and party-coordinated-expenditure
 #}
+ 
         {% if item[1]['type'] and cycle|int > 2006 and committee_id|count < 9 %}
           <a href="/data/{{ item[1]['type']['link'] }}/?{% for id in committee_id -%}committee_id={{ id }}&{%- endfor %}two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
           </a>
         {% elif item[1]['type'] and cycle|int > 2006 and committee_id|count == 9 %}
           <a href="/data/{{ item[1]['type']['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
+            {{ item[0]|currency }}
+          </a>
+        {% elif (item[1]['link']=="independent-expenditures" or item[1]['link'] == "party-coordinated-expenditures")and cycle|int > 2006 and committee_id|count == 9 %}
+          <a href="/data/{{ item[1]['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}">
             {{ item[0]|currency }}
           </a>
         {% else %}

--- a/fec/data/templates/macros/tables.jinja
+++ b/fec/data/templates/macros/tables.jinja
@@ -22,18 +22,18 @@
       <td class="simple-table__cell">
 {# 
 case 1: this page comes from data/candidate/<candidate_id>/ :
-The committee_id is a tuple list(the count =1 or 2)
+The committee_id is a tuple list(the count < 9). see example below:
   a)one candidate has only one committee, committee_id=['C00580100'], count=1
-  b)one candidate has two committees, committee_id = ['C00496075','C00462069']
-    count=2
+  b)one candidate has more then one committees, ex: committee_id = ['C00496075','C00462069','C00462069']
+    count = 3 (<9)
 
 case 2: this page comes from data/committee/<committee_id>/:
 The committee_id is a string, the count=9.
 
 case 3: for committe profile page.
-not 'type' object, so use 'link' to check for independent-expenditures and party-coordinated-expenditure
+not 'type' object, so use 'link' to check for 'independent-expenditures' and 'party-coordinated-expenditure'
 #}
- 
+
         {% if item[1]['type'] and cycle|int > 2006 and committee_id|count < 9 %}
           <a href="/data/{{ item[1]['type']['link'] }}/?{% for id in committee_id -%}committee_id={{ id }}&{%- endfor %}two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
@@ -42,6 +42,7 @@ not 'type' object, so use 'link' to check for independent-expenditures and party
           <a href="/data/{{ item[1]['type']['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
           </a>
+
         {% elif (item[1]['link']=="independent-expenditures" or item[1]['link'] == "party-coordinated-expenditures")and cycle|int > 2006 and committee_id|count == 9 %}
           <a href="/data/{{ item[1]['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}">
             {{ item[0]|currency }}


### PR DESCRIPTION
This PR fix the dead IE and PCE links in committee profile page.
Related Issue: 
[https://github.com/fecgov/FEC/issues/4828](https://github.com/fecgov/FEC/issues/4828)
[https://github.com/fecgov/fec-cms/issues/1744](https://github.com/fecgov/fec-cms/issues/1744)

Related PR:
[https://github.com/fecgov/fec-cms/pull/1819](https://github.com/fecgov/fec-cms/pull/1819)
[https://github.com/fecgov/fec-cms/pull/1884/files](https://github.com/fecgov/fec-cms/pull/1884/files)

Because PR1884 fixed multi committee_ids issue, by mistake remove the codes for handle IE and PCE links, so add back in this PR.

**How to test it**
1)setup fec-cms locally
2) test 3 cases and check all links in Financial summary section: 
a) has one committee in candidate profile page
[http://127.0.0.1:8000/data/candidate/H6AZ01199/](http://127.0.0.1:8000/data/candidate/H6AZ01199/)

b)has more then one committees in candidate profile page
[http://127.0.0.1:8000/data/candidate/H2NJ05014/?cycle=2016](http://127.0.0.1:8000/data/candidate/H2NJ05014/?cycle=2016)

c)committee profile page
[http://127.0.0.1:8000/data/committee/C00586826/?cycle=2016](http://127.0.0.1:8000/data/committee/C00586826/?cycle=2016)
