### PR TITLE
Add historical stats to mega menu

### DIFF
--- a/fec/fec/templates/partials/navigation/nav-data.html
+++ b/fec/fec/templates/partials/navigation/nav-data.html
@@ -14,6 +14,7 @@
             <li class="mega__item"><a href="/data/advanced?tab=candidates">Candidates</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=committees">Committees</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=bulk-data">Bulk data</a></li>
+            <li class="mega__item"><a href="/data/advanced/?tab=historical">Historical statistics</a></li>
           </ul>
         </div>
         <div class="usa-width-one-third u-padding--left">


### PR DESCRIPTION
Add `Historical statistics` link to mega menu that links to https://www.fec.gov//data/advanced/?tab=historical

- Resolves #2054 

## Impacted areas of the application:
Change to /fec/partials/navigation/nav-data.html

## Screenshots

<img width="1299" alt="screen shot 2018-07-11 at 4 08 36 pm" src="https://user-images.githubusercontent.com/5572856/42596736-b927eb22-8524-11e8-86ed-c2b8691b2b46.png">
