### PR TITLE
Searchbox and mega-headings for mobile menus

### DIFF
--- a/fec/fec/static/scss/components/_icon-headings.scss
+++ b/fec/fec/static/scss/components/_icon-headings.scss
@@ -94,7 +94,6 @@
     background-size: 50%;
     content: '';
     float: left;
-    margin-right: u(1.5rem);
   }
 }
 
@@ -105,7 +104,6 @@
     background-size: 50%;
     content: '';
     float: left;
-    margin-right: u(1.5rem);
   }
 }
 

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -27,16 +27,14 @@
 }
 
 .mega-heading__title {
-  display: none;
-  margin-left: u(-2rem);
+  display: block;
+  margin-left: u(3rem);
 
   a {
     border-bottom: 1px dotted $inverse !important;
   }
-  &::before {
-    margin-bottom: u(3rem);
-    height: u(5rem) !important;
-    width: u(5rem) !important;
+  &::before{
+    content: none !important;
   }
 }
 
@@ -163,7 +161,20 @@
   .mega-heading__title {
     display: block;
     margin-bottom: 0;
-  }
+    margin-left: u(-2rem);
+
+      a {
+        border-bottom: 1px dotted $inverse !important;
+      }
+
+      &::before {
+        margin-bottom: u(3rem);
+        height: u(5rem) !important;
+        width: u(5rem) !important;
+        content: ''!important;
+      }
+
+    }
 
   .mega__page-link {
     padding-left: u(2rem);

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -99,7 +99,6 @@
   line-height:1.2;
 
   &:first-of-type {
-    margin-top: u(1rem);
   }
 }
 
@@ -230,7 +229,7 @@
 
     &::before {
       margin-top: u(-.5rem);
-      margin-bottom: u(1rem);
+      margin-bottom: u(0rem);
     }
   }
 }

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -29,6 +29,7 @@
 .mega-heading__title {
   display: block;
   margin-left: u(3rem);
+  font-family:sans-serif;
 
   a {
     border-bottom: 1px dotted $inverse !important;
@@ -162,6 +163,7 @@
     display: block;
     margin-bottom: 0;
     margin-left: u(-2rem);
+    font-family:serif;
 
       a {
         border-bottom: 1px dotted $inverse !important;
@@ -189,4 +191,8 @@
   }
 }
 
-
+@media screen and (max-width: 40em){
+  .mega-heading__title{
+    font-size:1.6rem;
+  }
+}

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -27,15 +27,20 @@
 }
 
 .mega-heading__title {
-  display: block;
+  display: table-cell;
   margin-left: u(3rem);
   font-family:sans-serif;
+  font-size: u(1.6rem);
+
 
   a {
     border-bottom: 1px dotted $inverse !important;
   }
   &::before{
-    content: none !important;
+    content: '';
+    margin-bottom: u(3rem);
+    margin-right: u(1rem);
+    margin-left: u(1rem);
   }
 }
 
@@ -102,6 +107,13 @@
   }
 }
 
+@include media($med) {
+.icon-heading--data-flag-circle--secondary::before, .icon-heading--data-flag-circle--primary::before{
+  margin-right: u(1rem);
+  margin-left: u(.2rem);
+ }
+}
+
 // scss-lint:disable ImportantRule
 @include media($lg) {
   .mega-container {
@@ -164,16 +176,17 @@
     margin-bottom: 0;
     margin-left: u(-2rem);
     font-family:serif;
+    font-size: u(2.4rem);
 
       a {
         border-bottom: 1px dotted $inverse !important;
       }
 
       &::before {
-        margin-bottom: u(3rem);
         height: u(5rem) !important;
         width: u(5rem) !important;
         content: ''!important;
+        margin-right: u(1.5rem);
       }
 
     }
@@ -191,8 +204,17 @@
   }
 }
 
