### PR TITLE
Fixed logic for "All years" total

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -159,7 +159,7 @@ def candidate(request, candidate_id):
     # the cycle should never be beyond the one we're in.
     cycles = [cycle for cycle in candidate['cycles'] if cycle <= utils.current_cycle()]
     max_cycle = cycle if cycle <= utils.current_cycle() else utils.current_cycle()
-    show_full_election = election_full if cycle <= utils.current_cycle() else False
+    show_full_election = election_full if cycle > utils.current_cycle() else False
 
     # Annotate committees with most recent available cycle
     aggregate_cycles = (


### PR DESCRIPTION
## Summary

- Resolves #2107 
_When selecting a future election year, you will now get aggregate results for the full election year._

**Test cases:**
Any of these will now cover the entire election period instead of just the 2018 cycle.

http://localhost:8000/data/candidate/S4AR00103/?cycle=2020&election_full=true
http://localhost:8000/data/candidate/S8MN00438/?cycle=2020&election_full=true

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile pages