### PR TITLE
Show document length instead of size for archived MURs

### DIFF
--- a/fec/data/templatetags/filters.py
+++ b/fec/data/templatetags/filters.py
@@ -137,20 +137,6 @@ def filesize(value):
 
     return '%d %s' % (value, units[unit])
 
-# def _unique(values):
-#     ret = []
-#     for value in values:
-#         if value not in ret:
-#             ret.append(value)
-#     return ret
-
-
-# @app.template_filter()
-# def fmt_cycle_min_max(cycles):
-#     if len(cycles) > 1:
-#         return '{}–{}'.format(min(cycles), max(cycles))
-#     return cycles[0]
-
 @library.global_function
 def asset_for_css(key):
     """Looks up the hashed asset key in rev-manifest-css.json

--- a/fec/legal/templates/legal-archived-mur.jinja
+++ b/fec/legal/templates/legal-archived-mur.jinja
@@ -83,18 +83,18 @@
     <section id="documents" class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
       {% if 'documents' not in mur %}
-      <!-- Most archived MURs don't have nested documents, and have a MUR-level URL and PDF details -->
+      <!-- Most archived MURs don't have nested documents, and have MUR-level URL PDF details. For these, MUR URL is the PDF link -->
         <div class="content__section">
           <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">Case documents</a>
           (<a class="t-sans" href="{{ mur.url }}" target="_blank">{{ mur.pdf_size | filesize}}</a>)
         </div>
       {% endif %}
       {% if 'documents' in mur%}
-      <!-- Some archived MURs have nested documents and no MUR-level URL. See issue #2157 -->
+      <!-- Some archived MURs have nested documents and no MUR-level URL. For these, MUR URL is the canonical page, to be consistent with current MURs. See issue #2157 -->
         <table class="data-table data-table--text data-table--heading-borders">
         <tbody>
           {% for document in mur.documents %}
-            <td><a href="{{ document.url }}">Case documents, part {{ document.document_id }}</a> ({{ document.size | filesize }})</td>
+            <td><a href="{{ document.url }}">Case documents, part {{ document.document_id }}</a> {{ document.length | filesize }}</td>
             </tr>
           {% endfor %}
        {% endif %}


### PR DESCRIPTION
## Summary (required)

- Second PR to resolve #2157 
_Show document length instead of size for archived MURs. On the API side, we changed document `size` label to `length` for consistency with current MURs. @vrajmohan I'm sorry I forgot to update my branch before you merged it._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Archived MUR canonical pages

### Screenshots
<img width="392" alt="screen shot 2018-07-18 at 1 23 57 pm" src="https://user-images.githubusercontent.com/31420082/42906114-1cd2351e-8aa8-11e8-91a2-4ee34f63a892.png">


### Original PR
#2185 