### PR TITLE
Restore current-version icon to datatables

### DIFF
--- a/fec/fec/static/scss/datatables.scss
+++ b/fec/fec/static/scss/datatables.scss
@@ -1,4 +1,5 @@
 @import "global";
+@import 'common';
 
 @import "components/accordions";
 @import "components/messages";

--- a/fec/fec/static/scss/datatables.scss
+++ b/fec/fec/static/scss/datatables.scss
@@ -1,5 +1,4 @@
 @import "global";
-@import 'common';
 
 @import "components/accordions";
 @import "components/messages";


### PR DESCRIPTION
Restores current-version icon to datatables

- Addresses: green check-icons not showing up for "Current version" reports #1815
Add  `@import 'common';` to `/fec/fec/static/scss/datatables.scss` to restore green-check for current-version reports

## Impacted areas of the application
 [datatables.scss](https://github.com/18F/fec-cms/blob/develop/fec/fec/static/scss/datatables.scss)

## Screenshot
![may-01-2018 23-07-08](https://user-images.githubusercontent.com/5572856/39503539-78feefe0-4d94-11e8-9bbb-0219753a5235.gif)
