### PR TITLE
Removed bandit python requirement from develop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ requests==2.13.0
 slacker==0.8.6
 whitenoise==2.0.3
 wagtail==2.0.1
-bandit==1.4.0
 # TODO: pin version
 django-audit-log
 Jinja2==2.9.6


### PR DESCRIPTION
The bandit python requirement is unused and was removed in the latest release, however, the removal did not get merged back into develop. This removes it from develop.