### PR TITLE
Show multiple-part PDFs for archived MURs, if available

### DIFF
--- a/fec/legal/templates/legal-archived-mur.jinja
+++ b/fec/legal/templates/legal-archived-mur.jinja
@@ -82,10 +82,24 @@
     </section>
     <section id="documents" class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
-      <div class="content__section">
-        <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">Case documents</a>
-        (<a class="t-sans" href="{{ mur.url }}" target="_blank">{{ mur.pdf_size | filesize}}</a>)
-      </div>
+      {% if 'documents' not in mur %}
+      <!-- Most archived MURs don't have nested documents, and have a MUR-level URL and PDF details -->
+        <div class="content__section">
+          <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">Case documents</a>
+          (<a class="t-sans" href="{{ mur.url }}" target="_blank">{{ mur.pdf_size | filesize}}</a>)
+        </div>
+      {% endif %}
+      {% if 'documents' in mur%}
+      <!-- Some archived MURs have nested documents and no MUR-level URL. See issue #2157 -->
+        <table class="data-table data-table--text data-table--heading-borders">
+        <tbody>
+          {% for document in mur.documents %}
+            <td><a href="{{ document.url }}">Case documents, part {{ document.document_id }}</a> ({{ document.size | filesize }})</td>
+            </tr>
+          {% endfor %}
+       {% endif %}
+      </tbody>
+    </table>
     </section>
     <section id="participants" class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom u-no-margin">Participants</h2>


### PR DESCRIPTION
## Summary (required)

- Resolves #2157 
_Show multi-part archived MURs._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Archived MUR canonical pages
- If API change isn't merged yet, connect to `dev` API and then look at http://localhost:8000/data/legal/matter-under-review/1251/
- After API change is merged, connect to `dev` API and then look at http://localhost:8000/data/legal/matter-under-review/1252/ (It's currently labeled 1252_A, which is wrong. We will address that with the reload)

## Screenshots
## Archived MUR with 1 document
<img width="659" alt="screen shot 2018-07-15 at 4 27 28 pm" src="https://user-images.githubusercontent.com/31420082/42738086-0427f1ec-884c-11e8-9026-7f207788cf2e.png">

## Archived MUR with > 1 document
![Screen Shot 2018-07-18 at 1.23.57 PM.png](https://images.zenhubusercontent.com/59a579f28f62dc7798c47359/3cc06dd4-3621-463e-84c7-358cbfdb4d6d)

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/archive_murs_multi_pdf_refactor | [link](https://github.com/fecgov/openFEC/pull/3278)

