### PR TITLE
[hotfix - merge with gitflow] Re-enable python tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,8 @@ jobs:
             npm run build-sass
             cd fec
             DJANGO_SETTINGS_MODULE=fec.settings.production python manage.py collectstatic --noinput -v 0
+            coverage run --source='.' manage.py test
+            coverage xml --omit="*migrations*"
             npm run test-single
 
       - run:

--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ command line, e.g.:
 env DATABASE_URL=postgresql://:@/cfdm_cms_test ./manage.py test
 ```
 
+For test coverage, run:
+```bash
+cd fec/
+coverage run --source='.' manage.py test
+coverage report --omit="*migrations*"
+```
+
 ## Enabling/toggling features
 [settings/base.py](https://github.com/fecgov/fec-cms/blob/develop/fec/fec/settings/base.py)
 includes a set of `FEATURES` which can also be enabled using environment flags:

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -11,16 +11,6 @@ set -o pipefail
 cd fec
 # Run migrations
 ./manage.py makemigrations
-./manage.py migrate wagtailadmin
-./manage.py migrate wagtailcore
-./manage.py migrate wagtaildocs
-./manage.py migrate wagtailembeds
-./manage.py migrate wagtailforms
-./manage.py migrate wagtailimages
-./manage.py migrate wagtailredirects
-./manage.py migrate wagtailsearch
-./manage.py migrate wagtailsearchpromotions
-./manage.py migrate wagtailusers
 ./manage.py migrate --noinput
 
 # Run application

--- a/fec/home/migrations/0001_initial.py
+++ b/fec/home/migrations/0001_initial.py
@@ -5,11 +5,19 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
+    dependencies = [('wagtailcore', '0040_page_draft_title')]
+
     operations = [
         migrations.CreateModel(
             name='HomePage',
             fields=[
-                ('page_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
+                ('page_ptr',
+                 models.OneToOneField(
+                     parent_link=True,
+                     auto_created=True,
+                     primary_key=True,
+                     serialize=False,
+                     to='wagtailcore.Page')),
             ],
             options={
                 'abstract': False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,5 +38,6 @@ boto3==1.7.21
 cg-django-uaa==1.2.0
 
 # Testing
+coverage==4.5.1
 pytest==3.2.3
 Faker==0.8.6


### PR DESCRIPTION
## Summary

In order to do our initial deploy after upgrading to wagtail 2, we needed to disable python tests in order for wagtail app database migrations to run first. This hotfix does a few things to re-enable python tests:

- re-adds wagtailcore dependency to initial migration
- re-adds python tests to circle config
- removed additional wagtail app migrations as those have already been applied on deploy to prod
- updated tests to include test coverage capabilities

**To test:**
1. pip install -r requirements.txt
2. ./manage.py test

Make sure tests run successfully

## Impacted areas of the application
List general components of the application that this PR will affect:

- python tests and migrations

