### PR TITLE
Add ADR datatable page

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -69,7 +69,7 @@ def load_search_results(query, query_type=None):
 def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwargs):
     filters = dict((key, value) for key, value in kwargs.items() if value)
 
-    if query or query_type in ['advisory_opinions', 'murs']:
+    if query or query_type in ['advisory_opinions', 'murs', 'adrs']:
         filters['hits_returned'] = limit
         filters['type'] = query_type
         filters['from_hit'] = offset
@@ -92,6 +92,9 @@ def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwa
 
     if 'murs' in results:
         results['murs_returned'] = len(results['murs'])
+
+    if 'adrs' in results:
+        results['adrs_returned'] = len(results['adrs'])
 
     return results
 

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -48,6 +48,7 @@ FEATURES = {
     'tips': bool(env.get_credential('FEC_FEATURE_TIPS', '')),
     'radform': bool(env.get_credential('FEC_FEATURE_RADFORM', '')),
     'linecharts': bool(env.get_credential('FEC_FEATURE_LINECHARTS', '')),
+    'adrs': bool(env.get_credential('FEC_FEATURE_ADRS', '')),
 }
 
 ENVIRONMENTS = {

--- a/fec/legal/templates/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/legal-search-results-adrs.jinja
@@ -1,0 +1,36 @@
+{% extends "layouts/legal-doc-search-results.jinja" %}
+{% import 'macros/legal.jinja' as legal %}
+{% set document_type_display_name = 'Alternative dispute resolutions' %}
+
+{% block header %}
+<header class="page-header slab slab--primary">
+  {{ breadcrumb.breadcrumbs('Search results', [('/legal-resources', 'Legal resources'), ('/legal-resources/enforcement', 'Enforcement')]) }}
+</header>
+{% endblock %}
+
+{% block filters %}
+  {{ legal.keyword_search(result_type, query) }}
+  <div class="filter">
+    <label class="label" for="adr_no">ADR number</label>
+    <input id="adr_no" name="adr_no" type="text" value="{{ adr_no }}">
+  </div>
+  <div class="filter">
+    <label class="label" for="adr_respondents">ADR respondents</label>
+    <input id="adr_respondents" name="adr_respondents" type="text" value="{{ adr_respondents }}">
+  </div>
+  <div class="filter">
+    <button type="submit" class="button button--cta">Apply filters</button>
+  </div>
+{% endblock %}
+
+{% block results %}
+{% with adrs = results.adrs %}
+
+{% include 'partials/legal-search-results-adrs.jinja' %}
+{% endwith %}
+
+{% with results=results %}
+{% include 'partials/legal-pagination.jinja' %}
+{% endwith %}
+
+{% endblock %}

--- a/fec/legal/templates/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/legal-search-results-adrs.jinja
@@ -1,6 +1,6 @@
 {% extends "layouts/legal-doc-search-results.jinja" %}
 {% import 'macros/legal.jinja' as legal %}
-{% set document_type_display_name = 'Alternative dispute resolutions' %}
+{% set document_type_display_name = 'Alternative dispute resolution' %}
 
 {% block header %}
 <header class="page-header slab slab--primary">

--- a/fec/legal/templates/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/legal-search-results-adrs.jinja
@@ -23,6 +23,17 @@
   </div>
 {% endblock %}
 
+{% block message %}
+<div class="data-container__tags">
+  <div class="row">
+    <h3 class="tags__title">Viewing <span class="tags__count">{{ results.total_adrs }}</span>  filtered results for:</h3>
+  </div>
+</div>
+<div class="message message--info u-no-margin-top">
+  <p>You can search all FEC ADR cases using keywords, ADR case numbers, names of respondents and more. For additional search filters, you can still search ADR cases using our legacy <a href="http://eqs.fec.gov">FEC Enforcement Query System</a>.</p>
+</div>
+{% endblock %}
+
 {% block results %}
 {% with results=results %}
 

--- a/fec/legal/templates/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/legal-search-results-adrs.jinja
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block results %}
-{% with adrs = results.adrs %}
+{% with results=results %}
 
 {% include 'partials/legal-search-results-adrs.jinja' %}
 {% endwith %}

--- a/fec/legal/templates/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/legal-search-results-adrs.jinja
@@ -11,12 +11,12 @@
 {% block filters %}
   {{ legal.keyword_search(result_type, query) }}
   <div class="filter">
