### PR TITLE
Update MUR filters to use generic `case_` filters

### DIFF
--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -11,12 +11,12 @@
 {% block filters %}
   {{ legal.keyword_search(result_type, query) }}
   <div class="filter">
-    <label class="label" for="mur_no">MUR number</label>
-    <input id="mur_no" name="mur_no" type="text" value="{{ mur_no }}">
+    <label class="label" for="case_no">MUR number</label>
+    <input id="case_no" name="case_no" type="text" value="{{ case_no }}">
   </div>
   <div class="filter">
-    <label class="label" for="mur_respondents">MUR respondents</label>
-    <input id="mur_respondents" name="mur_respondents" type="text" value="{{ mur_respondents }}">
+    <label class="label" for="case_respondents">MUR respondents</label>
+    <input id="case_respondents" name="case_respondents" type="text" value="{{ case_respondents }}">
   </div>
   <div class="filter">
     <button type="submit" class="button button--cta">Apply filters</button>

--- a/fec/legal/templates/partials/legal-pagination.jinja
+++ b/fec/legal/templates/partials/legal-pagination.jinja
@@ -2,12 +2,12 @@
 <div class="dataTables_info">{{ results.offset | int + 1 }}&ndash;{{ results.offset | int + results[result_type + '_returned'] | int }} of about {{ results.total_all }}</div>
 <div class="dataTables_paginate">
 {% if results.offset | int > 0 %}
-<a class="paginate_button previous" href="/data/legal/search/{{ result_type }}/?search={{ query }}&mur_respondents={{mur_respondents}}&offset={{ results.offset | int - results.limit | int }}#results-{{ result_type }}">Previous</a>
+<a class="paginate_button previous" href="/data/legal/search/{{ result_type }}/?search={{ query }}&case_respondents={{case_respondents}}&offset={{ results.offset | int - results.limit | int }}#results-{{ result_type }}">Previous</a>
 {% else %}
 <span class="paginate_button previous is-disabled">Previous</span>
 {% endif %}
 {% if results.offset | int + results.limit | int  < results.total_all | int %}
-<a class="paginate_button next" href="/data/legal/search/{{ result_type }}/?search={{ query }}&mur_respondents={{mur_respondents}}&offset={{ results.offset | int + results.limit | int }}#results-{{ result_type }}">Next</a>
+<a class="paginate_button next" href="/data/legal/search/{{ result_type }}/?search={{ query }}&case_respondents={{case_respondents}}&offset={{ results.offset | int + results.limit | int }}#results-{{ result_type }}">Next</a>
 {% else %}
 <span class="paginate_button next is-disabled">Next</span>
 {% endif %}

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -116,18 +116,17 @@ def legal_doc_search_mur(request):
     results = {}
     query = request.GET.get('search', '')
     offset = request.GET.get('offset', 0)
-    mur_no = request.GET.get('case_no', '')
-    mur_respondents = request.GET.get('case_respondents', '')
-    mur_election_cycles = request.GET.get('case_election_cycles', '')
+    case_no = request.GET.get('case_no', '')
+    case_respondents = request.GET.get('case_respondents', '')
 
-    results = api_caller.load_legal_search_results(query, 'murs', offset=offset, case_no=mur_no, case_respondents=mur_respondents)
+    results = api_caller.load_legal_search_results(query, 'murs', offset=offset, case_no=case_no, case_respondents=case_respondents)
 
     return render(request, 'legal-search-results-murs.jinja', {
         'parent': 'legal',
         'results': results,
         'result_type': 'murs',
-        'mur_no': mur_no,
-        'mur_respondents': mur_respondents,
+        'case_no': case_no,
+        'case_respondents': case_respondents,
         'query': query
     })
 

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -116,11 +116,11 @@ def legal_doc_search_mur(request):
     results = {}
     query = request.GET.get('search', '')
     offset = request.GET.get('offset', 0)
-    mur_no = request.GET.get('mur_no', '')
-    mur_respondents = request.GET.get('mur_respondents', '')
-    mur_election_cycles = request.GET.get('mur_election_cycles', '')
+    mur_no = request.GET.get('case_no', '')
+    mur_respondents = request.GET.get('case_respondents', '')
+    mur_election_cycles = request.GET.get('case_election_cycles', '')
 
-    results = api_caller.load_legal_search_results(query, 'murs', offset=offset, mur_no=mur_no, mur_respondents=mur_respondents)
+    results = api_caller.load_legal_search_results(query, 'murs', offset=offset, case_no=mur_no, case_respondents=mur_respondents)
 
     return render(request, 'legal-search-results-murs.jinja', {
         'parent': 'legal',


### PR DESCRIPTION
## Summary (required)

- Resolves #2351 
**Refactor MUR search to use generic `case_` filters**

I left the template variables alone and changed only the API call, but I'm open to approaching it differently.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  MUR search

## Related PRs

https://github.com/fecgov/openFEC/pull/3365: Add ADRs and AFs to API