### PR TITLE
Feature/candidate filings tab

### DIFF
--- a/fec/data/templates/candidates-single.jinja
+++ b/fec/data/templates/candidates-single.jinja
@@ -58,7 +58,6 @@
             href="#section-2">About this candidate</a>
             <ul>
               <li><a href="#information">Candidate information</a></li>
-              <li><a href="#other">Other documents filed</a></li>
               <li><a href="#committees">Committees</a></li>
             </ul>
         </li>
@@ -104,6 +103,19 @@
               <li><a href="#electioneering-communication">Electioneering communication</a></li>
             </ul>
         </li>
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="filings"
+            tabindex="0"
+            aria-controls="panel6"
+            href="#section-6">Candidate filings</a>
+            <ul>
+              <li><a href="#statements-of-candidacy">Statements of candidacy</a></li>
+              <li><a href="#other">Other documents filed</a></li>
+            </ul>
+        </li>
         <li class="side-nav__item">
           <a class="button button--cta u-margin--top t-left-aligned button--two-candidates u-full-width" href="{{ get_election_url(candidate, cycle, district) }}">Compare to<br>opposing candidates</a>
         </li>
@@ -125,6 +137,7 @@
         {% include 'partials/candidate/raising.jinja' %}
         {% include 'partials/candidate/spending.jinja' %}
       {% endif %}
+      {% include 'partials/candidate/filings-tab.jinja' %}
     </div>
   </div>
 

--- a/fec/data/templates/candidates-single.jinja
+++ b/fec/data/templates/candidates-single.jinja
@@ -110,7 +110,7 @@
             data-name="filings"
             tabindex="0"
             aria-controls="panel6"
-            href="#section-6">Candidate filings</a>
+            href="#section-6">Filings</a>
             <ul>
               <li><a href="#statements-of-candidacy">Statements of candidacy</a></li>
               <li><a href="#other">Other documents filed</a></li>

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -125,26 +125,6 @@
       </ul>
       {% endif %}
     </div>
-
-    <div class="entity__figure entity__figure--narrow row" id="other">
-      <h3 class="heading--section u-no-margin">Other documents filed</h3>
-
-      <table
-          class="data-table data-table--heading-borders"
-          data-type="other-documents"
-          data-candidate="{{ candidate_id }}"
-          data-name="{{ name }}"
-          data-cycle="{{ cycle }}"
-        >
-        <thead>
-          <tr>
-            <th scope="col">Document</th>
-            <th scope="col">Version</th>
-            <th scope="col">Date filed</th>
-          </tr>
-        </thead>
-      </table>
-    </div>
   </div>
 
 </section>

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -39,17 +39,12 @@
                   <i class="icon-circle--check-outline--inline--left"></i>
                   <a href="{{ statement.pdf_url }}">Current version (PDF)</a>
                 </div>
-                {% else %}
-                <div class="t-block">
-                  <i class="icon-circle--clock-reverse--inline--left"></i>
-                  <a href="{{ statement.pdf_url }}">Previous version (PDF)</a>
-                </div>
-                {% endif %}
                 {% if statement.fec_file_id %}
                   <div class="t-small u-small-icon-padding--left"> {{ statement.fec_file_id }}</div>
                 {% endif %}
                 <div class="u-small-icon-padding--left"> Filed {{ statement.receipt_date }}</div>
               </li>
+              {% endif %}
             {% endfor %}
             </ul>
           </td>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -7,7 +7,7 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.election_cycle_select(cycles, max_cycle, id="cycle-5") }}
+    {{ select.candidate_cycle_select(cycles, cycle, 'filings')}}
 
     {% if committee_groups['P'] or committee_groups['A']%}
       <span class="t-sans t-bold">Data is included from these committees:</span>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -1,4 +1,5 @@
 {% import 'macros/cycle-select.jinja' as select %}
+{% import 'macros/entity-pages.jinja' as entity %}
 
 <section id="section-6" role="tabpanel" aria-hidden="true" aria-labelledby="section-6-heading">
 
