### PR TITLE
Refactor candidate view, fix 404's for future candidates

### DIFF
--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -27,27 +27,12 @@
 {% endif %}
 {% endmacro %}
 
-{% macro candidate_cycle_select(cycles, cycle=none, id='') %}
-{% set cycle = cycle | int %}
-  <div class="content__section">
-    <label for="{{id}}-cycle" class="label cycle-select__label">Election</label>
-    <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query" data-election-full="False">
-      {% for each in cycles | sort(reverse=True) %}
-        <option
-            value="{{ each }}"
-            {% if cycle and cycle <= each and cycle > (each - 2) %}selected{% endif %}
-          >{{ each }}</option>
-      {% endfor %}
-    </select>
-  </div>
-{% endmacro %}
-
-{% macro committee_cycle_select(cycles, cycle=none, id='') %}
+{% macro two_year_select(cycles, cycle=none, id='', election_full='') %}
 {% set cycle = cycle | int %}
   <div class="row content__section">
     <div class="cycle-select">
       <label for="{{id}}-cycle" class="label cycle-select__label">Two-year period</label>
-      <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query">
+      <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query" {% if election_full%}data-election-full="{{election_full}}"{%endif%}>
         {% for each in cycles | sort(reverse=True) %}
           <option
               value="{{ each }}"

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -84,7 +84,7 @@
         <div class="grid__item u-no-margin">
           <div class="callout callout--primary{% if loop.last %} u-no-margin{% endif %}" style="width: 100%; max-width: 300px">
             <h5 class="callout__title t-sans">
-              <a href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+              <a href="/data/committee/{{ committee.committee_id }}/?cycle={{ cycle }}">{{ committee.name }}</a>
             </h5>
             <span class="callout__subtitle term" data-term="principal campaign committee">Principal campaign committee</span>
           </div>
@@ -98,7 +98,7 @@
           <ul class="list--bulleted" style="margin-top: 1rem">
           {% for committee in committee_groups['A'] | reverse %}
             <li class="u-no-margin-bottom">
-              <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+              <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ cycle }}">{{ committee.name }}</a>
             </li>
           {% endfor %}
           </ul>
@@ -119,7 +119,7 @@
       <ul class="list--bulleted">
       {% for committee in committee_groups['J'] | reverse %}
         <li>
-          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ cycle }}">{{ committee.name }}</a>
         </li>
       {% endfor %}
       </ul>

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -48,7 +48,7 @@
                 {% if statement.fec_file_id %}
                   <div class="t-small u-small-icon-padding--left"> {{ statement.fec_file_id }}</div>
                 {% endif %}
-                <div class="u-small-icon-padding--left"> Filed {{ statement.receipt_date }}</div>
+                <div class="u-small-icon-padding--left"> Filed {{ statement.receipt_date|date }}</div>
               </li>
             {% endfor %}
             </ul>

--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -14,12 +14,12 @@
     <ul class="list--bulleted">
       {% for committee in committee_groups['P'] | reverse %}
       <li>
-        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ cycle }}">{{ committee.name }}</a>
       </li>
       {% endfor %}
       {% for committee in committee_groups['A'] | reverse %}
       <li>
-        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ cycle }}">{{ committee.name }}</a>
       </li>
       {% endfor %}
     </ul>

--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -30,7 +30,7 @@
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Total raised</h3>
           <a class="heading__right button--alt button--browse"
-              href="/data/receipts/?{% for committee in committee_ids %}committee_id={{ committee}}&{% endfor %}two_year_transaction_period={{ max_cycle }}">Browse receipts
+              href="/data/receipts/?{% for committee in committee_ids %}committee_id={{ committee}}&{% endfor %}two_year_transaction_period={{ cycle }}">Browse receipts
           </a>
         </div>
         <div class="tag__category u-no-margin">
@@ -42,7 +42,7 @@
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Total spent</h3>
           <a class="heading__right button--alt button--browse"
-              href="/data/disbursements/?{% for committee in committee_ids %}committee_id={{ committee}}&{% endfor %}two_year_transaction_period={{ max_cycle }}">Browse disbursements
+              href="/data/disbursements/?{% for committee in committee_ids %}committee_id={{ committee}}&{% endfor %}two_year_transaction_period={{ cycle }}">Browse disbursements
           </a>
         </div>
         <div class="tag__category u-no-margin">

--- a/fec/data/templates/partials/candidate/other-spending-tab.jinja
+++ b/fec/data/templates/partials/candidate/other-spending-tab.jinja
@@ -15,25 +15,25 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Independent expenditures</h3>
         <a class="heading__right button--alt button--browse"
-          href="/data/independent-expenditures/?min_date={{ cycle_start(min_cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(max_cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}">Filter this data</a>
+          href="/data/independent-expenditures/?min_date={{ cycle_start(min_cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}">Filter this data</a>
       </div>
       <div class="results-info results-info--simple js-other-spending-totals" data-spending-type="independentExpenditures">
         <div class="usa-width-one-half">
           <span class="label">Support</span>
           <span class="t-big-data js-support"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
         </div>
         <div class="usa-width-one-half">
           <span class="label">Oppose</span>
           <span class="t-big-data js-oppose"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>oppose</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>oppose</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
         </div>
       </div>
       <table
           class="data-table data-table--heading-borders"
           data-type="independent-expenditures"
           data-candidate="{{ candidate_id }}"
