### PR TITLE
Fixed election dropdown on candidate profile page

### DIFF
--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -30,15 +30,17 @@
 {% macro candidate_cycle_select(cycles, cycle=none, id='') %}
 {% set cycle = cycle | int %}
   <div class="content__section">
-    <label for="{{id}}-cycle" class="label cycle-select__label">Election</label>
-    <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query" data-election-full="False">
-      {% for each in cycles | sort(reverse=True) %}
-        <option
-            value="{{ each }}"
-            {% if cycle and cycle <= each and cycle > (each - 2) %}selected{% endif %}
-          >{{ each }}</option>
-      {% endfor %}
-    </select>
+    <div class="cycle-select js-cycle-select">
+      <label for="{{id}}-cycle" class="label cycle-select__label">Election</label>
+      <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query" data-election-full="False">
+        {% for each in cycles | sort(reverse=True) %}
+          <option
+              value="{{ each }}"
+              {% if cycle and cycle <= each and cycle > (each - 2) %}selected{% endif %}
+            >{{ each }}</option>
+        {% endfor %}
+      </select>
+    </div>
   </div>
 {% endmacro %}
 

--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -30,14 +30,14 @@
 {% macro candidate_cycle_select(cycles, cycle=none, id='') %}
 {% set cycle = cycle | int %}
   <div class="content__section">
-    <div class="cycle-select js-cycle-select">
-      <label for="{{id}}-cycle" class="label cycle-select__label">Election</label>
+    <div class="cycle-select">
+      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year period</label>
       <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query" data-election-full="False">
         {% for each in cycles | sort(reverse=True) %}
           <option
               value="{{ each }}"
               {% if cycle and cycle <= each and cycle > (each - 2) %}selected{% endif %}
-            >{{ each }}</option>
+            >{{ each|fmt_year_range }}</option>
         {% endfor %}
       </select>
     </div>


### PR DESCRIPTION
## Summary

- Resolves #2341 
_Inserts additional div container with cycle classes to fix election dropdown width._

http://localhost:8000/data/candidate/S2MA00170/?tab=raising
http://localhost:8000/data/candidate/S2MA00170/?tab=spending

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile pages: Raising & Spending tab