+
+
 @media screen and (max-width: 40em){
   .mega-heading__title{
-    font-size:1.6rem;
+    margin-left: u(1rem);
+    margin-top: u(1rem);
+    margin-bottom: u(3rem);
+
+    &::before {
+      margin-top: u(-.5rem);
+      margin-bottom: u(1rem);
+    }
   }
 }

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -24,6 +24,14 @@
 .mega__inner {
   padding: u(1rem);
   margin: u(1rem 0 0 0);
+
+  .icon-heading{
+    margin-left: u(1.2rem);
+
+    &::before{
+      margin-right: u(1rem);
+    }
+  }
 }
 
 .mega-heading__title {
@@ -31,6 +39,7 @@
   margin-left: u(3rem);
   font-family:sans-serif;
   font-size: u(1.6rem);
+  padding-top: u(1.11rem);
 
 
   a {
@@ -157,6 +166,13 @@
     .button--standard {
       color: $base;
       border: 1px solid $gray;
+    }
+  }
+  .mega__inner .icon-heading{
+    margin-left: 0;
+
+    &::before{
+      margin-right: u(2rem);
     }
   }
 

--- a/fec/fec/static/scss/components/_nav.scss
+++ b/fec/fec/static/scss/components/_nav.scss
@@ -253,3 +253,25 @@
     display: none;
   }
 }
+
+.mobile-search.utility-nav__search {
+  width: u(30rem);
+  padding: u(1rem);
+  display:block;
+
+  .twitter-typeahead input{
+
+  }
+ }
+
+
+@include media($lg) {
+  .mobile-search.utility-nav__search {
+    display:none;
+  }
+}
+
+
+
+
+

--- a/fec/fec/templates/partials/navigation/nav-about.html
+++ b/fec/fec/templates/partials/navigation/nav-about.html
@@ -6,12 +6,10 @@
           <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="/about/">Learn more about the FEC</a></h2>
         </div>
         <div class="usa-width-one-half mega__intro">
-          <ul class="usa-width-one-third">
+         <ul class="t-sans list--2-columns u-padding--top">
            <li class="mega__item"><a href="/updates">News and announcements</a></li>
            <li class="mega__item"><a href="/meetings">Commission meetings</a></li>
            <li class="mega__item"><a href="/about/mission-and-history/">Mission and history</a></li>
-          </ul>
-          <ul class="usa-width-one-third">
             <li class="mega__item"><a href="/about/leadership-and-structure/">Leadership and structure</a></li>
             <li class="mega__item"><a href="/about/reports-about-fec/">Reports about the FEC</a></li>
             <li class="mega__item"><a href="/about/careers/">Careers</a></li>

--- a/fec/fec/templates/partials/navigation/nav-data.html
+++ b/fec/fec/templates/partials/navigation/nav-data.html
@@ -6,13 +6,11 @@
           <h2 class="mega-heading__title icon-heading--data-flag-circle--primary"><a href="/data">Explore all data</a></h2>
         </div>
         <div class="usa-width-one-third mega__intro">
-          <ul class="usa-width-one-half">
+          <ul class="t-sans list--2-columns u-padding--top">
             <li class="mega__item"><a href="/data/advanced?tab=raising">Raising</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=spending">Spending</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=loans-debts">Loans and debts</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=filings">Filings and reports</a></li>
-          </ul>
-          <ul class="usa-width-one-half">
             <li class="mega__item"><a href="/data/advanced?tab=candidates">Candidates</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=committees">Committees</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=bulk-data">Bulk data</a></li>

--- a/fec/fec/templates/partials/navigation/nav-help.html
+++ b/fec/fec/templates/partials/navigation/nav-help.html
@@ -6,11 +6,9 @@
           <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="/help-candidates-and-committees/">Explore all compliance resources</a></h2>
       </div>
         <div class="usa-width-one-third mega__intro">
