### PR TITLE
Hotfix/committee filings tab

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -597,8 +597,7 @@ $(document).ready(function() {
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
             form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11', 'RFAI'],
-            report_type: ['24', '48'],
-            report_type: ['-Q1', '-Q2', '-Q3', '-YE'],
+            report_type: ['24', '48','-Q1', '-Q2', '-Q3', '-YE'],
             /* Performing an include would only show RFAI form types. For this reason, excludes need to be
                used for request_type
             

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,8 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    # ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'hotfix/committee-filings-tab'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),
 )

--- a/tasks.py
+++ b/tasks.py
@@ -74,8 +74,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    # ('dev', lambda _, branch: branch == 'develop'),
-    ('dev', lambda _, branch: branch == 'hotfix/committee-filings-tab'),
+    ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),
 )


### PR DESCRIPTION
## Summary

- Resolves https://github.com/fecgov/openFEC/issues/3286
_Filings tab for committees did not show filings in internet explorer due to multiple report_type declarations that are error in IE strict mode._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee profile pages