-    <label class="label" for="adr_no">ADR number</label>
-    <input id="adr_no" name="adr_no" type="text" value="{{ adr_no }}">
+    <label class="label" for="case_no">ADR number</label>
+    <input id="case_no" name="case_no" type="text" value="{{ case_no }}">
   </div>
   <div class="filter">
-    <label class="label" for="adr_respondents">ADR respondents</label>
-    <input id="adr_respondents" name="adr_respondents" type="text" value="{{ adr_respondents }}">
+    <label class="label" for="case_respondents">ADR respondents</label>
+    <input id="case_respondents" name="case_respondents" type="text" value="{{ case_respondents }}">
   </div>
   <div class="filter">
     <button type="submit" class="button button--cta">Apply filters</button>

--- a/fec/legal/templates/partials/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/partials/legal-search-results-adrs.jinja
@@ -1,11 +1,6 @@
-<div class="js-filter-tags data-container__tags">
-  <div class="row">
-    <h3 class="tags__title">Viewing <span class="tags__count">{{ results.total_adrs }}</span>  filtered results for:</h3>
-  </div>
-</div>
 <div class="simple-table simple-table--responsive simple-table--display legal-search-results legal-adr data-container__datatable">
   <div class="simple-table__header">
-    <div class="simple-table__header-cell cell--40">Case</div>
+    <div class="simple-table__header-cell cell--50">Case</div>
     <div class="simple-table__header-cell">Election cycle(s)</div>
     <div class="simple-table__header-cell">Closing date</div>
     <div class="simple-table__header-cell">Subject(s)</div>

--- a/fec/legal/templates/partials/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/partials/legal-search-results-adrs.jinja
@@ -1,0 +1,49 @@
+<div class="simple-table simple-table--responsive simple-table--display legal-search-results legal-mur data-container__datatable">
+  <div class="simple-table__header">
+    <div class="simple-table__header-cell cell--25">Case</div>
+    <div class="simple-table__header-cell">Election cycle(s)</div>
+    <div class="simple-table__header-cell">Closing date</div>
+    <div class="simple-table__header-cell">Subject(s)</div>
+  </div>
+  <div class="simple-table__row-group">
+  {% for adr in adrs %}
+    <div class="simple-table__row legal-search-result">
+      <div class="simple-table__cell">
+        <div class="t-sans">
+          <a title="{{ adr.name }}" href="/data/legal/alternative-dispute-resolution/{{ adr.no }}">
+            <span class="t-bold">ADR #{{ adr.no }}</span><br />
+            {{ adr.name.upper() }}
+          </a>
+          {% for document in adr.documents %}
+            <a href="https://www.fec.gov{{ document.url }}">Complaint</a><br />
+          {% endfor %}
+          {% if adr.highlights %}
+            <div class="t-sans u-padding--top">Keyword match:</div>
+            {% for highlight in adr.highlights %}
+              <div class="t-serif legal-search-result__hit u-padding--left">
+                &hellip;
+                  {{ highlight|safe }} &hellip;
+              </div>
+            {% endfor %}
+          {% endif %}
+        </div>
+      </div>
+      <div class="simple-table__cell">
+        <div class="t-sans">
+          {% for election_cycle in adr.election_cycles %}
+            {{ election_cycle }}<br />
+          {% endfor %}
+        </div>
+      </div>
+      <div class="simple-table__cell">
+        <div class="t-sans">{{ adr.close_date | date(fmt='%m/%d/%Y') }}</div>
+      </div>
+      <div class="simple-table__cell">
+        {% for subject in adr.subjects %}
+          <div class="t-sans">{{ subject }}</div>
+        {% endfor %}
+      </div>
+    </div>
+  {% endfor %}
+  </div>
+</div>

--- a/fec/legal/templates/partials/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/partials/legal-search-results-adrs.jinja
@@ -1,6 +1,6 @@
-<div class="simple-table simple-table--responsive simple-table--display legal-search-results legal-mur data-container__datatable">
+<div class="simple-table simple-table--responsive simple-table--display legal-search-results legal-adr data-container__datatable">
   <div class="simple-table__header">
-    <div class="simple-table__header-cell cell--25">Case</div>
+    <div class="simple-table__header-cell cell--40">Case</div>
     <div class="simple-table__header-cell">Election cycle(s)</div>
     <div class="simple-table__header-cell">Closing date</div>
     <div class="simple-table__header-cell">Subject(s)</div>
@@ -10,21 +10,18 @@
     <div class="simple-table__row legal-search-result">
       <div class="simple-table__cell">
         <div class="t-sans">
