### PR TITLE
Restore padding on doc dwnld links for Filings tab

### DIFF
--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -259,7 +259,7 @@
   }
 
   .dropdown__value {
-    padding: u(0 .75rem);
+    padding: u(.5rem .75rem);
   }
 }
 


### PR DESCRIPTION
Resolves: #2112 

![screen shot 2018-06-25 at 2 11 17 pm](https://user-images.githubusercontent.com/5572856/41867635-ad3430b4-7881-11e8-80ef-9efd872b1bad.png)

How to test:
Run this branch locally  `feature/fix-dropdown-menus-on-filings`
npm run build
Check this example page to make sure there is padding on the document dropdown
http://127.0.0.1:8000/data/committee/C00280743/?tab=filings