### PR TITLE
Add recipient committee type filters to receipts and individual contribution data tables

### DIFF
--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -1,17 +1,19 @@
+{% macro field(name='committee_type') %}
+
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="hsp-committee_type">
     <legend class="label" for="committee_type">Authorized committees</legend>
     <ul class="dropdown__selected">
       <li>
-        <input id="committee-type-checkbox-P" type="checkbox" name="committee_type" value="P">
+        <input id="committee-type-checkbox-P" type="checkbox" name="{{ name }}" value="P">
         <label class="dropdown__value" for="committee-type-checkbox-P">Presidential</label>
       </li>
       <li>
-        <input id="committee-type-checkbox-S" type="checkbox" name="committee_type" value="S">
+        <input id="committee-type-checkbox-S" type="checkbox" name="{{ name }}" value="S">
         <label class="dropdown__value" for="committee-type-checkbox-S">Senate</label>
       </li>
       <li>
-        <input id="committee-type-checkbox-H" type="checkbox" name="committee_type" value="H">
+        <input id="committee-type-checkbox-H" type="checkbox" name="{{ name }}" value="H">
         <label class="dropdown__value" for="committee-type-checkbox-H">House</label>
       </li>
     </ul>
@@ -23,7 +25,7 @@
     <legend class="label" for="committee_type">Independent expenditure committees</legend>
     <ul class="dropdown__selected">
       <li>
-        <input id="committee-type-checkbox-O" type="checkbox" name="committee_type" value="O">
+        <input id="committee-type-checkbox-O" type="checkbox" name="{{ name }}" value="O">
         <label class="dropdown__value" for="committee-type-checkbox-O">Super PAC (independent expenditure only)</label>
       </li>
     </ul>
@@ -32,11 +34,11 @@
       <div id="ie-dropdown" class="dropdown__panel" aria-hidden="true">
       <ul class="dropdown__list">
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-U" type="checkbox" name="committee_type" value="U">
+          <input id="committee-type-checkbox-U" type="checkbox" name="{{ name }}" value="U">
           <label class="dropdown__value" for="committee-type-checkbox-U">Single candidate independent expenditure</label>
         </li>
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-I" type="checkbox" name="committee_type" value="I">
+          <input id="committee-type-checkbox-I" type="checkbox" name="{{ name }}" value="I">
           <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditure filer (not a committee)</label>
         </li>
       </ul>
@@ -62,19 +64,19 @@
           <label class="dropdown__value" for="designation-checkbox-D">Leadership PAC</label>
         </li>
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-N" type="checkbox" name="committee_type" value="N">
+          <input id="committee-type-checkbox-N" type="checkbox" name="{{ name }}" value="N">
           <label class="dropdown__value" for="committee-type-checkbox-N">PAC - nonqualified</label>
         </li>
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-Q" type="checkbox" name="committee_type" value="Q">
+          <input id="committee-type-checkbox-Q" type="checkbox" name="{{ name }}" value="Q">
           <label class="dropdown__value" for="committee-type-checkbox-Q">PAC - qualified</label>
         </li>
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-V" type="checkbox" name="committee_type" value="V">
+          <input id="committee-type-checkbox-V" type="checkbox" name="{{ name }}" value="V">
           <label class="dropdown__value" for="committee-type-checkbox-V">PAC with non-contribution account - nonqualified</label>
         </li>
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-W" type="checkbox" name="committee_type" value="W">
+          <input id="committee-type-checkbox-W" type="checkbox" name="{{ name }}" value="W">
           <label class="dropdown__value" for="committee-type-checkbox-W">PAC with non-contribution account - qualified</label>
         </li>
         <li class="dropdown__subhead">Separate segregated funds</li>
@@ -122,30 +124,33 @@
       <div id="other-dropdown" class="dropdown__panel" aria-hidden="true">
       <ul class="dropdown__list">
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-C" type="checkbox" name="committee_type" value="C">
+          <input id="committee-type-checkbox-C" type="checkbox" name="{{ name }}" value="C">
           <label class="dropdown__value" for="committee-type-checkbox-C">Communication cost</label>
         </li>
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-D" type="checkbox" name="committee_type" value="D">
+          <input id="committee-type-checkbox-D" type="checkbox" name="{{ name }}" value="D">
           <label class="dropdown__value" for="committee-type-checkbox-D">Delegate committee</label>
         </li>
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-E" type="checkbox" name="committee_type" value="E">
+          <input id="committee-type-checkbox-E" type="checkbox" name="{{ name }}" value="E">
           <label class="dropdown__value" for="committee-type-checkbox-E">Electioneering communication</label>
         </li>
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-X" type="checkbox" name="committee_type" value="X">
+          <input id="committee-type-checkbox-X" type="checkbox" name="{{ name }}" value="X">
           <label class="dropdown__value" for="committee-type-checkbox-X">Party - nonqualified</label>
         </li>
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-Y" type="checkbox" name="committee_type" value="Y">
+          <input id="committee-type-checkbox-Y" type="checkbox" name="{{ name }}" value="Y">
           <label class="dropdown__value" for="committee-type-checkbox-Y">Party - qualified</label>
         </li>
         <li class="dropdown__item">
