### PR TITLE
Remove filter remove_digits from section titles and anchors

### DIFF
--- a/fec/home/templates/blocks/section.html
+++ b/fec/home/templates/blocks/section.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags %}
 {% load filters %}
 
-<section id="{% filter remove_digits|slugify %}{{ value.title }}{% endfilter %}" class="option {% if value.hide_title %}option--no-top-border{% endif %}">
+<section id="{{ value.title | slugify}}" class="option {% if value.hide_title %}option--no-top-border{% endif %}">
   {% if not value.hide_title %}<h2>{{ value.title }}</h2>{% endif %}
   {% if value.aside %}
     <div class="option__content">

--- a/fec/home/templates/partials/section-nav.html
+++ b/fec/home/templates/partials/section-nav.html
@@ -6,7 +6,7 @@
       <ul class="sidebar__content">
           {% for section in sections %}
             <li class="side-nav__item">
-              <a class="side-nav__link" href="#{% filter remove_digits|slugify %}{{ section.value.title }}{% endfilter %}">{{ section.value.title }}</a>
+              <a class="side-nav__link" href="#{{ section.value.title | slugify }}">{{ section.value.title }}</a>
             </li>
           {% endfor %}
           {% if citations %}


### PR DESCRIPTION
## Summary (required)

- One piece of #2264 

_Resource and collection template: the left nav is not scrolling to anchors.  Looks like the templates and the section nav partial were using the `filter remove_digit` function. Not sure why that was used in the creation of the anchors.  If numbers are **not** allowed in section title anchors, this should not be merged._

## Impacted areas of the application

- `fec/home/templates/blocks/section.html`
- `fec/home/templates/partials/section-nav.html`