### PR TITLE
Show RQ-4 RFAI's in the 24- and 48-hour reports section

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -573,8 +573,8 @@ $(document).ready(function() {
             report_type: ['-24', '-48'],
             /* Performing an include would only show RFAI form types. For this reason, excludes need to be
                used for request_type
-            
-            Exclude all request types except for: 
+
+            Exclude all request types except for:
                - RQ-2: RFAI referencing Report of Receipts and Expenditures
                - RQ-3: RFAI referencing second notice reports
                - RQ-4: RFAI referencing Independent Expenditure filer
@@ -601,11 +601,12 @@ $(document).ready(function() {
             report_type: ['-Q1', '-Q2', '-Q3', '-YE'],
             /* Performing an include would only show RFAI form types. For this reason, excludes need to be
                used for request_type
-            
-            Exclude all request types except for: 
+
+            Exclude all request types except for:
                - RQ-2: RFAI referencing Report of Receipts and Expenditures
+               - RQ-4: RFAI referencing Independent Expenditure filer
             */
-            request_type: ['-1', '-3', '-4', '-5', '-6', '-7', '-8', '-9'],
+            request_type: ['-1', '-3', '-5', '-6', '-7', '-8', '-9'],
             sort_hide_null: ['false']
           }, query),
         }, filingsOpts);
@@ -620,8 +621,8 @@ $(document).ready(function() {
             form_type: ['F1','RFAI'],
             /* Performing an include would only show RFAI form types. For this reason, excludes need to be
                used for request_type
-            
-            Exclude all request types except for: 
+
+            Exclude all request types except for:
                - RQ-1: RFAI referencing Statement of organization
                - RQ-6: RFAI referencing 2nd notice State of organization */
             request_type: ['-2','-3','-4','-5','-7','-8','-9'],
@@ -639,8 +640,8 @@ $(document).ready(function() {
             form_type: ['F1M', 'F8', 'F99', 'F12','RFAI'],
             /* Performing an include would only show RFAI form types. For this reason, excludes need to be
                used for request_type
-            
-            Exclude all request types except for: 
+
+            Exclude all request types except for:
                - RQ-9: RFAI referencing Multicandidate status */
             request_type: ['-1','-2','-3','-4','-5','-6','-7','-8'],
             sort_hide_null: ['false']


### PR DESCRIPTION
## Summary (required)

- Resolves #2174 
Add RFAIs of request_type 4 to 24/48 hour reports table. While RAD currently only sends RFAI's with code RQ-2, the RQ-4 code was used in the past and we need to display them.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee filings page

http://localhost:8000/data/committee/C90010661/?tab=filings under "24- and 48-hour reports" and look at the "RFAI: 24 HOUR NOTIFICATION 2010" which should have "RQ-4" in the upper right-hand corner when you download it.

## Screenshots
<img width="635" alt="screen shot 2018-07-13 at 7 40 48 am" src="https://user-images.githubusercontent.com/31420082/42690128-28988e74-8671-11e8-975f-c4101002c0ef.png">

## Related PRs
List related PRs against other branches:

Added RQ-2 https://github.com/fecgov/fec-cms/pull/2170
