### PR TITLE
Contact page url and route maintenance

### DIFF
--- a/fec/data/templates/macros/missing.jinja
+++ b/fec/data/templates/macros/missing.jinja
@@ -20,7 +20,7 @@
     <p>Think this result is a mistake or have questions?</p>
     <p>
       Send us more information in the feedback box or
-      <a href="https://www.fec.gov/contact-us/" target="_blank" rel="noopener noreferrer">contact us</a>.
+      <a href="https://www.fec.gov/contact/" target="_blank" rel="noopener noreferrer">contact us</a>.
     </p>
   </div>
 </div>

--- a/fec/fec/static/js/templates/feedback.hbs
+++ b/fec/fec/static/js/templates/feedback.hbs
@@ -23,7 +23,7 @@
         </div>
         <hr />
         <h3 class="t-sans">Or post public feedback anonymously</h3>
-        <p class="t-sans t-note">Tell us how we can improve the site using the form below.  This feedback will be posted publicly, so don't include sensitive information like your name, contact information or Social Security number.</p>
+        <p class="t-sans t-note">Tell us how we can improve the site using the form below. This feedback will be posted publicly, so don't include sensitive information like your name, contact information or Social Security number.</p>
         <label for="feedback-1" class="label">What were you trying to do, and how can we improve it? </label> <span class="label--help">(required)</em>
         <textarea id="feedback-1" name="action"></textarea>
         <label for="feedback-2" class="label">General feedback?</label>
@@ -32,7 +32,7 @@
         <span class="label--help">I'm a <span class="u-blank-space"></span> interested in <span class="u-blank-space"></span>.</span>
         <textarea id="feedback-3" name="about"></textarea>
         <button type="submit" class="button--cta feedback__button u-no-margin">Post</button>
-        <p class="t-sans t-note u-margin--top"><a href="https://github.com/FECgov/FEC/issues">Review all reported feedback</a>  |  <a href="/contact-us/">Contact the FEC about a specific question</a></p>
+        <p class="t-sans t-note u-margin--top"><a href="https://github.com/FECgov/FEC/issues">Review all reported feedback</a>  |  <a href="/contact/">Contact the FEC about a specific question</a></p>
       </fieldset>
     </form>
   </div>

--- a/fec/fec/static/js/templates/tables/noData.hbs
+++ b/fec/fec/static/js/templates/tables/noData.hbs
@@ -21,7 +21,7 @@
     <p>Think this result is a mistake or have questions?</p>
     <p>
       Send us more information in the feedback box or
-      <a href="https://www.fec.gov/contact-us/" target="_blank" rel="noopener noreferrer">contact us</a>.
+      <a href="https://www.fec.gov/contact/" target="_blank" rel="noopener noreferrer">contact us</a>.
     </p>
   </div>
 </div>

--- a/fec/fec/templates/partials/footer-navigation.html
+++ b/fec/fec/templates/partials/footer-navigation.html
@@ -15,7 +15,7 @@
             <a href="/press/">Press</a>
           </li>
           <li>
-            <a href="/contact-us/">Contact</a>
+            <a href="/contact/">Contact</a>
           </li>
         </ul>
       </div>

--- a/fec/fec/templates/partials/navigation/nav-about.html
+++ b/fec/fec/templates/partials/navigation/nav-about.html
@@ -18,7 +18,7 @@
            </ul>
            <ul class="usa-width-one-third">
             <li class="mega__item"><a href="/about/#working-with-the-fec">Working with the FEC</a></li>
