### PR TITLE
Fix link styles with updating line endings

### DIFF
--- a/fec/data/templates/macros/missing.jinja
+++ b/fec/data/templates/macros/missing.jinja
@@ -11,9 +11,7 @@
   <ul class="list--bulleted">
     <li>
       We’re still processing the data. Try looking for
-      <a href="https://www.fec.gov/data/filings/?data_type=efiling" target="_blank" rel="noopener noreferrer">
-        raw versions of committee filings.
-      </a>
+      <a href="https://www.fec.gov/data/filings/?data_type=efiling" target="_blank" rel="noopener noreferrer">raw versions of committee filings</a>.
       Raw files are only available for electronic filers.</li>
     <li>No one filed this type of activity during the time period.</li>
     <li>The filing deadline hasn’t passed yet.</li>
@@ -22,9 +20,7 @@
     <p>Think this result is a mistake or have questions?</p>
     <p>
       Send us more information in the feedback box or
-      <a href="https://www.fec.gov/contact-us/" target="_blank" rel="noopener noreferrer">
-        contact us.
-      </a>
+      <a href="https://www.fec.gov/contact-us/" target="_blank" rel="noopener noreferrer">contact us</a>.
     </p>
   </div>
 </div>

--- a/fec/fec/static/js/templates/tables/noData.hbs
+++ b/fec/fec/static/js/templates/tables/noData.hbs
@@ -10,9 +10,7 @@
     <ul class="list--bulleted">
       <li>
         We’re still processing the data. Try looking for
-        <a href="https://www.fec.gov/data/filings/?data_type=efiling" target="_blank" rel="noopener noreferrer">
-          raw versions of committee filings.
-        </a>
+        <a href="https://www.fec.gov/data/filings/?data_type=efiling" target="_blank" rel="noopener noreferrer">raw versions of committee filings</a>.
         Raw files are only available for electronic filers.
       </li>
       <li>No one filed this type of activity during the time period.</li>
@@ -23,9 +21,7 @@
     <p>Think this result is a mistake or have questions?</p>
     <p>
       Send us more information in the feedback box or
-      <a href="https://www.fec.gov/contact-us/" target="_blank" rel="noopener noreferrer">
-        contact us.
-      </a>
+      <a href="https://www.fec.gov/contact-us/" target="_blank" rel="noopener noreferrer">contact us</a>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Fix templates for missing and no data messages links

### Addresses #1939
Updates the jinga and handlebars templates which display no data messages. Update the link style formatting/spacing

### Impacted areas of the application
Templates using the `missing.jinja` and `noData.hbs`