### PR TITLE
Fix committee summary data description link

### DIFF
--- a/fec/data/templates/partials/advanced/committees.jinja
+++ b/fec/data/templates/partials/advanced/committees.jinja
@@ -23,7 +23,7 @@
                   <li><a href="/files/bulk-downloads/2010/committee_summary_2010.csv">2009–2010</a></li>
                   <li><a href="/files/bulk-downloads/2008/committee_summary_2008.csv">2007-2008</a></li>
                 </ul>
-                <p class="u-margin--top"><a href="/campaign-finance-data/committee-master-file-description">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
+                <p class="u-margin--top"><a href="/campaign-finance-data/committee-summary-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
               </div>
               <p>This file contains overall receipts and disbursements for each political committee, group or individual registered with the Federal Election Commission, along with a breakdown of overall receipts by source and totals for contributions to other committees, independent expenditures made, etc.</p>
             </div>


### PR DESCRIPTION
## Summary

- Resolves #2224 
_Fixes incorrect committee summary data description link. Check to make sure link is now correct._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  http://localhost:8000/data/advanced/?tab=committees