### PR TITLE
Feature/restore reverted audit search

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -215,6 +215,10 @@ candidate_status_extended = OrderedDict([
     ('P', 'Statutory candidate in prior cycle'),
 ])
 
+pac_party = OrderedDict([
+    ('PAC', 'PACs'),
+    ('PAR', 'Political Party Committees'),
+])
 pac_party_types = OrderedDict([
     ('N', 'PAC - nonqualified'),
     ('Q', 'PAC - qualified'),
@@ -224,14 +228,90 @@ pac_party_types = OrderedDict([
     ('Y', 'Party - qualified'),
     ('Z', 'National party nonfederal account'),
     ('U', 'Single candidate independent expenditure'),
-    ('O', 'Super PAC (independent expenditure only)'),
-    ('I', 'Independent expenditure filer (not a committee)')
+    ('O', 'Super PAC (independent expenditure only'),
+    ('I', 'Independent expenditor (person or group)')
 ])
 
 house_senate_types = OrderedDict([
     ('H', 'House'),
     ('S', 'Senate')
 ])
+
+
+primary_category_keys = ['primary_category_id', 'primary_category_name']
+sub_category_keys = ['sub_category_id', 'sub_category_name']
+
+audit_primary_categories_options = [
+    {
+        "primary_category_id": 'all',
+        "primary_category_name": 'All'
+    },
+    {
+        "primary_category_id": '2',
+        "primary_category_name": 'Allocation Issues'
+    },
+    {
+        "primary_category_id": '3',
+        "primary_category_name": 'Disclosure'
+    },
+    {
+        "primary_category_id": '5',
+        "primary_category_name": 'Excessive Contributions'
+    },
+    {
+        "primary_category_id": '1',
+        "primary_category_name": 'Failure to File Reports/Schedules/Notices'
+    },
+    {
+        "primary_category_id": '8',
+        "primary_category_name": 'Loans'
+    },
+    {
+        "primary_category_id": '7',
+        "primary_category_name": 'Misstatement of Financial Activity'
+    },
+    {
+        "primary_category_id": '14',
+        "primary_category_name": 'Net Outstanding Campaign/Convention ' +
+        'Expenditures/Obligations'
+    },
+    {
+        "primary_category_id": '16',
+        "primary_category_name": 'No Findings or Issues/Not a Committee'
+    },
+    {
+        "primary_category_id": '9',
+        "primary_category_name": 'Other'
+    },
+    {
+        "primary_category_id": '15',
+        "primary_category_name": 'Payments/Disgorgements'
+    },
+    {
+        "primary_category_id": '6',
+        "primary_category_name": 'Prohibited Contributions'
+    },
+    {
+        "primary_category_id": '4',
+        "primary_category_name": 'Recordkeeping'
+    },
+    {
+        "primary_category_id": '17',
+        "primary_category_name": 'Referred Findings Not Listed'
+    },
+    {
+        "primary_category_id": '13',
+        "primary_category_name": 'Repayment to US Treasury'
+    }
+]
+
+audit_sub_categories_options = [
+    {
+        "sub_category_id": 'all',
+        "sub_category_name": ' '
+    }
+]
+
 
 table_columns = OrderedDict([
     ('candidates', ['Name', 'Office', 'Election years', 'Party', 'State', 'District', 'First filing date']),
@@ -251,7 +331,8 @@ table_columns = OrderedDict([
     ('reports-presidential', ['Committee', 'Report type', 'Version', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
     ('reports-house-senate', ['Committee', 'Report type', 'Version', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
     ('reports-pac-party', ['Committee', 'Report type', 'Version', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements', 'Total independent expenditures']),
-    ('reports-ie-only', ['Filer', 'Report type', 'Version', 'Receipt date', 'Coverage end date', 'Total contributions', 'Total independent expenditures'])
+    ('reports-ie-only', ['Filer', 'Report type', 'Version', 'Receipt date', 'Coverage end date', 'Total contributions', 'Total independent expenditures']),
+    ('audit', ['Committee name', 'Election cycle', 'Final report', 'Findings and issues', 'Candidate']),
 ])
 
 line_numbers = {

--- a/fec/data/templates/macros/filters/dropdown-json.jinja
+++ b/fec/data/templates/macros/filters/dropdown-json.jinja
@@ -1,0 +1,24 @@
+{% macro select_json(name, label, keys, options={}, default=none) %}
+<div class="filter js-filter js-filter-control" data-filter="select"
+data-validate="false" data-modifies-filter="{{ name }}" data-required-default="{{ default }}">
+  <label for="{{ name }}" class="label">{{ label }}</label>
+  <select id={{ name }} name="{{ name }}">
+    {% for option in options %}
+      <option value={{option[keys[0]]}}>{{ option[keys[1]] }}</option>
+    {% endfor %}
+  </select>
+</div>
+{% endmacro %}
+
+
+{% macro select_json_indentation(name, label, keys, options={}, default=none) %}
+<div class="filter js-filter js-filter-control sub--filter--indent" data-filter="select"
+data-validate="false" data-modifies-filter="{{ name }}" data-required-default="{{ default }}">
+  <label for="{{ name }}" class="label">{{ label }}</label>
+  <select id={{ name }} name="{{ name }}">
+    {% for option in options %}
+      <option value={{option[keys[0]]}}>{{ option[keys[1]] }}</option>
+    {% endfor %}
+  </select>
+</div>
+{% endmacro %}

--- a/fec/data/templates/macros/filters/years.jinja
+++ b/fec/data/templates/macros/filters/years.jinja
@@ -37,3 +37,24 @@
   </div>
 </fieldset>
 {% endmacro %}
+
+
+{% macro cycleRange(name, label) %}
+<fieldset class="filter" id="{{name}}-field">
+  <legend class="label">{{ label }}</legend>
+  <div class="range range--amount">
+    <div class="range__input range__input--min js-filter" data-filter="range">
+      <label for="min_election_{{name}}">From</label>
+      <input id="min_election_{{name}}" type="text" name="min_election_{{name}}" data-range="min" data-prefix="" data-suffix="" tabindex="0">
+    </div>
+    <div class="range__hyphen">-</div>
+    <div class="range__input range__input--max js-filter" data-filter="range">
+      <label for="max_election_{{name}}">To</label>
+      <input id="max_election_{{name}}" type="text" name="max_election_{{name}}" data-range="max" data-prefix="" data-suffix="" tabindex="0">
+    </div>
+    <button class="button--go button--standard" type="button">
+      <span class="u-visually-hidden">Search</span>
+    </button>
+  </div>
+</fieldset>
+{% endmacro %}

--- a/fec/data/templates/macros/page-header.jinja
+++ b/fec/data/templates/macros/page-header.jinja
@@ -2,26 +2,41 @@
 <div class="page-header page-header--primary">
   <ul class="breadcrumbs">
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
-    {% if title != 'Campaign finance data' %}
+    {% if title == 'Audit' %}
       <li class="breadcrumbs__item">
         <span class="breadcrumbs__separator">&rsaquo;</span>
-        <a href="/data" class="breadcrumbs__link">Campaign finance data</a>
+        <a class="breadcrumbs__link" href="/legal-resources">Legal resources</a>
+      </li>
+      <li class="breadcrumbs__item">
+        <span class="breadcrumbs__separator">&rsaquo;</span>
+        <a class="breadcrumbs__link" href="/legal-resources/enforcement">Enforcing federal campaign finance law</a>
+      </li>
+      <li class="breadcrumbs__item breadcrumbs__item--current">
+        <span class="breadcrumbs__separator">&rsaquo;</span>
+        Audit search
+      </li>
+    {% else %}
+      {% if title != 'Campaign finance data' %}
+        <li class="breadcrumbs__item">
+          <span class="breadcrumbs__separator">&rsaquo;</span>
+          <a href="/data" class="breadcrumbs__link">Campaign finance data</a>
+        </li>
+      {% endif %}
+      {% for link in links %}
+      <li class="breadcrumbs__item">
+        <span class="breadcrumbs__separator">&rsaquo;</span>
+        {% if link[0] != '' %}
+          <a class="breadcrumbs__link" href="{{ link[0] }}">{{ link[1] }}</a>
+        {% else %}
+          <span>{{ link[1] }}</span>
+        {% endif %}
+      </li>
+      {% endfor %}
+      <li class="breadcrumbs__item breadcrumbs__item--current">
+        <span class="breadcrumbs__separator">&rsaquo;</span>
+        {{ title }}
       </li>
     {% endif %}
-    {% for link in links %}
-    <li class="breadcrumbs__item">
-      <span class="breadcrumbs__separator">&rsaquo;</span>
-      {% if link[0] != '' %}
-        <a class="breadcrumbs__link" href="{{ link[0] }}">{{ link[1] }}</a>
-      {% else %}
-        <span>{{ link[1] }}</span>
-      {% endif %}
-    </li>
-    {% endfor %}
-    <li class="breadcrumbs__item breadcrumbs__item--current">
-      <span class="breadcrumbs__separator">&rsaquo;</span>
-      {{ title }}
-    </li>
   </ul>
 </div>
 {% endmacro %}

--- a/fec/data/templates/partials/audit-filter.jinja
+++ b/fec/data/templates/partials/audit-filter.jinja
@@ -1,0 +1,42 @@
+{% extends 'partials/filters.jinja' %}
+
+{% import 'macros/filters/dropdown-json.jinja' as dropdown %}
+{% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
+{% import 'macros/filters/years.jinja' as years %}
+
+{% block filters %}
+<div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
+  <div class="filters__inner">
+ {# category/subcategory filter #}
+    {{
+  	  dropdown.select_json(
+          'primary_category_id',
+          'Findings and issue categories',
+          keys=constants.primary_category_keys,
+          options=constants.audit_primary_categories_options,
+          default=all
+      )
+    }}
+    {{
+  	  dropdown.select_json_indentation(
+        'sub_category_id',
+        'Sub Categories',
+        keys=constants.sub_category_keys,
+        options=constants.audit_sub_categories_options,
+        default=all
+      )
+    }}
+
+{# committee/candidate name/id filter #}
+    {{ typeahead.field('q', 'Committee name or ID', '', dataset='auditCommittees', allow_text=True) }}
+    {{ typeahead.field('qq', 'Authorized candidate name or ID', '', dataset='auditCandidates', allow_text=True) }}
+
+{# election cycle range filter #}
+  {{ years.cycleRange('cycle', 'Election cycles covered by audit' ) }}
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
+  <div class="accordion__content">
+    {% include 'partials/filters/audit-committee-types.jinja' %}
+  </div>
+</div>
+{% endblock %}

--- a/fec/data/templates/partials/filters/audit-committee-types.jinja
+++ b/fec/data/templates/partials/filters/audit-committee-types.jinja
@@ -1,0 +1,97 @@
+<div class="filter">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox">
+    <legend class="label" for="committee_type">Authorized committees</legend>
+    <ul class="dropdown__selected">
+      <li>
+        <input id="committee-type-checkbox-P" type="checkbox" name="committee_type" value="P">
+        <label class="dropdown__value" for="committee-type-checkbox-P">Presidential</label>
+      </li>
+      <li>
+        <input id="committee-type-checkbox-S" type="checkbox" name="committee_type" value="S">
+        <label class="dropdown__value" for="committee-type-checkbox-S">Senate</label>
+      </li>
+      <li>
+        <input id="committee-type-checkbox-H" type="checkbox" name="committee_type" value="H">
+        <label class="dropdown__value" for="committee-type-checkbox-H">House</label>
+      </li>
+    </ul>
+  </fieldset>
+</div>
+
+<div class="filter">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox">
+    <legend class="label" for="committee_type">Party committees</legend>
+    <ul class="dropdown__selected"></ul>
+    <div class="dropdown">
+      <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
+      <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
+        <ul class="dropdown__list">
+          <li>
+            <input id="committee-type-checkbox-X" type="checkbox" name="committee_type" value="X">
+            <label class="dropdown__value" for="committee-type-checkbox-X">Party - nonqualified</label>
+          </li>
+          <li>
+            <input id="committee-type-checkbox-Y" type="checkbox" name="committee_type" value="Y">
+            <label class="dropdown__value" for="committee-type-checkbox-Y">Party - qualified</label>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </fieldset>
+</div>
+
+<div class="filter">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox">
+    <legend class="label" for="committee_type">Independent expenditure committees</legend>
+    <ul class="dropdown__selected"></ul>
+    <div class="dropdown">
+      <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
+      <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
+        <ul class="dropdown__list">
+          <li>
+            <input id="committee-type-checkbox-O" type="checkbox" name="committee_type" value="O">
+            <label class="dropdown__value" for="committee-type-checkbox-O">Super PAC (independent expenditure only)</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-I" type="checkbox" name="committee_type" value="I">
+            <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditure filer (not a committee)</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-U" type="checkbox" name="committee_type" value="U">
+            <label class="dropdown__value" for="committee-type-checkbox-U">Single candidate independent expenditure committee</label>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </fieldset>
+</div>
+
+<div class="filter">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox">
+    <legend class="label" for="committee_type">PACs</legend>
+    <ul class="dropdown__selected"></ul>
+    <div class="dropdown">
+      <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
+      <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
+        <ul class="dropdown__list">
+          <li>
+            <input id="committee-type-checkbox-N" type="checkbox" name="committee_type" value="N">
+            <label class="dropdown__value" for="committee-type-checkbox-N">PAC - nonqualified</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-Q" type="checkbox" name="committee_type" value="Q">
+            <label class="dropdown__value" for="committee-type-checkbox-Q">PAC - qualified</label>
+          </li>
+          <li>
+            <input id="committee-type-checkbox-V" type="checkbox" name="committee_type" value="V">
+            <label class="dropdown__value" for="committee-type-checkbox-V">PAC with non-contribution account - nonqualified</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-W" type="checkbox" name="committee_type" value="W">
+            <label class="dropdown__value" for="committee-type-checkbox-W">PAC with non-contribution account - qualified</label>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -41,4 +41,5 @@ urlpatterns = [
         views_datatables.individual_contributions),
     url(r'^data/receipts/$', views_datatables.receipts),
     url(r'^data/reports/(?P<form_type>[\w-]+)/$', views_datatables.reports),
+    url(r'^legal-resources/enforcement/audit-search/$', views_datatables.audit),
 ]

--- a/fec/data/views_datatables.py
+++ b/fec/data/views_datatables.py
@@ -121,6 +121,15 @@ def loans(request):
         'columns': constants.table_columns['loans']
     })
 
+def audit(request):
+    return render(request, 'datatable.jinja', {
+        'parent': 'data',
+        'result_type': 'audit',
+        'slug': 'audit',
+        'title': 'Audit',
+        'columns': constants.table_columns['audit'],
+    })
+
 
 def party_coordinated_expenditures(request):
     return render(request, 'datatable.jinja', {

--- a/fec/fec/static/js/modules/audit-category-sub-category.js
+++ b/fec/fec/static/js/modules/audit-category-sub-category.js
@@ -1,0 +1,40 @@
+'use strict';
+var _ = require('underscore');
+
+/**
+ * two dropdowns:#primary_category_id and #sub_category_id
+ * when select one option from #primary_category_id dropdown, trigger change function
+ * to make a ajax call (api: audit-category) ,get sub_category_list(JSON type)back
+ * dynamically update the #sub_category_id dropdown list value.
+ */
+var $ = require('jquery');
+var helpers = require('./helpers');
+
+$("#primary_category_id").change(function(event) {
+
+  var $select = $('#sub_category_id');
+  $.getJSON(helpers.buildUrl(['audit-category'],{'primary_category_id': $('#primary_category_id').val(), 'per_page': 100}), function(data){
+    $select.html('<option selected value="all">All</option>')
+    $(".sub--filter--indent").css('opacity','.5').css({pointerEvents: "none"})
+
+    if (data.results[0]){
+    $.each(data.results[0].sub_category_list, function(key, val){
+      $select.append('<option value="' + val.sub_category_id + '">' + val.sub_category_name + '</option>');
+    });
+     $(".sub--filter--indent").css('opacity','1').css({pointerEvents: "auto"});
+    }
+  })
+})
+
+//for sub category filter-tag and results
+function showSubCategory(){
+    var sub_selected = $("#sub_category_id option:selected").text()
+    sub_selected == ("Choose a sub-category")  || ($("#sub_category_id").val() == "all")
+     ? $('.tag__category.sub').css('visibility','hidden')
+     : $('.tag__category.sub').css('visibility','visible')
+
+}
+
+$(document).bind('ready ajaxComplete', '#sub_category_id', showSubCategory);
+
+

--- a/fec/fec/static/js/modules/audit_tags.js
+++ b/fec/fec/static/js/modules/audit_tags.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var $ = require('jquery');
+var _ = require('underscore');
+
+var helpers = require('./helpers');
+
+var AuditCategorySubCategory = require('./audit-category-sub-category');
+
+var $auditCategoryTags= require('../templates/audit_tags.hbs');
+
+
+$('.data-container__tags').prepend($auditCategoryTags)
+$('.tag__category.sub').css('visibility','hidden')
+
+
+$("#primary_category_id").change(function(){
+    var current_category = $("#primary_category_id option:selected").text()
+    $('.tag__category.sub').css('visibility','hidden')
+    $('.tag__item.primary').contents()[0].nodeValue = "Findings and issue category: " + current_category
+    $("#primary_category_id").val() == 'all'
+     ? $('.tag__item.primary button').hide()
+     : $('.tag__item.primary button').show()
+});
+
+
+$("#sub_category_id").change(function() {
+    var current_sub = $("#sub_category_id option:selected").text()
+    $('.tag__item.sub').contents()[0].nodeValue = "Sub Category: "+ current_sub;
+})
+
+$('.js-close_sub').click(function() {
+    $("#primary_category_id").trigger('change')
+    $("#sub_category_id").val("all")
+})
+
+$('.js-close_primary').click(function() {
+   $("#primary_category_id").val("all")
+   $("#primary_category_id").trigger('change')
+   $('.tag__item.primary button').hide()
+})

--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -618,6 +618,62 @@ var loans = [
   modalTriggerColumn
 ];
 
+var audit = [
+  columnHelpers.urlColumn
+  ('link_to_report',
+    {
+      data: 'committee_name',
+      className: 'all align-top',
+      orderable: true
+    }
+  ),
+
+  {
+    data: 'cycle',
+    className: 'all align-top',
+    orderable: true
+  },
+
+  {
+    data: 'far_release_date',
+    className: 'min-tablet hide-panel column--small align-top',
+    orderable: true,
+    render: function(data, type, row) {
+      var parsed;
+      parsed = moment(row.far_release_date, 'YYYY-MM-DD');
+      return parsed.isValid() ? parsed.format('MM/DD/YYYY') : 'Invalid date';
+    }
+  },
+
+  {
+    data: 'primary_category_list',
+    className: 'all align-top',
+    orderable: false,
+    render: function (data){
+      if (data) {     
+        var html = '<ol class="list--numbered">'
+        for(var i in data){
+          html += '<li>' + data[i]['primary_category_name'] + '<ol>'
+          for(var j in data[i]['sub_category_list']){
+            html += '<li>'+ data[i]['sub_category_list'][j]['sub_category_name'] + '</li>'
+          }
+          html += '</ol></li>'
+        }
+        return html + '</ol>'
+      }
+      else {
+        return '';
+      }
+    }
+  },
+
+  {
+    data: 'candidate_name',
+    className: 'min-tablet hide-panel column--small align-top',
+    orderable: true
+  },
+];
+
 module.exports = {
   candidateColumn: candidateColumn,
   committeeColumn: committeeColumn,
@@ -637,5 +693,6 @@ module.exports = {
   filings: filings,
   receipts: receipts,
   reports: reports,
-  loans: loans
+  loans: loans,
+  audit: audit,
 };

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -32,7 +32,7 @@ var downloadCapFormatted = helpers.formatNumber(DOWNLOAD_CAP);
 var MAX_DOWNLOADS = 5;
 var DOWNLOAD_MESSAGES = {
   recordCap:
-    'Use <a href="' + window.BASE_PATH + '/advanced?tab=bulk-data">' +
+    'Use <a href="' + window.BASE_PATH + '/advanced?tab=other">' +
     'bulk data</a> to export more than ' +
     downloadCapFormatted +
     ' records.',
@@ -91,6 +91,10 @@ function mapSort(order, columns) {
 }
 
 function getCount(response) {
+  // for audit data set, retrun real data result rows
+  if (window.location.pathname === '/legal-resources/enforcement/audit-search/'){
+    return response.pagination.count;
+  }
   var pagination_count = response.pagination.count;
 
   if (response.pagination.count > 1000) {
@@ -471,7 +475,8 @@ DataTable.prototype.initFilters = function() {
       resultType: 'results',
       showResultCount: true
     });
-    this.$widgets.find('.js-filter-tags').prepend(tagList.$body);
+    this.$widgets.find('.js-filter-tags').prepend(tagList.
+      $body);
     this.filterPanel = new FilterPanel();
     this.filterSet = this.filterPanel.filterSet;
     $(window).on('popstate', this.handlePopState.bind(this));

--- a/fec/fec/static/js/modules/typeahead.js
+++ b/fec/fec/static/js/modules/typeahead.js
@@ -35,6 +35,22 @@ function formatCommittee(result) {
     id: result.id,
     type: 'committee'
   };
+} 
+
+function formatAuditCommittee(result) {
+  return {
+    name: result.name,
+    id: result.id,
+    type: 'auditCommittee'
+  };
+}
+
+function formatAuditCandidate(result) {
+  return {
+    name: result.name,
+    id: result.id,
+    type: 'auditCandidate'
+  };
 }
 
 function getUrl(resource) {
@@ -77,6 +93,26 @@ var committeeEngine = createEngine({
   }
 });
 
+var auditCommitteeEngine = createEngine({
+  remote: {
+    url: getUrl('audit_committees'),
+    wildcard: '%QUERY',
+    transform: function(response) {
+      return _.map(response.results, formatAuditCommittee);
+    },
+  }
+});
+
+var auditCandidateEngine = createEngine({
+  remote: {
+    url: getUrl('audit_candidates'),
+    wildcard: '%QUERY',
+    transform: function(response) {
+      return _.map(response.results, formatAuditCandidate);
+    },
+  }
+});
+
 var candidateDataset = {
   name: 'candidate',
   display: 'name',
@@ -110,6 +146,37 @@ var committeeDataset = {
   }
 };
 
+
+var auditCommitteeDataset = {
+  name: 'auditCommittees',
+  display: 'name',
+  limit: 10,
+  source: auditCommitteeEngine,
+  templates: {
+    header: '<span class="tt-suggestion__header">Select a committee:</span>',
+    pending: '<span class="tt-suggestion__loading">Loading committees...</span>',
+    notFound: Handlebars.compile(''), // This has to be empty to not show anything
+    suggestion: Handlebars.compile(
+      '<span class="tt-suggestion__name">{{ name }} ({{ id }})</span>'
+    )
+  }
+};
+
+var auditCandidateDataset = {
+  name: 'auditCandidates',
+  display: 'name',
+  limit: 10,
+  source: auditCandidateEngine,
+  templates: {
+    header: '<span class="tt-suggestion__header">Select a candidate:</span>',
+    pending: '<span class="tt-suggestion__loading">Loading candidates...</span>',
+    notFound: Handlebars.compile(''), // This has to be empty to not show anything
+    suggestion: Handlebars.compile(
+      '<span class="tt-suggestion__name">{{ name }} ({{ id }})</span>'
+    )
+  }
+};
+
 /* This is a fake dataset for showing an empty option with the query
  * when clicked, this will load the receipts page,
  * filtered to contributions from this person
@@ -124,7 +191,8 @@ var individualDataset = {
   },
   templates: {
     suggestion: function(datum) {
-      return '<span><strong>Search individual contributions from:</strong> "' + datum.id + '"</span>';
+      return '<span><strong>Search individual contributions from:</strong> "' + datum.id +
+      '"</span>';
     }
   }
 };
@@ -150,6 +218,8 @@ var siteDataset = {
 var datasets = {
   candidates: candidateDataset,
   committees: committeeDataset,
+  auditCandidates: auditCandidateDataset,
+  auditCommittees: auditCommitteeDataset,
   allData: [candidateDataset, committeeDataset],
   all: [candidateDataset, committeeDataset, individualDataset, siteDataset]
 };

--- a/fec/fec/static/js/pages/datatable-audit.js
+++ b/fec/fec/static/js/pages/datatable-audit.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+* audit datatable page
+* ---------------------
+* inital show all audit case.
+*
+*/
+
+var $ = require('jquery');
+
+var tables = require('../modules/tables');
+var columns = require('../modules/columns');
+var tablePanels = require('../modules/table-panels');
+var auditCategorySubcCategory = require('../modules/audit-category-sub-category');
+var auditTags = require('../modules/audit_tags');
+
+
+$(document).ready(function() {
+  var $table = $('#results');
+  new tables.DataTable($table, {
+    autoWidth: false,
+    title: 'Audit reports',
+    path: ['audit-case'],
+    columns: columns.audit,
+    order: [1, 'desc'],
+    useFilters: true,
+    useExport: true,
+    rowCallback: tables.modalRenderRow,
+    callbacks: {
+ //     afterRender: tablePanels.renderauditPanel(false)
+    }
+  });
+});

--- a/fec/fec/static/js/templates/audit_tags.hbs
+++ b/fec/fec/static/js/templates/audit_tags.hbs
@@ -1,0 +1,4 @@
+<ul class="tags" aria-hidden="false">
+  <li data-tag-category="" class="tag__category primary"><div data-id="" data-removable="true" class="tag__item primary">&nbsp;<button class="button js-close_primary tag__remove"><span class="u-visually-hidden">Remove</span></button></div></li>
+  <li data-tag-category="" class="tag__category sub"><div data-id="" data-removable="true" class="tag__item sub">&nbsp;<button class="button js-close_sub tag__remove"><span class="u-visually-hidden">Remove</span></button></div></li>
+</ul>

--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -150,6 +150,25 @@
     &:first-child {
       border-left: none;
     }
+
+    &.align-top {
+      vertical-align: top;
+    }
+
+    ul,
+    ol {
+      line-height: u(1rem);
+
+      li {
+        font-size: u(1.4rem);
+        line-height: u(1.4rem);
+
+        ol, li {
+          margin-left :u(.9rem);
+          line-height: u(1.4rem);
+        }
+      }
+    }
   }
 
   .sorting_disabled {

--- a/fec/fec/static/scss/components/_filters.scss
+++ b/fec/fec/static/scss/components/_filters.scss
@@ -248,6 +248,15 @@ $filter-button-width: u(4.6rem);
   .dropdown__button {
     margin-bottom: u(1rem);
   }
+
+  &.sub--filter--indent {
+    border-left: 3px solid $gray;
+    padding-left: 5%;
+
+    select, input {
+      width: 100%;
+    }
+  }
 }
 
 .filter__instructions {

--- a/fec/fec/static/scss/components/_list-styles.scss
+++ b/fec/fec/static/scss/components/_list-styles.scss
@@ -50,6 +50,7 @@
 }
 
 .list--numbered {
+
   & > li {
     list-style-type: decimal;
   }

--- a/fec/fec/static/scss/components/_tags.scss
+++ b/fec/fec/static/scss/components/_tags.scss
@@ -102,7 +102,7 @@
     }
   }
 }
-
+.tag__category__range--election,
 .tag__category__range--amount,
 .tag__category__range--date {
   .tag__item {

--- a/fec/fec/static/scss/datatables.scss
+++ b/fec/fec/static/scss/datatables.scss
@@ -1,5 +1,4 @@
 @import "global";
-@import 'common';
 
 @import "components/accordions";
 @import "components/messages";


### PR DESCRIPTION
Restore audit search latest iteration after revert in `release 20180502` with additional changes to typeahead/sub-string  search for committee ID/name based on request from stakeholder testing. 
- [x] Upon confirmation from Audit division testers and UX team, this is ready for review.
 **[How to test &#187;](#how-to-test)** 

<hr>

### Latest changes PR/Issues:

**Latest PR:** 
[openFEC #3119](https://github.com/fecgov/openFEC/pull/3119) : Fixed audit committee and candidate name sub-string search

**Latest Issues:** 
- [#1965](https://github.com/fecgov/fec-cms/issues/1965): Searching by candidate name in audit search needs to return multiple results as appropriate 
- [#1966](https://github.com/fecgov/fec-cms/issues/1966): Partial name and keyword committee searches in audit search should return comprehensive results 
- [#2027](https://github.com/fecgov/fec-cms/issues/2027): Ask SMEs to test revised Audit Search 

<hr>

### History:
**Last PR to fec-cms (before this one)**
fec-cms: https://github.com/fecgov/fec-cms/pull/1920
**Past Issue history:**
This migrates the classic audit search application from fec classic to the new fec website
[fec-cms] set default sub_category_id=all for audit-case endpoint #1882
Audit search styling and tags #1777 
Build audit search page #1304 <a id="how-to-test"></a> 
Review and Prioritize Feedback Received from Audit Team #1724



### How to test:
This branch was tested and approved before the revert. Since the revert had to be manually restored, all the functionality was re-tested and confirmed by UX-team /stakeholders and should be spot-checked by the PR reviewer(s) in addition to confirming the latest changes to  `typeahead/sub-string search` for `Candidate/Committee ID/Name` . 
Visit: https://fec-feature-cms.app.cloud.gov/legal-resources/enforcement/audit-search- 
--OR--
Checkout and run this branch locally:  `feature/restore-audit-search` and point to dev openFEC : `export FEC_API_URL=https://fec-dev-api.app.cloud.gov`
- To test latest changes: 
    - Type 'ted' into `Commitee name or ID` field. 
    - You should get three typeahead suggestions. If you hit enter, you should get three results in the 
      data table on the right. 
  - If you choose just one, you should get that one result in the data table in the right
  - Repeat the same action for the `Authorized candidate or ID field`
- Tips to  test overall audit search functionality:
  - Choose a Findings and issue category, then choose a subcategory. Make sure the filter tags show up in the head of the table.
  - Test removing these filters using the `x`. 
  - Test other filters in the filters panel.
  - There is still some missing functionality in this MVP (Most Viable Product), if you experience something you think is an issue, post a review and the assignees can determine if this is expected. Or you can check the [MVP document](https://docs.google.com/document/d/1oOIPdsIMhxfymYo6Scmny5kMseb499jefw8ZinLwQGE/edit#heading=h.u17mfbplznf0).

Thanks for your time!





