### PR TITLE
[MERGE BEFORE RELEASE] Fixed spacing error by restoring inadvertently-deleted class

### DIFF
--- a/fec/fec/static/scss/layout/_layout.scss
+++ b/fec/fec/static/scss/layout/_layout.scss
@@ -81,6 +81,15 @@
   padding: u(0 0 2rem 0);
 }
 
+.content__section--extra {
+  @include clearfix();
+  padding: u(2rem 0);
+
+  @include media($lg) {
+    padding: u(4rem 0);
+  }
+}
+
 //to allow a block of content to be indented to the right of an icon or other content
 .content__section--indent-left {
   margin: u(0 0 3rem 3rem);


### PR DESCRIPTION
Fixes spacing error by restoring inadvertently-deleted `.content__section--extra`  from _layout.scss.
This PR should fix this. (This  class was inadvertently deleted when adding styles for Adv Data)

**How to test:**
1) checkout `fix/header-spacing` branch
2) npm run build-sass
3) navigate to http://127.0.0.1:8000/updates/ and/or http://127.0.0.1:8000/about/reports-about-fec/foia-reports/
4) See if spacing is restored

**Screenshots of errors:**
![apr-13-2018-16-34-35](https://user-images.githubusercontent.com/5572856/38756903-11364dae-3f39-11e8-8cde-a27581a5845d.jpg)
![apr-13-2018-16-35-15](https://user-images.githubusercontent.com/5572856/38756904-113f6b78-3f39-11e8-8a68-80d156601cc5.jpg)
