### PR TITLE
Remove mid-year and year-end reporting deadline category

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -9,7 +9,6 @@ deadline_types = OrderedDict([
     ('25', 'Quarterly reports'),
     ('26', 'Monthly reports'),
     ('27', 'Pre- and post-election'),
-    ('21', 'Mid-year and year-end'),
 ])
 
 reporting_periods = OrderedDict([

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -38,7 +38,7 @@
         <li class="grid__item grid__item--with-button">
           <div class="t-sans t-bold">Next filing deadline:</div>
           <div class="js-next-filing-deadline"></div>
-          <a class="button button--alt button--calendar" href="/calendar/?calendar_category_id=21&calendar_category_id=25&calendar_category_id=26&calendar_category_id=27">All filing deadlines</a>
+          <a class="button button--alt button--calendar" href="/calendar/?calendar_category_id=25&calendar_category_id=26&calendar_category_id=27">All filing deadlines</a>
         </li>
         <li class="grid__item grid__item--with-button">
           <div class="t-sans t-bold">Next training or conference:</div>


### PR DESCRIPTION
## Summary (required)

- Resolves #2160
Because the info division isn't using the generic "Reporting Deadlines" category (category 21), this PR removes that checkbox from the reporting deadlines section of the calendar.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  https://www.fec.gov/calendar/
- "All filing deadlines" link on home page

## Screenshots

![image](https://user-images.githubusercontent.com/31420082/42337473-e9b9f19c-8054-11e8-8f49-f59b18d3ed46.png)