-          data-cycle="{{ max_cycle }}"
+          data-cycle="{{ cycle }}"
           data-election-full="{{ show_full_election }}"
           data-duration="{% if election_full %}{{ duration }}{% else %}2{% endif %}"
         >
@@ -57,26 +57,26 @@
           href="{{ url_for(
             'communication_costs',
             min_date=cycle_start(min_cycle) | date(fmt='%m-%d-%Y'),
-            max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
+            max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y')
           ) }}&candidate_id={{ candidate_id }}">Filter this data</a> #}
       </div>
       <div class="results-info results-info--simple js-other-spending-totals" data-spending-type="communicationCosts">
         <div class="usa-width-one-half">
           <span class="label">Support</span>
           <span class="t-big-data js-support"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
         </div>
         <div class="usa-width-one-half">
           <span class="label">Oppose</span>
           <span class="t-big-data js-oppose"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
         </div>
       </div>
       <table
           class="data-table data-table--heading-borders"
           data-type="communication-costs"
           data-candidate="{{ candidate_id }}"
-          data-cycle="{{ max_cycle }}"
+          data-cycle="{{ cycle }}"
           data-election-full="{{ show_full_election }}"
           data-duration="{% if election_full %}{{ duration }}{% else %}2{% endif %}"
         >
@@ -94,12 +94,12 @@
       <div class="heading--section heading--with-action u-no-margin">
         <h3 class="heading__left">Electioneering communication</h3>
         <a class="heading__right button--alt button--browse"
-          href="/data/electioneering-communications/?min_date={{ cycle_start(min_cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(max_cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}">Filter this data</a>
+          href="/data/electioneering-communications/?min_date={{ cycle_start(min_cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}">Filter this data</a>
       </div>
       <div class="results-info results-info--simple js-other-spending-totals" data-spending-type="electioneering">
         <div class="usa-width-one-half">
           <span class="t-big-data js-total-electioneering u-margin--top"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others that mentioned this candidate <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others that mentioned this candidate <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
         </div>
       </div>
 
@@ -107,7 +107,7 @@
           class="data-table data-table--heading-borders"
           data-type="electioneering"
           data-candidate="{{ candidate_id }}"
-          data-cycle="{{ max_cycle }}"
+          data-cycle="{{ cycle }}"
           data-election-full="{{ show_full_election }}"
           data-duration="{% if election_full %}{{ duration }}{% else %}2{% endif %}"
         >

--- a/fec/data/templates/partials/candidate/other-spending-tab.jinja
+++ b/fec/data/templates/partials/candidate/other-spending-tab.jinja
@@ -15,18 +15,18 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Independent expenditures</h3>
         <a class="heading__right button--alt button--browse"
-          href="/data/independent-expenditures/?min_date={{ cycle_start(min_cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}">Filter this data</a>
+          href="/data/independent-expenditures/?min_date={{ cycle_start(cycle_start_year) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}">Filter this data</a>
       </div>
       <div class="results-info results-info--simple js-other-spending-totals" data-spending-type="independentExpenditures">
         <div class="usa-width-one-half">
           <span class="label">Support</span>
           <span class="t-big-data js-support"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(cycle_start_year)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
         </div>
         <div class="usa-width-one-half">
           <span class="label">Oppose</span>
           <span class="t-big-data js-oppose"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>oppose</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>oppose</strong> from <strong>{{cycle_start(cycle_start_year)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
         </div>
       </div>
       <table
@@ -56,7 +56,7 @@
 {#         <a class="heading__right button--alt button--browse"
           href="{{ url_for(
             'communication_costs',
-            min_date=cycle_start(min_cycle) | date(fmt='%m-%d-%Y'),
+            min_date=cycle_start(cycle_start_year) | date(fmt='%m-%d-%Y'),
             max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y')
           ) }}&candidate_id={{ candidate_id }}">Filter this data</a> #}
       </div>
@@ -64,12 +64,12 @@
         <div class="usa-width-one-half">
           <span class="label">Support</span>
           <span class="t-big-data js-support"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(cycle_start_year)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
         </div>
         <div class="usa-width-one-half">
           <span class="label">Oppose</span>
           <span class="t-big-data js-oppose"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(cycle_start_year)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
         </div>
       </div>
       <table
@@ -94,12 +94,12 @@
       <div class="heading--section heading--with-action u-no-margin">
         <h3 class="heading__left">Electioneering communication</h3>
         <a class="heading__right button--alt button--browse"
