### PR TITLE
Fix earmarked contributor name display on Receipts

### DIFF
--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -403,7 +403,7 @@ var individualContributions = [
     orderable: false,
     className: 'all hide-panel-tablet',
     render: function(data, type, row, meta) {
-      if (data && helpers.globals.EARMARKED_CODES.indexOf(row.receipt_type) === -1){
+        if(data &&  !(_.contains(helpers.globals.EARMARKED_CODES, row.receipt_type))){
         return columnHelpers.buildEntityLink(
           data.name,
           helpers.buildAppUrl(['committee', data.committee_id]),
@@ -486,7 +486,7 @@ var receipts = [
     orderable: false,
     className: 'all',
     render: function(data, type, row, meta) {
-      if (data && helpers.globals.EARMARKED_CODES.indexOf(row.receipt_type) === -1){
+        if(data &&  !(_.contains(helpers.globals.EARMARKED_CODES, row.receipt_type))){
         return columnHelpers.buildEntityLink(
           data.name,
           helpers.buildAppUrl(['committee', data.committee_id]),

--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -403,7 +403,7 @@ var individualContributions = [
     orderable: false,
     className: 'all hide-panel-tablet',
     render: function(data, type, row, meta) {
-      if (data && row.receipt_type !== helpers.globals.EARMARKED_CODE) {
+      if (data && helpers.globals.EARMARKED_CODES.indexOf(row.receipt_type) === -1){
         return columnHelpers.buildEntityLink(
           data.name,
           helpers.buildAppUrl(['committee', data.committee_id]),
@@ -486,13 +486,14 @@ var receipts = [
     orderable: false,
     className: 'all',
     render: function(data, type, row, meta) {
-      if (data && row.receipt_type !== helpers.globals.EARMARKED_CODE) {
+      if (data && helpers.globals.EARMARKED_CODES.indexOf(row.receipt_type) === -1){
         return columnHelpers.buildEntityLink(
           data.name,
           helpers.buildAppUrl(['committee', data.committee_id]),
           'committee'
         );
-      } else {
+       }
+      else {
         return row.contributor_name;
       }
     }
@@ -650,7 +651,7 @@ var audit = [
     className: 'all align-top',
     orderable: false,
     render: function (data){
-      if (data) {     
+      if (data) {
         var html = '<ol class="list--numbered">'
         for(var i in data){
           html += '<li>' + data[i]['primary_category_name'] + '<ol>'

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -95,11 +95,16 @@ Handlebars.registerHelper({
 });
 
 var globals = {
-  EARMARKED_CODE: '15E'
-};
+  EARMARKED_CODES: ['15E', '24I', '24T']
+}
 
-Handlebars.registerHelper('global', function(value) {
-  return globals[value];
+Handlebars.registerHelper('isEarmarked', function(receipt_type) {
+  if (globals.EARMARKED_CODES.indexOf(receipt_type) > -1) {
+     return true;
+  }
+  else {
+    return false;
+  }
 });
 
 Handlebars.registerHelper('decodeAmendment', function(value) {

--- a/fec/fec/static/js/templates/receipts.hbs
+++ b/fec/fec/static/js/templates/receipts.hbs
@@ -4,9 +4,9 @@
     <tr>
       {{#panelRow "Name"}}
         {{#if contributor}}
-          {{#if (eq receipt_type (global 'EARMARKED_CODE'))}}
-            {{contributor_name}}
-          {{else}}
+          {{#if (isEarmarked receipt_type) }}
+           {{contributor_name}}
+          {{else }}
             <a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a>
           {{/if}}
         {{else}}
@@ -15,7 +15,7 @@
       {{/panelRow}}
     </tr>
     {{#if contributor}}
-      {{#if (eq receipt_type (global 'EARMARKED_CODE'))}}
+      {{#if (isEarmarked receipt_type) }}
         {{#panelRow "Earmarked by"}}
           <a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a>
         {{/panelRow}}


### PR DESCRIPTION
Fix incorrect display of `contributor` for earmarked contributions on Receipts and Individual contributions datatables for main table and details panel.

 Resolves #1924 - Display problem with earmarked contributions

**[How to test &#187;](#how-to-test)** 

**Summary:**
    `https://www.fec.gov/data/receipts/*` was only showing correct contributor for earmarked receipt-type:`15E`, and not for `24T` and `24I`.

Example: https://www.fec.gov/data/receipts/?two_year_transaction_period=2018&data_type=processed&contributor_name=OELSNER%2C+GEOFFREY
- Changed the globals variable named `EARMARKED CODE` from a singular value(15E) to an array of values:  `EARMARKED_CODES: ['15E', '24I', '24T' ]`
- New HBS helper to check for existence of receipt-type in this array
- New inline functions in columns.js to check for lack of existence of variable in this array

Note: The existing logic in HBS template for the details panel checks wether the receipt_code is an earmarked code while the existing logic in columns.js checks if it is not an earmarked code. I did not want to change this logic as some [backend code was written](https://github.com/fecgov/fec-cms/issues/1924#issue-314791565) to resolve for earmarked codes and that may depend on this particular order of boolean logic to work.

## Impacted areas of the application
modified:   fec/static/js/modules/columns.js
modified:   fec/static/js/modules/helpers.js
modified:   fec/static/js/templates/receipts.hbs

## Screenshots
![oelsner_geoffrey_earmarked](https://user-images.githubusercontent.com/5572856/41209409-69d9e82e-6cf9-11e8-94ab-8b65e0cece7a.jpg)
 <a id="how-to-test"></a> 

### How to test:
- Checkout and run this branch locally: `feature/earmarked-contributor-name`
- Point to dev API or some OpenFEC instance that populates datatables locally: `export FEC_API_URL=https://fec-dev-api.app.cloud.gov
- Check this example to see that the contributor name is `OELSNER, GEOFFREY` and check the details panel for the same. [http://127.0.0.1:8000/data/receipts/?two_year_transaction_period=2018&data_type=processed&contributor_name=OELSNER%2C+GEOFFREY&min_date=01%2F01%2F2017&max_date=06%2F09%2F2018](http://127.0.0.1:8000/data/receipts/?two_year_transaction_period=2018&data_type=processed&contributor_name=OELSNER%2C+GEOFFREY&min_date=01%2F01%2F2017&max_date=06%2F09%2F2018)
- I will check with @jchumley to add other names to test against earmarked contributions in `data/receipts` and `data/receipts/individual-contributions`