### PR TITLE
Change default presidential year to 2020

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 START_YEAR = 1979
 END_YEAR = 2018
 DEFAULT_TIME_PERIOD = 2018
-DEFAULT_PRESIDENTIAL_YEAR = 2016
+DEFAULT_PRESIDENTIAL_YEAR = 2020
 DISTRICT_MAP_CUTOFF = 2018 # The year we show district maps for on election pages
 
 states = OrderedDict([


### PR DESCRIPTION
## Summary (required)

- Resolves #2152 
_Change default presidential year to 2020._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Presidential candidate data table http://localhost:8000/data/candidates/president/
- `DEFAULT_PRESIDENTIAL_YEAR` constant

## Screenshots

## Before
![image](https://user-images.githubusercontent.com/31420082/42112260-3d0879f8-7bb5-11e8-83c5-da6a081ad4a4.png)

## After
<img width="669" alt="screen shot 2018-06-29 at 3 53 58 pm" src="https://user-images.githubusercontent.com/31420082/42112211-1afc7e72-7bb5-11e8-885c-03e445f478db.png">

## Related PRs

Fixing 2020 and future election totals: https://github.com/fecgov/openFEC/pull/3219

