### PR TITLE
Update about-candidate to display committee info in multiple rows

### DIFF
--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -80,25 +80,31 @@
       {% if committee_groups['P'] or committee_groups['A'] %}
       <h4>Authorized campaign committees:</h4>
 
-      <div class="usa-width-one-half">
-      {% for committee in committee_groups['P'] | reverse %}
-        <div class="callout callout--primary{% if loop.last %} u-no-margin{% endif %}">
-          <h5 class="callout__title t-sans">
-            <a href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
-          </h5>
-          <span class="callout__subtitle term" data-term="principal campaign committee">Principal campaign committee</span>
+      <div class='grid grid--2-wide'>
+        <div class="grid__item">
+        {% for committee in committee_groups['P'] | reverse %}
+          <div class="callout callout--primary{% if loop.last %} u-no-margin{% endif %}">
+            <h5 class="callout__title t-sans">
+              <a href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+            </h5>
+            <span class="callout__subtitle term" data-term="principal campaign committee">Principal campaign committee</span>
+          </div>
+        {% endfor %}
         </div>
-      {% endfor %}
       </div>
 
-      <ul class="list--bulleted row">
-      {% for committee in committee_groups['A'] | reverse %}
-        <li>
-          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
-        </li>
-      {% endfor %}
-      </ul>
-      {% endif %}
+      <div class='grid grid--2-wide'>
+        <div class="grid__item">
+          <ul class="list--bulleted row">
+          {% for committee in committee_groups['A'] | reverse %}
+            <li>
+              <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+            </li>
+          {% endfor %}
+          </ul>
+        {% endif %}
+        </div>
+      </div>
 
       {% if committee_groups['J'] %}
       <hr class="hr--lighter">


### PR DESCRIPTION
## Update about-candidate to display committee info in multiple rows

- Resolves #1906 
- Display candidate committee info into grid elements to make multiple rows

## Updates

- Changes the `about-candidate.jinja` template

## Screenshots

<img width="596" alt="screen shot 2018-07-11 at 11 30 10 am" src="https://user-images.githubusercontent.com/693815/42593465-e522d888-8522-11e8-9bad-361f9f133799.png">