-          href="/data/electioneering-communications/?min_date={{ cycle_start(min_cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}">Filter this data</a>
+          href="/data/electioneering-communications/?min_date={{ cycle_start(cycle_start_year) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}">Filter this data</a>
       </div>
       <div class="results-info results-info--simple js-other-spending-totals" data-spending-type="electioneering">
         <div class="usa-width-one-half">
           <span class="t-big-data js-total-electioneering u-margin--top"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others that mentioned this candidate <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others that mentioned this candidate <strong>{{cycle_start(cycle_start_year)|date_full}} to {{cycle_end(cycle)|date_full}}.</strong></span>
         </div>
       </div>
 

--- a/fec/data/templates/partials/candidate/raising.jinja
+++ b/fec/data/templates/partials/candidate/raising.jinja
@@ -5,25 +5,21 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.candidate_cycle_select(cycles, max_cycle, id="cycle-5") }}
+    {{ select.candidate_cycle_select(cycles, cycle, id="cycle-5") }}
 
     {% if committee_groups['P'] or committee_groups['A']%}
       <span class="t-sans t-bold">Data is included from these committees:</span>
 
       <ul class="list--bulleted">
         {% for committee in committee_groups['P'] | reverse %}
-        {% if committee.cycle == max_cycle %}
         <li>
           <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
         </li>
-        {% endif %}
         {% endfor %}
         {% for committee in committee_groups['A'] | reverse %}
-        {% if committee.cycle == max_cycle %}
         <li>
           <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
         </li>
-        {% endif %}
         {% endfor %}
       </ul>
     {% endif %}
@@ -39,7 +35,7 @@
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Total receipts</h3>
           <a class="heading__right button--alt button--browse"
-              href="/data/receipts/?two_year_transaction_period={{ max_cycle }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all receipts</a>
+              href="/data/receipts/?two_year_transaction_period={{ cycle }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all receipts</a>
         </div>
         <div class="content__section--narrow">
           <div class="row u-margin-bottom">
@@ -63,7 +59,7 @@
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Individual contributions</h3>
           <a class="heading__right button--alt button--browse"
-              href="/data/receipts/individual-contributions/?two_year_transaction_period={{ max_cycle }}&{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
+              href="/data/receipts/individual-contributions/?two_year_transaction_period={{ cycle }}&{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
           </div>
         <div class="row">
           <fieldset class="toggles js-toggles">
@@ -93,7 +89,7 @@
             <table
                 class="data-table data-table--heading-borders"
                 data-type="contributor-state"
-                data-cycle="{{ max_cycle }}"
+                data-cycle="{{ cycle }}"
               >
               <thead>
                 <th scope="col">State</th>
@@ -103,7 +99,7 @@
           </div>
 
           <div class="map-panel">
-            <div class="state-map" data-candidate-id="{{ candidate_id }}" data-cycle="{{ max_cycle }}">
+            <div class="state-map" data-candidate-id="{{ candidate_id }}" data-cycle="{{ cycle }}">
               <div class="legend-container">
                 <span class="t-sans t-block">By state: total amount received</span>
                 <svg></svg>
@@ -122,7 +118,7 @@
           <table
              class="data-table data-table--heading-borders"
              data-type="contribution-size"
-             data-cycle="{{ max_cycle }}">
+             data-cycle="{{ cycle }}">
             <thead>
               <th scope="col">Contribution size</th>
               <th scope="col">Total contributed</th>
@@ -148,7 +144,7 @@
               data-candidate-id="{{ candidate_id }}"
               data-committee-id="{% for c in committee_groups['P'] | reverse %}{{ c.committee_id }},{% endfor %}{% for c in committee_groups['A'] | reverse %}{{ c.committee_id }},{% endfor %}"
               data-name="{{ name }}"
-              data-cycle="{{ max_cycle }}"
+              data-cycle="{{ cycle }}"
               data-duration="2"
             >
             <thead>

--- a/fec/data/templates/partials/candidate/raising.jinja
+++ b/fec/data/templates/partials/candidate/raising.jinja
@@ -13,12 +13,12 @@
       <ul class="list--bulleted">
         {% for committee in committee_groups['P'] | reverse %}
         <li>
-          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ cycle }}">{{ committee.name }}</a>
         </li>
         {% endfor %}
         {% for committee in committee_groups['A'] | reverse %}
         <li>
-          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ cycle }}">{{ committee.name }}</a>
         </li>
         {% endfor %}
       </ul>

--- a/fec/data/templates/partials/candidate/raising.jinja
+++ b/fec/data/templates/partials/candidate/raising.jinja
@@ -5,7 +5,7 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.candidate_cycle_select(cycles, cycle, id="cycle-5") }}
+    {{ select.two_year_select(cycles, cycle, id="cycle-5", election_full="false") }}
 
     {% if committee_groups['P'] or committee_groups['A']%}
       <span class="t-sans t-bold">Data is included from these committees:</span>

--- a/fec/data/templates/partials/candidate/spending.jinja
+++ b/fec/data/templates/partials/candidate/spending.jinja
@@ -15,12 +15,12 @@
     <ul class="list--bulleted">
       {% for committee in committee_groups['P'] | reverse %}
       <li>
