### PR TITLE
Fix candidate compare button

### DIFF
--- a/fec/data/templates/candidates-single.jinja
+++ b/fec/data/templates/candidates-single.jinja
@@ -117,7 +117,7 @@
             </ul>
         </li>
         <li class="side-nav__item">
-          <a class="button button--cta u-margin--top t-left-aligned button--two-candidates u-full-width" href="{{ get_election_url(candidate, cycle, district) }}">Compare to<br>opposing candidates</a>
+          <a class="button button--cta u-margin--top t-left-aligned button--two-candidates u-full-width" href="{{ get_election_url(candidate, election_year, district) }}">Compare to<br>opposing candidates</a>
         </li>
       </ul>
     </nav>

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -54,8 +54,8 @@
 
       <div class="usa-width-one-fourth">
         <div class="card">
-          {% if get_election_url(candidate, cycle, district) %}
-          <a href="{{ get_election_url(candidate, cycle, district) }}">
+          {% if get_election_url(candidate, election_year, district) %}
+          <a href="{{ get_election_url(candidate, election_year, district) }}">
             <div class="card__image__container">
               <img class="icon--complex" src="/static/img/i-elections--primary.svg" alt="Icon representing elections">
             </div>

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -145,6 +145,25 @@ class TestCandidate(TestCase):
         assert candidate["election_years"] == [2018, 2020]
         assert candidate["election_year"] == 2018
 
+    def test_past_special_returns_election_year(
+            self, load_with_nested_mock, load_candidate_totals_mock,
+            load_candidate_statement_of_candidacy_mock):
+
+        # Candidate ran in 2017 and 2018. Passing 2020 as cycle.
+        # Election years should be rounded, election year should be 2018
+        test_candidate = copy.deepcopy(self.STOCK_CANDIDATE)
+        test_candidate["cycles"] = [2016, 2018]
+        test_candidate["election_years"] = [2017, 2018]
+
+        load_with_nested_mock.return_value = (
+            test_candidate,
+            mock.MagicMock(),
+            2020
+        )
+        candidate = get_candidate('C001', 2020, True)
+        assert candidate["election_years"] == [2018]
+        assert candidate["election_year"] == 2018
+
     def test_candidate_with_future_cycle_falls_back_to_present(
             self, load_with_nested_mock, load_candidate_totals_mock,
             load_candidate_statement_of_candidacy_mock):

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -143,7 +143,7 @@ class TestCandidate(TestCase):
         )
         candidate = get_candidate('C001', 2016, True)
         assert candidate["election_years"] == [2018, 2020]
-        assert candidate["election_year"] == 2017
+        assert candidate["election_year"] == 2018
 
     def test_candidate_with_future_cycle_falls_back_to_present(
             self, load_with_nested_mock, load_candidate_totals_mock,

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -118,9 +118,11 @@ def get_candidate(candidate_id, cycle, election_full):
         )
 
     election_year = next(
-        (year for year in sorted(candidate['election_years']) if year >= cycle),
+        (year for year in sorted(candidate['election_years']) if year + year % 2 >= cycle),
         None,
     )
+    if election_year:
+        election_year = election_year + election_year % 2
 
     result_type = 'candidates'
     duration = election_durations.get(candidate['office'], 2)

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -117,12 +117,20 @@ def get_candidate(candidate_id, cycle, election_full):
             election_full=election_full,
         )
 
+    # Addresses issue#1644 - make any odd year special election an even year
+    #  for displaying elections for pulldown menu in Candidate pages
+    #  Using Set to ensure no duplicate years in final list
+    even_election_years = list({ year + (year % 2) for year in candidate.get('election_years', []) })
+
     election_year = next(
-        (year for year in sorted(candidate['election_years']) if year + year % 2 >= cycle),
+        (year for year in sorted(even_election_years) if year >= cycle),
         None,
     )
-    if election_year:
-        election_year = election_year + election_year % 2
+
+    # If the candidate is not running in a future election, 
+    # return the most recent even eleciton year
+    if not election_year:
+        election_year = max(even_election_years)
 
     result_type = 'candidates'
     duration = election_durations.get(candidate['office'], 2)
@@ -137,11 +145,6 @@ def get_candidate(candidate_id, cycle, election_full):
         'electionFull': election_full,
         'candidateID': candidate['candidate_id']
     }
-
-     # Addresses issue#1644 - make any odd year special election an even year
-    #  for displaying elections for pulldown menu in Candidate pages
-    #  Using Set to ensure no duplicate years in final list
-    even_election_years = list({ year + (year % 2) for year in candidate.get('election_years', []) })
 
     # In the case of when a presidential or senate candidate has filed
     # for a future year that's beyond the current cycle,


### PR DESCRIPTION
## Summary

- Resolves #2321 
Fixes candidate compare button by using election year. If there's an odd election year passed, it will make it an even year.

## Test URLs:
**Candidate: Jon Ossoff**
- http://localhost:8000/data/candidate/H8GA06195/

**Candidate: Elizabeth Warren**
- http://localhost:8000/data/candidate/S2MA00170/