### PR TITLE
Update wagtail to v2.2.1 and responsive video styling

### DIFF
--- a/fec/fec/static/scss/base.scss
+++ b/fec/fec/static/scss/base.scss
@@ -20,6 +20,7 @@
 @import "components/overlay";
 @import "components/pagination";
 @import "components/posts";
+@import "components/responsive-object";
 @import "components/search-bar";
 @import "components/search-results";
 @import "components/side-nav";

--- a/fec/fec/static/scss/components/_responsive-object.scss
+++ b/fec/fec/static/scss/components/_responsive-object.scss
@@ -1,0 +1,9 @@
+.responsive-object {
+	width: 100% !important;
+	height: auto !important;
+	padding: 0 !important;
+
+	iframe {
+		width: 100% !important;
+	}
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ psycopg2==2.7.1
 requests==2.13.0
 slacker==0.8.6
 whitenoise==2.0.3
-wagtail==2.0.1
+wagtail==2.2.1
 # TODO: pin version
 django-audit-log
 Jinja2==2.9.6


### PR DESCRIPTION
## Summary (required)

- Resolves #2336 
- Upgrades the wagtail version
- Adds the `responsive-object` styling to fix embedded videos in wagtail
- Add copy and paste functionality to wagtail draftail editor

## Impacted areas of the application
- Upgrade wagtail python package
- additional database migrations
  - `wagtaildocs.0008_document_file_size`
  - `wagtailimages.0020_add-verbose-name`
  - `wagtailimages.0021_image_file_hash`
  - `wagtailredirects.0006_redirect_increase_max_length`
  - `wagtailusers.0007_userprofile_current_time_zone`
  - `wagtailusers.0008_userprofile_avatar`
- add `scss` component for class `.responsive-object`