-        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ cycle }}">{{ committee.name }}</a>
       </li>
       {% endfor %}
       {% for committee in committee_groups['A'] | reverse %}
       <li>
-        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ cycle }}">{{ committee.name }}</a>
       </li>
       {% endfor %}
     </ul>

--- a/fec/data/templates/partials/candidate/spending.jinja
+++ b/fec/data/templates/partials/candidate/spending.jinja
@@ -7,7 +7,7 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.candidate_cycle_select(cycles, cycle, id="cycle-4") }}
+    {{ select.two_year_select(cycles, cycle, id="cycle-4", election_full="false") }}
 
     {% if committee_groups['P'] or committee_groups['A']%}
     <span class="t-sans t-bold">Data is included from these committees:</span>

--- a/fec/data/templates/partials/candidate/spending.jinja
+++ b/fec/data/templates/partials/candidate/spending.jinja
@@ -7,25 +7,21 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.candidate_cycle_select(cycles, max_cycle, id="cycle-4") }}
+    {{ select.candidate_cycle_select(cycles, cycle, id="cycle-4") }}
 
     {% if committee_groups['P'] or committee_groups['A']%}
     <span class="t-sans t-bold">Data is included from these committees:</span>
 
     <ul class="list--bulleted">
       {% for committee in committee_groups['P'] | reverse %}
-      {% if committee.cycle == max_cycle %}
       <li>
         <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
       </li>
-      {% endif %}
       {% endfor %}
       {% for committee in committee_groups['A'] | reverse %}
-      {% if committee.cycle == max_cycle %}
       <li>
         <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
       </li>
-      {% endif %}
       {% endfor %}
     </ul>
     {% endif %}
@@ -42,7 +38,7 @@
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Total disbursements</h3>
             <a class="heading__right button--alt button--browse"
-              href="/data/disbursements/?two_year_transaction_period={{ max_cycle }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all disbursements</a>
+              href="/data/disbursements/?two_year_transaction_period={{ cycle }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all disbursements</a>
         </div>
 
         <div class="content__section--narrow">
@@ -67,7 +63,7 @@
         <div class="heading--section heading--with-action u-no-margin">
           <h3 class="heading__left">Disbursement transactions</h3>
           <a class="heading__right button--alt button--browse"
-              href="/data/disbursements/?two_year_transaction_period={{ max_cycle }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
+              href="/data/disbursements/?two_year_transaction_period={{ cycle }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
         </div>
 
         <div class="results-info results-info--simple">
@@ -85,7 +81,7 @@
             data-type="itemized-disbursements"
             data-committee-id="{% for id in committee_ids %}{{ id }}{% if not loop.last %},{% endif %}{% endfor %}"
             data-name="{{ name }}"
-            data-cycle="{{ max_cycle }}"
+            data-cycle="{{ cycle }}"
             data-duration="2"
           >
           <thead>

--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -3,7 +3,7 @@
 <section id="section-2" role="tabpanel" aria-hidden="true" aria-labelledby="section-2-heading">
   <h2 id="section-2-heading">About this committee</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
-    {{ select.committee_cycle_select(cycles, cycle, 'about')}}
+    {{ select.two_year_select(cycles, cycle, 'about')}}
     <div class="entity__figure row">
       <h3 class="heading--section">Committee information</h3>
       <table class="t-sans usa-width-three-fourths">

--- a/fec/data/templates/partials/committee/filings.jinja
+++ b/fec/data/templates/partials/committee/filings.jinja
@@ -6,7 +6,7 @@
     Committee filings
   </h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
-    {{ select.committee_cycle_select(cycles, cycle, 'filings')}}
+    {{ select.two_year_select(cycles, cycle, 'filings')}}
     {% if has_raw_filings %}
       {{ entity.raw_filings_table(cycle, committee_id, min_receipt_date) }}
     {% endif %}

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -5,7 +5,7 @@
 <section id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
   <h2 id="section-1-heading">Financial summary</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
-    {{ select.committee_cycle_select(cycles, cycle, 'summary')}}
+    {{ select.two_year_select(cycles, cycle, 'summary')}}
     {% if reports and totals %}
       {% if committee_type == 'I' %}
         <div class="entity__figure">

--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -13,7 +13,7 @@
 <section id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
   <h2 id="section-3-heading">Raising</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
-    {{ select.committee_cycle_select(cycles, cycle, 'receipts')}}
+    {{ select.two_year_select(cycles, cycle, 'receipts')}}
     {% if totals and committee_type not in ['C', 'E', 'I'] %}
       <div id="total-receipts" class="entity__figure row">
         <div class="heading--section heading--with-action">

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -12,7 +12,7 @@
 <section id="section-4" role="tabpanel" aria-hidden="true" aria-labelledby="section-4-heading">
   <h2 id="section-4-heading">Spending</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
