### PR TITLE
updated feedback drawer to new styles based on design ticket

### DIFF
--- a/fec/fec/static/js/templates/feedback.hbs
+++ b/fec/fec/static/js/templates/feedback.hbs
@@ -1,9 +1,9 @@
 <div>
-  <button class="js-feedback feedback__toggle button--cta-primary" aria-controls="feedback" aria-expanded="false" type="button">Feedback</button>
+  <button class="js-feedback feedback__toggle button--cta-secondary" aria-controls="feedback" aria-expanded="false" type="button">Feedback</button>
   <div id="feedback" class="js-feedback-box feedback" aria-hidden="true">
     <button class="js-feedback button--down feedback__close"><span class="u-visually-hidden">Close</span></button>
     <div class="js-status" aria-hidden="true">
-      <div class="message message--inverse js-message">
+      <div class="message js-message">
       </div>
       <ul class="list--buttons">
         <li><button class="js-reset button--cta-primary feedback__button" type="button">Submit another issue</button></li>
@@ -12,17 +12,27 @@
     <form id="feedback-form" class="container">
       <fieldset>
         <legend class="feedback__title">Help us improve FEC.gov</legend>
-        <p class="t-sans">Don't include sensitive information like your name, contact information or Social Security number.</p>
-        <label for="feedback-1" class="label">What were you trying to do and how can we improve it?*</label>
+        <h3 class="t-sans">Test new features with our design team</h3>
+        <div class="signup__row">
+          <div class="signup__button">
+          <a class="button--cta" href="https://ethn.io/12085">Sign up</a>
+          </div>
+          <div class="signup__note">
+            <p class="t-sans t-note">Sign up for a 30 minute video call to  help us test new website features.</p>
+          </div>
+        </div>
+        <hr />
+        <h3 class="t-sans">Or post public feedback anonymously</h3>
+        <p class="t-sans t-note">Tell us how we can improve the site using the form below.  This feedback will be posted publicly, so don't include sensitive information like your name, contact information or Social Security number.</p>
+        <label for="feedback-1" class="label">What were you trying to do, and how can we improve it? </label> <span class="label--help">(required)</em>
         <textarea id="feedback-1" name="action"></textarea>
         <label for="feedback-2" class="label">General feedback?</label>
         <textarea id="feedback-2" name="feedback"></textarea>
         <label for="feedback-3" class="label">Tell us about yourself</label>
         <span class="label--help">I'm a <span class="u-blank-space"></span> interested in <span class="u-blank-space"></span>.</span>
         <textarea id="feedback-3" name="about"></textarea>
-        <p class="t-sans">This information will be reported on GitHub where it will be publicly visible. You can review all reported feedback on <a href="https://github.com/fecgov/fec/issues">our GitHub page</a>.</p>
-        <p class="t-sans t-note">*Required</p>
-        <button type="submit" class="button--standard feedback__button">Submit</button>
+        <button type="submit" class="button--cta feedback__button u-no-margin">Post</button>
+        <p class="t-sans t-note u-margin--top"><a href="https://github.com/FECgov/FEC/issues">Review all reported feedback</a>  |  <a href="/contact-us/">Contact the FEC about a specific question</a></p>
       </fieldset>
     </form>
   </div>

--- a/fec/fec/static/scss/components/_buttons.scss
+++ b/fec/fec/static/scss/components/_buttons.scss
@@ -427,7 +427,7 @@
 }
 
 .button--down {
-  @include u-icon($arrow-down-border, $primary-contrast);
+  @include u-icon($arrow-down-border, $primary);
 }
 
 .button--cancel {

--- a/fec/fec/static/scss/components/_feedback.scss
+++ b/fec/fec/static/scss/components/_feedback.scss
@@ -4,9 +4,9 @@
 //
 
 .feedback {
-  background-color: $base;
+  background-color: $gray-lightest;
   bottom: u(.5rem);
-  color: $inverse;
+  color: $base;
   display: block;
   left: u(.5rem);
   overflow-y: scroll;
@@ -17,13 +17,27 @@
   z-index: $z-feedback;
 
   legend {
-    color: $inverse;
+    color: $base;
+  }
+
+  label {
+    margin-bottom: u(-0.5rem);
+  }
+
+  hr {
+    border-top: 1px dotted $gray-dark;
+    margin: u(0 0 1rem 0);
+  }
+
+  .t-note {
+    font-style: normal;
+    line-height: u(2rem);
   }
 
   textarea {
     height: u(7rem);
     margin-bottom: u(2rem);
-    border-color: $inverse;
+    border-color: $base;
 
     &:last-of-type {
       margin-bottom: u(1rem);
@@ -31,10 +45,10 @@
   }
 
   a:not(.button--cta-primary) {
-    border-color: $inverse;
+    border-color: $base;
   }
 
-  .label {
+  h3 {
     &:first-of-type {
       margin-top: u(2rem);
     }
@@ -60,6 +74,24 @@
       display: block !important;
       top: 2000px;
     }
+  }
+}
+
+.signup__row {
+  clear:both;
+  display: table;
+
+  .signup__button {
+    float: left;
+    display:block;
+    margin-top: u(0.3rem);
+  }
+
+  .signup__note {
+    float: left;
+    display:block;
+    width: u(30rem);
+    margin-left: u(1rem);
   }
 }
 

--- a/fec/fec/static/scss/mixins/_utilities.scss
+++ b/fec/fec/static/scss/mixins/_utilities.scss
@@ -68,7 +68,7 @@
 
 .u-blank-space {
   display: inline-block;
-  border-bottom: 1px solid $inverse;
+  border-bottom: 1px solid $base;
   width: u(5rem);
 }
 


### PR DESCRIPTION
## Summary

- Resolves #1876 
_This adds the new feedback drawer design to the website. Includes new sign up button to have users sign up with for usability testing._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Feedback drawer on all pages

## Screenshots

#### Feedback drawer pulled up
![screen shot 2018-06-06 at 11 19 40 am](https://user-images.githubusercontent.com/12799132/41047899-90b25d86-697b-11e8-9d91-fb97da092ff8.png)

#### Feedback drawer closed with orange button on bottom right
![screen shot 2018-06-06 at 11 19 29 am](https://user-images.githubusercontent.com/12799132/41047900-90bf6d0a-697b-11e8-97de-2bd01b6f9bb9.png)

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

____

**IF ANY OF THE ABOVE FIELDS DO NOT APPLY, PLEASE DELETE THEM BEFORE SUBMITTING**
