### PR TITLE
Fix Form 1 and Form 2 original/amendment labels

### DIFF
--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -388,7 +388,12 @@ function amendmentVersionDescription(row) {
   }
 
   // Filings with amendment_indicator = N are the originals
-  if (row.amendment_indicator === API.amendment_indicator_new) {
+  // Amendment chain should be 1 - this handles filings with unknown versions
+  // and F1N & F2 that are filed as N but are not originals
+  if (
+    row.amendment_indicator === API.amendment_indicator_new &&
+    row.amendment_chain.length === 1
+  ) {
     description = ' Original';
   }
 

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -416,7 +416,8 @@ function amendmentVersionDescription(row) {
     if (row.amendment_chain) {
       amendment_num = row.amendment_chain.length - 1;
     }
-    if (amendment_num === 0) {
+    // Don't show amendment number for F1 and F2 - it's unreliable data
+    if (amendment_num === 0 || row.form_type == 'F2' || row.form_type == 'F1') {
       amendment_num = '';
     }
     description = ' Amendment ' + amendment_num;


### PR DESCRIPTION
## Summary (required)

- Resolves #2403 
**Hide amendment version, only show "Original" when it's confirmed for F1 and F2**

## Impacted areas of the application
List general components of the application that this PR will affect:

- Only show 'original' if amendment chain is 1 
- Don't show amendment number for F1 and F2 due to unreliable data **Note** This is still wonky for F1N's that were filed when we first moved to file ID's around 2006:
<img width="719" alt="screen shot 2018-09-28 at 9 41 57 am" src="https://user-images.githubusercontent.com/31420082/46216764-4e92c480-c30e-11e8-9a91-fd4ffac35e38.png">



## Testing links
http://localhost:8000/data/committee/C00491951/?tab=filings&cycle=2014
http://localhost:8000/data/candidate/H8WI01024/?tab=filings
http://localhost:8000/data/candidate/H8CA05035/?tab=filings

## Screenshots

### Only show "Original" when it's confirmed with an amendment_chain of 1
<img width="706" alt="screen shot 2018-09-28 at 11 01 36 am" src="https://user-images.githubusercontent.com/31420082/46216571-e7751000-c30d-11e8-897d-74f65fa7ce23.png">



###  Hide amendment version for F1 and F2, because the data is unreliable
<img width="700" alt="screen shot 2018-09-28 at 9 41 46 am" src="https://user-images.githubusercontent.com/31420082/46216461-9f55ed80-c30d-11e8-932e-9c8fb7c6c833.png">


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
`feature/fix-most-recent-logic` | https://github.com/fecgov/openFEC/pull/3392
