### PR TITLE
[MERGE WITH GITFLOW] Hotfix to data-landing and reroutes of spending/raising breakdowns

### DIFF
--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -46,8 +46,8 @@
 
   <section class="content__section">
     <h2 class="t-ruled--bottom">Compare candidates in an election</h2>
-    <div class="grid" id="election-lookup">
-      <div class="grid__item">
+    <div id="election-lookup">
+      <div class="usa-width-three-fourths">
         <form action="/data/elections" class="content__section">
           <div class="search-controls__state">
             <label for="state" class="label">State</label>
@@ -76,9 +76,9 @@
             <button type="submit" class="button--search--text button--standard">Search</button>
           </div>
         </form>
-        <div class="election-map election-map--small"></div>
-
+      </div>
     </div>
+    <div class="election-map election-map--small usa-width-one-whole"></div>
   </section>
 
   </section>
@@ -186,6 +186,7 @@
       </div>
     </div>
   </section>
+</div>
 {% endblock %}
 {% block scripts %}
 <script src="{{ asset_for_js('dataviz-common.js') }}"></script>

--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -26,14 +26,6 @@
           {{ search.search('hero', button_color="button--standard") }}
           <span class="t-note t-sans search__example">Examples: Obama for America; C00431445; Bush, George W.; P00003335; or enter an image number for a filing.</span>
         </div>
-        <div class="example--primary">
-          <h4 class="example__title">Top raising candidates in {{ constants.DEFAULT_TIME_PERIOD | fmt_year_range }}:</h4>
-          <ul class="t-sans">
-            {% for candidate in top_candidates_raising %}
-              <li><a href="/data/candidate/{{ candidate.candidate_id }}">{{ candidate.name }}</a></li>
-            {% endfor %}
-          </ul>
-        </div>
       </div>
       <div class="grid__item card t-left-aligned">
         <h2>Find contributions from <br> specific individuals</h2>
@@ -48,24 +40,13 @@
           </div>
           <span class="t-note t-sans search__example">Examples: your name, a celebrity, someone running for office.</span>
         </form>
-        <div class="example--primary">
-          <h4 class="example__title">Possible uses of this data:</h4>
-          <ul class="t-sans">
-            <li><a href="/data/receipts/individual-contributions/?min_amount=2000">All contributions over $2,000</a></li>
-            <li><a href="/data/receipts/individual-contributions/?min_date={{ first_of_year }}&max_date={{ last_of_year }}">All contributions in this year</a></li>
-            <li><a href="/data/receipts/individual-contributions/">Browse all and apply custom filters</a></li>
-          </ul>
-        </div>
       </div>
     </div>
   </section>
 
   <section class="content__section">
-    <h2>Compare candidates in an election</h2>
-    <div class="grid grid--2-wide" id="election-lookup">
-      <div class="grid__item">
-        <div class="election-map election-map--small"></div>
-      </div>
+    <h2 class="t-ruled--bottom">Compare candidates in an election</h2>
+    <div class="grid" id="election-lookup">
       <div class="grid__item">
         <form action="/data/elections" class="content__section">
           <div class="search-controls__state">
@@ -95,15 +76,8 @@
             <button type="submit" class="button--search--text button--standard">Search</button>
           </div>
         </form>
-        <div class="example--primary">
-          <h4 class="example__title">Trending elections</h4>
-          <ul class="t-sans">
-            <li><a href="/data/elections/house/GA/6/2018">Georgia, congressional district 6 special election</a></li>
-            <li><a href="/data/elections/senate/AL/2018">Alabama senate special election</a></li>
-            <li><a href="/data/elections/president/2016">2016 US presidential election</a></li>
-          </ul>
-        </div>
-      </div>
+        <div class="election-map election-map--small"></div>
+
     </div>
   </section>
 
@@ -212,145 +186,7 @@
       </div>
     </div>
   </section>
