### PR TITLE
Re-add datatable counts

### DIFF
--- a/fec/fec/static/js/modules/filters/filter-tags.js
+++ b/fec/fec/static/js/modules/filters/filter-tags.js
@@ -6,7 +6,7 @@ var _ = require('underscore');
 var BODY_TEMPLATE = _.template(
   '<div>' +
     '<div class="row">' +
-    '<h3 class="tags__title">Viewing all' +
+    '<h3 class="tags__title">Viewing ' +
     '<span class="js-count" aria-hidden="true"></span> ' +
     '<span class="js-result-type">filtered {{ resultType }} for:</span>' +
     '</h3>' +

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -493,7 +493,7 @@ DataTable.prototype.initFilters = function() {
   if (this.opts.useFilters) {
     var tagList = new filterTags.TagList({
       resultType: 'results',
-      showResultCount: false
+      showResultCount: true
     });
     this.$widgets.find('.js-filter-tags').prepend(tagList.$body);
     this.filterPanel = new FilterPanel();


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/openFEC/issues/3104 along with https://github.com/fecgov/openFEC/pull/3421

Re-add datatable counts now that we've fixed them with https://github.com/fecgov/openFEC/pull/3421

## Impacted areas of the application
List general components of the application that this PR will affect:

-  All campaign finance data tables

## Impacted areas of the application
List general components of the application that this PR will affect:

Receipts
-  http://localhost:8000/data/receipts/
- http://localhost:8000/data/receipts/individual-contributions/

Disbursements
- http://localhost:8000/data/disbursements/
- http://localhost:8000/data/independent-expenditures/
- http://localhost:8000/data/party-coordinated-expenditures/
- http://localhost:8000/data/electioneering-communications/
- http://localhost:8000/data/communication-costs/

Loans
- http://localhost:8000/data/loans/

Candidates
- http://localhost:8000/data/candidates/
- http://localhost:8000/data/candidates/president/
- http://localhost:8000/data/candidates/senate/
- http://localhost:8000/data/candidates/house/

Committees
- http://localhost:8000/data/committees/

Filings and Reports
- http://localhost:8000/data/filings/
- http://localhost:8000/data/reports/presidential/
- http://localhost:8000/data/reports/house-senate/
- http://localhost:8000/data/reports/pac-party/


## Screenshots

## Before
### Table counts
<img width="351" alt="screen shot 2018-09-17 at 12 51 42 pm" src="https://user-images.githubusercontent.com/31420082/45637646-01466580-ba79-11e8-9407-caedf9ce2db3.png">
<img width="338" alt="screen shot 2018-09-17 at 12 51 51 pm" src="https://user-images.githubusercontent.com/31420082/45637651-05728300-ba79-11e8-9feb-8fb935e06211.png">



### Left filter counts
<img width="202" alt="screen shot 2018-09-17 at 12 09 16 pm" src="https://user-images.githubusercontent.com/31420082/45636423-aa8b5c80-ba75-11e8-84e1-7a243660d55d.png">

<img width="252" alt="screen shot 2018-09-17 at 12 09 32 pm" src="https://user-images.githubusercontent.com/31420082/45636415-a3fce500-ba75-11e8-8223-a97c1df144c2.png">


## After
### Table counts
<img width="395" alt="screen shot 2018-09-17 at 12 17 48 pm" src="https://user-images.githubusercontent.com/31420082/45636285-4c5e7980-ba75-11e8-930e-44ada3392457.png">

### Left filter counts
<img width="237" alt="screen shot 2018-09-17 at 12 17 54 pm" src="https://user-images.githubusercontent.com/31420082/45636291-4ff20080-ba75-11e8-8e08-5dd456eba850.png">
<img width="245" alt="screen shot 2018-09-17 at 12 17 44 pm" src="https://user-images.githubusercontent.com/31420082/45636295-52545a80-ba75-11e8-86f2-fdcd69f6b226.png">

### Related branches/PRs
`hotfix/remove-datatable-counts` https://github.com/fecgov/fec-cms/pull/2378
