### PR TITLE
Revert "[MERGE BEFORE RELEASE] Fixed spacing error by restoring inadvertently-deleted class"

### DIFF
--- a/fec/fec/static/scss/layout/_layout.scss
+++ b/fec/fec/static/scss/layout/_layout.scss
@@ -81,15 +81,6 @@
   padding: u(0 0 2rem 0);
 }
 
-.content__section--extra {
-  @include clearfix();
-  padding: u(2rem 0);
-
-  @include media($lg) {
-    padding: u(4rem 0);
-  }
-}
-
 //to allow a block of content to be indented to the right of an icon or other content
 .content__section--indent-left {
   margin: u(0 0 3rem 3rem);


### PR DESCRIPTION
Reverts fecgov/fec-cms#1921

We needed to revert the merge of audit search as the Audit division has requested that we delay the launch of this tool

This is connected with this other revert PR https://github.com/fecgov/fec-cms/pull/1963