### PR TITLE
[MERGE WITH GIT FLOW] Fix committee pages for types 'C', 'E', and 'I'

### DIFF
--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -2,16 +2,19 @@
 {% import 'macros/disclaimer.jinja' as disclaimer %}
 {% import 'macros/cycle-select.jinja' as select %}
 
+{% if totals %}
+  {% if totals.0.transaction_coverage_date is not none %}
+    {% set transaction_end = totals.0.transaction_coverage_date %}
+  {% else %}
+    {% set transaction_end = totals.0.coverage_end_date %}
+  {% endif %}
+{% endif %}
+
 <section id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
   <h2 id="section-3-heading">Raising</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'receipts')}}
     {% if totals and committee_type not in ['C', 'E', 'I'] %}
-      {% if totals.0.transaction_coverage_date is not none %}
-        {% set transaction_end = totals.0.transaction_coverage_date %}
-      {% else %}
-        {% set transaction_end = totals.0.coverage_end_date %}
-      {% endif %}
       <div id="total-receipts" class="entity__figure row">
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Total receipts</h3>

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -1,17 +1,20 @@
 {% import 'macros/disclaimer.jinja' as disclaimer %}
 {% import 'macros/cycle-select.jinja' as select %}
 
+{% if totals %}
+  {% if totals.0.transaction_coverage_date is not none %}
+    {% set transaction_end = totals.0.transaction_coverage_date %}
+  {% else %}
+    {% set transaction_end = totals.0.coverage_end_date %}
+  {% endif %}
+{% endif %}
+
 <section id="section-4" role="tabpanel" aria-hidden="true" aria-labelledby="section-4-heading">
   <h2 id="section-4-heading">Spending</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'disbursements')}}
 
     {% if totals and committee_type not in ['C', 'E', 'I'] %}
-      {% if totals.0.transaction_coverage_date is not none %}
-        {% set transaction_end = totals.0.transaction_coverage_date %}
-      {% else %}
-        {% set transaction_end = totals.0.coverage_end_date %}
-      {% endif %}
     <div id="total-disbursements" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">


### PR DESCRIPTION
## Summary (required)

- Partial resolution for #2294
Fix committee pages for types 'C', 'E', and 'I'.  Assign transaction_end at top of jinja template.  `transaction_end` wasn't getting assigned for committee types 'C', 'E', and 'I', resulting in an error


## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee profile pages

Test with http://localhost:8000/data/committee/C90011875/?tab=spending

## Related PRs
List related PRs against other branches:

https://github.com/fecgov/fec-cms/pull/2223 
https://github.com/fecgov/fec-cms/issues/2247