### PR TITLE
Restore i-document,i-star and i-speaker icon classes

### DIFF
--- a/fec/fec/static/scss/components/_icons.scss
+++ b/fec/fec/static/scss/components/_icons.scss
@@ -51,6 +51,12 @@
   &.i-star {
     @include u-icon-bg($star, $base);
   }
+
+  &.i-speaker {
+    @include u-icon-bg($speaker, $base);
+  }
+
+
 }
 
 .icon--small {

--- a/fec/fec/static/scss/components/_icons.scss
+++ b/fec/fec/static/scss/components/_icons.scss
@@ -43,6 +43,14 @@
   &.i-download {
     @include u-icon-bg($download, $base);
   }
+
+  &.i-document {
+    @include u-icon-bg($document, $base);
+  }
+
+  &.i-star {
+    @include u-icon-bg($star, $base);
+  }
 }
 
 .icon--small {


### PR DESCRIPTION
Restores missing star, document and speaker(audio) icons to search result, document and meeting pages
- Addresses : Icons missing from site search results list #1838
- Also restores audio icon to meeting pages
- Document searches do not work locally or on feature, so the only way (i could think of) to test this locally is to change the CSS class in the inspector to the newly added classes to make sure the icons show up. see screenshot below.

## Impacted areas of the application
https://github.com/fecgov/fec-cms/blob/develop/fec/fec/static/scss/components/_icons.scss

## Screenshots
### Search Results:
![may-01-2018 14-44-16](https://user-images.githubusercontent.com/5572856/39487878-887a5266-4d4e-11e8-9208-b6388200e24c.gif)

### Document Pages:
![may-01-2018 14-52-35](https://user-images.githubusercontent.com/5572856/39488172-6c58c210-4d4f-11e8-9b52-767158663622.gif)

### Meeting page
![may-01-2018 15-03-44](https://user-images.githubusercontent.com/5572856/39488742-2b620382-4d51-11e8-8184-5784961f864a.gif)




