### PR TITLE
Fix underscore.string.js Snik vulnerability

### DIFF
--- a/fec/data/templates/candidates-single.jinja
+++ b/fec/data/templates/candidates-single.jinja
@@ -58,7 +58,6 @@
             href="#section-2">About this candidate</a>
             <ul>
               <li><a href="#information">Candidate information</a></li>
-              <li><a href="#other">Other documents filed</a></li>
               <li><a href="#committees">Committees</a></li>
             </ul>
         </li>
@@ -104,6 +103,19 @@
               <li><a href="#electioneering-communication">Electioneering communication</a></li>
             </ul>
         </li>
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="filings"
+            tabindex="0"
+            aria-controls="panel6"
+            href="#section-6">Candidate filings</a>
+            <ul>
+              <li><a href="#statements-of-candidacy">Statements of candidacy</a></li>
+              <li><a href="#other">Other documents filed</a></li>
+            </ul>
+        </li>
         <li class="side-nav__item">
           <a class="button button--cta u-margin--top t-left-aligned button--two-candidates u-full-width" href="{{ get_election_url(candidate, cycle, district) }}">Compare to<br>opposing candidates</a>
         </li>
@@ -125,6 +137,7 @@
         {% include 'partials/candidate/raising.jinja' %}
         {% include 'partials/candidate/spending.jinja' %}
       {% endif %}
+      {% include 'partials/candidate/filings-tab.jinja' %}
     </div>
   </div>
 

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -114,26 +114,6 @@
       </ul>
       {% endif %}
     </div>
-
-    <div class="entity__figure entity__figure--narrow row" id="other">
-      <h3 class="heading--section u-no-margin">Other documents filed</h3>
-
-      <table
-          class="data-table data-table--heading-borders"
-          data-type="other-documents"
-          data-candidate="{{ candidate_id }}"
-          data-name="{{ name }}"
-          data-cycle="{{ cycle }}"
-        >
-        <thead>
-          <tr>
-            <th scope="col">Document</th>
-            <th scope="col">Version</th>
-            <th scope="col">Date filed</th>
-          </tr>
-        </thead>
-      </table>
-    </div>
   </div>
 
 </section>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -7,7 +7,7 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.election_cycle_select(cycles, max_cycle, id="cycle-5") }}
+    {{ select.candidate_cycle_select(cycles, cycle, 'filings')}}
 
     {% if committee_groups['P'] or committee_groups['A']%}
       <span class="t-sans t-bold">Data is included from these committees:</span>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -1,4 +1,5 @@
 {% import 'macros/cycle-select.jinja' as select %}
+{% import 'macros/entity-pages.jinja' as entity %}
 
 <section id="section-6" role="tabpanel" aria-hidden="true" aria-labelledby="section-6-heading">
 
@@ -6,29 +7,8 @@
 
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
+    {{ select.candidate_cycle_select(cycles, cycle, 'filings')}}
 
-    {{ select.candidate_cycle_select(cycles, max_cycle) }}
-
-    {% if committee_groups['P'] or committee_groups['A']%}
-      <span class="t-sans t-bold">Data is included from these committees:</span>
-
-      <ul class="list--bulleted">
-        {% for committee in committee_groups['P'] | reverse %}
-        {% if committee.cycle == max_cycle %}
-        <li>
-          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
-        </li>
-        {% endif %}
-        {% endfor %}
-        {% for committee in committee_groups['A'] | reverse %}
-        {% if committee.cycle == max_cycle %}
-        <li>
-          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
-        </li>
-        {% endif %}
-        {% endfor %}
-      </ul>
-    {% endif %}
 
     <div id="individual-contribution-transactions" class="entity__figure row">
       <div class="content__section">
@@ -57,7 +37,7 @@
               data-candidate-id="{{ candidate_id }}"
               data-committee-id="{% for c in committee_groups['P'] | reverse %}{{ c.committee_id }},{% endfor %}{% for c in committee_groups['A'] | reverse %}{{ c.committee_id }},{% endfor %}"
               data-name="{{ name }}"
-              data-cycle="{{ max_cycle }}"
+              data-cycle="{{ cycle }}"
               data-duration="2"
             >
             <thead>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -1,0 +1,99 @@
