### PR TITLE
Remove Gemnasium badge - now using Snyk

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![CircleCI](https://circleci.com/gh/fecgov/fec-cms.svg?style=svg)](https://circleci.com/gh/fecgov/fec-cms)
 
 **Master**
-[![Dependency Status](https://gemnasium.com/badges/github.com/fecgov/fec-cms.svg)](https://gemnasium.com/github.com/fecgov/fec-cms)
 [![Known Vulnerabilities](https://snyk.io/test/github/fecgov/fec-cms/badge.svg)](https://snyk.io/test/github/fecgov/fec-cms)
 
 ## Campaign finance for everyone


### PR DESCRIPTION
Remove Gemnasium badge on README.md - now using Snyk to track vulnerabilities
