### PR TITLE
Joint fundraising committee filter for Audit Search

### DIFF
--- a/fec/data/templates/partials/filters/audit-committee-types.jinja
+++ b/fec/data/templates/partials/filters/audit-committee-types.jinja
@@ -95,3 +95,15 @@
     </div>
   </fieldset>
 </div>
+
+<div class="filter">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox">
+    <legend class="label" for="committee_type">Other committees</legend>
+    <ul class="dropdown__selected">
+      <li>
+        <input id="designation-checkbox-J" type="checkbox" name="committee_designation" value="J">
+        <label class="dropdown__value" for="designation-checkbox-J">Joint fundraising committee</label>
+      </li>
+    </ul>
+  </fieldset>
+</div>


### PR DESCRIPTION
Add `Joint fundraising committee` filter to audit search

- Resolves #2093

Related OpenFEC PR: https://github.com/fecgov/openFEC/pull/3231

## Screenshots
<img width="714" alt="screen shot 2018-07-01 at 9 45 53 pm" src="https://user-images.githubusercontent.com/5572856/42141633-421f083e-7d78-11e8-976b-047e74dcc742.png">
<hr/>
<img width="581" alt="screen shot 2018-07-01 at 9 46 11 pm" src="https://user-images.githubusercontent.com/5572856/42141638-4ad8db8a-7d78-11e8-818c-d1a2e8f733e0.png">