+{% import 'macros/cycle-select.jinja' as select %}
+
+<section id="section-6" role="tabpanel" aria-hidden="true" aria-labelledby="section-6-heading">
+
+  <h2 id="section-6-heading">Candidate filings</h2>
+
+
+  <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
+
+    {{ select.election_cycle_select(cycles, max_cycle, id="cycle-5") }}
+
+    {% if committee_groups['P'] or committee_groups['A']%}
+      <span class="t-sans t-bold">Data is included from these committees:</span>
+
+      <ul class="list--bulleted">
+        {% for committee in committee_groups['P'] | reverse %}
+        {% if committee.cycle == max_cycle %}
+        <li>
+          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        </li>
+        {% endif %}
+        {% endfor %}
+        {% for committee in committee_groups['A'] | reverse %}
+        {% if committee.cycle == max_cycle %}
+        <li>
+          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        </li>
+        {% endif %}
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    <div id="individual-contribution-transactions" class="entity__figure row">
+      <div class="content__section">
+        <div class="heading--section heading--with-action">
+          <h3 class="heading__left">Statements of candidacy</h3>
+          <a class="heading__right button--alt button--browse"
+              href="/data/receipts/individual-contributions/?two_year_transaction_period={{ max_cycle }}&{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
+          </div>
+
+
+        <div id="all-transactions" class="panel-toggle-element">
+          <div class="results-info results-info--simple">
+            <div class="u-float-left tag__category">
+              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{two_year_totals.coverage_end_date|date}}</div>
+            </div>
+            <div class="u-float-right">
+              <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="individual-contributions" aria-hidden="true">
+              </div>
+              <button type="button" class="js-export button button--cta button--export" data-export-for="individual-contributions">Export</button>
+            </div>
+          </div>
+
+          <table
+              class="data-table data-table--heading-borders"
+              data-type="statements-of-candidacy"
+              data-candidate-id="{{ candidate_id }}"
+              data-committee-id="{% for c in committee_groups['P'] | reverse %}{{ c.committee_id }},{% endfor %}{% for c in committee_groups['A'] | reverse %}{{ c.committee_id }},{% endfor %}"
+              data-name="{{ name }}"
+              data-cycle="{{ max_cycle }}"
+              data-duration="2"
+            >
+            <thead>
+              <tr>
+                <th scope="col">Document</th>
+                <th scope="col">Version</th>
+                <th scope="col">Receipt date</th>
+                <th scope="col">Image number</th>
+              </tr>
+            </thead>
+          </table>
+        </div>
+      </div>
+    </div>
+
+
+
+    <div class="entity__figure entity__figure row" id="other">
+      <h3 class="heading--section u-no-margin">Other documents filed</h3>
+
+      <table
+          class="data-table data-table--heading-borders"
+          data-type="other-documents"
+          data-candidate="{{ candidate_id }}"
+          data-name="{{ name }}"
+          data-cycle="{{ cycle }}"
+        >
+        <thead>
+          <tr>
+            <th scope="col">Document</th>
+            <th scope="col">Version</th>
+            <th scope="col">Date filed</th>
+          </tr>
+        </thead>
+      </table>
+    </div>
+  </div>
+
+</section>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -7,7 +7,7 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.candidate_cycle_select(cycles, cycle, 'filings')}}
+    {{ select.candidate_cycle_select(cycles, max_cycle) }}
 
     {% if committee_groups['P'] or committee_groups['A']%}
       <span class="t-sans t-bold">Data is included from these committees:</span>

--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     url(r'^data/elections/(?P<office>\w+)/(?P<state>\w+)/(?P<district>\w+)/(?P<cycle>[0-9]+)/$', views.elections),
     url(r'^data/elections/(?P<office>\w+)/(?P<state>\w+)/(?P<cycle>[0-9]+)/$', views.elections),
     url(r'^data/elections/(?P<office>\w+)/(?P<cycle>[0-9]+)/$', views.elections),
+
     url(r'^data/elections/$', views.elections_lookup),
 
     # Feedback Tool

--- a/fec/fec/static/js/modules/election-utils.js
+++ b/fec/fec/static/js/modules/election-utils.js
@@ -5,8 +5,9 @@
 var _ = require('underscore');
 var topojson = require('topojson');
 
-var s = require('underscore.string');
-_.mixin(s.exports());
+var sprintf = require('sprintf-js').sprintf
+//var s = require('underscore.string');
+//.mixin(s.exports());
 
 var fips = require('./fips');
 