-    {{ select.committee_cycle_select(cycles, cycle, 'disbursements')}}
+    {{ select.two_year_select(cycles, cycle, 'disbursements')}}
 
     {% if totals and committee_type not in ['C', 'E', 'I'] %}
     <div id="total-disbursements" class="entity__figure row">

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -16,6 +16,7 @@ class TestCandidate(TestCase):
         "name": "Lady Liberty",
         "cycles": [2014, 2016, 2018],
         "election_years": [2016, 2018],
+        "two_year_period": 2016,
         "election_districts": ["01", "02"],
         "office": "H",
         "office_full": "House",
@@ -103,14 +104,7 @@ class TestCandidate(TestCase):
                 'committee_id': 'C003'}]
         }
 
-        assert candidate['committees_authorized'] == (
-            candidate['committee_groups']['P'] +
-            candidate['committee_groups']['A'])
-        assert candidate['committee_ids'] == [
-            committee['committee_id']
-            for committee in candidate['committees_authorized']
-        ]
-
+        assert candidate['committee_ids'] == ['C001', 'C002']
         assert candidate['elections'] == [(2018, '02'), (2016, '01')]
         assert candidate['candidate'] == test_candidate
         assert candidate['context_vars'] == {

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -63,8 +63,8 @@ class TestCandidate(TestCase):
         assert candidate['candidate_id'] == test_candidate['candidate_id']
         assert candidate['name'] == test_candidate['name']
         assert candidate['cycles'] == test_candidate['cycles']
+        assert candidate['cycle'] == cycle
         assert candidate['min_cycle'] == cycle - 2
-        assert candidate['max_cycle'] == cycle
         assert candidate['election_year'] == cycle
         assert candidate['election_years'] == test_candidate['election_years']
         assert candidate['office'] == test_candidate['office']
@@ -73,8 +73,8 @@ class TestCandidate(TestCase):
         assert candidate['district'] == test_candidate['district']
         assert candidate['party_full'] == test_candidate['party_full']
         assert candidate['incumbent_challenge_full'] == test_candidate[
-                'incumbent_challenge_full']
-        assert candidate['cycle'] == cycle
+            'incumbent_challenge_full']
+
         assert candidate['result_type'] == 'candidates'
         assert candidate['duration'] == 2
         assert candidate['report_type'] == 'house-senate'

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -58,7 +58,7 @@ class TestCandidate(TestCase):
             cycle
         )
         load_candidate_totals_mock.return_value = {}
-        candidate = get_candidate('C001', 2018, show_full_election)
+        candidate = get_candidate('C001', cycle, show_full_election)
 
         assert candidate['candidate_id'] == test_candidate['candidate_id']
         assert candidate['name'] == test_candidate['name']

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -86,21 +86,18 @@ class TestCandidate(TestCase):
                 'cycles': [2016, 2014, 2012, 2018],
                 'name': 'My Primary Campaign Committee',
                 'cycle': 2016,
-                'related_cycle': 2016,
                 'committee_id': 'C001'}],
             'A': [{
                 'designation': 'A',
                 'cycles': [2016, 2014, 2012, 2018],
                 'name': 'My Authorized Campaign Committee',
                 'cycle': 2016,
-                'related_cycle': 2016,
                 'committee_id': 'C002'}],
             'J': [{
                 'designation': 'J',
                 'cycles': [2016, 2014, 2012, 2018],
                 'name': 'Joint Fundraising Committee',
                 'cycle': 2016,
-                'related_cycle': 2016,
                 'committee_id': 'C003'}]
         }
 

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -64,7 +64,7 @@ class TestCandidate(TestCase):
         assert candidate['name'] == test_candidate['name']
         assert candidate['cycles'] == test_candidate['cycles']
         assert candidate['cycle'] == cycle
-        assert candidate['min_cycle'] == cycle - 2
+        assert candidate['cycle_start_year'] == cycle - 2
         assert candidate['election_year'] == cycle
         assert candidate['election_years'] == test_candidate['election_years']
         assert candidate['office'] == test_candidate['office']
@@ -74,7 +74,6 @@ class TestCandidate(TestCase):
         assert candidate['party_full'] == test_candidate['party_full']
         assert candidate['incumbent_challenge_full'] == test_candidate[
             'incumbent_challenge_full']
-
         assert candidate['result_type'] == 'candidates'
         assert candidate['duration'] == 2
         assert candidate['report_type'] == 'house-senate'

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -179,7 +179,7 @@ def get_candidate(candidate_id, cycle, election_full):
     # And pass through the data processing utils
     aggregate = api_caller.load_candidate_totals(
         candidate['candidate_id'],
-        cycle=max_cycle,
+        cycle=cycle,
         election_full=election_full,
     )
     if aggregate:
@@ -197,7 +197,7 @@ def get_candidate(candidate_id, cycle, election_full):
     # raising and spending tabs
     two_year_totals = api_caller.load_candidate_totals(
         candidate['candidate_id'],
-        cycle=max_cycle,
+        cycle=cycle,
         election_full=False
     )
 
@@ -231,7 +231,6 @@ def get_candidate(candidate_id, cycle, election_full):
         'min_cycle': min_cycle,
         'report_type': report_type,
         'cycles': cycles,
