### PR TITLE
Update missing and no data message templates #1939

### DIFF
--- a/fec/data/templates/macros/missing.jinja
+++ b/fec/data/templates/macros/missing.jinja
@@ -1,15 +1,31 @@
 {% macro missing_financials(entity, cycle) %}
 <div class="message message--info">
-  <p>We don't have any financial data for <span class="t-bold">{{ entity }}</span> in <span class="t-bold">{{ cycle | fmt_year_range }}</span>.</p>
+  <p>
+    We don't have
+    <span class="t-bold">
+      {{ entity }}
+    </span>
+    for <span class="t-bold">{{ cycle | fmt_year_range }}</span>.
+  </p>
   <p>This can be because:</p>
   <ul class="list--bulleted">
-    <li>There hasn't been a filing deadline yet or</li>
-    <li>A filing deadline has passed, but the FEC hasn’t finished processing the financial data</li>
+    <li>
+      We’re still processing the data. Try looking for
+      <a href="https://www.fec.gov/data/filings/?data_type=efiling" target="_blank" rel="noopener noreferrer">
+        raw versions of committee filings
+      </a>.
+      Raw files are only available for electronic filers.</li>
+    <li>No one filed this type of activity during the time period.</li>
+    <li>The filing deadline hasn’t passed yet.</li>
   </ul>
-  <p>To find the most recent activity for this candidate or committee, try changing the election cycle.</p>
   <div class="message--alert__bottom">
-    <p>Think this was a mistake?</p>
-    <p>Send us an <a href="mailto:{{ webmanager_email }}">email</a> or file a <a href="https://github.com/fecgov/fec/issues">GitHub issue</a>.
+    <p>Think this result is a mistake or have questions?</p>
+    <p>
+      Send us more information in the feedback box or
+      <a href="https://www.fec.gov/contact-us/" target="_blank" rel="noopener noreferrer">
+        contact us
+      </a>.
+    </p>
   </div>
 </div>
 {% endmacro %}

--- a/fec/data/templates/macros/missing.jinja
+++ b/fec/data/templates/macros/missing.jinja
@@ -12,8 +12,8 @@
     <li>
       We’re still processing the data. Try looking for
       <a href="https://www.fec.gov/data/filings/?data_type=efiling" target="_blank" rel="noopener noreferrer">
-        raw versions of committee filings
-      </a>.
+        raw versions of committee filings.
+      </a>
       Raw files are only available for electronic filers.</li>
     <li>No one filed this type of activity during the time period.</li>
     <li>The filing deadline hasn’t passed yet.</li>
@@ -23,8 +23,8 @@
     <p>
       Send us more information in the feedback box or
       <a href="https://www.fec.gov/contact-us/" target="_blank" rel="noopener noreferrer">
-        contact us
-      </a>.
+        contact us.
+      </a>
     </p>
   </div>
 </div>

--- a/fec/fec/static/js/templates/tables/noData.hbs
+++ b/fec/fec/static/js/templates/tables/noData.hbs
@@ -1,16 +1,31 @@
 <div class="message message--info">
-  <p>We don't have itemized {{dataType}} for <strong>{{name}}</strong> in <strong>{{timePeriod}}</strong>.</p>
-  <p>This can be because:</p>
-  <ul class="list--bulleted">
-    {{#if reason }}
+  <p>We don't have <strong>{{dataType}}</strong> for <strong>{{timePeriod}}</strong>.</p>
+  {{#if reason }}
+    <p>This is because:</p>
+    <ul class="list--bulleted">
       <li>{{reason}}</li>
-    {{/if}}
-    <li>There hasn't been a filing deadline yet or</li>
-    <li>A filing deadline has passed, but the FEC hasn’t finished processing the financial data</li>
-  </ul>
-  <p>To find the most recent activity for this candidate or committee, try changing the election cycle.</p>
+    </ul>
+  {{else}}
+    <p>This can be because:</p>
+    <ul class="list--bulleted">
+      <li>
+        We’re still processing the data. Try looking for
+        <a href="https://www.fec.gov/data/filings/?data_type=efiling" target="_blank" rel="noopener noreferrer">
+          raw versions of committee filings
+        </a>.
+        Raw files are only available for electronic filers.
+      </li>
+      <li>No one filed this type of activity during the time period.</li>
+      <li>The filing deadline hasn’t passed yet.</li>
+    </ul>
+  {{/if}}
   <div class="message--alert__bottom">
-    <p>Think this was a mistake?</p>
-    <p>Send us an <a href="mailto:{{ email }}">email</a> or file a <a href="https://github.com/fecgov/fec/issues">GitHub issue</a>.
+    <p>Think this result is a mistake or have questions?</p>
+    <p>
+      Send us more information in the feedback box or
+      <a href="https://www.fec.gov/contact-us/" target="_blank" rel="noopener noreferrer">
+        contact us
+      </a>.
+    </p>
   </div>
 </div>

--- a/fec/fec/static/js/templates/tables/noData.hbs
+++ b/fec/fec/static/js/templates/tables/noData.hbs
@@ -11,8 +11,8 @@
       <li>
         We’re still processing the data. Try looking for
         <a href="https://www.fec.gov/data/filings/?data_type=efiling" target="_blank" rel="noopener noreferrer">
-          raw versions of committee filings
-        </a>.
+          raw versions of committee filings.
+        </a>
         Raw files are only available for electronic filers.
       </li>
       <li>No one filed this type of activity during the time period.</li>
@@ -24,8 +24,8 @@
     <p>
       Send us more information in the feedback box or
       <a href="https://www.fec.gov/contact-us/" target="_blank" rel="noopener noreferrer">
-        contact us
-      </a>.
+        contact us.
+      </a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Update templates for missing and no data messages

- Addresses #1939

Updates the jinga and handlebars templates which display `no data` messages. The jinja template uses the new default message drafted in the issue. The handlebars template receives a `reason` parameter when querying https://api.open.fec.gov. The handlebars template displays the given reason if supplied or else it displays the updated default message.

### Impacted areas of the application

- Templates using the `missing.jinja` macro => data templates (`committees-single.jinja` & `candidates-single.jinja`)
- Whenever the browser makes an xhr request ie `.../?tab=spending`, it is using the `noData.hbs` template

### Screenshots

__Default message from `missing.jinja`__
![image](https://user-images.githubusercontent.com/693815/39928688-680e3ce8-550c-11e8-9637-81f62c804b8b.png)

__Messages with reasons from `noData.hbs`__
![image](https://user-images.githubusercontent.com/693815/39928764-984daa60-550c-11e8-9d22-ca95b1aec319.png)

![image](https://user-images.githubusercontent.com/693815/39928820-bcc9045c-550c-11e8-9b46-fb9ff8e1741d.png)

![image](https://user-images.githubusercontent.com/693815/39928984-3ef17572-550d-11e8-8644-931f8e4117f6.png)
