### PR TITLE
Add RFAIs of request_type 2 to 24/48 hour reports table

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -596,8 +596,16 @@ $(document).ready(function() {
           order: [[2, 'desc']],
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
-            form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11'],
+            form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11', 'RFAI'],
+            report_type: ['24', '48'],
             report_type: ['-Q1', '-Q2', '-Q3', '-YE'],
+            /* Performing an include would only show RFAI form types. For this reason, excludes need to be
+               used for request_type
+            
+            Exclude all request types except for: 
+               - RQ-2: RFAI referencing Report of Receipts and Expenditures
+            */
+            request_type: ['-1', '-3', '-4', '-5', '-6', '-7', '-8', '-9'],
             sort_hide_null: ['false']
           }, query),
         }, filingsOpts);


### PR DESCRIPTION
## Summary

- Resolves #2048 
_RFAIs of request type 2 were not being included in the 24/48 hour reports table. This PR fixes that._

### To test:
Check this committee page to make sure RFAI notifications show up like in the screenshot below:

http://localhost:8000/data/committee/C90017450/?tab=filings

## Screenshots

![screen shot 2018-07-06 at 2 39 00 pm](https://user-images.githubusercontent.com/12799132/42395061-62905a7c-812a-11e8-9e58-8a53e4e631f0.png)

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee profile page filings tab