@@ -6,29 +7,8 @@
 
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
+    {{ select.candidate_cycle_select(cycles, cycle, 'filings')}}
 
-    {{ select.candidate_cycle_select(cycles, max_cycle) }}
-
-    {% if committee_groups['P'] or committee_groups['A']%}
-      <span class="t-sans t-bold">Data is included from these committees:</span>
-
-      <ul class="list--bulleted">
-        {% for committee in committee_groups['P'] | reverse %}
-        {% if committee.cycle == max_cycle %}
-        <li>
-          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
-        </li>
-        {% endif %}
-        {% endfor %}
-        {% for committee in committee_groups['A'] | reverse %}
-        {% if committee.cycle == max_cycle %}
-        <li>
-          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
-        </li>
-        {% endif %}
-        {% endfor %}
-      </ul>
-    {% endif %}
 
     <div id="individual-contribution-transactions" class="entity__figure row">
       <div class="content__section">
@@ -57,7 +37,7 @@
               data-candidate-id="{{ candidate_id }}"
               data-committee-id="{% for c in committee_groups['P'] | reverse %}{{ c.committee_id }},{% endfor %}{% for c in committee_groups['A'] | reverse %}{{ c.committee_id }},{% endfor %}"
               data-name="{{ name }}"
-              data-cycle="{{ max_cycle }}"
+              data-cycle="{{ cycle }}"
               data-duration="2"
             >
             <thead>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -1,0 +1,99 @@
+{% import 'macros/cycle-select.jinja' as select %}
+
+<section id="section-6" role="tabpanel" aria-hidden="true" aria-labelledby="section-6-heading">
+
+  <h2 id="section-6-heading">Candidate filings</h2>
+
+
+  <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
+
+    {{ select.election_cycle_select(cycles, max_cycle, id="cycle-5") }}
+
+    {% if committee_groups['P'] or committee_groups['A']%}
+      <span class="t-sans t-bold">Data is included from these committees:</span>
+
+      <ul class="list--bulleted">
+        {% for committee in committee_groups['P'] | reverse %}
+        {% if committee.cycle == max_cycle %}
+        <li>
+          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        </li>
+        {% endif %}
+        {% endfor %}
+        {% for committee in committee_groups['A'] | reverse %}
+        {% if committee.cycle == max_cycle %}
+        <li>
+          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        </li>
+        {% endif %}
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    <div id="individual-contribution-transactions" class="entity__figure row">
+      <div class="content__section">
+        <div class="heading--section heading--with-action">
+          <h3 class="heading__left">Statements of candidacy</h3>
+          <a class="heading__right button--alt button--browse"
+              href="/data/receipts/individual-contributions/?two_year_transaction_period={{ max_cycle }}&{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
+          </div>
+
+
+        <div id="all-transactions" class="panel-toggle-element">
+          <div class="results-info results-info--simple">
+            <div class="u-float-left tag__category">
+              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{two_year_totals.coverage_end_date|date}}</div>
+            </div>
+            <div class="u-float-right">
+              <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="individual-contributions" aria-hidden="true">
+              </div>
+              <button type="button" class="js-export button button--cta button--export" data-export-for="individual-contributions">Export</button>
+            </div>
+          </div>
+
+          <table
+              class="data-table data-table--heading-borders"
+              data-type="statements-of-candidacy"
+              data-candidate-id="{{ candidate_id }}"
+              data-committee-id="{% for c in committee_groups['P'] | reverse %}{{ c.committee_id }},{% endfor %}{% for c in committee_groups['A'] | reverse %}{{ c.committee_id }},{% endfor %}"
+              data-name="{{ name }}"
+              data-cycle="{{ max_cycle }}"
+              data-duration="2"
+            >
+            <thead>
+              <tr>
+                <th scope="col">Document</th>
+                <th scope="col">Version</th>
+                <th scope="col">Receipt date</th>
+                <th scope="col">Image number</th>
+              </tr>
+            </thead>
+          </table>
+        </div>
+      </div>
+    </div>
+
+
+
+    <div class="entity__figure entity__figure row" id="other">
+      <h3 class="heading--section u-no-margin">Other documents filed</h3>
+
+      <table
+          class="data-table data-table--heading-borders"
+          data-type="other-documents"
+          data-candidate="{{ candidate_id }}"
+          data-name="{{ name }}"
+          data-cycle="{{ cycle }}"
+        >
+        <thead>
+          <tr>
+            <th scope="col">Document</th>
+            <th scope="col">Version</th>
+            <th scope="col">Date filed</th>
+          </tr>
+        </thead>
+      </table>
+    </div>
+  </div>
+
+</section>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -7,7 +7,7 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.candidate_cycle_select(cycles, cycle, 'filings')}}
+    {{ select.candidate_cycle_select(cycles, max_cycle) }}
 
     {% if committee_groups['P'] or committee_groups['A']%}
       <span class="t-sans t-bold">Data is included from these committees:</span>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -1,5 +1,6 @@
 {% import 'macros/cycle-select.jinja' as select %}
 {% import 'macros/entity-pages.jinja' as entity %}
