### PR TITLE
Restore lost icons on datatable/calendar pages

### DIFF
--- a/fec/fec/static/scss/calendar.scss
+++ b/fec/fec/static/scss/calendar.scss
@@ -1,4 +1,4 @@
-@import "global";
+@import "global-common";
 
 @import "components/accordions";
 @import "components/filters";

--- a/fec/fec/static/scss/datatables.scss
+++ b/fec/fec/static/scss/datatables.scss
@@ -1,4 +1,4 @@
-@import "global";
+@import "global-common";
 
 @import "components/accordions";
 @import "components/messages";


### PR DESCRIPTION
The import of `global-common.scss` into `datatables.scss` (not to be confused with components/_datatables.scss) somehow got reverted from when it was added in PR https://github.com/fecgov/fec-cms/pull/1962.

**This means on production, mega-menus viewed while on a datatable and calendar show no icons and look like this:**
![missing_icons](https://user-images.githubusercontent.com/5572856/41950180-d9b77738-7992-11e8-901c-ee57c9e46a67.jpg)


