### PR TITLE
[MERGE WITH GITFLOW - HOTFIX] Fix Bulk data and External sources links across site

### DIFF
--- a/fec/data/templates/advanced.jinja
+++ b/fec/data/templates/advanced.jinja
@@ -93,10 +93,10 @@
               <a
                 class="side-nav__link"
                 role="tab"
-                data-name="other"
+                data-name="external"
                 tabindex="0"
-                aria-controls="other"
-                href="#other"
+                aria-controls="external"
+                href="#external"
                 aria-selected="false">External sources</a>
             </li>
             <li class="side-nav__item" role="presentation">
@@ -119,7 +119,7 @@
           {% include 'partials/advanced/committees.jinja' %}
           {% include 'partials/advanced/filings-reports.jinja' %}
           {% include 'partials/advanced/historical.jinja' %}
-          {% include 'partials/advanced/other.jinja' %}
+          {% include 'partials/advanced/external.jinja' %}
           {% include 'partials/advanced/bulk-data.jinja' %}
         </div>
       </div>

--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -187,7 +187,7 @@
         </a>
       </div>
       <div class="grid__item">
-        <a href="/data/advanced?tab=other">
+        <a href="/data/advanced?tab=bulk-data">
           <aside class="card card--horizontal card--primary">
             <div class="card__image__container">
               <span class="card__icon i-bulk"><span class="u-visually-hidden">Icon of bulk data</span></span>

--- a/fec/data/templates/partials/advanced/external.jinja
+++ b/fec/data/templates/partials/advanced/external.jinja
@@ -1,4 +1,4 @@
-<section id="other" class="row" aria-hidden="true" role="tabpanel">
+<section id="external" class="row" aria-hidden="true" role="tabpanel">
   <h2>External sources</h2>
   <p>Certain information is reported to the FEC, but more information is reported to other governmental agencies.</p>
   <div class="content__section--ruled t-sans">

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -32,7 +32,7 @@ var downloadCapFormatted = helpers.formatNumber(DOWNLOAD_CAP);
 var MAX_DOWNLOADS = 5;
 var DOWNLOAD_MESSAGES = {
   recordCap:
-    'Use <a href="' + window.BASE_PATH + '/advanced?tab=other">' +
+    'Use <a href="' + window.BASE_PATH + '/advanced?tab=bulk-data">' +
     'bulk data</a> to export more than ' +
     downloadCapFormatted +
     ' records.',

--- a/fec/fec/templates/partials/navigation/nav-data.html
+++ b/fec/fec/templates/partials/navigation/nav-data.html
@@ -19,7 +19,7 @@
           <ul class="usa-width-one-half">
             <li class="mega__item"><a href="/data/advanced?tab=candidates">Candidates</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=committees">Committees</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=other">Bulk data and other sources</a></li>
+            <li class="mega__item"><a href="/data/advanced?tab=bulk-data">Bulk data and other sources</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=external">External sources</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary

- Addresses #1928 
Fixed External sources link and bulk data links across the site. Please check these areas here:

- http://localhost:8000/data/ - Check `Browse full advanced data sets` cards in this section
- information box up at the top right of the page has a bulk data link. That is pulled in through the tables.js, so modifying that file should fix all the locations below: 
   - http://localhost:8000/data/receipts/individual-contributions/?two_year_transaction_period=2018&min_date=01%2F01%2F2017&max_date=04%2F19%2F2018
   - http://localhost:8000/data/receipts/?two_year_transaction_period=2018&data_type=processed&min_date=01%2F01%2F2017&max_date=04%2F19%2F2018
   - http://localhost:8000/data/disbursements/?data_type=processed&two_year_transaction_period=2018&min_date=01%2F01%2F2017&max_date=04%2F19%2F2018
   - http://localhost:8000/data/filings/?data_type=processed
- Check menu to make sure `External sources` and `Bulk data and other sources` goes to the right section of advanced data

## Impacted areas of the application
List general components of the application that this PR will affect:

- Data menu
- Individual Contributions page information box
- Receipts page information box
- Disbursements page information box
- Filings page information box
- Data landing page