+{% import 'macros/missing.jinja' as missing %}
 
 <section id="section-6" role="tabpanel" aria-hidden="true" aria-labelledby="section-6-heading">
 
@@ -9,6 +10,7 @@
     <div class="content__section">
     {{ select.cycle_select(election_years, cycle, duration=duration, id="cycle-1") }}
     </div>
+    {% if two_year_totals.coverage_start_date %}
     <div id="individual-contribution-transactions" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">
@@ -52,7 +54,9 @@
         </div>
       </div>
     </div>
-
+    {% else %}
+      {{ missing.missing_financials(name, cycle) }}
+    {% endif %}
 
 
     <div class="entity__figure entity__figure row" id="other">

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -3,21 +3,18 @@
 
 <section id="section-6" role="tabpanel" aria-hidden="true" aria-labelledby="section-6-heading">
 
-  <h2 id="section-6-heading">Candidate filings</h2>
-
+  <h2 id="section-6-heading">Filings</h2>
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
     {{ select.cycle_select(election_years, cycle, duration=duration, id="cycle-1") }}
     </div>
-
-
     <div id="individual-contribution-transactions" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Statements of candidacy</h3>
           <a class="heading__right button--alt button--browse"
-              href="/data/receipts/individual-contributions/?two_year_transaction_period={{ max_cycle }}&{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
+              href="/data/filings/?cycle={{ cycle }}&form_type=F2&candidate_id={{ candidate_id }}">Filter this data</a>
           </div>
 
 

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -46,7 +46,7 @@
               <tr>
                 <th scope="col">Document</th>
                 <th scope="col">Version</th>
-                <th scope="col">Receipt date</th>
+                <th scope="col">Date filed</th>
                 <th scope="col">Image number</th>
                 <th scope="col">Pages</th>
               </tr>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -3,7 +3,7 @@
 
 <section id="section-6" role="tabpanel" aria-hidden="true" aria-labelledby="section-6-heading">
 
-  <h2 id="section-6-heading">Filings</h2>
+  <h2 id="section-6-heading">Candidate filings</h2>
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -7,7 +7,9 @@
 
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
-    {{ select.candidate_cycle_select(cycles, cycle, 'filings')}}
+    <div class="content__section">
+    {{ select.cycle_select(election_years, cycle, duration=duration, id="cycle-1") }}
+    </div>
 
 
     <div id="individual-contribution-transactions" class="entity__figure row">
@@ -15,7 +17,7 @@
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Statements of candidacy</h3>
           <a class="heading__right button--alt button--browse"
