### PR TITLE
Resource/Custom page template tweaks

### DIFF
--- a/fec/fec/static/scss/components/_type-styles.scss
+++ b/fec/fec/static/scss/components/_type-styles.scss
@@ -130,7 +130,8 @@
 
 // Set a bigger size to lead paragraphs
 .t-lead,
-.t-lead p {
+.t-lead p,
+.t-lead ul li {
   font-weight: regular;
   font-size: u(1.8rem);
   line-height: u(2.8rem);

--- a/fec/fec/static/scss/components/_type-styles.scss
+++ b/fec/fec/static/scss/components/_type-styles.scss
@@ -131,7 +131,8 @@
 // Set a bigger size to lead paragraphs
 .t-lead,
 .t-lead p,
-.t-lead ul li {
+.t-lead ul li,
+.t-lead ol li {
   font-weight: regular;
   font-size: u(1.8rem);
   line-height: u(2.8rem);

--- a/fec/home/blocks.py
+++ b/fec/home/blocks.py
@@ -135,6 +135,38 @@ class ReportingExampleCards(blocks.StructBlock):
         template = 'blocks/reporting-example-cards.html'
         icon = 'doc-empty'
 
+class CustomTableBlock(blocks.StructBlock):
+    """A custom table, works well with finacial information
+    Typicallyused for Statistical Press Release tables
+    """
+    custom_table_options = {
+    'startRows': 7,
+    'startCols': 6,
+    'colHeaders': True,
+    'rowHeaders': True,
+    'height': 108,
+    'language': 'en',
+    }
+
+    custom_table = blocks.StreamBlock([
+        ('title', blocks.CharBlock(required=False)),
+        ('table_intro', blocks.RichTextBlock(required=False)),
+        ('table', TableBlock(table_options=custom_table_options)),
+        ('footnote', blocks.CharBlock(required=False))
+    ])
+
+class ExampleImage(blocks.StructBlock):
+    """Creates an example module with an image and a caption, side-by-side
+    Typically used for showing reporting Examples
+    """
+    title = blocks.CharBlock(required=False)
+    caption = blocks.RichTextBlock(required=True)
+    image = ImageChooserBlock(required=True)
+
+    class Meta:
+        template = 'blocks/example-image.html'
+        icon = 'doc-empty'
+
 class ResourceBlock(blocks.StructBlock):
     """A section of a ResourcePage"""
     title = blocks.CharBlock(required=True)
@@ -153,9 +185,12 @@ class ResourceBlock(blocks.StructBlock):
         ('mur_search', MURSearchBlock()),
         ('audit_search', AuditSearchBlock()),
         ('table', TableBlock()),
+        ('custom_table', CustomTableBlock()),
         ('html', blocks.RawHTMLBlock()),
         ('reporting_example_cards', ReportingExampleCards()),
         ('contribution_limits_table', SnippetChooserBlock('home.EmbedTableSnippet', template = 'blocks/embed-table.html', icon='table')),
+        ('image', ImageChooserBlock()),
+        ('example_image', ExampleImage())
     ])
 
     aside = blocks.StreamBlock([
@@ -204,42 +239,12 @@ class ExampleParagraph(blocks.StructBlock):
 
 class ExampleForms(blocks.StructBlock):
     """For showing one or two example documents"""
-    title = blocks.CharBlock(required=True);
+    title = blocks.CharBlock(required=True)
     forms = blocks.ListBlock(ThumbnailBlock())
 
     class Meta:
         template = 'blocks/example-forms.html'
         icon = 'doc-empty'
-
-class ExampleImage(blocks.StructBlock):
-    """Creates an example module with an image and a caption, side-by-side
-    Typically used for showing reporting Examples
-    """
-    title = blocks.CharBlock(required=False)
-    caption = blocks.RichTextBlock(required=True)
-    image = ImageChooserBlock(required=True)
-
-    class Meta:
-        template = 'blocks/example-image.html'
-        icon = 'doc-empty'
-
-class CustomTableBlock(blocks.StructBlock):
-    """A custom table"""
-    custom_table_options = {
-    'startRows': 7,
-    'startCols': 6,
-    'colHeaders': True,
-    'rowHeaders': True,
-    'height': 108,
-    'language': 'en',
-    }
-
-    custom_table = blocks.StreamBlock([
-        ('title', blocks.CharBlock(required=False)),
-        ('table_intro', blocks.RichTextBlock(required=False)),
-        ('table', TableBlock(table_options=custom_table_options)),
-        ('footnote', blocks.CharBlock(required=False))
-    ])
 
     class Meta:
         template = 'blocks/custom_table.html'

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -874,8 +874,7 @@ class ResourcePage(Page):
         ('related_pages', blocks.ListBlock(blocks.PageChooserBlock()))
     ], null=True, blank=True)
     sections = StreamField([
-        ('sections', ResourceBlock()),
-        ('image', ImageChooserBlock())
+        ('sections', ResourceBlock())
     ], null=True, blank=True)
     citations = StreamField([
         ('citations', blocks.ListBlock(CitationsBlock()))

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -47,7 +47,7 @@ from home.blocks import (ThumbnailBlock, AsideLinkBlock,
                          OptionBlock, CollectionBlock, DocumentFeedBlurb,
                          ExampleParagraph, ExampleForms, ExampleImage,
                          CustomTableBlock, ReportingExampleCards, InternalButtonBlock,
-                         ExternalButtonBlock, SnippetChooserBlock)
+                         ExternalButtonBlock, SnippetChooserBlock, ExampleImage)
 
 
 stream_factory = functools.partial(
@@ -571,6 +571,7 @@ class CustomPage(Page):
         ('heading', blocks.CharBlock(classname='full title')),
         ('paragraph', blocks.RichTextBlock()),
         ('html', blocks.RawHTMLBlock()),
+        ('example_image', ExampleImage()),
         ('image', ImageChooserBlock()),
         ('table', TableBlock()),
         ('example_paragraph', ExampleParagraph()),
@@ -580,7 +581,7 @@ class CustomPage(Page):
         ('internal_button', InternalButtonBlock()),
         ('external_button', ExternalButtonBlock()),
         ('contribution_limits_table', SnippetChooserBlock('home.EmbedTableSnippet', template = 'blocks/embed-table.html', icon='table')),
-    ])
+    ], null=True)
     sidebar = stream_factory(null=True, blank=True)
     related_topics = StreamField([
         ('related_topics', blocks.ListBlock(


### PR DESCRIPTION
## Summary
Add requested blocks to `ResourcePage template:

- Add `example_image` and `image` blocks to Sections on Resource template and Body on Custom template
- Add `custom-table` to block to sections on Resource template

Remove `image block` from same level as sections (This was breaking scrollTo animation and not working itself as anchor in menu)

Fix incorrect small font size on `Intro field` ordered/unordered lists

**Resolves** #1916
**Resolves** #2304
This is on feature space for @dorothyyeager and @llienfec to test resource/custom  page templates to confirm that this covers everything needed. 

## Impacted areas of the application
This effects the Wagtail Resource Page and Custom Page templates
/fec/home/blocks.py
/fec/home/models.py
fec/fec/static/scss/components/_type_styles.scss

## Screenshots
### Resource Page
![wagtail_tweaks](https://user-images.githubusercontent.com/5572856/45334430-c60fd800-b548-11e8-98ef-74f3d8cb1713.jpg)

