### PR TITLE
Implement new menu designs

### DIFF
--- a/fec/fec/static/scss/components/_icon-headings.scss
+++ b/fec/fec/static/scss/components/_icon-headings.scss
@@ -60,6 +60,8 @@
   padding-left: u(3rem);
 }
 
+
+
 .icon-heading--raising-circle {
   &::before {
     $size: u(4rem);
@@ -77,6 +79,28 @@
     content: '';
     float: left;
     margin-right: u(1rem);
+  }
+}
+
+.icon-heading--data-flag-circle--primary {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($data-flag, $inverse, $primary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+}
+
+.icon-heading--data-flag-circle--secondary {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($data-flag, $inverse, $secondary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
   }
 }
 
@@ -170,6 +194,39 @@
   }
 }
 
+.icon-heading--person-location-circle {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($person-location, $inverse, $primary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+}
+
+.icon-heading--individual-contributions-circle {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($individual-contributions, $inverse, $primary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+}
+
+.icon-heading--magnifying-glass-circle {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($magnifying-glass, $inverse, $primary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+}
+
 // Data landing page links to breakdowns
 .icon-heading--graph-circle {
   &::before {
@@ -207,7 +264,8 @@
 
 .icon-heading--graph-circle,
 .icon-heading--graph-unordered-circle,
-.icon-heading--map-circle {
+.icon-heading--map-circle,
+.icon-heading--data-flag-circle {
   border-bottom: none;
   display: table;
 

--- a/fec/fec/static/scss/components/_icon-headings.scss
+++ b/fec/fec/static/scss/components/_icon-headings.scss
@@ -107,8 +107,8 @@
 // homepage - registration and reporting (on secondary [red] slab)
 .icon-heading--checklist-circle {
   &::before {
-    @include u-icon-circle($checklist, $inverse, $secondary-contrast, 4.5rem);
-    background-size: u(4rem);
+    @include u-icon-circle($checklist, $inverse, $secondary-contrast, 4rem);
+    background-size: u(3rem);
     content: '';
     float: left;
     margin-right: u(1.5rem);
@@ -117,8 +117,8 @@
 
 .icon-heading--question-bubble-circle {
   &::before {
-    @include u-icon-circle($question-bubble, $inverse, $secondary-contrast, 4.5rem);
-    background-size: u(4rem);
+    @include u-icon-circle($question-bubble, $inverse, $secondary-contrast, 4rem);
+    background-size: u(3rem);
     content: '';
     float: left;
     margin-right: u(1.5rem);
@@ -220,7 +220,7 @@
   &::before {
     $size: u(4rem);
     @include u-icon-circle($magnifying-glass, $inverse, $primary-contrast, $size);
-    background-size: 50%;
+    background-size: 45%;
     content: '';
     float: left;
     margin-right: u(1.5rem);
@@ -265,7 +265,14 @@
 .icon-heading--graph-circle,
 .icon-heading--graph-unordered-circle,
 .icon-heading--map-circle,
-.icon-heading--data-flag-circle {
+.icon-heading--data-flag-circle,
+.icon-heading--question-bubble-circle,
+.icon-heading--checklist-circle,
+.icon-heading--magnifying-glass-circle,
+.icon-heading--question-bubble-circle,
+.icon-heading--individual-contributions-circle,
+.icon-heading--person-location-circle
+ {
   border-bottom: none;
   display: table;
 
@@ -273,6 +280,7 @@
     line-height: 1.2;
     display: table-cell;
     vertical-align: middle;
+    color:inherit;
   }
 
   &::before {

--- a/fec/fec/static/scss/components/_icon-headings.scss
+++ b/fec/fec/static/scss/components/_icon-headings.scss
@@ -13,6 +13,11 @@
 
 .icon-heading {
   @include clearfix();
+  margin-top:0;
+
+  @include media($med) {
+    margin-top: u(1rem);
+  }
 }
 
 .icon-heading__image {
@@ -107,8 +112,9 @@
 // homepage - registration and reporting (on secondary [red] slab)
 .icon-heading--checklist-circle {
   &::before {
-    @include u-icon-circle($checklist, $inverse, $secondary-contrast, 4rem);
-    background-size: u(3rem);
+    $size: u(3.5rem);
+    @include u-icon-circle($checklist, $inverse, $secondary-contrast, $size);
+    background-size: 70%;
     content: '';
     float: left;
     margin-right: u(1.5rem);
@@ -117,8 +123,9 @@
 
 .icon-heading--question-bubble-circle {
   &::before {
-    @include u-icon-circle($question-bubble, $inverse, $secondary-contrast, 4rem);
-    background-size: u(3rem);
+    $size: u(3.5rem);
+    @include u-icon-circle($question-bubble, $inverse, $secondary-contrast, $size);
+    background-size: 70%;
     content: '';
     float: left;
     margin-right: u(1.5rem);
@@ -196,7 +203,7 @@
 
 .icon-heading--person-location-circle {
   &::before {
-    $size: u(4rem);
+    $size: u(3.5rem);
     @include u-icon-circle($person-location, $inverse, $primary-contrast, $size);
     background-size: 50%;
     content: '';
@@ -207,7 +214,7 @@
 
 .icon-heading--individual-contributions-circle {
   &::before {
-    $size: u(4rem);
+    $size: u(3.5rem);
     @include u-icon-circle($individual-contributions, $inverse, $primary-contrast, $size);
     background-size: 50%;
     content: '';
@@ -218,9 +225,9 @@
 
 .icon-heading--magnifying-glass-circle {
   &::before {
-    $size: u(4rem);
+    $size: u(3.5rem);
     @include u-icon-circle($magnifying-glass, $inverse, $primary-contrast, $size);
-    background-size: 45%;
+    background-size: 50%;
     content: '';
     float: left;
     margin-right: u(1.5rem);

--- a/fec/fec/static/scss/components/_icon-headings.scss
+++ b/fec/fec/static/scss/components/_icon-headings.scss
@@ -112,7 +112,7 @@
 // homepage - registration and reporting (on secondary [red] slab)
 .icon-heading--checklist-circle {
   &::before {
-    $size: u(3.5rem);
+    $size: u(4rem);
     @include u-icon-circle($checklist, $inverse, $secondary-contrast, $size);
     background-size: 70%;
     content: '';
@@ -123,7 +123,7 @@
 
 .icon-heading--question-bubble-circle {
   &::before {
-    $size: u(3.5rem);
+    $size: u(4rem);
     @include u-icon-circle($question-bubble, $inverse, $secondary-contrast, $size);
     background-size: 70%;
     content: '';
@@ -203,7 +203,7 @@
 
 .icon-heading--person-location-circle {
   &::before {
-    $size: u(3.5rem);
+    $size: u(4rem);
     @include u-icon-circle($person-location, $inverse, $primary-contrast, $size);
     background-size: 50%;
     content: '';
@@ -214,7 +214,7 @@
 
 .icon-heading--individual-contributions-circle {
   &::before {
-    $size: u(3.5rem);
+    $size: u(4rem);
     @include u-icon-circle($individual-contributions, $inverse, $primary-contrast, $size);
     background-size: 50%;
     content: '';
@@ -225,7 +225,7 @@
 
 .icon-heading--magnifying-glass-circle {
   &::before {
-    $size: u(3.5rem);
+    $size: u(4rem);
     @include u-icon-circle($magnifying-glass, $inverse, $primary-contrast, $size);
     background-size: 50%;
     content: '';
@@ -282,6 +282,7 @@
  {
   border-bottom: none;
   display: table;
+  padding-bottom: u(1.3rem);
 
   .icon-heading__text {
     line-height: 1.2;

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -23,13 +23,16 @@
 
 .mega__inner {
   padding: u(1rem);
+  margin: u(1rem 0 0 0);
 }
 
 .mega-heading__title {
   display: none;
   a {
     border-bottom: 1px dotted $inverse !important;
-    display:table;
+  }
+  &::before {
+    margin-bottom:u(3rem);
   }
 }
 
@@ -76,6 +79,7 @@
 .mega__item {
   margin-bottom: u(1.5rem);
   padding-left: u(2rem);
+  line-height:1.2;
 
   &:first-of-type {
     margin-top: u(1rem);

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -2,9 +2,9 @@
 //
 // For site nav
 //
-
+// change line7, before push to: a:not(.mega__page-link, .button) {
 .mega-container {
-  a:not(.mega__page-link, .button) {
+  a:not(.mega__page-link) {
     border-bottom: none;
 
     &:hover {
@@ -28,6 +28,10 @@
 
 .mega-heading__title {
   display: none;
+  a {
+    border-bottom: 1px dotted $inverse !important;
+    display:table;
+  }
 }
 
 .mega-heading {

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -28,13 +28,15 @@
 
 .mega-heading__title {
   display: none;
+  margin-left: u(-2rem);
+
   a {
     border-bottom: 1px dotted $inverse !important;
   }
   &::before {
-    margin-bottom:u(3rem);
-    height:u(5rem) !important;
-    width:u(5rem) !important;
+    margin-bottom: u(3rem);
+    height: u(5rem) !important;
+    width: u(5rem) !important;
   }
 }
 
@@ -175,3 +177,5 @@
     }
   }
 }
+
+

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -41,7 +41,7 @@
 }
 
 .mega__intro {
-  padding: u(1rem 1rem 0 1rem);
+  padding: u(0rem 1rem 0 1rem);
 }
 
 .mega__page-link {

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -2,9 +2,8 @@
 //
 // For site nav
 //
-// change line7, before push to: a:not(.mega__page-link, .button) {
 .mega-container {
-  a:not(.mega__page-link) {
+  a:not(.mega__page-link, .button) {
     border-bottom: none;
 
     &:hover {

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -33,6 +33,8 @@
   }
   &::before {
     margin-bottom:u(3rem);
+    height:u(5rem) !important;
+    width:u(5rem) !important;
   }
 }
 

--- a/fec/fec/templates/partials/navigation/nav-about.html
+++ b/fec/fec/templates/partials/navigation/nav-about.html
@@ -3,7 +3,7 @@
     <div class="mega__inner">
       <div class="row">
         <div class="usa-width-one-fourth">
-          <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="/about/">Learn more about FEC</a></h2>
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="/about/">Learn more about the FEC</a></h2>
         </div>
         <div class="usa-width-one-half mega__intro">
           <ul class="usa-width-one-third">

--- a/fec/fec/templates/partials/navigation/nav-about.html
+++ b/fec/fec/templates/partials/navigation/nav-about.html
@@ -1,27 +1,24 @@
 <div class="mega-container">
   <div class="mega mega--secondary">
     <div class="mega__inner">
-      <div class="mega-heading">
-        <h2 class="mega-heading__title"><a href="/about">About home</a></h2>
-      </div>
       <div class="row">
-        <div class="usa-width-one-third mega__intro">
-          <p>Learn more about the FEC's mission, history, and current events.</p>
-          <p><a href="/about" class="button button--alt-primary">Get started &raquo;</a></p>
+        <div class="usa-width-one-fourth">
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="/about/">Learn more about FEC</a></h2>
         </div>
-        <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="/updates">News and announcements</a></li>
-          <li><a class="mega__page-link" href="/meetings">Commission meetings</a></li>
-          <li><a class="mega__page-link" href="/about/mission-and-history/">Mission and history</a></li>
-          <li><a class="mega__page-link" href="/about/leadership-and-structure/">Leadership and structure</a></li>
-        </ul>
-        <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="/about/reports-about-fec/">Reports about the FEC</a></li>
-          <li><a class="mega__page-link" href="/about/careers/">Careers</a></li>
-          <li><a class="mega__page-link" href="/about/#working-with-the-fec">Working with the FEC</a></li>
-          <li><a class="mega__page-link" href="/contact-us">Contact</a></li>
-        </ul>
-        </ul>
+        <div class="usa-width-one-third mega__intro">
+          <ul class="usa-width-one-half">
+           <li class="mega__item"><a href="/updates">News and announcements</a></li>
+           <li class="mega__item"><a href="/meetings">Commission meetings</a></li>
+           <li class="mega__item"><a href="/about/mission-and-history/">Mission and history</a></li>
+           <li class="mega__item"><a href="/about/leadership-and-structure/">Leadership and structure</a></li>
+          </ul>
+          <ul class="usa-width-one-half">
+            <li class="mega__item"><a href="/about/reports-about-fec/">Reports about the FEC</a></li>
+            <li class="mega__item"><a href="/about/careers/">Careers</a></li>
+            <li class="mega__item"><a href="/about/#working-with-the-fec">Working with the FEC</a></li>
+            <li class="mega__item"><a href="/contact-us">Contact</a></li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/fec/fec/templates/partials/navigation/nav-about.html
+++ b/fec/fec/templates/partials/navigation/nav-about.html
@@ -5,16 +5,18 @@
         <div class="usa-width-one-fourth">
           <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="/about/">Learn more about FEC</a></h2>
         </div>
-        <div class="usa-width-one-third mega__intro">
-          <ul class="usa-width-one-half">
+        <div class="usa-width-one-half mega__intro">
+          <ul class="usa-width-one-third">
            <li class="mega__item"><a href="/updates">News and announcements</a></li>
            <li class="mega__item"><a href="/meetings">Commission meetings</a></li>
            <li class="mega__item"><a href="/about/mission-and-history/">Mission and history</a></li>
-           <li class="mega__item"><a href="/about/leadership-and-structure/">Leadership and structure</a></li>
           </ul>
-          <ul class="usa-width-one-half">
+          <ul class="usa-width-one-third">
+            <li class="mega__item"><a href="/about/leadership-and-structure/">Leadership and structure</a></li>
             <li class="mega__item"><a href="/about/reports-about-fec/">Reports about the FEC</a></li>
             <li class="mega__item"><a href="/about/careers/">Careers</a></li>
+           </ul>
+           <ul class="usa-width-one-third">
             <li class="mega__item"><a href="/about/#working-with-the-fec">Working with the FEC</a></li>
             <li class="mega__item"><a href="/contact-us">Contact</a></li>
           </ul>

--- a/fec/fec/templates/partials/navigation/nav-data.html
+++ b/fec/fec/templates/partials/navigation/nav-data.html
@@ -16,12 +16,11 @@
             <li class="mega__item"><a href="/data/advanced?tab=candidates">Candidates</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=committees">Committees</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=bulk-data">Bulk data</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=external">External sources</a></li>
           </ul>
         </div>
-        <div class="usa-width-one-fourth u-padding--left">
+        <div class="usa-width-one-third u-padding--left">
           <div class="icon-heading icon-heading--person-location-circle u-padding--bottom">
-            <p class="t-sans t-small icon-heading__text"><a href="/data/elections">Find elections. Search by state or ZIP code.</a></p>
+            <p class="t-sans t-small icon-heading__text"><a href="/data/elections">Find elections. Search by state or ZIP code</a></p>
           </div>
           <div class="icon-heading icon-heading--individual-contributions-circle">
             <p class="t-sans t-small icon-heading__text"> <a href="/data/receipts/individual-contributions">Look up contributions from specific individuals</a></p>

--- a/fec/fec/templates/partials/navigation/nav-data.html
+++ b/fec/fec/templates/partials/navigation/nav-data.html
@@ -1,15 +1,11 @@
 <div class="mega-container">
   <div class="mega">
     <div class="mega__inner">
-      <div class="mega-heading">
-        <h2 class="mega-heading__title"><a href="/data">Campaign finance home</a></h2>
-      </div>
       <div class="row">
-        <div class="usa-width-one-third mega__intro">
-          <p>Look up candidates and committees in federal elections and learn about the money raised and spent in elections.</p>
-          <p><a class="button button--alt-primary" href="/data">Get started &raquo;</a></p>
+        <div class="usa-width-one-fourth">
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--primary"><a href="/data">Explore all data</a></h2>
         </div>
-        <div class="usa-width-one-third">
+        <div class="usa-width-one-third mega__intro">
           <ul class="usa-width-one-half">
             <li class="mega__item"><a href="/data/advanced?tab=raising">Raising</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=spending">Spending</a></li>
@@ -19,31 +15,17 @@
           <ul class="usa-width-one-half">
             <li class="mega__item"><a href="/data/advanced?tab=candidates">Candidates</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=committees">Committees</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=bulk-data">Bulk data and other sources</a></li>
+            <li class="mega__item"><a href="/data/advanced?tab=bulk-data">Bulk data</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=external">External sources</a></li>
           </ul>
         </div>
         <div class="usa-width-one-fourth u-margin--top u-padding--left">
-          <a href="/data/elections">
-            <aside class="card card--primary card--horizontal mega__card">
-              <div class="card__image">
-                <span class="card__icon i-elections"><span class="u-visually-hidden">Icon representing elections</span></span>
-              </div>
-              <div class="card__content">
-                Find elections. Search by state or ZIP code.
-              </div>
-            </aside>
-          </a>
-          <a href="/data/receipts/individual-contributions">
-            <aside class="card card--primary card--horizontal mega__card">
-              <div class="card__image">
-                <span class="card__icon i-individual-contributions"><span class="u-visually-hidden">Icon representing individual contributions</span></span>
-              </div>
-              <div class="card__content">
-                Look up contributions from specific individuals
-              </div>
-            </aside>
-          </a>
+          <div class="icon-heading icon-heading--person-location-circle u-padding--bottom">
+            <p class="t-sans t-small"><a href="/data/elections">Find elections. Search by state or ZIP code.</a></p>
+          </div>
+          <div class="icon-heading icon-heading--individual-contributions-circle">
+            <p class="t-sans t-small"> <a href="/data/receipts/individual-contributions">Look up contributions from specific individuals</a></p>
+          </div>
         </div>
       </div>
     </div>

--- a/fec/fec/templates/partials/navigation/nav-data.html
+++ b/fec/fec/templates/partials/navigation/nav-data.html
@@ -19,7 +19,7 @@
           </ul>
         </div>
         <div class="usa-width-one-third u-padding--left">
-          <div class="icon-heading icon-heading--person-location-circle u-padding--bottom">
+          <div class="icon-heading icon-heading--person-location-circle">
             <p class="t-sans t-small icon-heading__text"><a href="/data/elections">Find elections. Search by state or ZIP code</a></p>
           </div>
           <div class="icon-heading icon-heading--individual-contributions-circle">

--- a/fec/fec/templates/partials/navigation/nav-data.html
+++ b/fec/fec/templates/partials/navigation/nav-data.html
@@ -21,10 +21,10 @@
         </div>
         <div class="usa-width-one-fourth u-margin--top u-padding--left">
           <div class="icon-heading icon-heading--person-location-circle u-padding--bottom">
-            <p class="t-sans t-small"><a href="/data/elections">Find elections. Search by state or ZIP code.</a></p>
+            <p class="t-sans t-small icon-heading__text"><a href="/data/elections">Find elections. Search by state or ZIP code.</a></p>
           </div>
           <div class="icon-heading icon-heading--individual-contributions-circle">
-            <p class="t-sans t-small"> <a href="/data/receipts/individual-contributions">Look up contributions from specific individuals</a></p>
+            <p class="t-sans t-small icon-heading__text"> <a href="/data/receipts/individual-contributions">Look up contributions from specific individuals</a></p>
           </div>
         </div>
       </div>

--- a/fec/fec/templates/partials/navigation/nav-data.html
+++ b/fec/fec/templates/partials/navigation/nav-data.html
@@ -19,7 +19,7 @@
             <li class="mega__item"><a href="/data/advanced?tab=external">External sources</a></li>
           </ul>
         </div>
-        <div class="usa-width-one-fourth u-margin--top u-padding--left">
+        <div class="usa-width-one-fourth u-padding--left">
           <div class="icon-heading icon-heading--person-location-circle u-padding--bottom">
             <p class="t-sans t-small icon-heading__text"><a href="/data/elections">Find elections. Search by state or ZIP code.</a></p>
           </div>

--- a/fec/fec/templates/partials/navigation/nav-help.html
+++ b/fec/fec/templates/partials/navigation/nav-help.html
@@ -4,7 +4,7 @@
       <div class="row">
         <div class="usa-width-one-fourth">
           <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="help-candidates-and-committees/">Explore all compliance resources</a></h2>
-        </div>
+      </div>
         <div class="usa-width-one-third mega__intro">
           <ul class="usa-width-one-half">
             <li class="mega__item"><a href="/help-candidates-and-committees/guides">Guides</a></li>
@@ -17,10 +17,10 @@
         </div>
         <div class="usa-width-one-fourth u-margin--top u-padding--left">
           <div class="icon-heading icon-heading--checklist-circle u-padding--bottom">
-            <p class="t-sans t-small"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Learn about electronic filing.</a></p>
+            <p class="t-sans t-small icon-heading__text"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Learn about electronic filing.</a></p>
           </div>
           <div class="icon-heading icon-heading--question-bubble-circle">
-            <p class="t-sans t-small"> <a href="/help-candidates-and-committees/question-rad/">Find and contact your committee's analyst.</a></p>
+            <p class="t-sans t-small icon-heading__text"> <a href="/help-candidates-and-committees/question-rad/">Find and contact your committee's analyst.</a></p>
           </div>
         </div>
       </div>

--- a/fec/fec/templates/partials/navigation/nav-help.html
+++ b/fec/fec/templates/partials/navigation/nav-help.html
@@ -1,22 +1,28 @@
 <div class="mega-container">
   <div class="mega mega--secondary">
     <div class="mega__inner">
-      <div class="mega-heading">
-        <h2 class="mega-heading__title"><a href="/help-candidates-and-committees">Candidates and committees home</a></h2>
-      </div>
       <div class="row">
-        <div class="usa-width-one-third mega__intro">
-          <p>Learn more about the groups that are active in federal elections and the requirements that apply to them.</p>
-          <p><a href="/help-candidates-and-committees" class="button button--alt-primary">Get started &raquo;</a></p>
+        <div class="usa-width-one-fourth">
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="help-candidates-and-committees/">Explore all compliance resources</a></h2>
         </div>
-        <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="/help-candidates-and-committees/guides">Guides</a></li>
-          <li><a class="mega__page-link" href="/help-candidates-and-committees/forms">Forms</a></li>
-        </ul>
-        <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="/help-candidates-and-committees/dates-and-deadlines">Dates and deadlines</a></li>
-          <li><a class="mega__page-link" href="https://transition.fec.gov/info/outreach.shtml">Trainings</a></li>
-        </ul>
+        <div class="usa-width-one-third mega__intro">
+          <ul class="usa-width-one-half">
+            <li class="mega__item"><a href="/help-candidates-and-committees/guides">Guides</a></li>
+            <li class="mega__item"><a href="/help-candidates-and-committees/forms">Forms</a></li>
+          </ul>
+          <ul class="usa-width-one-half">
+            <li class="mega__item"><a  href="/help-candidates-and-committees/dates-and-deadlines">Dates and deadlines</a></li>
+            <li class="mega__item"><a  href="https://transition.fec.gov/info/outreach.shtml">Trainings</a></li>
+          </ul>
+        </div>
+        <div class="usa-width-one-fourth u-margin--top u-padding--left">
+          <div class="icon-heading icon-heading--checklist-circle u-padding--bottom">
+            <p class="t-sans t-small"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Learn about electronic filing.</a></p>
+          </div>
+          <div class="icon-heading icon-heading--question-bubble-circle">
+            <p class="t-sans t-small"> <a href="/help-candidates-and-committees/question-rad/">Find and contact your committee's analyst.</a></p>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/fec/fec/templates/partials/navigation/nav-help.html
+++ b/fec/fec/templates/partials/navigation/nav-help.html
@@ -15,12 +15,12 @@
             <li class="mega__item"><a  href="https://transition.fec.gov/info/outreach.shtml">Trainings</a></li>
           </ul>
         </div>
-        <div class="usa-width-one-fourth u-padding--left">
+        <div class="usa-width-one-third u-padding--left">
           <div class="icon-heading icon-heading--checklist-circle u-padding--bottom">
-            <p class="t-sans t-small icon-heading__text"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Learn about electronic filing.</a></p>
+            <p class="t-sans t-small icon-heading__text"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Learn about electronic filing</a></p>
           </div>
           <div class="icon-heading icon-heading--question-bubble-circle">
-            <p class="t-sans t-small icon-heading__text"> <a href="/help-candidates-and-committees/question-rad/">Find and contact your committee's analyst.</a></p>
+            <p class="t-sans t-small icon-heading__text"> <a href="/help-candidates-and-committees/question-rad/">Find and contact your committee's analyst</a></p>
           </div>
         </div>
       </div>

--- a/fec/fec/templates/partials/navigation/nav-help.html
+++ b/fec/fec/templates/partials/navigation/nav-help.html
@@ -16,7 +16,7 @@
           </ul>
         </div>
         <div class="usa-width-one-third u-padding--left">
-          <div class="icon-heading icon-heading--checklist-circle u-padding--bottom">
+          <div class="icon-heading icon-heading--checklist-circle">
             <p class="t-sans t-small icon-heading__text"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Learn about electronic filing</a></p>
           </div>
           <div class="icon-heading icon-heading--question-bubble-circle">

--- a/fec/fec/templates/partials/navigation/nav-help.html
+++ b/fec/fec/templates/partials/navigation/nav-help.html
@@ -15,7 +15,7 @@
             <li class="mega__item"><a  href="https://transition.fec.gov/info/outreach.shtml">Trainings</a></li>
           </ul>
         </div>
-        <div class="usa-width-one-fourth u-margin--top u-padding--left">
+        <div class="usa-width-one-fourth u-padding--left">
           <div class="icon-heading icon-heading--checklist-circle u-padding--bottom">
             <p class="t-sans t-small icon-heading__text"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Learn about electronic filing.</a></p>
           </div>

--- a/fec/fec/templates/partials/navigation/nav-legal.html
+++ b/fec/fec/templates/partials/navigation/nav-legal.html
@@ -18,7 +18,7 @@
             <li class="mega__item"><a href="https://transition.fec.gov/law/policy.shtml">Policy and other guidance</a></li>
           </ul>
         </div>
-        <div class="usa-width-one-fourth u-margin--top u-padding--left">
+        <div class="usa-width-one-fourth u-padding--left">
           <div class="icon-heading icon-heading--magnifying-glass-circle u-padding--bottom">
             <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/">Search across all legal resources</a></p>
           </div>

--- a/fec/fec/templates/partials/navigation/nav-legal.html
+++ b/fec/fec/templates/partials/navigation/nav-legal.html
@@ -20,7 +20,7 @@
         </div>
         <div class="usa-width-one-fourth u-margin--top u-padding--left">
           <div class="icon-heading icon-heading--magnifying-glass-circle u-padding--bottom">
-            <p class="t-sans t-small"><a href="/legal-resources/">Search across all legal resources</a></p>
+            <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/">Search across all legal resources</a></p>
           </div>
         </div>
       </div>

--- a/fec/fec/templates/partials/navigation/nav-legal.html
+++ b/fec/fec/templates/partials/navigation/nav-legal.html
@@ -1,25 +1,28 @@
 <div class="mega-container">
   <div class="mega">
     <div class="mega__inner">
-      <div class="mega-heading">
-        <h2 class="mega-heading__title"><a href="/legal-resources">Legal home</a></h2>
-      </div>
       <div class="row">
-        <div class="usa-width-one-third mega__intro">
-          <p>Explore relevant statutes, regulations, Commission actions and court cases.</p>
-          <p><a href="/legal-resources" class="button button--alt-primary">Get started &raquo;</a></p>
+        <div class="usa-width-one-fourth">
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--primary"><a href="/legal-resources">Explore all legal resources</a></h2>
         </div>
-        <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="/data/legal/advisory-opinions">Advisory opinions</a></li>
-          <li><a class="mega__page-link" href="/legal-resources/enforcement">Enforcement</a></li>
-          <li><a class="mega__page-link" href="/data/legal/statutes">Statutes</a></li>
-          <li><a class="mega__page-link" href="/legal-resources/legislation">Legislation</a></li>
-        </ul>
-        <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="/legal-resources/regulations">Regulations</a></li>
-          <li><a class="mega__page-link" href="/legal-resources/court-cases">Court cases</a></li>
-          <li><a class="mega__page-link" href="https://transition.fec.gov/law/policy.shtml">Policy and other guidance</a></li>
-        </ul>
+        <div class="usa-width-one-third mega__intro">
+          <ul class="usa-width-one-half">
+            <li class="mega__item"><a href="/data/legal/advisory-opinions">Advisory opinions</a></li>
+            <li class="mega__item"><a href="/legal-resources/enforcement">Enforcement</a></li>
+            <li class="mega__item"><a href="/data/legal/statutes">Statutes</a></li>
+            <li class="mega__item"><a href="/legal-resources/legislation">Legislation</a></li>
+          </ul>
+          <ul class="usa-width-one-half">
+            <li class="mega__item"><a href="/legal-resources/regulations">Regulations</a></li>
+            <li class="mega__item"><a href="/legal-resources/court-cases">Court cases</a></li>
+            <li class="mega__item"><a href="https://transition.fec.gov/law/policy.shtml">Policy and other guidance</a></li>
+          </ul>
+        </div>
+        <div class="usa-width-one-fourth u-margin--top u-padding--left">
+          <div class="icon-heading icon-heading--magnifying-glass-circle u-padding--bottom">
+            <p class="t-sans t-small"><a href="/legal-resources/">Search across all legal resources</a></p>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/fec/fec/templates/partials/navigation/nav-legal.html
+++ b/fec/fec/templates/partials/navigation/nav-legal.html
@@ -19,7 +19,7 @@
           </ul>
         </div>
         <div class="usa-width-one-fourth u-padding--left">
-          <div class="icon-heading icon-heading--magnifying-glass-circle u-padding--bottom">
+          <div class="icon-heading icon-heading--magnifying-glass-circle">
             <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/">Search across all legal resources</a></p>
           </div>
         </div>


### PR DESCRIPTION
## Summary (required)

Addresses # Implement new menu designs #1905
- Updated main navigation menus for `About, CFD, H4CC, and Legal landing`

- [x] we need to decide how we want to underline the main title links `h2s` on each menu
- [x] also need to resolve horizontal  spacing issues across on the `about` menu

## Impacted areas of the application
main navigation menus for `CFD, H4CC, Legal landing, About `
## Screenshots:
### New CFD menu:
![data1](https://user-images.githubusercontent.com/5572856/39392538-78f76034-4a85-11e8-8799-8db45045908e.gif)

### New H4CC menu:
![help1](https://user-images.githubusercontent.com/5572856/39392542-8406c1cc-4a85-11e8-9cfa-c4ae01489cac.gif)

### New Legal landing menu:
![legal1](https://user-images.githubusercontent.com/5572856/39392544-8f83e5ac-4a85-11e8-873a-8024afb17c73.gif)

### New About menu:
![about1](https://user-images.githubusercontent.com/5572856/39392547-98aa8370-4a85-11e8-8efa-7e6b8145268b.gif)