-              href="/data/receipts/individual-contributions/?two_year_transaction_period={{ max_cycle }}&{% for id in candidate_ids %}&candidate_id={{ id }}{% endfor %}">Filter this data</a>
+              href="/data/receipts/individual-contributions/?two_year_transaction_period={{ max_cycle }}&{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
           </div>
 
 

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -15,7 +15,7 @@
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Statements of candidacy</h3>
           <a class="heading__right button--alt button--browse"
-              href="/data/receipts/individual-contributions/?two_year_transaction_period={{ max_cycle }}&{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
+              href="/data/receipts/individual-contributions/?two_year_transaction_period={{ max_cycle }}&{% for id in candidate_ids %}&candidate_id={{ id }}{% endfor %}">Filter this data</a>
           </div>
 
 

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -48,6 +48,7 @@
                 <th scope="col">Version</th>
                 <th scope="col">Receipt date</th>
                 <th scope="col">Image number</th>
+                <th scope="col">Pages</th>
               </tr>
             </thead>
           </table>

--- a/fec/data/templates/partials/candidate/raising.jinja
+++ b/fec/data/templates/partials/candidate/raising.jinja
@@ -5,28 +5,30 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.candidate_cycle_select(cycles, max_cycle, id="cycle-5") }}
+    <div class="content__section">
+    {{ select.cycle_select(election_years, cycle, duration=duration, id="cycle-1") }}
+    </div>
 
-    {% if committee_groups['P'] or committee_groups['A']%}
-      <span class="t-sans t-bold">Data is included from these committees:</span>
+      {% if committee_groups['P'] or committee_groups['A']%}
+        <span class="t-sans t-bold">Data is included from these committees:</span>
 
-      <ul class="list--bulleted">
-        {% for committee in committee_groups['P'] | reverse %}
-        {% if committee.cycle == max_cycle %}
-        <li>
-          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
-        </li>
-        {% endif %}
-        {% endfor %}
-        {% for committee in committee_groups['A'] | reverse %}
-        {% if committee.cycle == max_cycle %}
-        <li>
-          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
-        </li>
-        {% endif %}
-        {% endfor %}
-      </ul>
-    {% endif %}
+        <ul class="list--bulleted">
+          {% for committee in committee_groups['P'] | reverse %}
+          {% if committee.cycle == max_cycle %}
+          <li>
+            <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+          </li>
+          {% endif %}
+          {% endfor %}
+          {% for committee in committee_groups['A'] | reverse %}
+          {% if committee.cycle == max_cycle %}
+          <li>
+            <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+          </li>
+          {% endif %}
+          {% endfor %}
+        </ul>
+      {% endif %}
 
     {% if two_year_totals %}
       {% if two_year_totals.transaction_coverage_date is not none %}
@@ -56,6 +58,7 @@
         </div>
       </div>
     </div>
+
     {% endif %}
 
     <div id="individual-contribution-transactions" class="entity__figure row">
@@ -164,4 +167,5 @@
       </div>
     </div>
   </div>
+
 </section>