-          <a title="{{ adr.name }}" href="/data/legal/alternative-dispute-resolution/{{ adr.no }}">
-            <span class="t-bold">ADR #{{ adr.no }}</span><br />
+          <i class="icon i-folder icon--inline--left"></i>
+          <a class="t-bold" title="{{ adr.name }}" href="/data/legal/alternative-dispute-resolution/{{ adr.no }}">ADR #{{ adr.no }}</a><br />
             {{ adr.name.upper() }}
-          </a>
-          {% for document in adr.documents %}
-            <a href="https://www.fec.gov{{ document.url }}">Complaint</a><br />
-          {% endfor %}
           {% if adr.highlights %}
             <div class="t-sans u-padding--top">Keyword match:</div>
-            {% for highlight in adr.highlights %}
-              <div class="t-serif legal-search-result__hit u-padding--left">
-                &hellip;
-                  {{ highlight|safe }} &hellip;
-              </div>
-            {% endfor %}
+            <div class="legal-search-result__hit u-padding--left">
+              {% for highlight in adr.highlights %}
+                <span class="t-serif">
+                    {{ highlight|safe }} &hellip;
+                </span>
+              {% endfor %}
+            </div>
           {% endif %}
         </div>
       </div>

--- a/fec/legal/templates/partials/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/partials/legal-search-results-adrs.jinja
@@ -1,14 +1,16 @@
-<div class="simple-table simple-table--responsive simple-table--display legal-search-results legal-adr data-container__datatable">
-  <div class="simple-table__header">
-    <div class="simple-table__header-cell cell--50">Case</div>
-    <div class="simple-table__header-cell">Election cycle(s)</div>
-    <div class="simple-table__header-cell">Closing date</div>
-    <div class="simple-table__header-cell">Subject(s)</div>
-  </div>
-  <div class="simple-table__row-group">
-  {% for adr in results.adrs %}
-    <div class="simple-table__row legal-search-result">
-      <div class="simple-table__cell">
+<table class="simple-table simple-table--display">
+  <thead>
+    <tr class="simple-table__header">
+      <th class="simple-table__header-cell cell--50">Case</th>
+      <th class="simple-table__header-cell">Election cycle(s)</th>
+      <th class="simple-table__header-cell">Closing date</th>
+      <th class="simple-table__header-cell">Subject(s)</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for adr in results.adrs %}
+    <tr class="simple-table__row">
+      <td class="simple-table__cell">
         <div class="t-sans">
           <i class="icon i-folder icon--inline--left"></i>
           <a class="t-bold" title="{{ adr.name }}" href="/data/legal/alternative-dispute-resolution/{{ adr.no }}">ADR #{{ adr.no }}</a><br />
@@ -24,23 +26,23 @@
             </div>
           {% endif %}
         </div>
-      </div>
-      <div class="simple-table__cell">
+      </td>
+      <td class="simple-table__cell">
         <div class="t-sans">
           {% for election_cycle in adr.election_cycles %}
             {{ election_cycle }}<br />
           {% endfor %}
         </div>
-      </div>
-      <div class="simple-table__cell">
+      </td>
+      <td class="simple-table__cell">
         <div class="t-sans">{{ adr.close_date | date(fmt='%m/%d/%Y') }}</div>
-      </div>
-      <div class="simple-table__cell">
+      </td>
+      <td class="simple-table__cell">
         {% for subject in adr.subjects %}
           <div class="t-sans">{{ subject }}</div>
         {% endfor %}
-      </div>
-    </div>
-  {% endfor %}
-  </div>
-</div>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/fec/legal/templates/partials/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/partials/legal-search-results-adrs.jinja
@@ -1,3 +1,8 @@
+<div class="js-filter-tags data-container__tags">
+  <div class="row">
+    <h3 class="tags__title">Viewing <span class="tags__count">{{ results.total_adrs }}</span>  filtered results for:</h3>
+  </div>
+</div>
 <div class="simple-table simple-table--responsive simple-table--display legal-search-results legal-adr data-container__datatable">
   <div class="simple-table__header">
     <div class="simple-table__header-cell cell--40">Case</div>
@@ -6,7 +11,7 @@
     <div class="simple-table__header-cell">Subject(s)</div>
   </div>
   <div class="simple-table__row-group">
-  {% for adr in adrs %}
+  {% for adr in results.adrs %}
     <div class="simple-table__row legal-search-result">
       <div class="simple-table__cell">
         <div class="t-sans">

--- a/fec/legal/urls.py
+++ b/fec/legal/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from django.conf import settings
 
 from legal import views
 
