### PR TITLE
Fix/audit search subcats

### DIFF
--- a/fec/fec/static/js/modules/audit-category-sub-category.js
+++ b/fec/fec/static/js/modules/audit-category-sub-category.js
@@ -9,38 +9,39 @@
 var $ = require('jquery');
 var helpers = require('./helpers');
 
-$('#primary_category_id').change(function() {
-  var $select = $('#sub_category_id');
-  $.getJSON(
-    helpers.buildUrl(['audit-category'], {
-      primary_category_id: $('#primary_category_id').val(),
-      per_page: 100
-    }),
-    function(data) {
-      $select.html('<option selected value="all">All</option>');
-      $('.sub--filter--indent')
-        .css('opacity', '.5')
-        .css({ pointerEvents: 'none' });
-
-      if (data.results[0]) {
-        $.each(data.results[0].sub_category_list, function(key, val) {
-          $select.append(
-            '<option value="' +
-              val.sub_category_id +
-              '">' +
-              val.sub_category_name +
-              '</option>'
-          );
-        });
+function auditCategorySubcategory() {
+  $('#primary_category_id').change(function() {
+    var $select = $('#sub_category_id');
+    $.getJSON(
+      helpers.buildUrl(['audit-category'], {
+        primary_category_id: $('#primary_category_id').val(),
+        per_page: 100
+      }),
+      function(data) {
+        $select.html('<option selected value="all">All</option>');
         $('.sub--filter--indent')
-          .css('opacity', '1')
-          .css({ pointerEvents: 'auto' });
-      }
-    }
-  );
-});
+          .css('opacity', '.5')
+          .css({ pointerEvents: 'none' });
 
-//for sub category filter-tag and results
+        if (data.results[0]) {
+          $.each(data.results[0].sub_category_list, function(key, val) {
+            $select.append(
+              '<option value="' +
+                val.sub_category_id +
+                '">' +
+                val.sub_category_name +
+                '</option>'
+            );
+          });
+          $('.sub--filter--indent')
+            .css('opacity', '1')
+            .css({ pointerEvents: 'auto' });
+        }
+      }
+    );
+  });
+}
+
 function showSubCategory() {
   var sub_selected = $('#sub_category_id option:selected').text();
   sub_selected == 'Choose a sub-category' ||
@@ -49,4 +50,7 @@ function showSubCategory() {
     : $('.tag__category.sub').css('visibility', 'visible');
 }
 
-$(document).bind('ready ajaxComplete', '#sub_category_id', showSubCategory);
+module.exports = {
+  auditCategorySubcategory: auditCategorySubcategory,
+  showSubCategory: showSubCategory
+};

--- a/fec/fec/static/js/modules/audit_tags.js
+++ b/fec/fec/static/js/modules/audit_tags.js
@@ -3,31 +3,35 @@
 var $ = require('jquery');
 var $auditCategoryTags = require('../templates/audit_tags.hbs');
 
-$('.data-container__tags').prepend($auditCategoryTags);
-$('.tag__category.sub').css('visibility', 'hidden');
-
-$('#primary_category_id').change(function() {
-  var current_category = $('#primary_category_id option:selected').text();
+function auditTags() {
+  $('.data-container__tags').prepend($auditCategoryTags);
   $('.tag__category.sub').css('visibility', 'hidden');
-  $('.tag__item.primary').contents()[0].nodeValue =
-    'Findings and issue category: ' + current_category;
-  $('#primary_category_id').val() == 'all'
-    ? $('.tag__item.primary button').hide()
-    : $('.tag__item.primary button').show();
-});
+  $('#primary_category_id').change(function() {
+    var current_category = $('#primary_category_id option:selected').text();
+    $('.tag__category.sub').css('visibility', 'hidden');
+    $('.tag__item.primary').contents()[0].nodeValue =
+      'Findings and issue category: ' + current_category;
+    $('#primary_category_id').val() == 'all'
+      ? $('.tag__item.primary button').hide()
+      : $('.tag__item.primary button').show();
+  });
 
-$('#sub_category_id').change(function() {
-  var current_sub = $('#sub_category_id option:selected').text();
-  $('.tag__item.sub').contents()[0].nodeValue = 'Sub Category: ' + current_sub;
-});
+  $('#sub_category_id').change(function() {
+    var current_sub = $('#sub_category_id option:selected').text();
+    $('.tag__item.sub').contents()[0].nodeValue =
+      'Sub Category: ' + current_sub;
+  });
 
-$('.js-close_sub').click(function() {
-  $('#primary_category_id').trigger('change');
-  $('#sub_category_id').val('all');
-});
+  $('.js-close_sub').click(function() {
+    $('#primary_category_id').trigger('change');
+    $('#sub_category_id').val('all');
+  });
 
-$('.js-close_primary').click(function() {
-  $('#primary_category_id').val('all');
-  $('#primary_category_id').trigger('change');
-  $('.tag__item.primary button').hide();
-});
+  $('.js-close_primary').click(function() {
+    $('#primary_category_id').val('all');
+    $('#primary_category_id').trigger('change');
+    $('.tag__item.primary button').hide();
+  });
+}
+
+module.exports = auditTags;

--- a/fec/fec/static/js/pages/datatable-audit.js
+++ b/fec/fec/static/js/pages/datatable-audit.js
@@ -12,7 +12,21 @@ var $ = require('jquery');
 var tables = require('../modules/tables');
 var columns = require('../modules/columns');
 
+var auditCategorySubcategory = require('../modules/audit-category-sub-category');
+var auditTags = require('../modules/audit_tags');
+//for sub category filter-tag and results
+
+//fixes bug but need to still refactor to match conventions in rest of app
+auditCategorySubcategory.auditCategorySubcategory();
+
+$(document).bind(
+  'ready ajaxComplete',
+  '#sub_category_id',
+  auditCategorySubcategory.showSubCategory
+);
+
 $(document).ready(function() {
+  auditTags();
   var $table = $('#results');
   new tables.DataTable($table, {
     autoWidth: false,

--- a/fec/fec/static/js/pages/datatable-audit.js
+++ b/fec/fec/static/js/pages/datatable-audit.js
@@ -16,9 +16,6 @@ var auditCategorySubcategory = require('../modules/audit-category-sub-category')
 var auditTags = require('../modules/audit_tags');
 //for sub category filter-tag and results
 
-//fixes bug but need to still refactor to match conventions in rest of app
-auditCategorySubcategory.auditCategorySubcategory();
-
 $(document).bind(
   'ready ajaxComplete',
   '#sub_category_id',
@@ -26,6 +23,7 @@ $(document).bind(
 );
 
 $(document).ready(function() {
+  auditCategorySubcategory.auditCategorySubcategory();
   auditTags();
   var $table = $('#results');
   new tables.DataTable($table, {


### PR DESCRIPTION
## Summary 

- Resolves #2342
`var = require` statements were removed by the format-linter because they were not being used as variables. However, the require statement was still making the script available to the page and running it. So removing them broke part of the datatable. Worked with @apburnes to refactor these scripts so they can be required in the app without failing the linters.

## Impacted areas of the application:
List general components of the application that this PR will affect:
modified:   fec/static/js/modules/audit-category-sub-category.js
modified:   fec/static/js/modules/audit_tags.js
modified:   fec/static/js/pages/datatable-audit.js

To test:
Run this branch locally and 
1) Make sure that the Sub-category dropdown works and that the filter tag in the head of the table populates with `Findings and issue category: All` upon page-load 
2) And then this filter tag updates as `Findings and issues` and `Sub categories` dropdown options are selected. 
You can compare with  broken behavior here:
https://fec-stage-proxy.app.cloud.gov/legal-resources/enforcement/audit-search/