### PR TITLE
Remove reporting deadlines filter from calendar

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -6,7 +6,6 @@ election_types = OrderedDict([
 ])
 
 deadline_types = OrderedDict([
-    ('21', 'Reporting deadlines'),
     ('25', 'Quarterly reports'),
     ('26', 'Monthly reports'),
     ('27', 'Pre- and post-election')


### PR DESCRIPTION
Adresses:
Remove "All Reports" filter from calendar #1981

Category 21, does not seem to show any results for 2018 except for year-end report in January 2018, so removing this filter temporarily should not effect anything until we can determine why the data in this category (21) is inconsistent.