### PR TITLE
adding pytest_cache to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ pip-log.txt
 coverage.xml
 .tox
 nosetests.xml
+.pytest_cache
 
 # Translations
 *.mo


### PR DESCRIPTION
## Summary

Adds .pytest_cache to git ignore for newly implemented pytest