### PR TITLE
Recaptcha badge placement

### DIFF
--- a/fec/fec/static/js/templates/feedback.hbs
+++ b/fec/fec/static/js/templates/feedback.hbs
@@ -32,7 +32,7 @@
         <span class="label--help">I'm a <span class="u-blank-space"></span> interested in <span class="u-blank-space"></span>.</span>
         <textarea id="feedback-3" name="about"></textarea>
         <button class="g-recaptcha button--cta feedback__button u-no-margin" data-sitekey="6Lc0uGwUAAAAALGRGXt3mTteJeb_lbse2frNdWjv" data-callback="submitFeedback" data-badge="inline">Post</button>
-        <p class="feedback-links t-sans t-note u-margin--top"><a href="https://github.com/FECgov/FEC/issues">Review all reported feedback</a>  |  <a href="/contact/">Contact the FEC about a specific question</a>  |  <a href="/use-recaptcha/">Use of reCAPTCHA</a></p>
+        <p class="t-sans t-note u-margin--top"><a href="https://github.com/FECgov/FEC/issues">Review all reported feedback</a>  |  <a href="/contact/">Contact the FEC about a specific question</a>  |  <a href="/use-recaptcha/">Use of reCAPTCHA</a></p>
       </fieldset>
     </form>
   </div>

--- a/fec/fec/static/js/templates/feedback.hbs
+++ b/fec/fec/static/js/templates/feedback.hbs
@@ -31,8 +31,8 @@
         <label for="feedback-3" class="label">Tell us about yourself</label>
         <span class="label--help">I'm a <span class="u-blank-space"></span> interested in <span class="u-blank-space"></span>.</span>
         <textarea id="feedback-3" name="about"></textarea>
-        <button class="g-recaptcha button--cta feedback__button u-no-margin" data-sitekey="6Lc0uGwUAAAAALGRGXt3mTteJeb_lbse2frNdWjv" data-callback="submitFeedback" data-badge="bottomleft">Post</button>
-        <p class="t-sans t-note u-margin--top"><a href="https://github.com/FECgov/FEC/issues">Review all reported feedback</a>  |  <a href="/contact/">Contact the FEC about a specific question</a>  |  <a href="/use-recaptcha/">Use of reCAPTCHA</a></p>
+        <button class="g-recaptcha button--cta feedback__button u-no-margin" data-sitekey="6Lc0uGwUAAAAALGRGXt3mTteJeb_lbse2frNdWjv" data-callback="submitFeedback" data-badge="inline">Post</button>
+        <p class="feedback-links t-sans t-note u-margin--top"><a href="https://github.com/FECgov/FEC/issues">Review all reported feedback</a>  |  <a href="/contact/">Contact the FEC about a specific question</a>  |  <a href="/use-recaptcha/">Use of reCAPTCHA</a></p>
       </fieldset>
     </form>
   </div>

--- a/fec/fec/static/scss/components/_feedback.scss
+++ b/fec/fec/static/scss/components/_feedback.scss
@@ -118,7 +118,7 @@
 
 }
 
-#feedback-3 + div {
+.feedback textarea:last-of-type + div{
   height:0;
 }
 

--- a/fec/fec/static/scss/components/_feedback.scss
+++ b/fec/fec/static/scss/components/_feedback.scss
@@ -60,6 +60,11 @@
     top: u(1rem);
   }
 
+  .feedback-links {
+    position: relative;
+    bottom: u(6rem);
+  }
+
   @include media($lg) {
     @include transition(top .5s);
     height: 95vh;
@@ -110,6 +115,13 @@
 
 .feedback__button {
   margin-top: u(1rem);
+  position: relative;
+  bottom: u(6rem);
+}
+
+.grecaptcha-badge {
+  position: relative;
+  bottom: u(-10rem);
 }
 
 @media print {

--- a/fec/fec/static/scss/components/_feedback.scss
+++ b/fec/fec/static/scss/components/_feedback.scss
@@ -10,7 +10,7 @@
   display: block;
   left: u(.5rem);
   overflow-y: scroll;
-  padding: u(2rem .5rem);
+  padding: u(2rem .5rem 8rem .5rem);
   position: fixed;
   right: u(.5rem);
   top: u(.5rem);
@@ -60,17 +60,12 @@
     top: u(1rem);
   }
 
-  .feedback-links {
-    position: relative;
-    bottom: u(6rem);
-  }
-
   @include media($lg) {
     @include transition(top .5s);
     height: 95vh;
     left: auto;
     overflow: auto;
-    padding: u(3rem 3rem 0 3rem);
+    padding: u(3rem 3rem 8rem 3rem);
     right: u(4rem);
     top: 5vh;
     width: u(52rem);
@@ -115,13 +110,16 @@
 
 .feedback__button {
   margin-top: u(1rem);
-  position: relative;
-  bottom: u(6rem);
 }
 
 .grecaptcha-badge {
   position: relative;
   bottom: u(-10rem);
+
+}
+
+#feedback-3 + div {
+  height:0;
 }
 
 @media print {


### PR DESCRIPTION
## Summary (required)
- Placement of recaptcha badge under the submit button and links at bottom of feedback drawer instead of docked above the button as it renders by default
- Fix relative spacing issues with button/links so that if feedback badge does not render due to cacheing, it just leaves a blank space at bottom of drawer.

- Resolves #2205
- Related PR https://github.com/fecgov/fec-cms/issues/2353

## Impacted areas of the application
	modified:   fec/static/js/templates/feedback.hbs
	modified:   fec/static/scss/components/_feedback.scss

## Screenshots
#### Cached view: (hopefully this will be rare, if at-all on production) 
<img width="1215" alt="screen shot 2018-10-02 at 10 48 43 pm" src="https://user-images.githubusercontent.com/5572856/46387884-1d601e80-c697-11e8-8dac-266e72898691.png">
<hr>

#### Normal view:
<img width="1150" alt="screen shot 2018-10-02 at 11 08 38 pm" src="https://user-images.githubusercontent.com/5572856/46388104-6664a280-c698-11e8-9f1d-cc82d022d072.png">




