### PR TITLE
Use cycle select macro to generate raising/spending cycles

### DIFF
--- a/fec/data/templates/raising-breakdown.jinja
+++ b/fec/data/templates/raising-breakdown.jinja
@@ -1,5 +1,6 @@
 {% extends "layouts/sidebar-page.jinja" %}
 {% import "macros/breakdowns.jinja" as breakdowns %}
+{% import 'macros/cycle-select.jinja' as select %}
 
 {% block css %}
 <link rel="stylesheet" type="text/css" href="{{ asset_for_css('data-landing.css') }}" />
@@ -11,12 +12,7 @@
 
 {% block sidebar %}
 <form action="" method="get" class="breakdown-cycle">
-  <label for="cycle" class="label">Time period</label>
-  <select id="cycle" name="cycle" class="js-cycle" aria-controls="raising-breakdowns">
-    <option value="2018" {% if cycle == '2018' %}selected{% endif %}>2017&ndash;2018</option>
-    <option value="2016" {% if cycle == '2016' %}selected{% endif %}>2015&ndash;2016</option>
-    <option value="2012" {% if cycle == '2012' %}selected{% endif %}>2011&ndash;2012</option>
-  </select>
+  {{ select.cycle_select(cycles, cycle, location='form', range=True) }}
   <noscript>
     <button type="submit" class="button button--cta">Submit</button>
   </noscript>

--- a/fec/data/templates/spending-breakdown.jinja
+++ b/fec/data/templates/spending-breakdown.jinja
@@ -1,5 +1,6 @@
 {% extends "layouts/sidebar-page.jinja" %}
 {% import "macros/breakdowns.jinja" as breakdowns %}
+{% import 'macros/cycle-select.jinja' as select %}
 
 {% block css %}
 <link rel="stylesheet" type="text/css" href="{{ asset_for_css('data-landing.css') }}" />
@@ -11,12 +12,7 @@
 
 {% block sidebar %}
 <form action="" method="get" class="breakdown-cycle">
-  <label for="cycle" class="label">Time period</label>
-  <select id="cycle" name="cycle" class="js-cycle" aria-controls="spending-breakdown">
-    <option value="2018" {% if cycle == '2018' %}selected{% endif %}>2017&ndash;2018</option>
-    <option value="2016" {% if cycle == '2016' %}selected{% endif %}>2015&ndash;2016</option>
-    <option value="2012" {% if cycle == '2012' %}selected{% endif %}>2011&ndash;2012</option>
-  </select>
+  {{ select.cycle_select(cycles, cycle, location='form', range=True) }}
   <noscript>
     <button type="submit" class="button button--cta">Submit</button>
   </noscript>

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -269,7 +269,7 @@ def committee(request, committee_id):
     committee, all_candidates, cycle = api_caller.load_with_nested('committee', committee_id, 'candidates', cycle)
 
     # When there are multiple candidate records of various offices (H, S, P) linked to a single
-    # committee ID, we want to associate the candidate record with the matching committee type 
+    # committee ID, we want to associate the candidate record with the matching committee type
     # For each candidate, check if the committee type is equal to the candidate's office. If true
     # add that candidate to the list of candidates to return
     candidates = []
@@ -286,7 +286,7 @@ def committee(request, committee_id):
     # without cycle query parameter
     # See https://github.com/fecgov/openFEC/issues/1536
     # For each candidate, set related_cycle to the candidate's time period
-    # relative to the selected cycle. 
+    # relative to the selected cycle.
     for candidate in candidates:
         election_years = []
         for election_year in candidate['election_years']:
@@ -295,7 +295,7 @@ def committee(request, committee_id):
                 election_years.append(election_year)
 
         candidate['related_cycle'] = cycle if election_years else None
-    
+
 
     # Load financial totals and reports for a given committee
     financials = api_caller.load_cmte_financials(committee_id, cycle=cycle)
@@ -418,6 +418,7 @@ def elections(request, office, cycle, state=None, district=None):
 
 def raising(request):
     top_category = request.GET.get('top_category', 'P')
+    cycles = utils.get_cycles(utils.current_cycle())
     cycle = request.GET.get('cycle', constants.DEFAULT_TIME_PERIOD)
 
     if top_category in ['pac']:
@@ -440,6 +441,7 @@ def raising(request):
         'top_category': top_category,
         'coverage_start_date': datetime.date(cycle - 1, 1, 1),
         'coverage_end_date': coverage_end_date,
+        'cycles': cycles,
         'cycle': cycle,
         'top_raisers': top_raisers['results'],
         'page_info': utils.page_info(top_raisers['pagination'])
@@ -448,6 +450,7 @@ def raising(request):
 
 def spending(request):
     top_category = request.GET.get('top_category', 'P')
+    cycles = utils.get_cycles(utils.current_cycle())
     cycle = request.GET.get('cycle', constants.DEFAULT_TIME_PERIOD)
 
     if top_category in ['pac']:
@@ -468,6 +471,7 @@ def spending(request):
         'top_category': top_category,
         'coverage_start_date': datetime.date(cycle - 1, 1, 1),
         'coverage_end_date': coverage_end_date,
+        'cycles': cycles,
         'cycle': cycle,
         'top_spenders': top_spenders['results'],
         'page_info': utils.page_info(top_spenders['pagination'])


### PR DESCRIPTION
## Summary

- Addresses https://github.com/fecgov/fec-cms/issues/1550 and https://github.com/fecgov/fec-cms/issues/1947
_Make raising/spending page cycles data-driven. This means we won't need to manually add future cycles to these dropdowns._
Thank you @apburnes for your help!

## Impacted areas of the application
- https://www.fec.gov/data/spending/
- https://www.fec.gov/data/raising/

## Screenshots

## Before
### Raising
<img width="281" alt="screen shot 2018-04-25 at 10 03 54 am" src="https://user-images.githubusercontent.com/31420082/39251152-98aade5e-4870-11e8-8881-29f846e1f276.png">

### Spending

<img width="275" alt="screen shot 2018-04-25 at 10 03 34 am" src="https://user-images.githubusercontent.com/31420082/39251157-9ba279be-4870-11e8-9a1d-5bd0afa7666c.png">

## After

### Raising
<img width="280" alt="screen shot 2018-04-25 at 10 02 59 am" src="https://user-images.githubusercontent.com/31420082/39251173-a8b58678-4870-11e8-8921-c1aa12c04c28.png">

### Spending
<img width="295" alt="screen shot 2018-04-25 at 10 03 16 am" src="https://user-images.githubusercontent.com/31420082/39251188-b1e43c4e-4870-11e8-84b1-b7c14abd31e1.png">