@@ -18,7 +19,7 @@ function encodeDistrict(state, district) {
 }
 
 function decodeDistrict(district) {
-  district = _.sprintf('%04d', district);
+  district = sprintf('%04d', district);
   return {
     state: fips.fipsByCode[parseInt(district.substring(0, 2))].STUSAB,
     district: parseInt(district.substring(2, 4))

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -547,7 +547,7 @@ function initStatementsOfCandidacyTable() {
     query: {
       candidate_id: candidateId,
       form_type: ['F2'],
-      // two_year_transaction_period: opts.cycle,
+       //two_year_transaction_period: opts.cycle,
       /* Performing an include would only show RFAI form types. For this reason, excludes need to be
          used for request_type
 

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -191,11 +191,11 @@ var individualContributionsColumns = [
 ];
 
 var statementsOfCandidacyColumns = [
-  columnHelpers.urlColumn('pdf_url', {
-    data: 'document_description',
-    className: 'all column--medium',
-    orderable: false
-  }),
+  //   columnHelpers.urlColumn('pdf_url', {
+  //   data: 'document_description',
+  //   className: 'all column--medium',
+  //   orderable: false
+  // }),
   {
     data: 'document_description',
     className: 'all column--doc-download',
@@ -207,20 +207,21 @@ var statementsOfCandidacyColumns = [
       var csv_url = row.csv_url ? row.csv_url : null;
       var fec_url = row.fec_url ? row.fec_url : null;
       var html_url = row.html_url ? row.html_url : null;
+      console.log(pdf_url)
 
       // If it's a Form 3L we should append that to the doc title
       if (row.form_type == 'F3L') {
         doc_description = doc_description + ' - Lobbyist Bundling Report';
       }
 
-      return {
+      return reportType({
         doc_description: doc_description,
         amendment_version: amendment_version,
         fec_url: fec_url,
         pdf_url: pdf_url,
         csv_url: csv_url,
         html_url: html_url
-      };
+      });
     }
   },
   {
@@ -536,13 +537,17 @@ function initContributionsTables() {
 }
 function initStatementsOfCandidacyTable() {
   var $table = $('table[data-type="statements-of-candidacy"]');
-  var candidateId = $table.data('candidate');
+  var candidateId = $table.data('candidate-id');
   var path = ['filings'];
+  // var opts = {
+  //   cycle: $table.data('cycle')
+  // };
   tables.DataTable.defer($table, {
     path: path,
     query: {
       candidate_id: candidateId,
       form_type: ['F2'],
+      // two_year_transaction_period: opts.cycle,
       /* Performing an include would only show RFAI form types. For this reason, excludes need to be
          used for request_type
 
@@ -556,7 +561,15 @@ function initStatementsOfCandidacyTable() {
     dom: tables.simpleDOM,
     pagingType: 'simple',
     lengthMenu: [10, 30, 50],
-    hideEmpty: false
+    hideEmpty: false,
+    callbacks: {
+      afterRender: filings.renderModal
+    },
+    drawCallback: function () {
+      this.dropdowns = $table.find('.dropdown').map(function(idx, elm) {
+        return new dropdown.Dropdown($(elm), {checkboxes: false});
+      });
+    }
   });
 }
 

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -15,6 +15,10 @@ var events = require('../modules/events');
 var OtherSpendingTotals = require('../modules/other-spending-totals');
 var filings = require('../modules/filings');
 
+var dropdown = require('../modules/dropdowns');
+var reportType = require('../templates/reports/reportType.hbs');
+
+
 var aggregateCallbacks = {
   afterRender: tables.barsAfterRender.bind(undefined, undefined),
 };
@@ -187,6 +191,11 @@ var individualContributionsColumns = [
 ];
 
 var statementsOfCandidacyColumns = [
+  columnHelpers.urlColumn('pdf_url', {
+    data: 'document_description',
+    className: 'all column--medium',
+    orderable: false
+  }),
   {
     data: 'document_description',
     className: 'all column--doc-download',

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
     "a11y-dialog": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/a11y-dialog/-/a11y-dialog-4.0.0.tgz",
-      "integrity": "sha512-V+crwnrqGkuQrDYP6ZIsvlQYMCVymxSbtnxrevRtSnLAIzXyYg+6gnwuiajhT2nyYEU4lSpEKkxbLbgOvPT7qg=="
+      "integrity": "sha1-70fwzsuQHsOgaxlClX9WRck0ros="
     },
     "abbrev": {
       "version": "1.0.9",
@@ -220,6 +220,14 @@
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
       }
     },
     "aria-accordion": {
@@ -11439,10 +11447,9 @@
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
     },
     "sshpk": {
       "version": "1.13.1",
@@ -12327,11 +12334,6 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-    },
-    "underscore.string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.0.tgz",
-      "integrity": "sha1-T/mMb6K5c672Oipn33ENLfoVYJo="
     },
     "union-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-input-mask": "^0.7.8",
+    "sprintf-js": "^1.1.1",
     "topojson": "1.6.19",
     "typeahead.js": "0.11.1",
     "underscore": "^1.8.3",
-    "underscore.string": "3.2.0",
     "urijs": "1.17.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Snik flagged a high priority vulverability with underscore.string.js 

- Resolves #2163

Replace undscore.string.js with [sprintf-js](https://www.npmjs.com/package/sprintf-js)

## Impacted areas of the application
election-utils.js makes all underscore.string.js functions available to undercore.js via the `_.` prefix on [line 8](https://github.com/fecgov/fec-cms/blob/c017f643eda80da8e14f0ebf66d6e26adff9ea80/fec/fec/static/js/modules/election-utils.js#L8).
election-utils.js then uses the sprintf function of underscore.string.js at [line 21](https://github.com/fecgov/fec-cms/blob/c017f643eda80da8e14f0ebf66d6e26adff9ea80/fec/fec/static/js/modules/election-utils.js#L21)

We remove the underscore,string.js module and  use sprintf-js in its place. 

### How to test:
- checkout and run this branch locally: `feature/underscore.string-fix`
- npm install
- npm run build
- npm run test-single
- Go to this page: http://127.0.0.1:8000/data/
- Choose a state and districts from the map and confirm that everything is working correctly