### PR TITLE
Removed <a> from anchor

### DIFF
--- a/fec/fec/draftail/anchor.py
+++ b/fec/fec/draftail/anchor.py
@@ -6,14 +6,6 @@ def anchor_entity_decorator(props):
     return DOM.create_element('span', {
         'data-anchor': props['anchor'],
         'id': props['anchor'],
-        'style': {
-            'fontSize': '2.4rem',
-            'margin': '0 0 1em 0',
-            'fontFamily': 'gandhi,serif',
-            'fontSize': '2rem',
-            'fontWeight': '700',
-            'lineHeight': '1.2'
-        } ,
     }, props['children'])
 
 

--- a/fec/fec/static/js/draftail/Anchor.js
+++ b/fec/fec/static/js/draftail/Anchor.js
@@ -43,12 +43,7 @@ class AnchorSource extends React.Component {
 const Anchor = ({children}) => (
   <span
     style={{
-      fontSize: '2.4rem',
-      margin: '0 0 1em 0',
-      fontFamily: 'gandhi,serif',
-      fontSize: '2rem',
-      fontWeight: '700',
-      lineHeight: '1.2'
+      backgroundColor: '#00FFFF',
     }}
   >
     {children}

--- a/fec/fec/static/js/init.js
+++ b/fec/fec/static/js/init.js
@@ -103,8 +103,4 @@ $(document).ready(function() {
       $link.remove();
     }
   });
-
-  // helpers.anchorify
-  // Add 'a' href to anchor links
-  helpers.anchorify('data-anchor');
 });


### PR DESCRIPTION
## Summary

_Needed to update the draftail anchor component to remove the <a> tag from the anchor so that this component is not a link by default. Also updated the styles for the anchor when published and within the editor._