### PR TITLE
[WIP] Adds Recaptcha capabilities on website forms

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 from distutils.util import strtobool
 
+import requests
 import datetime
 import github3
 import json
@@ -505,27 +506,35 @@ def feedback(request):
         # '{"param":"value"}'. Needs to be decoded in Python 3
         data = json.loads(request.body.decode("utf-8"))
 
-        if not any([data['action'], data['feedback'], data['about']]):
+        if not any([data['action'], data['feedback'], data['about'], data['g-recaptcha-response']]):
             return JsonResponse({'status': False}, status=500)
         else:
-            title = 'User feedback on ' + request.META.get('HTTP_REFERER')
+            # verify recaptcha
+            verifyRecaptcha = requests.post("https://www.google.com/recaptcha/api/siteverify", data={'secret': settings.FEC_RECAPTCHA_SECRET_KEY, 'response': data['g-recaptcha-response']})
+            recaptchaResponse = verifyRecaptcha.json()
+            if not recaptchaResponse['success']:
+                # if captcha failed, return failure
+                return JsonResponse({'status': False}, status=500)
+            else:
+                # captcha passed, we're ready to submit the issue.
+                title = 'User feedback on ' + request.META.get('HTTP_REFERER')
 
-            body = ("## What were you trying to do and how can we improve it?\n %s \n\n"
-                    "## General feedback?\n %s \n\n"
-                    "## Tell us about yourself\n %s \n\n"
-                    "## Details\n"
-                    "* URL: %s \n"
-                    "* User Agent: %s") % (
-                        data['action'],
-                        data['feedback'],
-                        data['about'],
-                        request.META.get('HTTP_REFERER'),
-                        request.META['HTTP_USER_AGENT'])
+                body = ("## What were you trying to do and how can we improve it?\n %s \n\n"
+                        "## General feedback?\n %s \n\n"
+                        "## Tell us about yourself\n %s \n\n"
+                        "## Details\n"
+                        "* URL: %s \n"
+                        "* User Agent: %s") % (
+                            data['action'],
+                            data['feedback'],
+                            data['about'],
+                            request.META.get('HTTP_REFERER'),
+                            request.META['HTTP_USER_AGENT'])
 
-            client = github3.login(token=settings.FEC_GITHUB_TOKEN)
-            issue = client.repository('fecgov', 'fec').create_issue(title, body=body)
+                client = github3.login(token=settings.FEC_GITHUB_TOKEN)
+                issue = client.repository('fecgov', 'fec').create_issue(title, body=body)
 
-            return JsonResponse(issue.to_json(), status=201)
+                return JsonResponse(issue.to_json(), status=201)
     else:
         raise Http404()
 

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -25,6 +25,7 @@ FEC_API_KEY_PUBLIC = env.get_credential('FEC_WEB_API_KEY_PUBLIC', '')
 # Disables crawling for all of our environments except for production
 FEC_CMS_ROBOTS = True
 
+FEC_RECAPTCHA_SECRET_KEY = env.get_credential('FEC_RECAPTCHA_SECRET_KEY')
 FEC_GITHUB_TOKEN = env.get_credential('FEC_GITHUB_TOKEN')
 
 # Config for the ServiceNow API for contacting RAD

--- a/fec/fec/static/js/init.js
+++ b/fec/fec/static/js/init.js
@@ -25,6 +25,11 @@ window.$ = window.jQuery = $;
 var Sticky = require('component-sticky');
 var FormNav = require('./modules/form-nav').FormNav;
 