-          <input id="committee-type-checkbox-Z" type="checkbox" name="committee_type" value="Z">
+          <input id="committee-type-checkbox-Z" type="checkbox" name="{{ name }}" value="Z">
           <label class="dropdown__value" for="committee-type-checkbox-Z">National party nonfederal account</label>
         </li>
       </ul>
     </div>
   </fieldset>
 </div>
+
+
+{% endmacro %}

--- a/fec/data/templates/partials/committees-filter.jinja
+++ b/fec/data/templates/partials/committees-filter.jinja
@@ -22,7 +22,8 @@
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
   <div class="accordion__content">
-    {% include 'partials/filters/committee-types.jinja' %}
+    {% import 'macros/filters/committee-types.jinja' as committee_type %}
+    {{ committee_type.field() }}
   </div>
 </div>
 {% endblock %}

--- a/fec/data/templates/partials/individual-contributions-filter.jinja
+++ b/fec/data/templates/partials/individual-contributions-filter.jinja
@@ -27,7 +27,8 @@ Filter individual contributions
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Recipient committee type</button>
   <div class="accordion__content">
-    {% include 'partials/filters/committee-types.jinja' %}
+    {% import 'macros/filters/committee-types.jinja' as committee_type %}
+    {{ committee_type.field(name='recipient_committee_type') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Transaction details</button>
   <div class="accordion__content">

--- a/fec/data/templates/partials/individual-contributions-filter.jinja
+++ b/fec/data/templates/partials/individual-contributions-filter.jinja
@@ -25,6 +25,10 @@ Filter individual contributions
     {{ text.field('contributor_zip', 'ZIP code', {'maxlength':5}) }}
     {% include 'partials/filters/occupation-employer.jinja' %}
   </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Recipient committee type</button>
+  <div class="accordion__content">
+    {% include 'partials/filters/committee-types.jinja' %}
+  </div>
   <button type="button" class="js-accordion-trigger accordion__button">Transaction details</button>
   <div class="accordion__content">
     {{ range.amount('amount', 'Contribution amount') }}

--- a/fec/data/templates/partials/receipts-filter.jinja
+++ b/fec/data/templates/partials/receipts-filter.jinja
@@ -42,7 +42,8 @@ Filter receipts
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Recipient committee type</button>
   <div class="accordion__content">
-    {% include 'partials/filters/committee-types.jinja' %}
+    {% import 'macros/filters/committee-types.jinja' as committee_type %}
+    {{ committee_type.field(name='recipient_committee_type') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Receipt details</button>
   <div class="accordion__content">

--- a/fec/data/templates/partials/receipts-filter.jinja
+++ b/fec/data/templates/partials/receipts-filter.jinja
@@ -40,6 +40,10 @@ Filter receipts
     {% include 'partials/filters/occupation-employer.jinja' %}
     {% include 'partials/filters/unique-receipts.jinja' %}
   </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Recipient committee type</button>
+  <div class="accordion__content">
+    {% include 'partials/filters/committee-types.jinja' %}
+  </div>
   <button type="button" class="js-accordion-trigger accordion__button">Receipt details</button>
   <div class="accordion__content">
     {{ range.amount('amount', 'Receipt amount') }}


### PR DESCRIPTION
## Summary (required)

- Resolves #2129 : Add `recipient_committee_type` filters to receipts and individual contribution data tables. Add a macro for committee type filters so we can pass the API the `recipient_committee_type` filter 

## Impacted areas of the application
List general components of the application that this PR will affect:

**Turn filter into macro**
- http://localhost:8000/data/committees/

**Add filter macro to receipts and individual contributions data tables**
-  http://localhost:8000/data/receipts/?two_year_transaction_period=2018&data_type=processed&min_date=01%2F01%2F2017&max_date=06%2F25%2F2018&committee_type=P
- http://localhost:8000/data/receipts/individual-contributions/?two_year_transaction_period=2018&min_date=01%2F01%2F2017&max_date=06%2F25%2F2018

## Screenshots

<img width="661" alt="screen shot 2018-06-28 at 11 21 05 am" src="https://user-images.githubusercontent.com/31420082/42047496-65dfa33e-7ace-11e8-8650-569cf1a09d46.png">
<img width="487" alt="screen shot 2018-06-28 at 11 21 23 am" src="https://user-images.githubusercontent.com/31420082/42047503-693bf67c-7ace-11e8-88c5-b6fc13ce272f.png">


