### PR TITLE
Fixed data description link for Contributions by individuals

### DIFF
--- a/fec/data/templates/partials/advanced/bulk-data.jinja
+++ b/fec/data/templates/partials/advanced/bulk-data.jinja
@@ -187,7 +187,7 @@
             <li><a href="/files/bulk-downloads/1982/indiv82.zip">1981–1982</a></li>
             <li><a href="/files/bulk-downloads/1980/indiv80.zip">1979–1980</a></li>
           </ul>
-          <p class="u-margin--top"><a href="/campaign-finance-data/contributions-committees-candidates-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
+          <p class="u-margin--top"><a href="/campaign-finance-data/contributions-individuals-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
         </div>
         <p class="icon-download--inline--left"><a href="/files/bulk-downloads/data_dictionaries/indiv_header_file.csv">Header file</a></p>
         <p>The individual contributions file contains each contribution from an individual to a federal committee. It includes the ID number of the committee receiving the contribution, the name, city, state, zip code, and place of business of the contributor along with the date and amount of the contribution.</p>


### PR DESCRIPTION
## Summary

- Resolves #2032 
_Fixes incorrect link under bulk-data (http://localhost:8000/data/advanced/?tab=bulk-data) under the Contributions to individuals expander. Link now points to correct link for that data description: http://localhost:8000/campaign-finance-data/contributions-individuals-file-description/_

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Bulk data page