-        'max_cycle': max_cycle,
         'show_full_election': show_full_election,
         'committee_groups': committee_groups,
         'committees_authorized': committees_authorized,

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -127,20 +127,6 @@ def get_candidate(candidate_id, cycle, election_full):
         if cycle_in_range(cycle_tmp)
     ]
 
-    # Annotate committees with most recent available cycle
-    aggregate_cycles = (
-        list(range(cycle, cycle - cycle_duration, -2))
-        if show_full_election
-        else [cycle]
-    )
-    for committee in committees:
-        committee['related_cycle'] = (
-            max(cycle for cycle in aggregate_cycles
-                if cycle in committee['cycles'])
-            if show_full_election
-            else candidate['two_year_period']
-        )
-
     # Group the committees by designation
     committee_groups = groupby(committees, lambda each: each['designation'])
     authorized_committee_ids = [
@@ -205,7 +191,6 @@ def get_candidate(candidate_id, cycle, election_full):
         'result_type': 'candidates',
         'duration': cycle_duration,
         'cycle_start_year': cycle_start_year,
-
         'report_type': report_type,
         'cycles': cycles,
         'show_full_election': show_full_election,

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -84,12 +84,25 @@ def advanced(request):
     })
 
 
+def cycle_in_range(cycle):
+    try:
+        return cycle <= utils.current_cycle()
+    except:
+        return False
+
+
 def get_candidate(candidate_id, cycle, election_full):
 
+    show_full_election = election_full if cycle_in_range(cycle) else False
+
+    if not cycle_in_range(cycle):
+        cycle = utils.current_cycle()
+
+    # Get candidate/committee info and latest cycle
     candidate, committees, cycle = api_caller.load_with_nested(
         'candidate', candidate_id, 'committees',
         cycle=cycle, cycle_key='two_year_period',
-        election_full=election_full,
+        election_full=show_full_election,
     )
 
     # cycle corresponds to the two-year period for which the committee has
@@ -123,96 +136,85 @@ def get_candidate(candidate_id, cycle, election_full):
             if year >= cycle),
         None,
     )
+    # Round odd year special elections for election dropdowns
+    # Use Set to ensure no duplicate years
+    even_election_years = list(
+        {year + (year % 2) for year in candidate.get('election_years', [])}
+    )
 
-    result_type = 'candidates'
-    duration = election_durations.get(candidate['office'], 2)
-    cycle_start_year = cycle - duration if election_full else cycle
+    cycle_duration = election_durations.get(candidate['office'], 2)
+    cycle_start_year = cycle - cycle_duration if show_full_election else cycle
     report_type = report_types.get(candidate['office'])
 
-    # For JavaScript
-    context_vars = {
-        'cycles': candidate['cycles'],
-        'name': candidate['name'],
-        'cycle': cycle,
-        'electionFull': election_full,
-        'candidateID': candidate['candidate_id']
-    }
-
-    # Addresses issue#1644 - make any odd year special election an even year
-    #  for displaying elections for pulldown menu in Candidate pages
-    #  Using Set to ensure no duplicate years in final list
-    even_election_years = list(
-       {year + (year % 2) for year in candidate.get('election_years', [])})
-
-    # In the case of when a presidential or senate candidate has filed
-    # for a future year that's beyond the current cycle,
-    # set a max_cycle var to the current cycle we're in
-    # and when calling the API for totals, set election_full to False.
-    # The max_cycle value is also referenced in the templates for setting
-    # the cycle for itemized tables. Because these are only in 2-year chunks,
+    # Because the API only has totals through the current cycle,
     # the cycle should never be beyond the one we're in.
-    cycles = [cycle for cycle in candidate['cycles'] if cycle <= utils.current_cycle()]
-    max_cycle = cycle if cycle <= utils.current_cycle() else utils.current_cycle()
-    show_full_election = election_full if cycle <= utils.current_cycle() else False
+    cycles = [
+        cycle_tmp for cycle_tmp in candidate['cycles']
+        if cycle_in_range(cycle_tmp)
+    ]
 
     # Annotate committees with most recent available cycle
     aggregate_cycles = (
-        list(range(cycle, cycle - duration, -2))
-        if election_full
+        list(range(cycle, cycle - cycle_duration, -2))
+        if show_full_election
         else [cycle]
     )
     for committee in committees:
         committee['related_cycle'] = (
             max(cycle for cycle in aggregate_cycles
                 if cycle in committee['cycles'])
-            if election_full
+            if show_full_election
             else candidate['two_year_period']
         )
 
     # Group the committees by designation
     committee_groups = groupby(committees, lambda each: each['designation'])
-    committees_authorized = committee_groups.get('P', []) + committee_groups.get('A', [])
+    authorized_committee_ids = [
+        committee['committee_id'] for committee in committees
+        if committee.get('designation') in ('P', 'A')
+    ]
 
