### PR TITLE
Add code.json file to root directory for code.gov open source inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ Lastly run migrations to account for any very recent changes that are not presen
 run this command:
 `./manage.py migrate`
 
+### Generating code.json
+
+Code.gov uses the code.json file located at fec.gov/code.json to inventory our repositories. The file is generated using [LLNL's scraper tool](https://github.com/LLNL/scraper). Follow the instructions in scraper's README file to generate a new code.json, or manually update as needed.
+
+Examples of code.json files: https://github.com/GSA/code-gov/blob/master/METADATA_EXAMPLES.md
+
 ## Deploy
 *Likely only useful for FEC team members*
 

--- a/fec/fec/templates/code.json
+++ b/fec/fec/templates/code.json
@@ -1,0 +1,317 @@
+{
+    "agency": "FEC",
+    "measurementType": {
+        "ifOther": "TBD",
+        "method": "other"
+    },
+    "releases": [
+        {
+            "organization": "Federal Election Commission",
+            "contact": {
+                "URL": "https://github.com/fecgov/fec/issues",
+                "email": "opensource@fec.gov"
+            },
+            "date": {
+                "created": "2018-08-03T12:50:00+00:00",
+                "lastModified": "2018-08-03T12:49:57+00:00",
+                "metadataLastUpdated": "2018-08-03T12:49:57+00:00"
+            },
+            "description": "A general discussion forum for FEC.gov. This is the best place to submit general feedback.",
+            "downloadURL": "https://api.github.com/repos/fecgov/FEC/downloads",
+            "homepageURL": "https://github.com/fecgov/FEC",
+            "laborHours": 1092.0,
+            "languages": [],
+            "name": "FEC",
+            "permissions": {
+                "usageType": "openSource",
+                "licenses": [
+                    {
+                        "URL": "https://github.com/fecgov/FEC/blob/master/LICENSE.md",
+                        "name": "CC0"
+                    }
+                ]
+            },
+            "repositoryURL": "https://github.com/fecgov/FEC",
+            "status": "Production",
+            "tags": [
+                "FEC",
+                "github",
+                "feedback",
+                "discussion"
+            ],
+            "vcs": "git"
+        },
+        {
+            "organization": "Federal Election Commission",
+            "contact": {
+                "URL": "https://github.com/fecgov/fec/issues",
+                "email": "opensource@fec.gov"
+            },
+            "date": {
+                "created": "2018-08-07T14:55:33+00:00",
+                "lastModified": "2018-08-06T20:48:06+00:00",
+                "metadataLastUpdated": "2018-08-03T12:49:57+00:00"
+            },
+            "description": "The first RESTful API for the Federal Election Commission. We're aiming to make campaign finance more accessible for journalists, academics, developers, and other transparency seekers.",
+            "downloadURL": "https://api.github.com/repos/fecgov/openFEC/downloads",
+            "homepageURL": "https://api.open.fec.gov/developers/",
+            "laborHours": 204966.6666666667,
+            "languages": [
+                "Python",
+                "PLpgSQL",
+                "JavaScript",
+                "HTML",
+                "SQLPL",
+                "Shell",
+                "CSS"
+            ],
+            "name": "openFEC",
+            "permissions": {
+                "usageType": "openSource",
+                "licenses": [
+                    {
+                        "URL": "https://github.com/fecgov/openFEC/blob/master/LICENSE.md",
+                        "name": "CC0"
+                    }
+                ]
+            },
+            "repositoryURL": "https://github.com/fecgov/openFEC",
+            "status": "Production",
+            "tags": [
+                "FEC",
+                "github",
+                "API",
+                "campaign finance"
+            ],
+            "vcs": "git"
+        },
+        {
+            "organization": "Federal Election Commission",
+            "contact": {
+                "URL": "https://github.com/fecgov/fec/issues",
+                "email": "opensource@fec.gov"
+            },
+            "date": {
+                "created": "2018-08-08T04:21:05+00:00",
+                "lastModified": "2018-08-06T16:12:26+00:00",
+                "metadataLastUpdated": "2018-08-03T12:49:57+00:00"
+            },
+            "description": "The content management system (CMS) for the new Federal Election Commission website.",
+            "downloadURL": "https://api.github.com/repos/fecgov/fec-cms/downloads",
+            "homepageURL": "https://www.fec.gov",
+            "laborHours": 46696.0,
+            "languages": [
+                "HTML",
+                "JavaScript",
+                "Python",
+                "CSS",
+                "Shell"
+            ],
+            "name": "fec-cms",
+            "permissions": {
+                "usageType": "openSource",
+                "licenses": [
+                    {
+                        "URL": "https://github.com/fecgov/fec-cms/blob/master/LICENSE.md",
+                        "name": "CC0"
+                    }
+                ]
+            },
+            "repositoryURL": "https://github.com/fecgov/fec-cms",
+            "relatedCode": [
+                {
+                    "name": "U.S. Web Design System",
+                    "URL": "https://github.com/uswds/uswds"
+                }
+            ],
+            "status": "Production",
+            "tags": [
+                "FEC",
+                "github",
+                "agency website",
+                "content"
+            ],
+            "vcs": "git"
+        },
+        {
+            "organization": "Federal Election Commission",
+            "contact": {
+                "URL": "https://github.com/fecgov/fec/issues",
+                "email": "opensource@fec.gov"
+            },
+            "date": {
+                "created": "2018-07-12T15:14:41+00:00",
+                "lastModified": "2018-07-12T15:14:38+00:00",
+                "metadataLastUpdated": "2018-08-03T12:49:57+00:00"
+            },
+            "description": "Reverse proxy app to combine multiple applications.",
+            "downloadURL": "https://api.github.com/repos/fecgov/fec-proxy/downloads",
+            "homepageURL": "https://github.com/fecgov/fec-proxy",
+            "laborHours": 52.0,
+            "languages": [],
+            "name": "fec-proxy",
+            "permissions": {
+                "usageType": "openSource",
+                "licenses": [
+                    {
+                        "URL": "https://github.com/fecgov/fec-proxy/blob/master/LICENSE.md",
+                        "name": "CC0"
+                    }
+                ]
+            },
+            "repositoryURL": "https://github.com/fecgov/fec-proxy",
+            "status": "Production",
+            "tags": [
+                "FEC",
+                "github",
+                "proxy"
+            ],
+            "vcs": "git"
+        },
+        {
+            "organization": "Federal Election Commission",
+            "contact": {
+                "URL": "https://github.com/fecgov/fec/issues",
+                "email": "opensource@fec.gov"
+            },
+            "date": {
+                "created": "2018-07-17T17:12:41+00:00",
+                "lastModified": "2018-07-17T14:46:12+00:00",
+                "metadataLastUpdated": "2018-08-03T12:49:57+00:00"
+
+            },
+            "description": "The Federal Election Commission's web-based application that makes regulations easier to find, read and understand.",
+            "downloadURL": "https://api.github.com/repos/fecgov/fec-eregs/downloads",
+            "homepageURL": "https://www.fec.gov/regulations",
+            "laborHours": 8406.666666666668,
+            "languages": [
+                "CSS",
+                "HTML",
+                "Python",
+                "JavaScript"
+            ],
+            "name": "fec-eregs",
+            "permissions": {
+                "usageType": "openSource",
+                "licenses": [
+                    {
+                        "URL": "https://github.com/fecgov/fec-eregs/blob/master/LICENSE.md",
+                        "name": "CC0"
+                    }
+                ]
+            },
+            "repositoryURL": "https://github.com/fecgov/fec-eregs",
+            "relatedCode": [
+                {
+                    "name": "regulations-core",
+                    "URL": "https://github.com/eregs/regulations-core"
+                },
+                {
+                    "name": "regulations-site",
+                    "URL": "https://github.com/eregs/regulations-site"
+                },
+                {
+                    "name": "regulations-parser",
+                    "URL": "https://github.com/eregs/regulations-parser"
+                }
+            ],
+            "status": "Production",
+            "tags": [
+                "FEC",
+                "github",
+                "regulations",
+                "search",
+                "eRegs",
+                "CFR"
+            ],
+            "vcs": "git"
+        },
+        {
+            "organization": "Federal Election Commission",
+            "contact": {
+                "URL": "https://github.com/fecgov/fec/issues",
+                "email": "opensource@fec.gov"
+            },
+            "date": {
+                "created": "2018-07-02T22:12:06+00:00",
+                "lastModified": "2018-06-13T23:12:32+00:00",
+                "metadataLastUpdated": "2018-08-03T12:49:57+00:00"
+            },
+            "description": "Pattern Library for the new FEC.gov",
+            "downloadURL": "https://api.github.com/repos/fecgov/fec-pattern-library/downloads",
+            "homepageURL": "https://fec-pattern-library.app.cloud.gov/",
+            "laborHours": 11110.666666666666,
+            "languages": [
+                "HTML",
+                "JavaScript",
+                "CSS",
+                "Shell"
+            ],
+            "name": "fec-pattern-library",
+            "permissions": {
+                "usageType": "openSource",
+                "licenses": [
+                    {
+                        "URL": "https://github.com/fecgov/fec-pattern-library/blob/master/LICENSE.md",
+                        "name": "CC0"
+                    }
+                ]
+            },
+            "repositoryURL": "https://github.com/fecgov/fec-pattern-library",
+            "relatedCode": [
+                {
+                    "name": "U.S. Web Design System",
+                    "URL": "https://github.com/uswds/uswds"
+                }
+            ],
+            "status": "Production",
+            "tags": [
+                "FEC",
+                "github",
+                "styles",
+                "design patterns"
+            ],
+            "vcs": "git"
+        },
+        {
+            "organization": "Federal Election Commission",
+            "contact": {
+                "URL": "https://github.com/fecgov/fec/issues",
+                "email": "opensource@fec.gov"
+            },
+            "date": {
+                "created": "2018-05-29T23:58:34+00:00",
+                "lastModified": "2018-05-29T23:58:31+00:00",
+                "metadataLastUpdated": "2018-08-03T12:49:57+00:00"
+            },
+            "description": "Terraform configuration and CircleCI for managing custom FEC infrastructure in AWS.",
+            "downloadURL": "https://api.github.com/repos/fecgov/fec-infrastructure/downloads",
+            "homepageURL": "https://github.com/fecgov/fec-infrastructure",
+            "laborHours": 17.333333333333336,
+            "languages": [
+                "HCL"
+            ],
+            "name": "fec-infrastructure",
+            "permissions": {
+                "usageType": "openSource",
+                "licenses": [
+                    {
+                        "URL": "https://github.com/fecgov/fec-infrastructure/blob/master/LICENSE.md",
+                        "name": "CC0"
+                    }
+                ]
+            },
+            "repositoryURL": "https://github.com/fecgov/fec-infrastructure",
+            "status": "Production",
+            "tags": [
+                "FEC",
+                "github",
+                "ferraform",
+                "configuration",
+                "AWS"
+            ],
+            "vcs": "git"
+        }
+    ],
+    "version": "2.0.0"
+}

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -28,6 +28,11 @@ urlpatterns = [
     url(r'', include('data.urls')),  # URLs for /data
     url(r'', include('legal.urls')),  # URLs for legal pages
     url(r'', include(wagtail_urls)),
+    url(r'^code\.json$',
+        TemplateView.as_view(
+            template_name='code.json'
+        )
+    )
 ]
 
 if settings.FEC_CMS_ENVIRONMENT != 'LOCAL':


### PR DESCRIPTION
## Summary (required)
Innovation sprint issue: add code.json file for code.gov open source inventory for repos:

1. FEC
2. fec-cms
3. openFEC
4. fec-eregs
5. fec-proxy
6. fec-infrastructure
7. fec-pattern-library

- code.json generated using https://github.com/LLNL/scraper
- Format: https://code.gov/#/policy-guide/docs/compliance/inventory-code
- Validator: https://code.gov/#/policy-guide/docs/compliance/inventory-code/tools/validate-schema

- [x] Compare labor hours in LLNL scraper to GSA's logic: https://github.com/GSA/code-gov/blob/master/LABOR_HOUR_CALC.md
- [x] Add tags
- [x] Take a look at contact info
- [x] Confirm date info
- [X] Update individual license to link to our default license files per @PaulClark2 
- [x] Add "FEC" tags to repos
- [x] Link to individual license files

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Should appear here: http://localhost:8000/code.json and later https://www.fec.gov/code.json