-
-  <div class="content__section--extra">
-    <h2 class="t-ruled--bottom">Get started with campaign finance data</h2>
-    <section class="content__section" id="raising">
-      <h3 class="u-no-margin">Raising</h3>
-      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">party committees</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported raising, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have different reporting schedules.</p>
-      <div class="content__section">
-        <div class="heading--section heading--with-action">
-          <h4 class="heading__left t-upper">Cumulative amount raised by committees</h4>
-          <div class="heading__right">
-            <ul class="list--buttons">
-              <li><a class="button button--standard button--table" href="/data/receipts">Explore data</a></li>
-              <li><button class="button button--standard js-ga-event"  data-a11y-dialog-show="raised-modal" data-ga-event="Raised methodology modal clicked" aria-controls="raised-modal">
-              Methodology</button></li>
-            </ul>
-          </div>
-        </div>
-        {{ overviews.overview('raised', 'landing')}}
-         <a class="breakdown-link" href="/data/raising">Raising breakdown &raquo;</a>
-         <ul class="grid grid--4-wide t-sans">
-           <li class="grid__item">
-             <a href="/data/raising#top-raisers" class="icon-heading--graph-circle">
-               <div class="icon-heading__text"><span>Who's raising the most</span></div>
-             </a>
-           </li>
-           <li class="grid__item is-disabled">
-             <div class="icon-heading--map-circle" title="Coming soon">
-               <div class="icon-heading__text"><span>Where contributions come from</span></div>
-             </div>
-           </li>
-           <li class="grid__item is-disabled">
-             <div class="icon-heading--graph-unordered-circle" title="Coming soon">
-               <div class="icon-heading__text"><span>The size of contributions</span></div>
-             </div>
-           </li>
-         </ul>
-      </div>
-    </section>
-    <section class="content__section content__section--ruled" id="spending">
-      <h3 class="u-no-margin">Spending</h3>
-      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">party committees</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported spending, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have different reporting schedules.</p>
-      <div class="content__section">
-        <div class="heading--section heading--with-action">
-          <h4 class="heading__left t-upper">Cumulative amount spent by committees</h4>
-          <div class="heading__right">
-            <ul class="list--buttons">
-              <li><a class="button button--standard button--table" href="/data/disbursements">Explore data</a></li>
-              <li><button class="button button--standard js-ga-event"  data-a11y-dialog-show="spending-modal" data-ga-event="Spending methodology modal clicked" aria-controls="spending-modal">Methodology</button></li>
-            </ul>
-          </div>
-        </div>
-        {{ overviews.overview('spent', 'landing') }}
-        <a class="breakdown-link" href="spending">Spending breakdown &raquo;</a>
-        <ul class="grid grid--4-wide t-sans">
-          <li class="grid__item">
-            <a href="/data/spending#top-spenders" class="icon-heading--graph-circle">
-              <div class="icon-heading__text"><span>Who's spending the most</span></div>
-            </a>
-          </li>
-          <li class="grid__item is-disabled">
-            <div class="icon-heading--graph-unordered-circle" title="Coming soon">
-              <div class="icon-heading__text"><span>What's spent on day-to-day activities</span></div>
-            </div>
-          </li>
-          <li class="grid__item is-disabled">
-            <div class="icon-heading--map-circle" title="Coming soon">
-              <div class="icon-heading__text"><span>Where money is spent to support and oppose candidates</span></div>
-            </div>
-          </li>
-        </ul>
-      </div>
-    </section>
-  </div>
-</div>
 {% endblock %}
-
-{% block modals %}
-<div class="js-modal modal" id="raised-modal" aria-hidden="true">
-  <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide></div>
-  <div role="dialog" class="modal__content" aria-labelledby="raised-modal-title">
-    <div role="document">
-      <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide title="Close this dialog window"></button>
-      <h2 id="raised-modal-title" tabindex="0">Methodology</h2>
-      <p>This data includes Forms 3, 3P, and 3X.</p>
-      <h3>Methodology overview</h3>
-      <p><strong>Money raised</strong> includes each of the following:</p>
-      <ul class="list--bulleted">
-        <li><em>Adjusted receipts</em> for PACs, parties, congressional filers and presidential filers</li>
-      </ul>
-      <p><em>Adjusted receipts</em> are the total receipts minus the following:</p>
-      <ul class="list--bulleted">
-        <li>Contribution refunds</li>
-        <li>Contributions from political party committees and other political committees</li>
-        <li>Loan repayments</li>
-        <li>Offsets to operating expenditures</li>
-        <li>Transfers from nonfederal accounts for allocated activities</li>
-      </ul>
-      <p><span>The form-by-form breakdown for adjusted receipts is:</span></p>
-      <ul class="list--bulleted">
-        <li><strong>Form 3:</strong> <em>line 16</em> - (<em>line 11(b)</em> + <em>line 11(c)</em> + <em>line 14</em> + <em>line 19(c)</em> + <em>line 20(d))</em></li>
-        <li><strong>Form 3P:</strong> <em>line 22</em> - (<em>line 17(b)</em> + <em>line 17(c)</em> + <em>line 20(d)</em> + <em>line 27(c)</em> + <em>line 28(d)</em>)</li>
-        <li><strong>Form 3X:</strong> <em>line 19</em> - (<em>line 11(b)</em> + <em>line 11(c)</em> + <em>line 15</em> + <em>line 16</em> + <em>line 18(a)</em> + <em>line 26</em> + <em>line 28(d)</em>)</li>
-      </ul>
-    </div>
-  </div>
-</div>
-<div class="js-modal modal" id="spending-modal" aria-hidden="true">
-  <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide></div>
-  <div role="dialog" class="modal__content" aria-labelledby="spending-modal-title">
-    <div role="document">
-      <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide title="Close this dialog window"></button>
-      <h2 id="spending-modal-title">Methodology</h2>
-      <p>This data includes Forms 3, 3P, and 3X.</p>
-      <h5>Methodology overview</h5>
-      <p><strong>Money spent</strong> includes each of the following:</p>
-      <ul class="list--bulleted">
-        <li><em>Adjusted disbursements</em> for PACs, parties, congressional filers and presidential filers</li>
-      </ul>
-      <p><em>Adjusted disbursements</em> are total disbursements minus the following:</p>
-      <ul class="list--bulleted">
-        <li>Contribution refunds</li>
-        <li>Contributions to candidates and other political committees</li>
-        <li>Loan repayments</li>
-        <li>Nonfederal share of allocated disbursements</li>
-        <li>Offsets to expenditures</li>
-        <li>Other disbursements</li>
-        <li>Transfers to other authorized committees and affiliated committees</li>
-      </ul>
-      <p>The form-by-form breakdown for adjusted disbursements is:</p>
-      <ul class="list--bulleted">
-        <li><strong>Form 3:</strong> <em>line 22</em> - (<em>line 18</em> + <em>line 19(c)</em> + <em>line 20(d)</em> + <em>line 21</em>)</li>
-        <li><strong>Form 3P:</strong> <em>line 30</em> - (<em>line 20(d)</em> + <em>line 24</em> + <em>line 27(c)</em> + <em>line 28(d)</em> + <em>line 29</em>)</li>
-        <li><strong>Form 3X:</strong> <em>line 31</em> - (<em>line 21(a)(ii)</em> + <em>line 22</em> + <em>line 23</em> + <em>line 26</em> + <em>line 28(d)</em> + <em>line 29</em>)</li>
-      </ul>
-    </div>
-  </div>
-</div>
-{% endblock %}
-
 {% block scripts %}
 <script src="{{ asset_for_js('dataviz-common.js') }}"></script>
 <script src="{{ asset_for_js('data-landing.js') }}"></script>

