### PR TITLE
Include missing "Suite" in committee addresses 

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -319,6 +319,7 @@ def committee(request, committee_id):
         'committee_type': committee['committee_type'],
         'designation_full': committee['designation_full'],
         'street_1': committee['street_1'],
+        'street_2': committee['street_2'],
         'city': committee['city'],
         'state': committee['state'],
         'zip': committee['zip'],


### PR DESCRIPTION
Include missing "Suite" in committee addresses  on "About this committee" pages

- Addresses https://github.com/fecgov/fec-cms/issues/1888

- Added `Street_2` to template variables on data/views.py 

**[How to test &#187;](#how-to-test)** 

## Impacted areas of the application
modified:   data/views.py

## Screenshots
![suite](https://user-images.githubusercontent.com/5572856/40954721-cf5872d8-6853-11e8-88bb-c152daf2aaa4.jpg)
 <a id="how-to-test"></a> 

## How to Test:
Check out and run this branch locally: `feature/add-suite-to-committee-address`
Make sure suite numbers show on committee profile information on `About this committee` pages.
Example Pages:
http://127.0.0.1:8000/data/committee/C00507574/?tab=about-committee
http://127.0.0.1:8000/data/committee/C00438291/?tab=about-committee
http://127.0.0.1:8000/data/committee/C00590315/?tab=about-committee