-            <li class="mega__item"><a href="/contact-us">Contact</a></li>
+            <li class="mega__item"><a href="/contact/">Contact</a></li>
           </ul>
         </div>
       </div>

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -19,7 +19,6 @@ urlpatterns = [
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^calendar/$', home_views.calendar),
     url(r'^about/leadership-and-structure/commissioners/$', home_views.commissioners),
-    url(r'^contact-us/$', home_views.contact),
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^help-candidates-and-committees/question-rad/$', home_views.contact_rad),
     url(r'^help-candidates-and-committees/guides/$', home_views.guides),

--- a/fec/home/templates/home/collection_page.html
+++ b/fec/home/templates/home/collection_page.html
@@ -75,7 +75,7 @@
 {% block related_topics %}
 <div class="grid grid--4-wide">
   <div class="grid__item">
-    <a href="/contact-us">
+    <a href="/contact/">
       <aside class="card card--horizontal card--secondary">
         <div class="card__image__container">
             <span class="card__icon i-question-bubble"><span class="u-visually-hidden">Icon representing a question</span></span>

--- a/fec/home/templates/home/custom_page.html
+++ b/fec/home/templates/home/custom_page.html
@@ -41,7 +41,7 @@
         {% if self.show_contact_link %}
           <div class="sidebar__related-links">
             <h4 class="label sidebar__question">Need help?</h4>
-            <a href="/contact-us">Get help from the FEC by phone or email</a>
+            <a href="/contact/">Get help from the FEC by phone or email</a>
           </div>
         {% endif %}
       </div>

--- a/fec/home/templates/home/resource_page.html
+++ b/fec/home/templates/home/resource_page.html
@@ -67,7 +67,7 @@
 <div class="grid grid--4-wide">
   {% if self.show_contact_card %}
     <div class="grid__item">
-      <a href="/contact-us">
+      <a href="/contact/">
         <aside class="card card--horizontal card--secondary">
           <div class="card__image__container">
               <span class="card__icon i-question-bubble"><span class="u-visually-hidden">Icon representing a question</span></span>

--- a/fec/home/tests/test_views.py
+++ b/fec/home/tests/test_views.py
@@ -12,12 +12,6 @@ class TestViews(TestCase):
     self.assertTemplateUsed(resp, 'home/contact-form.html')
     self.assertEqual(resp.context['self']['content_section'], 'help')
 
-  def test_contact_page(self):
-    resp = self.client.get('/contact-us/')
-    self.assertEqual(resp.status_code, 200)
-    self.assertTemplateUsed(resp, 'home/contact.html')
-    self.assertEqual(resp.context['self']['content_section'], 'contact')
-
   def test_calendar(self):
     resp = self.client.get('/calendar/')
     self.assertEqual(resp.status_code, 200)

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -183,18 +183,6 @@ def calendar(request):
       'self': page_context,
     })
 
-
-def contact(request):
-    page_context = {
-      'content_section': 'contact',
-      'title': 'Contact'
-    }
-
-    return render(request, 'home/contact.html', {
-      'self': page_context,
-    })
-
-
 def commissioners(request):
     chair_commissioner = CommissionerPage.objects.filter(commissioner_title__contains='Chair') \
       .exclude(commissioner_title__contains='Vice').first()


### PR DESCRIPTION
Resolves #2077 

- [x] Change the link in the feedback tool 
- [x] Change the link in the menu
- [x] Remove in urls.py
- [x] Remove from home/views.py
- [x] Search for other instances of `/contact-us/` links in repo and change to `/contact/`
- [ ] Redirect in Wagtail. Redirect URL: `/contact-us/` -to-  Wagtail Page: `/contact/`
- [ ] Delete the useless `Contact us` wagtail page https://fec-prod-proxy.app.cloud.gov/admin/pages/search/?q=contact+us (This page has nothing to do with the old contact-us hardcoded page-- from what I can tell, it's just a leftover wagtail page from 2016 but must be deleted for the redirect to work.
- [ ] As soon as the release build finishes deploy, publish the new contact page: https://fec-prod-proxy.app.cloud.gov/admin/pages/9810/edit/

**Affected areas of application:**
        modified:   data/templates/macros/missing.jinja
	modified:   fec/static/js/templates/feedback.hbs
	modified:   fec/static/js/templates/tables/noData.hbs
	modified:   fec/templates/partials/footer-navigation.html
	modified:   fec/templates/partials/navigation/nav-about.html
	modified:   fec/urls.py
	modified:   home/templates/home/collection_page.html
	modified:   home/templates/home/custom_page.html
	modified:   home/templates/home/resource_page.html
	modified:   home/tests/test_views.py
	modified:   home/views.py
