### PR TITLE
Adds feature flag for line charts

### DIFF
--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -187,6 +187,7 @@
       </div>
     </div>
   </section>
+  {% if FEATURES.linecharts %}
   <div class="content__section--extra">
     <h2 class="t-ruled--bottom">Get started with campaign finance data</h2>
     <section class="content__section" id="raising">
@@ -261,6 +262,7 @@
       {{ reaction.reaction_box('spent', 'landing') }}
     </section>
   </div>
+  {% endif %}
 </div>
 {% endblock %}
 

--- a/fec/data/templates/partials/advanced/raising.jinja
+++ b/fec/data/templates/partials/advanced/raising.jinja
@@ -39,6 +39,7 @@
           </div>
         </div>
       </li>
+      {% if FEATURES.linecharts %}
       <li>
         <section class="content__section" style="padding-top: 3rem;">
           <div class="heading--section heading--with-action" style="border: none;padding: 0">
@@ -90,6 +91,7 @@
           {{ reaction.reaction_box('raised', 'advanced') }}
         </section>
       </li>
+      {% endif %}
     </ul>
   </div>
 </section>

--- a/fec/data/templates/partials/advanced/spending.jinja
+++ b/fec/data/templates/partials/advanced/spending.jinja
@@ -95,7 +95,7 @@
           </div>
         </div>
       </li>
-      <li>
+      {% if FEATURES.linecharts %}
       <li>
         <section class="content__section" style="padding-top: 3rem;">
           <div class="heading--section heading--with-action" style="border: none;padding: 0">
@@ -149,6 +149,7 @@
           {{ reaction.reaction_box('spent', 'advanced') }}
         </section>
       </li>
+      {% endif %}
     </ul>
   </div>
 </section>

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -46,6 +46,7 @@ FEATURES = {
     'agendas': bool(env.get_credential('FEC_FEATURE_AGENDAS', '')),
     'tips': bool(env.get_credential('FEC_FEATURE_TIPS', '')),
     'radform': bool(env.get_credential('FEC_FEATURE_RADFORM', '')),
+    'linecharts': bool(env.get_credential('FEC_FEATURE_LINECHARTS', '')),
 }
 
 ENVIRONMENTS = {
@@ -141,6 +142,7 @@ TEMPLATES = [
                 'TRANSITION_URL': FEC_TRANSITION_URL,
                 'CLASSIC_URL': FEC_CLASSIC_URL,
                 'FEC_CMS_ENVIRONMENT': FEC_CMS_ENVIRONMENT,
+                'FEATURES': FEATURES,
             },
         }
     },

--- a/fec/fec/static/js/pages/data-landing.js
+++ b/fec/fec/static/js/pages/data-landing.js
@@ -21,8 +21,7 @@ function Overview(selector, type, index) {
   this.zeroPadTotals();
 
   $(window).on('resize', this.zeroPadTotals.bind(this));
-
-  if (helpers.isInViewport(this.$element)) {
+  if (this.$element.length > 0 && helpers.isInViewport(this.$element)) {
     this.init();
   } else {
     $(window).on('scroll', this.init.bind(this));


### PR DESCRIPTION
## Summary

_For easier feature control, this PR adds a feature flag for the line chart feature._

- To leave the linecharts turned on, set the flag in the environment: `export FEC_FEATURE_LINECHARTS=true`
- To turn off the linechart feature, remove the FEC_FEATURE_LINECHARTS from the environment variables

## What to test
List general components of the application that this PR will affect:

- Data landing: http://localhost:8000/data/
- Raising advanced data page: http://localhost:8000/data/advanced/?tab=raising
- Spending advanced data page: http://localhost:8000/data/advanced/?tab=spending

## To do:
- [ ] After merging this PR, we need to add FEC_FEATURE_LINECHARTS to all 3 environments 