### PR TITLE
Update date parsing for plot points to work on iphone too

### DIFF
--- a/fec/fec/static/js/modules/line-chart-committees.js
+++ b/fec/fec/static/js/modules/line-chart-committees.js
@@ -10,6 +10,7 @@ var helpers = require('./helpers');
 var parseM = d3.time.format('%b');
 var parseMY = d3.time.format('%b %Y');
 var parseMDY = d3.time.format('%m/%d/%Y');
+var parsePlotPoints = d3.time.format('%Y-%m-01T%H:%M:%S.%L');
 
 var bisectDate = d3.bisector(function(d) {
   return d.date;
@@ -234,7 +235,7 @@ LineChartCommittees.prototype.drawChart = function() {
   var lineBuilder = d3.svg
     .line()
     .x(function(d) {
-      var myDate = new Date(parseMY(d.date));
+      var myDate = new Date(parsePlotPoints(d.date));
       return x(myDate);
     })
     .y(function(d) {
@@ -259,7 +260,7 @@ LineChartCommittees.prototype.drawChart = function() {
       .enter()
       .append('circle')
       .attr('cx', function(d) {
-        var myDate = new Date(parseMY(d.date));
+        var myDate = new Date(parsePlotPoints(d.date));
         return x(myDate);
       })
       .attr('cy', function(d) {
@@ -324,7 +325,7 @@ LineChartCommittees.prototype.handleMouseMove = function() {
 LineChartCommittees.prototype.moveCursor = function(datum) {
   var target = datum ? datum : this.getCursorStartPosition();
   var i = this.chartData.indexOf(target);
-  var myDate = new Date(parseMY(target.date));
+  var myDate = new Date(parsePlotPoints(target.date));
   this.cursor.attr('x1', this.x(myDate)).attr('x2', this.x(myDate));
   this.nextDatum = this.chartData[i + 1] || false;
   this.prevDatum = this.chartData[i - 1] || false;

--- a/fec/fec/static/js/modules/line-chart.js
+++ b/fec/fec/static/js/modules/line-chart.js
@@ -10,6 +10,7 @@ var helpers = require('./helpers');
 var parseM = d3.time.format('%b');
 var parseMY = d3.time.format('%b %Y');
 var parseMDY = d3.time.format('%m/%d/%Y');
+var parsePlotPoints = d3.time.format('%Y-%m-01T%H:%M:%S.%L');
 
 var bisectDate = d3.bisector(function(d) {
   return d.date;
@@ -231,7 +232,7 @@ LineChart.prototype.drawChart = function() {
   var lineBuilder = d3.svg
     .line()
     .x(function(d) {
-      var myDate = new Date(parseMY(d.date));
+      var myDate = new Date(parsePlotPoints(d.date));
       return x(myDate);
     })
     .y(function(d) {
@@ -256,7 +257,7 @@ LineChart.prototype.drawChart = function() {
       .enter()
       .append('circle')
       .attr('cx', function(d) {
-        var myDate = new Date(parseMY(d.date));
+        var myDate = new Date(parsePlotPoints(d.date));
         return x(myDate);
       })
       .attr('cy', function(d) {
@@ -319,7 +320,7 @@ LineChart.prototype.handleMouseMove = function() {
 LineChart.prototype.moveCursor = function(datum) {
   var target = datum ? datum : this.getCursorStartPosition();
   var i = this.chartData.indexOf(target);
-  var myDate = new Date(parseMY(target.date));
+  var myDate = new Date(parsePlotPoints(target.date));
   this.cursor.attr('x1', this.x(myDate)).attr('x2', this.x(myDate));
   this.nextDatum = this.chartData[i + 1] || false;
   this.prevDatum = this.chartData[i - 1] || false;


### PR DESCRIPTION
## Updates date parsing to also work on iphone browsers

_Adds an updated date format for plotting the chart line and points to work on Iphone_

## Impacted areas of the application
- `line-chart.js`
- `line-chart-committees.js`

### Fix Reference
- https://stackoverflow.com/questions/21883699/safari-javascript-date-nan-issue-yyyy-mm-dd-hhmmss/21884244#21884244