### PR TITLE
Use new transaction_coverage_date for candidate and committee raising/spending pages

### DIFF
--- a/fec/data/templates/partials/candidate/raising.jinja
+++ b/fec/data/templates/partials/candidate/raising.jinja
@@ -29,6 +29,11 @@
     {% endif %}
 
     {% if two_year_totals %}
+      {% if two_year_totals.transaction_coverage_date is not none %}
+        {% set transaction_end = two_year_totals.transaction_coverage_date %}
+      {% else %}
+        {% set transaction_end = two_year_totals.coverage_end_date %}
+      {% endif %}
     <div id="total-receipts" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">
@@ -81,7 +86,7 @@
         <div id="contributor-state" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <div class="tag__category">
-              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{two_year_totals.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
             </div>
           </div>
           <div class="map-table">
@@ -111,7 +116,7 @@
         <div id="contribution-size" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <div class="tag__category">
-              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{two_year_totals.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
             </div>
           </div>
           <table
@@ -128,7 +133,7 @@
         <div id="all-transactions" class="panel-toggle-element">
           <div class="results-info results-info--simple">
             <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{two_year_totals.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
             </div>
             <div class="u-float-right">
               <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="individual-contributions" aria-hidden="true">

--- a/fec/data/templates/partials/candidate/spending.jinja
+++ b/fec/data/templates/partials/candidate/spending.jinja
@@ -31,6 +31,12 @@
     {% endif %}
 
     {% if two_year_totals %}
+      {% if two_year_totals.transaction_coverage_date is not none %}
+        {% set transaction_end = two_year_totals.transaction_coverage_date %}
+      {% else %}
+        {% set transaction_end = two_year_totals.coverage_end_date %}
+      {% endif %}
+
     <div id="total-disbursements" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">
@@ -66,7 +72,7 @@
 
         <div class="results-info results-info--simple">
           <div class="u-float-left tag__category">
-            <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{two_year_totals.coverage_end_date|date}}</div>
+            <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
           </div>
           <div class="u-float-right">
             <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="itemized-disbursements" aria-hidden="true">

--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -7,6 +7,11 @@
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'receipts')}}
     {% if totals and committee_type not in ['C', 'E', 'I'] %}
+      {% if totals.0.transaction_coverage_date is not none %}
+        {% set transaction_end = totals.0.transaction_coverage_date %}
+      {% else %}
+        {% set transaction_end = totals.0.coverage_end_date %}
+      {% endif %}
       <div id="total-receipts" class="entity__figure row">
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Total receipts</h3>
@@ -62,7 +67,7 @@
           <div class="results-info results-info--simple">
             {% if totals %}
             <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{transaction_end|date}}</div>
             </div>
             {% endif %}
             <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-state">Export</button>
@@ -94,7 +99,7 @@
           <div class="results-info results-info--simple">
             {% if totals %}
             <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{transaction_end|date}}</div>
             </div>
             {% endif %}
             <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="contribution-size">Export</button>
@@ -114,7 +119,7 @@
           <div class="results-info results-info--simple">
             {% if totals %}
             <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{transaction_end|date}}</div>
             </div>
             {% endif %}
             <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-employer">Export</button>
@@ -137,7 +142,7 @@
           <div class="results-info results-info--simple">
             {% if totals %}
             <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{transaction_end|date}}</div>
             </div>
             {% endif %}
             <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-occupation">Export</button>
@@ -160,7 +165,7 @@
           <div class="results-info results-info--simple">
             {% if totals %}
             <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{transaction_end|date}}</div>
             </div>
             {% endif %}
             <div class="u-float-right">

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -7,6 +7,11 @@
     {{ select.committee_cycle_select(cycles, cycle, 'disbursements')}}
 
     {% if totals and committee_type not in ['C', 'E', 'I'] %}
+      {% if totals.0.transaction_coverage_date is not none %}
+        {% set transaction_end = totals.0.transaction_coverage_date %}
+      {% else %}
+        {% set transaction_end = totals.0.coverage_end_date %}
+      {% endif %}
     <div id="total-disbursements" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">
@@ -83,7 +88,7 @@
       <p>This tab shows spending that this committee has made in support of or opposition to a candidate. None of the funds are directly given to or spent by the candidate.</p>
       {% if totals %}
       <div class="tag__category">
-        <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
+        <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{transaction_end|date}}</div>
       </div>
       {% endif %}
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="independent-expenditure-committee" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">
@@ -128,7 +133,7 @@
         <div class="results-info results-info--simple">
           {% if totals %}
           <div class="u-float-left tag__category">
-            <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
+            <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{transaction_end|date}}</div>
           </div>
           {% endif %}
           <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="disbursements-by-recipient">Export</button>
@@ -151,7 +156,7 @@
         <div class="results-info results-info--simple">
           {% if totals %}
           <div class="u-float-left tag__category">
-            <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
+            <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{transaction_end|date}}</div>
           </div>
           {% endif %}
           <div class="u-float-right">
@@ -184,7 +189,7 @@
         <div class="results-info results-info--simple">
           {% if totals %}
           <div class="u-float-left tag__category">
-            <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
+            <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{transaction_end|date}}</div>
           </div>
           {% endif %}
           <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="disbursements-by-recipient-id">Export</button>


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/openFEC/issues/3217
_Display transaction_coverage_date in the "Coverage dates" section of candidate and committee raising/spending pages_

- Totals-level data should continue to use `coverage_end_date`
- Transaction-level data is only available as it's processed - use new `transaction_coverage_date` field in API if it's available.
- If no data is available for `transaction_coverage_date` (for example, only one report has been received and it's un-processed, fall back to `coverage_end_date`
 
## Impacted areas of the application
List general components of the application that this PR will affect:

- Candidate raising/spending pages  "Coverage dates"
- Committee raising/spending pages "Coverage dates"

## Screenshots

<img width="932" alt="screen shot 2018-07-26 at 4 58 34 pm" src="https://user-images.githubusercontent.com/31420082/43288726-b99ec0b6-90f6-11e8-8160-1c50f2713b73.png">

## Related PRs
List related PRs against other branches:

https://github.com/fecgov/openFEC/pull/3310