-          <ul class="usa-width-one-half">
+          <ul class="t-sans list--2-columns u-padding--top">
             <li class="mega__item"><a href="/help-candidates-and-committees/guides">Guides</a></li>
             <li class="mega__item"><a href="/help-candidates-and-committees/forms">Forms</a></li>
-          </ul>
-          <ul class="usa-width-one-half">
             <li class="mega__item"><a  href="/help-candidates-and-committees/dates-and-deadlines">Dates and deadlines</a></li>
             <li class="mega__item"><a  href="https://transition.fec.gov/info/outreach.shtml">Trainings</a></li>
           </ul>

--- a/fec/fec/templates/partials/navigation/nav-legal.html
+++ b/fec/fec/templates/partials/navigation/nav-legal.html
@@ -6,13 +6,11 @@
           <h2 class="mega-heading__title icon-heading--data-flag-circle--primary"><a href="/legal-resources">Explore all legal resources</a></h2>
         </div>
         <div class="usa-width-one-third mega__intro">
-          <ul class="usa-width-one-half">
+          <ul class="t-sans list--2-columns u-padding--top">
             <li class="mega__item"><a href="/data/legal/advisory-opinions">Advisory opinions</a></li>
             <li class="mega__item"><a href="/legal-resources/enforcement">Enforcement</a></li>
             <li class="mega__item"><a href="/data/legal/statutes">Statutes</a></li>
             <li class="mega__item"><a href="/legal-resources/legislation">Legislation</a></li>
-          </ul>
-          <ul class="usa-width-one-half">
             <li class="mega__item"><a href="/legal-resources/regulations">Regulations</a></li>
             <li class="mega__item"><a href="/legal-resources/court-cases">Court cases</a></li>
             <li class="mega__item"><a href="https://transition.fec.gov/law/policy.shtml">Policy and other guidance</a></li>

--- a/fec/fec/templates/partials/navigation/navigation.html
+++ b/fec/fec/templates/partials/navigation/navigation.html
@@ -1,6 +1,26 @@
 <nav class="site-nav js-site-nav">
   <div id="site-menu" class="site-nav__container">
     <ul class="site-nav__panel site-nav__panel--main">
+      <li class="mobile-search utility-nav__search">
+        <form accept-charset="UTF-8" action="/search" id="search_form" class="combo" method="get" role="search">
+          <input type="hidden" name="type" value="candidates">
+          <input type="hidden" name="type" value="committees">
+          <input type="hidden" name="type" value="site">
+          <label class="u-visually-hidden" for="query">Search</label>
+          <div class="combo combo--search combo--search--mini">
+            <input
+              class="js-site-search combo__input"
+              autocomplete="off"
+              id="query"
+              name="query"
+              type="text"
+              aria-label="Search FEC.gov">
+            <button type="submit" class="button--standard combo__button button--search">
+              <span class="u-visually-hidden">Search</span>
+            </button>
+         </div>
+        </form>
+      </li>
       <li><h2 class="site-nav__title u-under-lg-only">Menu</h2></li>
       <li class="site-nav__item u-under-lg-only">
         <a class="site-nav__link" href="/" rel="home">


### PR DESCRIPTION
Add searchbox to menu at mobile/tables/phablet sizes and put main mega-heading ("Explore all...") links in the menu at those sizes.

- Resolves #2083
**Related issues:**
https://github.com/fecgov/fec-cms/issues/2036 - Add main landing pages to mobile menu
https://github.com/fecgov/fec-cms/issues/1827 - Site search doesn't show up in mobile/collapsed menus
https://github.com/fecgov/fec-cms/issues/935#issuecomment-293567899 -Design site search in header #935
## Impacted areas of the application
modified:   fec/static/scss/components/_mega-menu.scss
modified:   fec/static/scss/components/_nav.scss
modified:   fec/templates/partials/navigation/navigation.html

## Screenshots
![pr_scrnsht](https://user-images.githubusercontent.com/5572856/41478185-c346ed82-7094-11e8-9107-479fedccc740.gif)