### PR TITLE
Fix record article page breadcrumbs

### DIFF
--- a/fec/home/templates/home/updates/record_page.html
+++ b/fec/home/templates/home/updates/record_page.html
@@ -11,7 +11,7 @@
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     <li class="breadcrumbs__item">
       <span class="breadcrumbs__separator">›</span>
-      <a class="breadcrumbs__link" href="/updates?record-category={{self.get_category_display|slugify}}">FEC Record: {{ self.get_category_display }}</a>
+      <a class="breadcrumbs__link" href="/updates?update_type=fec-record&category={{self.get_category_display|slugify}}">FEC Record: {{ self.get_category_display }}</a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--current">
       <span class="breadcrumbs__separator">›</span>


### PR DESCRIPTION
## Summary (required)

- Resolves #2390 
_Record article page breadcrumbs now link back to the correct publication type and category._

## What to test:
- [x] Check to make sure that when you are on a particular record article, the breadcrumb links back to the correct record article publication type and category type.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Record article page breadcrumbs