### PR TITLE
Edit grammar for Campaign Finance Data #1907

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -224,8 +224,8 @@ pac_party_types = OrderedDict([
     ('Y', 'Party - qualified'),
     ('Z', 'National party nonfederal account'),
     ('U', 'Single candidate independent expenditure'),
-    ('O', 'Super PAC (independent expenditure only'),
-    ('I', 'Independent expenditor (person or group)')
+    ('O', 'Super PAC (independent expenditure only)'),
+    ('I', 'Independent expenditure filer (not a committee)')
 ])
 
 house_senate_types = OrderedDict([

--- a/fec/data/templates/datatable.jinja
+++ b/fec/data/templates/datatable.jinja
@@ -14,7 +14,7 @@
 
 {% block body %}
 
-{{ header.header(breadcrumbs_title | title, breadcrumbs) }}
+{{ header.header(breadcrumbs_title, breadcrumbs) }}
 
 <section class="main__content--full data-container__wrapper">
   {% include 'partials/' + slug + '-filter.jinja' %}

--- a/fec/data/templates/partials/filters/committee-types.jinja
+++ b/fec/data/templates/partials/filters/committee-types.jinja
@@ -37,7 +37,7 @@
         </li>
         <li class="dropdown__item">
           <input id="committee-type-checkbox-I" type="checkbox" name="committee_type" value="I">
-          <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditor (person or group)</label>
+          <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditure filer (not a committee)</label>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Edit grammar for Campaign Finance Data

### Addresses #1907

- Fixed the breadcrumbs layout to show __PAC and party committee reports__
<img width="525" alt="screen shot 2018-05-09 at 4 46 10 pm" src="https://user-images.githubusercontent.com/693815/39836245-1a33d3c0-53a9-11e8-828a-48fe75f7b5f7.png">

- Fix filter names for __Super PAC (independent expenditure only)__ and __Independent expenditure filer (not a committee)_ and make sure their listed properly within the select menu
<img width="997" alt="screen shot 2018-05-09 at 4 46 16 pm" src="https://user-images.githubusercontent.com/693815/39836343-611552b4-53a9-11e8-8a25-207aadbc00ba.png">
<img width="322" alt="screen shot 2018-05-09 at 4 46 53 pm" src="https://user-images.githubusercontent.com/693815/39836399-9e4758f8-53a9-11e8-9cac-1a4c5f5236c3.png">


### Impacted areas of the application

- Updates the views on the `/data/*` path
