### PR TITLE
Fix link to candidate summary file description

### DIFF
--- a/fec/data/templates/partials/advanced/candidates.jinja
+++ b/fec/data/templates/partials/advanced/candidates.jinja
@@ -23,7 +23,7 @@
                   <li><a href="/files/bulk-downloads/2010/candidate_summary_2010.csv">2009–2010</a></li>
                   <li><a href="/files/bulk-downloads/2008/candidate_summary_2008.csv">2007-2008</a></li>
                 </ul>
-                <p class="u-margin--top"><a href="/campaign-finance-data/all-candidates-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
+                <p class="u-margin--top"><a href="/campaign-finance-data/candidate-summary-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
               </div>
               <p>This file contains information for each candidate who has registered with the FEC or appears on an official state ballot for an election to the U.S. House of Representatives, U.S. Senate or U.S. President.</p>
             </div>


### PR DESCRIPTION
## Summary
The "Data description for this file" link under `All Candidates` on [/data/advanced/?tab=candidates](https://www.fec.gov/data/advanced/?tab=candidates) was linking to the `all-candidates` description page instead of the correct `candidate summary` description page.

- Resolves #2284 

## Impacted areas of the application
modified:   data/templates/partials/advanced/candidates.jinja

**How to test:**
1) checkout feature/fix-candidate-summary-link
2) go to http://127.0.0.1:8000/data/advanced/?tab=candidates
3) make sure "Data description for this file" link under `All candidates` goes to  http://127.0.0.1:8000/campaign-finance-data/candidate-summary-file-description/