### PR TITLE
Upgrade Django and django-dependent packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.13
+Django==1.11.15
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ wagtail==2.2.1
 # TODO: pin version
 django-audit-log
 Jinja2==2.9.6
-django_jinja==2.3.1
+django_jinja==2.4.1
 CacheControl==0.11.5
 cachetools==1.0.2
 github3.py==0.9.6
@@ -35,7 +35,7 @@ beautifulsoup4==4.5.1
 django-storages==1.5.2
 boto3==1.7.21
 
-cg-django-uaa==1.2.0
+cg-django-uaa==1.3.0
 
 # Testing
 coverage==4.5.1


### PR DESCRIPTION
## Summary (required)

- Resolves #2263: **[Med] Snyk: Open Redirect (due 10/8/18)**
Upgrade Django and django-dependent packages

## Impacted areas of the application
List general components of the application that this PR will affect:
- `django`: Python web framework: https://docs.djangoproject.com/en/2.1/releases/1.11.15/
- `django-jinja`: jinja/HTML templates https://github.com/niwinz/django-jinja
- `cg-django-uaa`: cloud.gov UAA authentication backend https://github.com/18F/cg-django-uaa

## Testing

Tested with a manual deploy to `dev` and logged in to Wagtail. As of 10/11 at 9:20 ET, changes are still live at https://fec-dev-proxy.app.cloud.gov/. Follow `develop` builds: https://circleci.com/gh/fecgov/fec-cms/tree/develop
