### PR TITLE
Upgrade boto3 to 1.7.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ python-dateutil==2.6.0
 # Content import
 beautifulsoup4==4.5.1
 django-storages==1.5.2
-boto3==1.4.4
+boto3==1.7.21
 
 cg-django-uaa==1.0.1
 


### PR DESCRIPTION
## Summary (required)
Fixes #3087.

The minimum version required to fix the issue is 1.5.31. Upgrading to
1.7.21, which is the latest release at this time.

## Impacted areas of the application
Uploads