--- a/fec/data/templates/partials/candidate/spending.jinja
+++ b/fec/data/templates/partials/candidate/spending.jinja
@@ -7,7 +7,9 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.candidate_cycle_select(cycles, max_cycle, id="cycle-4") }}
+     <div class="content__section">
+    {{ select.cycle_select(election_years, cycle, duration=duration, id="cycle-1") }}
+    </div>
 
     {% if committee_groups['P'] or committee_groups['A']%}
     <span class="t-sans t-bold">Data is included from these committees:</span>

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -547,7 +547,7 @@ function initStatementsOfCandidacyTable() {
     query: {
       candidate_id: candidateId,
       form_type: ['F2'],
-      // two_year_transaction_period: opts.cycle,
+       //two_year_transaction_period: opts.cycle,
       /* Performing an include would only show RFAI form types. For this reason, excludes need to be
          used for request_type
 

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -191,11 +191,11 @@ var individualContributionsColumns = [
 ];
 
 var statementsOfCandidacyColumns = [
-  columnHelpers.urlColumn('pdf_url', {
-    data: 'document_description',
-    className: 'all column--medium',
-    orderable: false
-  }),
+  //   columnHelpers.urlColumn('pdf_url', {
+  //   data: 'document_description',
+  //   className: 'all column--medium',
+  //   orderable: false
+  // }),
   {
     data: 'document_description',
     className: 'all column--doc-download',
@@ -207,20 +207,21 @@ var statementsOfCandidacyColumns = [
       var csv_url = row.csv_url ? row.csv_url : null;
       var fec_url = row.fec_url ? row.fec_url : null;
       var html_url = row.html_url ? row.html_url : null;
+      console.log(pdf_url)
 
       // If it's a Form 3L we should append that to the doc title
       if (row.form_type == 'F3L') {
         doc_description = doc_description + ' - Lobbyist Bundling Report';
       }
 
-      return {
+      return reportType({
         doc_description: doc_description,
         amendment_version: amendment_version,
         fec_url: fec_url,
         pdf_url: pdf_url,
         csv_url: csv_url,
         html_url: html_url
-      };
+      });
     }
   },
   {
@@ -536,13 +537,17 @@ function initContributionsTables() {
 }
 function initStatementsOfCandidacyTable() {
   var $table = $('table[data-type="statements-of-candidacy"]');
-  var candidateId = $table.data('candidate');
+  var candidateId = $table.data('candidate-id');
   var path = ['filings'];
+  // var opts = {
+  //   cycle: $table.data('cycle')
+  // };
   tables.DataTable.defer($table, {
     path: path,
     query: {
       candidate_id: candidateId,
       form_type: ['F2'],
+      // two_year_transaction_period: opts.cycle,
       /* Performing an include would only show RFAI form types. For this reason, excludes need to be
          used for request_type
 
@@ -556,7 +561,15 @@ function initStatementsOfCandidacyTable() {
     dom: tables.simpleDOM,
     pagingType: 'simple',
     lengthMenu: [10, 30, 50],
-    hideEmpty: false
+    hideEmpty: false,
+    callbacks: {
+      afterRender: filings.renderModal
+    },
+    drawCallback: function () {
+      this.dropdowns = $table.find('.dropdown').map(function(idx, elm) {
+        return new dropdown.Dropdown($(elm), {checkboxes: false});
+      });
+    }
   });
 }
 

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -15,6 +15,10 @@ var events = require('../modules/events');
 var OtherSpendingTotals = require('../modules/other-spending-totals');
 var filings = require('../modules/filings');
 
+var dropdown = require('../modules/dropdowns');
+var reportType = require('../templates/reports/reportType.hbs');
+
+
 var aggregateCallbacks = {
   afterRender: tables.barsAfterRender.bind(undefined, undefined),
 };
@@ -187,6 +191,11 @@ var individualContributionsColumns = [
 ];
 
 var statementsOfCandidacyColumns = [
+  columnHelpers.urlColumn('pdf_url', {
+    data: 'document_description',
+    className: 'all column--medium',
+    orderable: false
+  }),
   {
     data: 'document_description',
     className: 'all column--doc-download',

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -547,7 +547,7 @@ function initStatementsOfCandidacyTable() {
     query: {
       candidate_id: candidateId,
       form_type: ['F2'],
-       //two_year_transaction_period: opts.cycle,
+       cycle: opts.cycle,
       /* Performing an include would only show RFAI form types. For this reason, excludes need to be
          used for request_type
 

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -191,11 +191,6 @@ var individualContributionsColumns = [
 ];
 
 var statementsOfCandidacyColumns = [
-  //   columnHelpers.urlColumn('pdf_url', {
-  //   data: 'document_description',
-  //   className: 'all column--medium',
-  //   orderable: false
-  // }),
   {
     data: 'document_description',
     className: 'all column--doc-download',
@@ -252,8 +247,28 @@ var statementsOfCandidacyColumns = [
   render: function(data, type, row) {
         return row.beginning_image_number;
       }
+  },
+  {
+  data: 'beginning_image_number',
+  orderable: false,
+  className: 'min-tablet hide-panel column--xs column--number',
+  render: function(data, type, row) {
+    // Image numbers in 2015 and later begin with YYYYMMDD,
+    // which makes for a very big number.
+    // This results in inaccurate subtraction
+    // so instead we slice it after the first 8 digits
+    // Earlier image numbers are only 11 digits, so we just leave those as-is
+    var shorten = function(number) {
+      if (number.toString().length === 18) {
+        return Number(number.toString().slice(8));
+      } else {
+        return number;
+      }
+    };
+    var pages = shorten(row.ending_image_number) - shorten(row.beginning_image_number) + 1;
+    return pages.toLocaleString();
   }
-
+ }
 ]
 
 // Begin datatable functions in order of tab appearance

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -202,7 +202,6 @@ var statementsOfCandidacyColumns = [
       var csv_url = row.csv_url ? row.csv_url : null;
       var fec_url = row.fec_url ? row.fec_url : null;
       var html_url = row.html_url ? row.html_url : null;
-      console.log(pdf_url)
 
       // If it's a Form 3L we should append that to the doc title
       if (row.form_type == 'F3L') {
@@ -566,13 +565,7 @@ function initStatementsOfCandidacyTable() {
     query: {
       candidate_id: candidateId,
       form_type: ['F2'],
-       cycle: opts.cycle,
-      /* Performing an include would only show RFAI form types. For this reason, excludes need to be
-         used for request_type
-
-      Exclude all request types except for:
-      // RQ-5: RFAI referencing Statement of Candidacy */
-      request_type: ['-1','-2','-3','-4','-6','-7','-8','-9'],
+      cycle: opts.cycle,
       sort_hide_null: ['false']
     },
     columns: statementsOfCandidacyColumns,

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -276,11 +276,15 @@ function initOtherDocumentsTable() {
   var $table = $('table[data-type="other-documents"]');
   var candidateId = $table.data('candidate');
   var path = ['filings'];
+   var opts = {
+     cycle: $table.data('cycle')
+   };
   tables.DataTable.defer($table, {
     path: path,
     query: {
       candidate_id: candidateId,
       form_type: ['F99','RFAI'],
+      cycle:opts.cycle,
       /* Performing an include would only show RFAI form types. For this reason, excludes need to be
          used for request_type
 
@@ -539,9 +543,9 @@ function initStatementsOfCandidacyTable() {
   var $table = $('table[data-type="statements-of-candidacy"]');
   var candidateId = $table.data('candidate-id');
   var path = ['filings'];
-  // var opts = {
-  //   cycle: $table.data('cycle')
-  // };
+  var opts = {
+     cycle: $table.data('cycle')
+   };
   tables.DataTable.defer($table, {
     path: path,
     query: {


### PR DESCRIPTION
## Summary 
Create "Filings" tab, list last after "Spending by others to support or oppose" tab and populate based on checklist:
**Completion criteria:**
- [x] Create "Filings" tab, list last after "Spending by others to support or oppose"
- [x] Add logic to "About this candidate" tab to list only the candidate's current version of their Form 2 Statement of candidacy
- [x] Create a 'Statements of candidacy' table on "Filings" tab, include all versions including current version
- [x] Move `Other documents` table from "About this candidate" tab to "Filings" tab. This table should follow the `Statements of candidacy` table
- [x] Include document "Image number" in `Statements of candidacy` table. Order of columns should be: Document > Version > Date filed > **Image number** > Pages
- [x] Update side nav and subnav items to correspond with new sections. Under Filings, Statements or candidacy and Other documents should be listed. Under About this candidate, Candidate information and Committees should be listed, and Other documents removed. 
- [x] Remaining issue with how to consistently present Statements of candidacy between the `About` and `Filings` tabs. Need to better understand business logic for document versioning. We have noticed some inconsistencies in how documents are listed as either `Current version` or `Past version`. Also want to avoid the `null` classification if possible.

- Resolves #2154



