### PR TITLE
Removes hardcoded contact page information

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -58,7 +58,8 @@ stream_factory = functools.partial(
         ('html', blocks.RawHTMLBlock()),
         ('image', ImageChooserBlock()),
         ('table', TableBlock()),
-        ('custom_table', CustomTableBlock())
+        ('custom_table', CustomTableBlock()),
+        ('contact', ContactInfoBlock())
     ],
 )
 

--- a/fec/home/templates/home/press_landing_page.html
+++ b/fec/home/templates/home/press_landing_page.html
@@ -63,28 +63,6 @@
       <div id="contact" class="option">
         <h2>Contact</h2>
         {{ self.contact_intro }}
-        <ul class="grid--3-wide row">
-          <li class="grid__item contact-item">
-            <div class="contact-item__icon">
-              <img src="{% static "img/i-phone--primary.svg" %}" alt="Icon of a phone">
-            </div>
-            <div class="contact-item__content">
-              <h5 class="contact-item__title">Local</h5>
-              <span class="t-block">(202) 694-1220</span>
-              <span class="t-block">7:00 a.m. to 6:00 p.m.</span>
-              <span class="t-block">M-F, Eastern Time</span>
-            </div>
-          </li>
-          <li class="grid__item contact-item">
-            <div class="contact-item__icon">
-              <img src="{% static "img/i-email--primary.svg" %}" alt="Icon of an email envelope">
-            </div>
-            <div class="contact-item__content">
-              <span class="t-block"><a href="mailto:press@fec.gov">press@fec.gov</a></span>
-            </div>
-          </li>
-        </ul>
-        <p>If you need to reach the Press Office during non-business hours, please call the FEC's Press Officer, Judith Ingram, at (202) 531-2882.</p>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Summary

- Resolves #2374 
_This PR removes the hardcoded contact page information from the press landing page and leaves only the intro section. Needed to do this so that we can insert an HTML block into the contact intro for easier changes without needing a code change._

Follow-up issue to insert the HTML block is here: https://github.com/fecgov/fec-cms/issues/2375

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Press landing page