### PR TITLE
Rename calendar category 21 to 'Mid-year and year-end', move to bottom

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -6,10 +6,10 @@ election_types = OrderedDict([
 ])
 
 deadline_types = OrderedDict([
-    ('21', 'Reporting deadlines'),
     ('25', 'Quarterly reports'),
     ('26', 'Monthly reports'),
-    ('27', 'Pre- and post-election')
+    ('27', 'Pre- and post-election'),
+    ('21', 'Mid-year and year-end'),
 ])
 
 reporting_periods = OrderedDict([


### PR DESCRIPTION
## Summary (required)

- Resolves #1981 
_Rename calendar category 21 to 'Mid-year and year-end' and move to the bottom of the list._

## Impacted areas of the application
List general components of the application that this PR will affect:

- https://www.fec.gov/calendar/
- http://127.0.0.1:8000/calendar/?calendar_category_id=21

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/31420082/41369654-7d3b9392-6f13-11e8-9119-0da19e4b8099.png)

### After
![image](https://user-images.githubusercontent.com/31420082/41369682-8c86f418-6f13-11e8-93c1-892f4042c789.png)

