### PR TITLE
Remove sort by district - API sorts by 'sort_order(P,S,H), district'

### DIFF
--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -56,7 +56,6 @@
                 </select>
               </div>
               <div class="search-controls__submit">
-                <input type="hidden" value="district" name="sort" />
                 <button type="submit" class="button--search--text button--standard">Search</button>
               </div>
             </fieldset>


### PR DESCRIPTION
## Summary (required)

- Discovered while testing #2087 
Remove sort by district - API sorts by 'sort_order(P,S,H), district'

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Election search - http://localhost:8000/data/elections

## Screenshots

## Before: President out of order
<img width="554" alt="screen shot 2018-08-13 at 10 08 53 am" src="https://user-images.githubusercontent.com/31420082/44037214-c28b4890-9ee1-11e8-989d-378b8f8ba5f1.png">

## After: Properly ordered Pres, Senate, House by district
<img width="534" alt="screen shot 2018-08-13 at 10 08 24 am" src="https://user-images.githubusercontent.com/31420082/44037216-c598d638-9ee1-11e8-8d37-290d8084ac2b.png">

## Related PRs

Add 2020/2022 to election profile pages: https://github.com/fecgov/fec-cms/pull/2254