### PR TITLE
Make related media optional in reporting_example template

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -1119,7 +1119,7 @@ class ReportingExamplePage(Page):
     related_media_title = models.CharField(blank=True, null=True, max_length=255)
     related_media = StreamField([
         ('continue_learning', blocks.ListBlock(ThumbnailBlock(), icon='doc-empty', template='blocks/related-media.html')),
-    ], null=True)
+    ], null=True, blank=True)
 
     content_panels = Page.content_panels + [
         FieldPanel('pre_title'),


### PR DESCRIPTION
## Summary 

Make related media optional in reporting_example template so that new `reporting_example` pages can be published without r`elated media` 

- Resolves #2398
Related to issue #2389

## Impacted areas of the application
modified:   home/models.py (no migration)