-    committee_ids = [committee['committee_id'] for committee in committees_authorized]
-
-    # Get aggregate totals for the financial summary
-    # And pass through the data processing utils
-    aggregate = api_caller.load_candidate_totals(
+    # Get aggregate totals and process for financial summary
+    aggregate_totals = api_caller.load_candidate_totals(
         candidate['candidate_id'],
         cycle=cycle,
-        election_full=election_full,
+        election_full=show_full_election,
     )
-    if aggregate:
-        raising_summary = utils.process_raising_data(aggregate)
-        spending_summary = utils.process_spending_data(aggregate)
-        cash_summary = utils.process_cash_data(aggregate)
+    if aggregate_totals:
+        raising_summary = utils.process_raising_data(aggregate_totals)
+        spending_summary = utils.process_spending_data(aggregate_totals)
+        cash_summary = utils.process_cash_data(aggregate_totals)
     else:
         raising_summary = None
         spending_summary = None
         cash_summary = None
 
-    aggregate = aggregate
-
-    # Get totals for the last two-year period of a cycle for showing on
-    # raising and spending tabs
+    # Get totals for the last two-year period for raising and spending tabs
     two_year_totals = api_caller.load_candidate_totals(
         candidate['candidate_id'],
         cycle=cycle,
         election_full=False
     )
 
-    # Get the statements of candidacy
     statement_of_candidacy = api_caller.load_candidate_statement_of_candidacy(
         candidate['candidate_id'],
         cycle=cycle
     )
 
-    # Get all the elections
     elections = sorted(
         zip(candidate['election_years'], candidate['election_districts']),
         key=lambda pair: pair[0],
         reverse=True,
     )
+
+    # For JavaScript
+    context_vars = {
+        'cycles': candidate['cycles'],
+        'name': candidate['name'],
+        'cycle': cycle,
+        'electionFull': show_full_election,
+        'candidateID': candidate['candidate_id']
+    }
 
     return {
         'name': candidate['name'],
@@ -226,19 +228,19 @@ def get_candidate(candidate_id, cycle, election_full):
         'incumbent_challenge_full': candidate['incumbent_challenge_full'],
         'election_year': election_year,
         'election_years': even_election_years,
-        'result_type': result_type,
-        'duration': duration,
+        'result_type': 'candidates',
+        'duration': cycle_duration,
         'cycle_start_year': cycle_start_year,
+
         'report_type': report_type,
         'cycles': cycles,
         'show_full_election': show_full_election,
         'committee_groups': committee_groups,
-        'committees_authorized': committees_authorized,
-        'committee_ids': committee_ids,
+        'committee_ids': authorized_committee_ids,
         'raising_summary': raising_summary,
         'spending_summary': spending_summary,
         'cash_summary': cash_summary,
-        'aggregate': aggregate,
+        'aggregate': aggregate_totals,
         'two_year_totals': two_year_totals,
         'statement_of_candidacy': statement_of_candidacy,
         'elections': elections,
@@ -252,8 +254,7 @@ def candidate(request, candidate_id):
     if cycle is not None:
         cycle = int(cycle)
 
-    election_full = request.GET.get('election_full', True)
-    election_full = bool(strtobool(str(election_full)))
+    election_full = bool(strtobool(request.GET.get('election_full', 'True')))
 
     candidate = get_candidate(candidate_id, cycle, election_full)
     return render(request, 'candidates-single.jinja', candidate)

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -207,12 +207,6 @@ def get_candidate(candidate_id, cycle, election_full):
         cycle=cycle
     )
 
-    if statement_of_candidacy:
-        for statement in statement_of_candidacy:
-            # convert string to python datetime and parse for readable output
-            statement['receipt_date'] = datetime.datetime.strptime(statement['receipt_date'], '%Y-%m-%dT%H:%M:%S')
-            statement['receipt_date'] = statement['receipt_date'].strftime('%m/%d/%Y')
-
     # Get all the elections
     elections = sorted(
         zip(candidate['election_years'], candidate['election_districts']),

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -126,7 +126,7 @@ def get_candidate(candidate_id, cycle, election_full):
 
     result_type = 'candidates'
     duration = election_durations.get(candidate['office'], 2)
-    min_cycle = cycle - duration if election_full else cycle
+    cycle_start_year = cycle - duration if election_full else cycle
     report_type = report_types.get(candidate['office'])
 
     # For JavaScript
@@ -228,7 +228,7 @@ def get_candidate(candidate_id, cycle, election_full):
         'election_years': even_election_years,
         'result_type': result_type,
         'duration': duration,
-        'min_cycle': min_cycle,
+        'cycle_start_year': cycle_start_year,
         'report_type': report_type,
         'cycles': cycles,
         'show_full_election': show_full_election,

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -105,32 +105,6 @@ def get_candidate(candidate_id, cycle, election_full):
         election_full=show_full_election,
     )
 
-    # cycle corresponds to the two-year period for which the committee has
-    # financial activity. when selected election cycle is not in list of
-    # election years, get the next election cycle
-    if election_full and cycle and cycle not in candidate['election_years']:
-
-        next_cycle = next(
-            (
-                year for year in sorted(candidate['election_years'])
-                if year > cycle
-            ),
-            max(candidate['election_years']),
-        )
-
-        # If the next_cycle is odd set it to whatever the cycle value was-
-        # falls back to the cycle and then set election_full to false
-        # This solves issue# 1945 with odd year special elections
-        if next_cycle % 2 > 0:
-            next_cycle = cycle
-            election_full = False
-        # get the next election cycle data for this candidate
-        candidate, committees, cycle = api_caller.load_with_nested(
-            'candidate', candidate_id, 'committees',
-            cycle=next_cycle, cycle_key='two_year_period',
-            election_full=election_full,
-        )
-
     election_year = next(
         (year for year in sorted(candidate['election_years'])
             if year >= cycle),

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -91,8 +91,10 @@ def get_candidate(candidate_id, cycle, election_full):
         cycle=cycle, cycle_key='two_year_period',
         election_full=election_full,
     )
-    # cycle corresponds to the two-year period for which the committee has financial activity.
-    # when selected election cycle is not in list of election years, get the next election cycle
+
+    # cycle corresponds to the two-year period for which the committee has
+    # financial activity. when selected election cycle is not in list of
+    # election years, get the next election cycle
     if election_full and cycle and cycle not in candidate['election_years']:
 
         next_cycle = next(
@@ -103,8 +105,8 @@ def get_candidate(candidate_id, cycle, election_full):
             max(candidate['election_years']),
         )
 
-        # If the next_cycle is odd set it to whatever the cycle value was- falls back to the cycle
-        # and then set election_full to false
+        # If the next_cycle is odd set it to whatever the cycle value was-
+        # falls back to the cycle and then set election_full to false
         # This solves issue# 1945 with odd year special elections
         if next_cycle % 2 > 0:
             next_cycle = cycle
@@ -117,7 +119,8 @@ def get_candidate(candidate_id, cycle, election_full):
         )
 
     election_year = next(
-        (year for year in sorted(candidate['election_years']) if year >= cycle),
+        (year for year in sorted(candidate['election_years'])
+            if year >= cycle),
         None,
     )
 
