### PR TITLE
Audit search "Filter added" popup message for ALL filters

### DIFF
--- a/fec/data/templates/partials/filters/audit-committee-types.jinja
+++ b/fec/data/templates/partials/filters/audit-committee-types.jinja
@@ -2,15 +2,15 @@
   <fieldset class="js-dropdown js-filter" data-filter="checkbox">
     <legend class="label" for="committee_type">Authorized committees</legend>
     <ul class="dropdown__selected">
-      <li>
+      <li class="dropdown__item">
         <input id="committee-type-checkbox-P" type="checkbox" name="committee_type" value="P">
         <label class="dropdown__value" for="committee-type-checkbox-P">Presidential</label>
       </li>
-      <li>
+      <li class="dropdown__item">
         <input id="committee-type-checkbox-S" type="checkbox" name="committee_type" value="S">
         <label class="dropdown__value" for="committee-type-checkbox-S">Senate</label>
       </li>
-      <li>
+      <li class="dropdown__item">
         <input id="committee-type-checkbox-H" type="checkbox" name="committee_type" value="H">
         <label class="dropdown__value" for="committee-type-checkbox-H">House</label>
       </li>
@@ -26,11 +26,11 @@
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
       <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
         <ul class="dropdown__list">
-          <li>
+          <li class="dropdown__item">
             <input id="committee-type-checkbox-X" type="checkbox" name="committee_type" value="X">
             <label class="dropdown__value" for="committee-type-checkbox-X">Party - nonqualified</label>
           </li>
-          <li>
+          <li class="dropdown__item">
             <input id="committee-type-checkbox-Y" type="checkbox" name="committee_type" value="Y">
             <label class="dropdown__value" for="committee-type-checkbox-Y">Party - qualified</label>
           </li>
@@ -48,7 +48,7 @@
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
       <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
         <ul class="dropdown__list">
-          <li>
+          <li class="dropdown__item">
             <input id="committee-type-checkbox-O" type="checkbox" name="committee_type" value="O">
             <label class="dropdown__value" for="committee-type-checkbox-O">Super PAC (independent expenditure only)</label>
           </li>
@@ -74,7 +74,7 @@
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
       <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
         <ul class="dropdown__list">
-          <li>
+          <li class="dropdown__item">
             <input id="committee-type-checkbox-N" type="checkbox" name="committee_type" value="N">
             <label class="dropdown__value" for="committee-type-checkbox-N">PAC - nonqualified</label>
           </li>
@@ -82,7 +82,7 @@
             <input id="committee-type-checkbox-Q" type="checkbox" name="committee_type" value="Q">
             <label class="dropdown__value" for="committee-type-checkbox-Q">PAC - qualified</label>
           </li>
-          <li>
+          <li class="dropdown__item">
             <input id="committee-type-checkbox-V" type="checkbox" name="committee_type" value="V">
             <label class="dropdown__value" for="committee-type-checkbox-V">PAC with non-contribution account - nonqualified</label>
           </li>


### PR DESCRIPTION
The last change to audit search PR# https://github.com/fecgov/fec-cms/pull/2029 did not make it in for some reason. Perhaps due to the way we manually restored the branch.

Just before merge, @JonellaCulmer  caught:  The green "filter added" message and accompanying checkbox for each dropdown filter was only working for some filters.
https://github.com/fecgov/fec-cms/pull/2029#pullrequestreview-125203578

This PR fixes that.

**How to Test**
- Checkout and run this branch locally: `fix/audit-search-filter-messages` 
- Point to some instance of OpenFEC that populates datatables locally.
- Go to: http://127.0.0.1:8000/legal-resources/enforcement/audit-search
- Check that the green "filter added"message shows up for ALL filters under `Committee type` when choosing a filter from dropdown.(See example screenshot of this broken for the first PAC filter on production)
![jun-20-2018 01-02-57](https://user-images.githubusercontent.com/5572856/41638366-078b9e94-7427-11e8-88cd-c4c957975471.gif)

