### PR TITLE
Fix "Explore all compliance resources" link on menu

### DIFF
--- a/fec/fec/templates/partials/navigation/nav-help.html
+++ b/fec/fec/templates/partials/navigation/nav-help.html
@@ -3,7 +3,7 @@
     <div class="mega__inner">
       <div class="row">
         <div class="usa-width-one-fourth">
-          <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="help-candidates-and-committees/">Explore all compliance resources</a></h2>
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="/help-candidates-and-committees/">Explore all compliance resources</a></h2>
       </div>
         <div class="usa-width-one-third mega__intro">
           <ul class="usa-width-one-half">


### PR DESCRIPTION
Addresses: https://github.com/fecgov/fec-cms/issues/2034

This his link needs to be relative to the top level, not to the page it is on--needs a leading slash
 ` help-candidates-and-committees/ `
--changed to--
` /help-candidates-and-committees/ `

**How to test:**
Checkout and run this branch locally:
`feature/fix-explore-h4cc-link-on-megamenu`
Spot check that  the mega menu link for `Explore all compliance resources` link works on home page and on other pages