@@ -135,10 +138,11 @@ def get_candidate(candidate_id, cycle, election_full):
         'candidateID': candidate['candidate_id']
     }
 
-     # Addresses issue#1644 - make any odd year special election an even year
+    # Addresses issue#1644 - make any odd year special election an even year
     #  for displaying elections for pulldown menu in Candidate pages
     #  Using Set to ensure no duplicate years in final list
-    even_election_years = list({ year + (year % 2) for year in candidate.get('election_years', []) })
+    even_election_years = list(
+       {year + (year % 2) for year in candidate.get('election_years', [])})
 
     # In the case of when a presidential or senate candidate has filed
     # for a future year that's beyond the current cycle,
@@ -159,7 +163,8 @@ def get_candidate(candidate_id, cycle, election_full):
     )
     for committee in committees:
         committee['related_cycle'] = (
-            max(cycle for cycle in aggregate_cycles if cycle in committee['cycles'])
+            max(cycle for cycle in aggregate_cycles
+                if cycle in committee['cycles'])
             if election_full
             else candidate['two_year_period']
         )
@@ -168,8 +173,6 @@ def get_candidate(candidate_id, cycle, election_full):
     committee_groups = groupby(committees, lambda each: each['designation'])
     committees_authorized = committee_groups.get('P', []) + committee_groups.get('A', [])
 
-    committee_groups = committee_groups
-    committees_authorized = committees_authorized
     committee_ids = [committee['committee_id'] for committee in committees_authorized]
 
     # Get aggregate totals for the financial summary


### PR DESCRIPTION
## Summary (required)

- Replaces PR https://github.com/fecgov/fec-cms/pull/2316 - bad branch name
- Resolves #2294 
Refactor candidate view, fix 404's for future cycle candidates without committees, simplify 2-year select macro and use it for the candidate raising/spending pages

## Impacted areas of the application
List general components of the application that this PR will affect:

- Candidate profile pages
- Candidate raising/spending pages now show two-year period label (that's what we display) instead of election (election label was incorrect). Committee two-year period dropdowns should be unchanged - renamed to `two_year_select`

- Test previously 404-ing candidate pages: 
http://localhost:8000/data/candidate/H0TX09168/
http://localhost:8000/data/candidate/P40003832/
- Test future/past House/Senate/Presidential pages

## Screenshots:
## Before
<img width="407" alt="screen shot 2018-08-29 at 9 43 12 am" src="https://user-images.githubusercontent.com/31420082/44791666-24fc4700-ab70-11e8-9e9d-4c9ddf7c3908.png">

## After
<img width="417" alt="screen shot 2018-08-29 at 9 43 21 am" src="https://user-images.githubusercontent.com/31420082/44791674-29286480-ab70-11e8-91ed-f861c7688a52.png">

## Related PRs
#2302 *Add tests for candidate view*
#2311  *Refactor tests for candidate view*