### PR TITLE
Update links to statute PDFs (2015 GPO version)

### DIFF
--- a/fec/legal/templates/legal-statutes-landing.jinja
+++ b/fec/legal/templates/legal-statutes-landing.jinja
@@ -50,14 +50,14 @@
       <li>
         <p>Access the FEC’s compilation of statutes. That PDF contains Title 52, Subtitle III, Title 26, Subtitle H and additional provisions of the U.S. Code that aren’t enforced by FEC but are relevant to people involved in federal elections.</p>
         <div class="grid grid--2-wide">
-          {{ document.thumbnail("Federal Election Campaign Laws by the FEC", "https://transition.fec.gov/law/feca/feca.pdf", img="img/thumbnail--feca.jpg", size="1.6MB") }}
+          {{ document.thumbnail("Federal Election Campaign Laws by the FEC", "https://www.fec.gov/resources/cms-content/documents/feca.pdf", img="img/thumbnail--feca.jpg", size="1.7MB") }}
         </div>
       </li>
       <li>
         <p>Access the Government Printing Office (GPO) version of Title 52, Subtitle III and Title 26, Subtitle H.</p>
         <div class="grid grid--2-wide">
-          {{ document.thumbnail("Title 52, Voting and Elections, GPO", "https://www.gpo.gov/fdsys/pkg/USCODE-2014-title52/pdf/USCODE-2014-title52-subtitleIII.pdf", img="img/thumbnail--title52.jpg", size="377KB") }}
-          {{ document.thumbnail("Title 26, Internal Revenue Code, GPO", "https://www.gpo.gov/fdsys/pkg/USCODE-2014-title26/pdf/USCODE-2014-title26-subtitleH.pdf", img="img/thumbnail--title26.jpg", size="201KB") }}
+          {{ document.thumbnail("Title 52, Voting and Elections, GPO", "https://www.gpo.gov/fdsys/pkg/USCODE-2015-title52/pdf/USCODE-2015-title52-subtitleIII.pdf", img="img/thumbnail--title52.jpg", size="387KB") }}
+          {{ document.thumbnail("Title 26, Internal Revenue Code, GPO", "https://www.gpo.gov/fdsys/pkg/USCODE-2015-title26/pdf/USCODE-2015-title26-subtitleH.pdf", img="img/thumbnail--title26.jpg", size="215KB") }}
         </div>
       </li>
   </div>


### PR DESCRIPTION
Updated file sizes and linked to FECA now uploaded on FEC CMS as well as the updated 2015 versions of title 52 and title 26 on GPO.

- Resolves # [_2169_]

