### PR TITLE
Add next 4 election years (2019-2022) to candidates data table

### DIFF
--- a/fec/data/templates/macros/filters/years.jinja
+++ b/fec/data/templates/macros/filters/years.jinja
@@ -18,7 +18,7 @@
 </fieldset>
 {% endmacro %}
 
-{% macro years(name, label) %}
+{% macro years(name, label, start_year=constants.START_YEAR, end_year=constants.END_YEAR) %}
 <fieldset class="js-filter js-dropdown filter" data-filter="checkbox">
   <legend class="label">{{ label }}</legend>
   <ul class="dropdown__selected"></ul>
@@ -26,7 +26,7 @@
     <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
     <div id="{{ name }}-dropdown" class="dropdown__panel" aria-hidden="true">
       <ul class="dropdown__list">
-      {% for year in range(constants.END_YEAR, constants.START_YEAR, -1) %}
+      {% for year in range(end_year, start_year, -1) %}
         <li class="dropdown__item">
           <input id="{{ name }}-checkbox-{{ year }}" name="{{ name }}" type="checkbox" value="{{ year }}" />
           <label class="dropdown__value" for="{{name}}-checkbox-{{ year }}">{{ year }}</label>

--- a/fec/data/templates/partials/candidates-filter.jinja
+++ b/fec/data/templates/partials/candidates-filter.jinja
@@ -9,7 +9,7 @@
 <div class="filters__inner">
   {{ typeahead.field('q', 'Candidate name or ID', '', dataset='candidates', allow_text=True) }}
 
-  {{ years.years('election_year', 'Election year') }}
+  {{ years.years('election_year', 'Election year', end_year=constants.END_YEAR + 4) }}
   {% include 'partials/filters/office-sought.jinja' %}
   {% include 'partials/filters/parties.jinja' %}
   {{ states.field('state') }}


### PR DESCRIPTION
## Summary (required)

- Resolves #2103
So that users can see candidates who have registered in future elections (usually senate/presidential), add next 4 election years (currently 2019-2022) to candidate data table (https://www.fec.gov/data/candidates/). Because `constants.END_YEAR` is used in a number of other places, I added parameters to the `years.jinja` macro `years` so I could override the end date.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  https://www.fec.gov/data/candidates/ (fec/data/templates/partials/candidates-filter.jinja)
- fec/data/templates/macros/filters/years.jinja

## Screenshots

## Before
<img width="291" alt="screen shot 2018-06-19 at 8 10 09 am" src="https://user-images.githubusercontent.com/31420082/41596430-5ad68d28-7398-11e8-9f30-3406d9ccfe86.png">

## After
<img width="271" alt="screen shot 2018-06-19 at 8 05 35 am" src="https://user-images.githubusercontent.com/31420082/41596435-5e86320c-7398-11e8-8232-813c7be976ff.png">

Local testing link: http://localhost:8000/data/candidates/