+var feedbackWidget = null;
+var submitFeedback = function() {
+  feedbackWidget.submit();
+}
+
 $(document).ready(function() {
 
   // Initialize glossary
@@ -70,7 +75,7 @@ $(document).ready(function() {
   });
 
   // Initialize feedback widget
-  new feedback.Feedback('/data/issue/');
+  feedbackWidget = new feedback.Feedback('/data/issue/');
 
   $('.js-form-nav').each(function() {
     new FormNav(this);

--- a/fec/fec/static/js/init.js
+++ b/fec/fec/static/js/init.js
@@ -25,9 +25,11 @@ window.$ = window.jQuery = $;
 var Sticky = require('component-sticky');
 var FormNav = require('./modules/form-nav').FormNav;
 
+// initialize a feedbackWidget which will be set after document is loaded.
 var feedbackWidget = null;
-var submitFeedback = function() {
-  feedbackWidget.submit();
+// expose a global function for Recaptcha to invoke after the challenge is complete.
+window.submitFeedback = function(token) {
+  feedbackWidget.submit(token);
 }
 
 $(document).ready(function() {

--- a/fec/fec/static/js/modules/feedback.js
+++ b/fec/fec/static/js/modules/feedback.js
@@ -34,7 +34,6 @@ function Feedback(url, parent) {
 
   this.$button.on('click', this.toggle.bind(this));
   this.$reset.on('click', this.reset.bind(this));
-  this.$form.on('submit', this.submit.bind(this));
 
   accessibility.removeTabindex(this.$box);
 
@@ -62,7 +61,7 @@ Feedback.prototype.hide = function() {
   accessibility.removeTabindex(this.$box);
 };
 
-Feedback.prototype.submit = function(e) {
+Feedback.prototype.submit = function(token) {
   /**
    * setup JQuery's AJAX methods to setup CSRF token in the request before sending it off.
    * http://stackoverflow.com/questions/5100539/django-csrf-check-failing-with-an-ajax-post-request
@@ -76,8 +75,6 @@ Feedback.prototype.submit = function(e) {
      }
   });
 
-  e.preventDefault();
-
   var data = _.chain(this.$box.find('textarea'))
     .map(function(elm) {
       var $elm = $(elm);
@@ -85,6 +82,9 @@ Feedback.prototype.submit = function(e) {
     })
     .object()
     .value();
+    
+  // explicitly set token as g-recaptcha-response
+  data['g-recaptcha-response'] = token;
 
   if (!_.some(_.values(data))) {
     var message =

--- a/fec/fec/static/js/modules/feedback.js
+++ b/fec/fec/static/js/modules/feedback.js
@@ -82,18 +82,20 @@ Feedback.prototype.submit = function(token) {
     })
     .object()
     .value();
-    
-  // explicitly set token as g-recaptcha-response
-  data['g-recaptcha-response'] = token;
 
-  if (!_.some(_.values(data))) {
+  // only action field is required
+  if (!data['action']) {
     var message =
       '<h2 class="feedback__title">Input required</h2>' +
-      '<p>Please fill out at least one field.</p>';
+      '<p>Please fill out the required field.</p>';
     var buttonText = 'Try again';
     this.message(message, buttonText, 'error');
+    grecaptcha.reset();
     return;
   }
+
+  // explicitly set token as g-recaptcha-response
+  data['g-recaptcha-response'] = token;
 
   var promise = $.ajax({
     method: 'POST',

--- a/fec/fec/static/js/pages/contact-form.js
+++ b/fec/fec/static/js/pages/contact-form.js
@@ -18,6 +18,12 @@ function ContactForm($elm) {
   this.initOtherReason();
   this.category.on('change', this.toggleOtherReason.bind(this));
   this.$cancel.on('click', this.clearForm.bind(this));
+
+  this.$submit = $elm.find('.js-submit');
+  this.$submit.on('click', function(e) {
+    e.preventDefault();
+    grecaptcha.execute();
+  });
 }
 
 ContactForm.prototype.initTypeahead = function() {

--- a/fec/fec/static/js/templates/feedback.hbs
+++ b/fec/fec/static/js/templates/feedback.hbs
@@ -31,7 +31,7 @@
         <label for="feedback-3" class="label">Tell us about yourself</label>
         <span class="label--help">I'm a <span class="u-blank-space"></span> interested in <span class="u-blank-space"></span>.</span>
         <textarea id="feedback-3" name="about"></textarea>
-        <button type="submit" class="button--cta feedback__button u-no-margin">Post</button>
+        <button class="g-recaptcha button--cta feedback__button u-no-margin" data-sitekey="6Lc0uGwUAAAAALGRGXt3mTteJeb_lbse2frNdWjv" data-callback="submitFeedback" data-badge="bottomleft">Post</button>
         <p class="t-sans t-note u-margin--top"><a href="https://github.com/FECgov/FEC/issues">Review all reported feedback</a>  |  <a href="/contact/">Contact the FEC about a specific question</a></p>
       </fieldset>
     </form>

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -13,6 +13,9 @@
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
     {% endblock %}
+
+    <script src='https://www.google.com/recaptcha/api.js'></script>
+
   </head>
 
   <body class="{% block body_class %}{% endblock %}">

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -14,7 +14,6 @@
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
     {% endblock %}
 
-    <script src='https://www.google.com/recaptcha/api.js'></script>
 
   </head>
 
@@ -156,6 +155,8 @@
     {# Global javascript #}
     <script type="text/javascript" src="{% asset_for_js 'vendor.js' %}"></script>
     <script type="text/javascript" src="{% asset_for_js 'init.js' %}"></script>
+    <script src='https://www.google.com/recaptcha/api.js'></script>
+
 
     {% block extra_js %}
     {# Override this in templates to add extra javascript #}

--- a/fec/fec/tests/js/feedback.js
+++ b/fec/fec/tests/js/feedback.js
@@ -87,7 +87,16 @@ describe('feedback', function() {
       sinon.stub(this.feedback, 'handleSuccess');
       sinon.stub(this.feedback, 'handleError');
       this.event = {preventDefault: sinon.spy()};
+      this.token = "fake-token";
       this.feedback.$box.find('textarea').val('awesome site good job');
+      var grecaptchaMock = sinon.stub({
+            render: function (options) { },
+            reset: function (id) { },
+            getResponse: function (id) { },
+            execute: function() { }
+        })
+
+      window.grecaptcha = grecaptchaMock;
     });
 
     afterEach(function() {
@@ -98,8 +107,8 @@ describe('feedback', function() {
 
     it('skips submit on empty inputs', function() {
       var message = sinon.spy(this.feedback, 'message');
-      this.feedback.$box.find('textarea').val('');
-      this.feedback.submit(this.event);
+      this.feedback.$box.find('#feedback-1').val('');
+      this.feedback.submit(this.token);
       expect(message).to.have.been.called;
       expect(this.ajaxStub).to.have.not.been.called;
     });
@@ -107,7 +116,7 @@ describe('feedback', function() {
     it('calls handleSuccess on success', function() {
       var deferred = $.Deferred().resolve({});
       this.ajaxStub.returns(deferred);
-      this.feedback.submit(this.event);
+      this.feedback.submit(this.token);
       expect(this.feedback.handleSuccess).to.have.been.called;
       expect(this.feedback.handleError).to.have.not.been.called;
     });
@@ -115,7 +124,7 @@ describe('feedback', function() {
     it('calls handleError on error', function() {
       var deferred = $.Deferred().reject();
       this.ajaxStub.returns(deferred);
-      this.feedback.submit(this.event);
+      this.feedback.submit(this.token);
       expect(this.feedback.handleSuccess).to.have.not.been.called;
       expect(this.feedback.handleError).to.have.been.called;
     });

--- a/fec/home/templates/home/contact-form.html
+++ b/fec/home/templates/home/contact-form.html
@@ -146,12 +146,7 @@
             {% endfor %}
 
             <div class="contact-form__element">
-              <div id="recaptcha" class="g-recaptcha"
-                                  data-sitekey="6Lc0uGwUAAAAALGRGXt3mTteJeb_lbse2frNdWjv"
-                                  data-callback="submitContactForm"
-                                  data-size="invisible"
-                                  data-badge="bottomleft"></div>
-              <button class="js-submit button button--cta">Submit</button>
+              <button class="g-recaptcha js-submit button button--cta" data-sitekey="6Lc0uGwUAAAAALGRGXt3mTteJeb_lbse2frNdWjv" data-callback="submitContactForm" data-badge="bottomleft">Submit</button>
               <span class="contact-form__reset t-sans">Or <button type="button" class="js-cancel button--unstyled">cancel submission and clear form</button></span>
             </div>
           </form>

--- a/fec/home/templates/home/contact-form.html
+++ b/fec/home/templates/home/contact-form.html
@@ -146,6 +146,11 @@
             {% endfor %}
 
             <div class="contact-form__element">
+              <div id="recaptcha" class="g-recaptcha"
+                                  data-sitekey="6Lc0uGwUAAAAALGRGXt3mTteJeb_lbse2frNdWjv"
+                                  data-callback="submitContactForm"
+                                  data-size="invisible"
+                                  data-badge="bottomleft"></div>
               <button class="js-submit button button--cta">Submit</button>
               <span class="contact-form__reset t-sans">Or <button type="button" class="js-cancel button--unstyled">cancel submission and clear form</button></span>
             </div>
@@ -155,8 +160,14 @@
     {% endif %}
   </div>
 </article>
+
 {% endblock %}
 
 {% block extra_js %}
+  <script type="text/javascript">
+    function submitContactForm() {
+      $('.js-contact-form').submit();
+    }
+  </script>
   <script type="text/javascript" src="{% asset_for_js 'contact-form.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Resolves #2205 

We needed a way to safeguard against bots submitting to our forms on the website. There are currently 2 forms that this effects: Feedback drawer (globally across our website) and RAD Contact analyst form.

This uses invisible reCAPTCHA, which requires no additional work on the user's side to submit a form. The reCAPTCHA will only be invoked after the user clicks on the submit/post button. By default only the most suspicious traffic will be prompted to solve a captcha. Read more here: https://developers.google.com/recaptcha/docs/versions#invisible

This PR utilizes the "automatically bind the challenge to a button" to invoke the invisible reCAPTCHA.

1) Feedback drawer implementation: https://developers.google.com/recaptcha/docs/invisible#auto_render. This is used for the feedback drawer, since it is used on every page on our site and can be easily invoked with the `submitFeedback`callback function. 

2) RAD Contact form implementation: https://developers.google.com/recaptcha/docs/invisible#programmatic_execute. This was needed for the RAD Contact form. Since the RAD form is inside of a separate template and the JS is tied via a module export, the submit callback function had to be handled within the HTML form itself and the invoke recaptcha function is defined within the JS file for the call back to work.

Both forms handle server side verification through the `views.py` in data and home. Uses the `g-recaptcha-response` POST parameter. https://developers.google.com/recaptcha/docs/verify

To do: Need to fix tests

## Impacted areas of the application
List general components of the application that this PR will affect:

- Feedback drawer (On every page of the site)
- RAD Contact form (http://localhost:8000/help-candidates-and-committees/question-rad/)