### PR TITLE
[MERGE WITH GIT FLOW] Fix missing F6's on committee filings page

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -573,8 +573,8 @@ $(document).ready(function() {
             report_type: ['-24', '-48'],
             /* Performing an include would only show RFAI form types. For this reason, excludes need to be
                used for request_type
-            
-            Exclude all request types except for: 
+
+            Exclude all request types except for:
                - RQ-2: RFAI referencing Report of Receipts and Expenditures
                - RQ-3: RFAI referencing second notice reports
                - RQ-4: RFAI referencing Independent Expenditure filer
@@ -597,12 +597,14 @@ $(document).ready(function() {
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
             form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11', 'RFAI'],
-            report_type: ['24', '48','-Q1', '-Q2', '-Q3', '-YE'],
+            report_type: ['-Q1', '-Q2', '-Q3', '-YE'],
             /* Performing an include would only show RFAI form types. For this reason, excludes need to be
                used for request_type
-            
-            Exclude all request types except for: 
+
+            Exclude all request types except for:
                - RQ-2: RFAI referencing Report of Receipts and Expenditures
+
+            Exclude quarterly report_types so F5 quarterlies don't appear
             */
             request_type: ['-1', '-3', '-4', '-5', '-6', '-7', '-8', '-9'],
             sort_hide_null: ['false']
@@ -619,8 +621,8 @@ $(document).ready(function() {
             form_type: ['F1','RFAI'],
             /* Performing an include would only show RFAI form types. For this reason, excludes need to be
                used for request_type
-            
-            Exclude all request types except for: 
+
+            Exclude all request types except for:
                - RQ-1: RFAI referencing Statement of organization
                - RQ-6: RFAI referencing 2nd notice State of organization */
             request_type: ['-2','-3','-4','-5','-7','-8','-9'],
@@ -638,8 +640,8 @@ $(document).ready(function() {
             form_type: ['F1M', 'F8', 'F99', 'F12','RFAI'],
             /* Performing an include would only show RFAI form types. For this reason, excludes need to be
                used for request_type
-            
-            Exclude all request types except for: 
+
+            Exclude all request types except for:
                - RQ-9: RFAI referencing Multicandidate status */
             request_type: ['-1','-2','-3','-4','-5','-6','-7','-8'],
             sort_hide_null: ['false']


### PR DESCRIPTION
## Summary (required)

- Resolves #2194 
_Fix missing F6's on committee filings page._

Some 48hr reports (form type F6) have a `NULL` report type. We were filtering by `report_type = ['24', '48','-Q1', '-Q2', '-Q3', '-YE']`. When the API searches for specific "include" values (24/48), it excludes null values and only returns filings have have `24` or `48` in the `report_type` field. 

[Example API call - no results](https://api.open.fec.gov/v1/committee/C00606939/filings/?api_key=5yyI90SU3Xb73TVlv4wrEhQxYcCwMWCywQiGdYbJ&sort_hide_null=false&sort=-receipt_date&per_page=100&page=1&form_type=F5&form_type=F24&form_type=F6&form_type=F9&form_type=F10&form_type=F11&form_type=RFAI&report_type=24&report_type=48&report_type=-Q1&report_type=-Q2&report_type=-Q3&report_type=-YE&request_type=-1&request_type=-3&request_type=-4&request_type=-5&request_type=-6&request_type=-7&request_type=-8&request_type=-9&cycle=2018)

Example query on API side:
```
SELECT *  FROM ofec_filings_all_mv 
     WHERE (ofec_filings_all_mv.report_type NOT IN ('Q1', 'Q2', 'Q3', 'YE') OR ofec_filings_all_mv.report_type IS NULL) AND ofec_filings_all_mv.report_type IN ('24', '48') AND ofec_filings_all_mv.form_type IN ('F5', 'F24', 'F6', 'F9', 'F10', 'F11', 'RFAI', 'FRQ') AND (ofec_filings_all_mv.request_type NOT IN ('1', '3', '4', '5', '6', '7', '8', '9') OR ofec_filings_all_mv.request_type IS NULL) AND ofec_filings_all_mv.cycle IN (2018) AND ofec_filings_all_mv.committee_id = 'C00606939'
```

If we just filter by ['-Q1', '-Q2', '-Q3', '-YE'] we will still get the results we want.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee filing page - 24/48 reports section
- Test 48hr reports here: http://127.0.0.1:8000/data/committee/C00606939/?tab=filings#notices
- Make sure RFAI's and 24hr notices show up here: http://localhost:8000/data/committee/C90017450/?tab=filings

## Screenshots
<img width="563" alt="screen shot 2018-07-18 at 3 01 07 pm" src="https://user-images.githubusercontent.com/31420082/42902087-6eed2d3e-8a9b-11e8-98eb-f227fa795c6a.png">
<img width="677" alt="screen shot 2018-07-18 at 3 00 00 pm" src="https://user-images.githubusercontent.com/31420082/42902090-71411bd6-8a9b-11e8-8f3c-ce02330d547a.png">


## Related PRs
List related PRs against other branches:
Hotfix/committee filings tab   https://github.com/fecgov/fec-cms/pull/2189
Show RQ-4 RFAI's in the 24- and 48-hour reports section https://github.com/fecgov/fec-cms/pull/2183
Add RFAIs of request_type 2 to 24/48 hour reports table  https://github.com/fecgov/fec-cms/pull/2170