### PR TITLE
Updated links to point to new cms training page

### DIFF
--- a/fec/fec/templates/partials/navigation/nav-help.html
+++ b/fec/fec/templates/partials/navigation/nav-help.html
@@ -10,7 +10,7 @@
             <li class="mega__item"><a href="/help-candidates-and-committees/guides">Guides</a></li>
             <li class="mega__item"><a href="/help-candidates-and-committees/forms">Forms</a></li>
             <li class="mega__item"><a  href="/help-candidates-and-committees/dates-and-deadlines">Dates and deadlines</a></li>
-            <li class="mega__item"><a  href="https://transition.fec.gov/info/outreach.shtml">Trainings</a></li>
+            <li class="mega__item"><a  href="/help-candidates-and-committees/trainings/">Trainings</a></li>
           </ul>
         </div>
         <div class="usa-width-one-third u-padding--left">

--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -104,7 +104,7 @@
       </li>
       <li class="grid__item grid__item--with-img">
         <img src="{% static 'img/feature--training.jpg' %}" alt="">
-        <h3 class="u-margin--top"><a href="https://transition.fec.gov/info/outreach.shtml">Education and learning</a></h3>
+        <h3 class="u-margin--top"><a href="/help-candidates-and-committees/trainings/">Education and learning</a></h3>
         <p>Videos, trainings, webinars and conferences</p>
       </li>
     </ul>


### PR DESCRIPTION
## Summary

- Resolves #2319 
- Updated  training link on Help for candidates and committees main navigation menu and link with picture labeled "Education and learning" on help for candidates and committees landing page

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Help for candidates and committees navigation menu
- Services landing page education and outreach link