--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -13,8 +13,8 @@ urlpatterns = [
     url(r'^data/elections/(?P<office>\w+)/(?P<state>\w+)/(?P<cycle>[0-9]+)/$', views.elections),
     url(r'^data/elections/(?P<office>\w+)/(?P<cycle>[0-9]+)/$', views.elections),
     url(r'^data/elections/$', views.elections_lookup),
-    url(r'^data/raising/$', views.raising),
-    url(r'^data/spending/$', views.spending),
+    url(r'^data/raising/$', views_datatables.receipts),
+    url(r'^data/spending/$', views_datatables.disbursements),
 
     # Feedback Tool
     url(r'^data/issue/$', views.feedback),

--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -13,8 +13,6 @@ urlpatterns = [
     url(r'^data/elections/(?P<office>\w+)/(?P<state>\w+)/(?P<cycle>[0-9]+)/$', views.elections),
     url(r'^data/elections/(?P<office>\w+)/(?P<cycle>[0-9]+)/$', views.elections),
     url(r'^data/elections/$', views.elections_lookup),
-    url(r'^data/raising/$', views_datatables.receipts),
-    url(r'^data/spending/$', views_datatables.disbursements),
 
     # Feedback Tool
     url(r'^data/issue/$', views.feedback),

--- a/fec/fec/static/js/pages/data-landing.js
+++ b/fec/fec/static/js/pages/data-landing.js
@@ -38,8 +38,9 @@ Overview.prototype.zeroPadTotals = function() {
   helpers.zeroPad(this.selector + ' .js-snapshot', '.snapshot__item-number', '.figure__decimals');
 };
 
-new Overview('.js-raised-overview', 'raised', 1);
-new Overview('.js-spent-overview', 'spent', 2);
+//temporarily removed to remove line-charts from landng.jinja without error
+//new Overview('.js-raised-overview', 'raised', 1);
+//new Overview('.js-spent-overview', 'spent', 2);
 
 $(document).ready(function() {
   new lookup.ElectionLookup('#election-lookup', false);


### PR DESCRIPTION
## Summary:
Remove incorrect data references until we are able to correct the underlying data.
Edits to: https://www.fec.gov/data/ 
Reroute [spending](https://www.fec.gov/data/spending/) and [raising](https://www.fec.gov/data/raising/) breakdown page URLS to their respective datatables.

**Adresses:**
Resolves #2068 - Disable/hide/remove top raising candidates in 2017–2018 
Resolves #2069 - Disable/hide/remove possible uses of this data 
Resolves #2070 - Disable/hide/remove trending elections list 
Resolves #2071 - Disable/hide/remove raising line chart 
Resolves #2072 - Disable/hide/remove spending line chart 
Resolves #2073 - Disable/hide/remove raising breakdown 
Resolves #2074 - Disable/hide/remove spending breakdown 

## Impacted areas of the application
modified:   **data/templates/landing.jinja**
modified:   **data/urls.py**
modified:   **fec/static/js/pages/data-landing.js** : Commented out the instantiation of the spending and raising charts in `data-landing.js` to avoid page-breaking JS-error caused by removing these items from `landing.jinja`. This change will not effect any other pages as this is currently the only place this script is used in the /data app.

### Two screenshot options for altered data landing page:
(@JonellaCulmer may have add'l comments; Option 1 is in this PR)
### Option 1: ![full-width](https://user-images.githubusercontent.com/5572856/41185607-17dda396-6b58-11e8-826a-db89eff82f96.png)

### Option 2: ![2-up](https://user-images.githubusercontent.com/5572856/41185612-1f22157e-6b58-11e8-98af-28308665a1c9.png)

