### PR TITLE
Fix filings tab responsive issues

### DIFF
--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -261,7 +261,7 @@ var statementsOfCandidacyColumns = [
   {
     data: 'beginning_image_number',
     orderable: false,
-    className: 'min-tablet hide-panel column--xs column--number',
+    className: 'min-desktop',
     render: function(data, type, row) {
       return row.beginning_image_number;
     }
@@ -269,7 +269,7 @@ var statementsOfCandidacyColumns = [
   {
     data: 'beginning_image_number',
     orderable: false,
-    className: 'min-tablet hide-panel column--xs column--number',
+    className: 'min-desktop',
     render: function(data, type, row) {
       // Image numbers in 2015 and later begin with YYYYMMDD,
       // which makes for a very big number.


### PR DESCRIPTION
## Summary
Filings tab was not responding properly to different screen sizes causing table to be cut off and not match experience of other tables in the profile pages.

- Resolves #2381

Add proper class names to hide image number and pages at med breakpoint


## Impacted areas of the application
modified:   fec/static/js/pages/candidate-single.js

![resp_scrnsht](https://user-images.githubusercontent.com/5572856/45660869-f61b2600-bac8-11e8-8da0-a16f0ee4afb7.gif)
