### PR TITLE
Temporarily disable link for "other" state aggregates, add AA, AE, AP, ZZ filters and links

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -1,4 +1,7 @@
 from collections import OrderedDict
+import operator
+
+from data import utils
 
 START_YEAR = 1979
 END_YEAR = 2018
@@ -64,6 +67,12 @@ states = OrderedDict([
     ('WI', 'Wisconsin'),
     ('WY', 'Wyoming'),
 ])
+
+contributor_states = OrderedDict(sorted(utils.extend(states, {
+    ('AA', 'Armed Forces Americas'),
+    ('AE', 'Armed Forces Europe'),
+    ('AP', 'Armed Forces Pacific'),
+    ('ZZ', 'Foreign Countries'), }).items(), key=operator.itemgetter(1)))
 
 parties = OrderedDict([
     ('DEM', 'Democratic Party'),

--- a/fec/data/templates/macros/filters/contributor-states.jinja
+++ b/fec/data/templates/macros/filters/contributor-states.jinja
@@ -1,0 +1,21 @@
+{% macro field(name='name', id_suffix='') %}
+<div class="filter">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox">
+    <legend class="label" for="state">State or Territory</legend>
+    <ul class="dropdown__selected"></ul>
+    <div class="dropdown">
+      <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
+      <div id="state-dropdown{{id_suffix}}" class="dropdown__panel" aria-hidden="true">
+        <ul class="dropdown__list">
+          {% for state in constants.contributor_states.items() %}
+            <li class="dropdown__item">
+              <input name="{{ name }}" id="state-checkbox-{{state[0]}}{{id_suffix}}" type="checkbox" value="{{ state[0] }}">
+              <label class="dropdown__value" for="state-checkbox-{{ state[0] }}{{id_suffix}}">{{ state[1] }}</label>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </fieldset>
+</div>
+{% endmacro %}

--- a/fec/data/templates/partials/individual-contributions-filter.jinja
+++ b/fec/data/templates/partials/individual-contributions-filter.jinja
@@ -3,7 +3,7 @@
 {% import 'macros/filters/text.jinja' as text %}
 {% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
 
-{% import 'macros/filters/states.jinja' as states %}
+{% import 'macros/filters/contributor-states.jinja' as states %}
 {% import 'macros/filters/date.jinja' as date %}
 {% import 'macros/filters/range.jinja' as range %}
 

--- a/fec/data/templates/partials/receipts-filter.jinja
+++ b/fec/data/templates/partials/receipts-filter.jinja
@@ -3,7 +3,7 @@
 {% import 'macros/filters/text.jinja' as text %}
 {% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
 
-{% import 'macros/filters/states.jinja' as states %}
+{% import 'macros/filters/contributor-states.jinja' as states %}
 {% import 'macros/filters/date.jinja' as date %}
 {% import 'macros/filters/range.jinja' as range %}
 {% import 'macros/filters/checkbox.jinja' as checkbox %}

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -240,3 +240,12 @@ def three_days_ago():
     """Find the date three days ago"""
     three_days_ago = datetime.datetime.today() - datetime.timedelta(days=3)
     return three_days_ago.strftime('%m/%d/%y')
+
+
+def extend(*dicts):
+    """Create a new dictionary from multiple existing dictionaries
+    without overwriting."""
+    new_dict = {}
+    for each in dicts:
+        new_dict.update(each)
+    return new_dict

--- a/fec/fec/static/js/modules/column-helpers.js
+++ b/fec/fec/static/js/modules/column-helpers.js
@@ -124,6 +124,10 @@ function buildTotalLink(path, getParams) {
       ));
       link.setAttribute('href', uri);
       span.appendChild(link);
+      // Temporarily disable "other" state aggs
+      if (params.contributor_state == 'OT'){
+        span.textContent = helpers.currency(data);
+      }
     } else {
       span.textContent = helpers.currency(data);
     }


### PR DESCRIPTION
## Summary (required)

- Resolves #2237 
Temporarily disable link for "other" state aggregates, fix non-filtering links for (AA, AE, AP, ZZ)

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate/committee raising pages - individuals by state

- Test by running openFEC branch `feature/fix-sched_a-by-state-display` locally and look at http://127.0.0.1:8000/data/committee/C00370007/?tab=raising
- Click through to "Armed Forces Pacific" or "Armed Forces America" - should filter properly
-   'Armed Forces Americas', 'Armed Forces Europe', 'Armed Forces Pacific', 'Foreign Countries' all appear in dropdown

## Screenshots

<img width="521" alt="screen shot 2018-08-01 at 7 34 54 pm" src="https://user-images.githubusercontent.com/31420082/43554459-7f03edca-95c2-11e8-8195-0913bf257cf7.png">

<img width="800" alt="screen shot 2018-08-02 at 10 37 27 am" src="https://user-images.githubusercontent.com/31420082/43590915-25d6f28c-9640-11e8-89bc-39a619f24ce8.png">

<img width="315" alt="screen shot 2018-08-02 at 11 42 47 am" src="https://user-images.githubusercontent.com/31420082/43594834-356bc44e-9649-11e8-97aa-3537de857061.png">

## Related PRs
List related PRs against other branches:

https://github.com/fecgov/openFEC/pull/3321/files
