### PR TITLE
Move polyfills scripts to be loaded for all /data routes

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -11,7 +11,9 @@
   <link rel="stylesheet" type="text/css" href="{{ asset_for_css('base.css') }}" />
   {% endblock css %}
 
-  {% block head_js %}{% endblock %}
+  {% block head_js %}
+    <script src="{{ asset_for_js('polyfills.js') }}"></script>
+  {% endblock %}
 
   <script>
     BASE_PATH = '/data';

--- a/fec/legal/templates/legal-search-results-advisory_opinions.jinja
+++ b/fec/legal/templates/legal-search-results-advisory_opinions.jinja
@@ -2,10 +2,6 @@
 {% import 'macros/legal.jinja' as legal %}
 {% set document_type_display_name = 'advisory opinions' %}
 
-{% block head_js %}
-<script src="{{ asset_for_js('polyfills.js') }}"></script>
-{% endblock %}
-
 {% block header %}
 <header class="page-header slab slab--primary">
   {{ breadcrumb.breadcrumbs('Search results', [('/legal-resources', 'Legal resources'), ('/data/legal/advisory-opinions/', 'Advisory opinions')]) }}


### PR DESCRIPTION
## Move polyfills into all routes under `/data` to support maps in IE

- Closes https://github.com/fecgov/openFEC/issues/3407

## Impacted areas of the application
- Move the current polyfills used to support IE in the legal app to be used for all `/data` routes.
- Now it will support all maps, graphs, react, and any unsupported js methods in IE
