### PR TITLE
Show exact counts under 500K

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -661,11 +661,15 @@ DataTable.prototype.fetchSuccess = function(resp) {
   var changeCount = this.newCount - this.currentCount;
 
   var countHTML =
-    this.newCount > 0
-      ? 'about <span class="tags__count">' +
+    this.newCount > 0 && this.newCount <= 500000
+      ? '<span class="tags__count">' +
         this.newCount.toLocaleString('en-US') +
         '</span>'
-      : '<span class="tags__count">0</span>';
+      : this.newCount > 500000
+        ? 'about <span class="tags__count">' +
+          this.newCount.toLocaleString('en-US') +
+          '</span>'
+        : '<span class="tags__count">0</span>';
   this.$widgets.find('.js-count').html(countHTML);
 
   filterSuccessUpdates(changeCount);

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -95,15 +95,9 @@ function mapSort(order, column) {
 }
 
 function getCount(response) {
-  // for audit data set, retrun real data result rows
-  if (
-    window.location.pathname === '/legal-resources/enforcement/audit-search/'
-  ) {
-    return response.pagination.count;
-  }
   var pagination_count = response.pagination.count;
 
-  if (response.pagination.count > 1000) {
+  if (response.pagination.count > 500000) {
     pagination_count = Math.round(response.pagination.count / 1000) * 1000;
   }
 

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -457,11 +457,11 @@ describe('data table', function() {
       expect(results).to.deep.equal(expected);
     });
 
-    it('should return round responses over 1000 to the nearest thousand', function() {
-      var response = { pagination: { count: 1500 }, results: 'test'};
+    it('should return round responses over 500000 to the nearest thousand', function() {
+      var response = { pagination: { count: 512345 }, results: 'test'};
       var expected = {
-        recordsTotal: 2000,
-        recordsFiltered: 2000,
+        recordsTotal: 512000,
+        recordsFiltered: 512000,
         data: 'test'
       };
       var results = tables.mapResponse(response);


### PR DESCRIPTION
## Summary (required)

Resolves #2450: **Use exact counts for datatable results**

- Because the API now returns accurate counts above 500,000, provide the exact counts where results are 500,000 or less.
-  Remove the "about" when the results are 500,000 or less.
- Remove the audit check because we have  around 1K audits total,  I didn't think we'd ever get over 500,000, and it might slightly improve performance not to do the extra check.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Data table counts

## Screenshots
<img width="622" alt="screen shot 2018-10-15 at 4 38 32 pm" src="https://user-images.githubusercontent.com/31420082/46976988-e592a700-d098-11e8-8eac-9ba4d9a1b916.png">
<img width="489" alt="screen shot 2018-10-15 at 4 38 21 pm" src="https://user-images.githubusercontent.com/31420082/46976989-e75c6a80-d098-11e8-9dc8-8dd820b9144d.png">

