### PR TITLE
Re-enable Python tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
             npm run build-sass
             cd fec
             DJANGO_SETTINGS_MODULE=fec.settings.production python manage.py collectstatic --noinput -v 0
+            ./manage.py test
             npm run test-single
 
       - run:

--- a/fec/home/migrations/0001_initial.py
+++ b/fec/home/migrations/0001_initial.py
@@ -3,13 +3,22 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 
+
 class Migration(migrations.Migration):
+
+    dependencies = [('wagtailcore', '0040_page_draft_title')]
 
     operations = [
         migrations.CreateModel(
             name='HomePage',
             fields=[
-                ('page_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
+                ('page_ptr',
+                 models.OneToOneField(
+                     parent_link=True,
+                     auto_created=True,
+                     primary_key=True,
+                     serialize=False,
+                     to='wagtailcore.Page')),
             ],
             options={
                 'abstract': False,


### PR DESCRIPTION
## Summary (required)

- Gets `develop` set up with Python tests until we can hotfix with #2221 

Re-enable Python tests

## Steps to test

- Comment out the `dependencies = [('wagtailcore', '0040_page_draft_title')]` line in `0001_initial.py` (Once we get a new dump file from `prod` after the release we won't have to do this)
- Restore local db with latest dump (7/27/18) if you haven't already.
```
dropdb cfdm_cms_test
createdb cfdm_cms_test
pg_restore --dbname cfdm_cms_test --no-acl --no-owner fec_cms_gov_cloud_prod_07-27-2018.dump
````
 https://github.com/fecgov/fec-cms/wiki/Locally-restore-wagtail-postgres-database
- Run migrations
```
cd fec
# Run migrations
./manage.py migrate wagtailadmin
./manage.py migrate wagtailcore
./manage.py migrate wagtaildocs
./manage.py migrate wagtailembeds
./manage.py migrate wagtailforms
./manage.py migrate wagtailimages
./manage.py migrate wagtailredirects
./manage.py migrate wagtailsearch
./manage.py migrate wagtailsearchpromotions
./manage.py migrate wagtailusers
./manage.py makemigrations
./manage.py migrate --noinput
```
- Uncomment out the `dependencies = [('wagtailcore', '0040_page_draft_title')]` line in `0001_initial.py`
- Run migrations: 
```
./manage.py makemigrations
./manage.py migrate --noinput
```

- Run python tests - `./manage.py test`
- Make sure they're actually running my modifying a test to make it fail