### PR TITLE
Fix recaptcha for Internet Explorer

### DIFF
--- a/fec/fec/static/scss/components/_feedback.scss
+++ b/fec/fec/static/scss/components/_feedback.scss
@@ -109,17 +109,23 @@
 }
 
 .feedback__button {
-  margin-top: u(1rem);
+  margin-top:1rem;
 }
 
 .grecaptcha-badge {
   position: relative;
   bottom: u(-10rem);
+}
 
+.feedback__button {
+  margin-top:1rem;
 }
 
 .feedback textarea:last-of-type + div{
-  height:0;
+display:block;
+height:0px;
+width:1px;
+zoom:1;
 }
 
 @media print {

--- a/fec/fec/static/scss/components/_feedback.scss
+++ b/fec/fec/static/scss/components/_feedback.scss
@@ -117,15 +117,12 @@
   bottom: u(-10rem);
 }
 
-.feedback__button {
-  margin-top:1rem;
-}
-
-.feedback textarea:last-of-type + div{
-display:block;
-height:0px;
-width:1px;
-zoom:1;
+/*this hides the recaptcha containing div so we can move the badge to bottom*/
+.feedback textarea:last-of-type + div {
+  display: block;
+  height: 0px;
+  width: 1px;
+  zoom: 1;
 }
 
 @media print {

--- a/fec/fec/static/scss/components/_feedback.scss
+++ b/fec/fec/static/scss/components/_feedback.scss
@@ -109,7 +109,7 @@
 }
 
 .feedback__button {
-  margin-top:1rem;
+  margin-top: u(1rem);
 }
 
 .grecaptcha-badge {
@@ -117,7 +117,7 @@
   bottom: u(-10rem);
 }
 
-/*this hides the recaptcha containing div so we can move the badge to bottom*/
+/* Hides the recaptcha containing div so we can move the badge to bottom */
 .feedback textarea:last-of-type + div {
   display: block;
   height: 0px;


### PR DESCRIPTION
## Summary 
Recaptcha badge placement was breakimg in  Internet Explorer
- Resolves #2205
- Related PR #2353, #2421

## Impacted areas of the application

modified:   fec/static/scss/components/_feedback.scss
This appears on all pages of site inside feedback tool

## Screenshots
![recaptcha_ie](https://user-images.githubusercontent.com/5572856/46473352-d87adb80-c7ad-11e8-8748-474259e21354.jpg)