@@ -14,9 +15,14 @@ urlpatterns = [
 
     url(r'^data/legal/search/advisory-opinions/$', views.legal_doc_search_ao),
     url(r'^data/legal/search/enforcement/$', views.legal_doc_search_mur),
-    url(r'^data/legal/search/adrs/$', views.legal_doc_search_adr),
     url(r'^data/legal/search/murs/$', views.legal_doc_search_mur),
     url(r'^data/legal/search/regulations/$',
         views.legal_doc_search_regulations),
     url(r'^data/legal/search/statutes/$', views.legal_doc_search_statutes),
 ]
+
+if settings.FEATURES['adrs']:
+    urlpatterns += url(
+        r'^data/legal/search/adrs/$', views.legal_doc_search_adr
+    ),
+

--- a/fec/legal/urls.py
+++ b/fec/legal/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
 
     url(r'^data/legal/search/advisory-opinions/$', views.legal_doc_search_ao),
     url(r'^data/legal/search/enforcement/$', views.legal_doc_search_mur),
+    url(r'^data/legal/search/adrs/$', views.legal_doc_search_adr),
     url(r'^data/legal/search/murs/$', views.legal_doc_search_mur),
     url(r'^data/legal/search/regulations/$',
         views.legal_doc_search_regulations),

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -119,6 +119,26 @@ def legal_doc_search_mur(request):
         'query': query
     })
 
+def legal_doc_search_adr(request):
+    results = {}
+    query = request.GET.get('search', '')
+    offset = request.GET.get('offset', 0)
+    adr_no = request.GET.get('adr_no', '')
+    adr_respondents = request.GET.get('adr_respondents', '')
+    adr_election_cycles = request.GET.get('adr_election_cycles', '')
+    print ('adrs: ' + query)
+
+    results = api_caller.load_legal_search_results(query, 'adrs', offset=offset, adr_no=adr_no, adr_respondents=adr_respondents)
+
+    return render(request, 'legal-search-results-adrs.jinja', {
+        'parent': 'legal',
+        'results': results,
+        'result_type': 'adrs',
+        'adr_no': adr_no,
+        'adr_respondents': adr_respondents,
+        'query': query
+    })
+
 
 def legal_doc_search_regulations(request):
     results = {}

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -126,7 +126,6 @@ def legal_doc_search_adr(request):
     case_no = request.GET.get('case_no', '')
     case_respondents = request.GET.get('case_respondents', '')
     adr_election_cycles = request.GET.get('adr_election_cycles', '')
-    print ('adrs: ' + query)
 
     results = api_caller.load_legal_search_results(query, 'adrs', offset=offset, case_no=case_no, case_respondents=case_respondents)
 

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -123,19 +123,19 @@ def legal_doc_search_adr(request):
     results = {}
     query = request.GET.get('search', '')
     offset = request.GET.get('offset', 0)
-    adr_no = request.GET.get('adr_no', '')
-    adr_respondents = request.GET.get('adr_respondents', '')
+    case_no = request.GET.get('case_no', '')
+    case_respondents = request.GET.get('case_respondents', '')
     adr_election_cycles = request.GET.get('adr_election_cycles', '')
     print ('adrs: ' + query)
 
-    results = api_caller.load_legal_search_results(query, 'adrs', offset=offset, adr_no=adr_no, adr_respondents=adr_respondents)
+    results = api_caller.load_legal_search_results(query, 'adrs', offset=offset, case_no=case_no, case_respondents=case_respondents)
 
     return render(request, 'legal-search-results-adrs.jinja', {
         'parent': 'legal',
         'results': results,
         'result_type': 'adrs',
-        'adr_no': adr_no,
-        'adr_respondents': adr_respondents,
+        'case_no': case_no,
+        'case_respondents': case_respondents,
         'query': query
     })
 


### PR DESCRIPTION
## Summary

- Resolves #2436 
_This adds ADR datatable page to the enforcement legal features._

## How to test
1. `vi ~/.bash_profile` and insert this feature flag for ADRs `export FEC_FEATURE_ADRS=true`
2. Open a new terminal window and run the branch
3. Go to http://localhost:8000/data/legal/search/adrs/ to test the page. At this point, none of the canonical ADR links will work since that is phase 2 of the development for this feature.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Enforcement ADR datatable page

## Screenshots
<img width="1677" alt="screen shot 2018-10-19 at 4 40 27 pm" src="https://user-images.githubusercontent.com/12799132/47242770-d889f680-d3bd-11e8-93ee-687c111a664b.png">

