### PR TITLE
Set postgresql PATH correctly in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
             sudo apt-get update -qq && sudo apt-get install -y build-essential postgresql-client
-            echo '/usr/lib/postgresql/9.6/bin/:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/lib/postgresql/9.6/bin/:$PATH' >> $BASH_ENV
             echo "en_US.UTF-8 UTF-8" | sudo tee /etc/locale.gen
             sudo locale-gen en_US.UTF-8
 


### PR DESCRIPTION
This fixes error messages in CircleCI builds that look like:
```
/tmp/.bash_env-..-0-build: line 1: /usr/lib/postgresql/9.6/bin/:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:
No such file or directory
```