### PR TITLE
Add test coverage for committee profile page

### DIFF
--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -32,7 +32,7 @@ class TestCommittee(TestCase):
         'filing_frequency': 'Q',
         'cycle': 2018,
         'city': 'BRENTWOOD',
-        'name': 'MY JOINT FUNDRAISING COMMITTEE'
+        'name': 'MY JOINT FUNDRAISING COMMITTEE',
     }
 
     STOCK_FINANCIALS = {
@@ -187,15 +187,18 @@ class TestCommittee(TestCase):
         assert committee['state'] == test_committee['state']
         assert committee['zip'] == test_committee['zip']
         assert committee['treasurer_name'] == test_committee['treasurer_name']
-        # assert committee['parent'] == test_committee['parent']
+        assert committee['parent'] == 'data'
         assert committee['cycle'] == test_committee['cycle']
         assert committee['cycles'] == test_committee['cycles']
-        # assert committee['year'] == test_committee['year']
-        # assert committee['result_type'] == test_committee['result_type']
-        # assert committee['report_type'] == test_committee['report_type']
-        # assert committee['reports'] == test_committee['reports']
+        assert committee['year'] == test_committee['cycle']
+        assert committee['result_type'] == 'committees'
+        assert committee['report_type'] == 'pac-party'
+        assert committee['reports'] == self.STOCK_FINANCIALS['reports']
+        assert committee['party_full'] == test_committee['party_full']
         assert committee['context_vars'] == {
             'cycle': 2018,
             'timePeriod': '2017–2018',
             'name': 'MY JOINT FUNDRAISING COMMITTEE'
         }
+        assert committee['totals'] == []
+        assert committee['candidates'] == []

--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -1,0 +1,201 @@
+from unittest import TestCase
+from unittest import mock
+import copy
+
+from data import api_caller
+from data.views import get_committee
+
+
+@mock.patch.object(api_caller, '_call_api')
+@mock.patch.object(api_caller, 'load_cmte_financials')
+@mock.patch.object(api_caller, 'load_with_nested')
+class TestCommittee(TestCase):
+
+    STOCK_COMMITTEE = {
+        'organization_type_full': None,
+        'zip': '37024',
+        'committee_type': 'N',
+        'committee_type_full': 'PAC - Nonqualified',
+        'committee_id': 'C001',
+        'designation_full': 'Joint fundraising committee',
+        'party_full': None,
+        'street_2': None,
+        'designation': 'J',
+        'state_full': 'Tennessee',
+        'party': None,
+        'street_1': 'PO BOX 123',
+        'state': 'TN',
+        'treasurer_name': 'SMITH, SUSAN',
+        'candidate_ids': [],
+        'organization_type': None,
+        'cycles': [2018],
+        'filing_frequency': 'Q',
+        'cycle': 2018,
+        'city': 'BRENTWOOD',
+        'name': 'MY JOINT FUNDRAISING COMMITTEE'
+    }
+
+    STOCK_FINANCIALS = {
+        'reports': [
+            {
+                'non_allocated_fed_election_activity_period': None,
+                'allocated_federal_election_levin_share_period': None,
+                'total_disbursements_period': 7400.0,
+                'coverage_end_date': '2018-09-30T00:00:00+00:00',
+                'document_description': 'OCTOBER QUARTERLY 2018',
+                'refunded_political_party_committee_contributions_ytd': None,
+                'loans_made_period': None,
+                'net_operating_expenditures_period': None,
+                'committee_type': 'N',
+                'committee_name': 'GREEN VICTORY FUND',
+                'amendment_indicator_full': 'NEW',
+                'net_contributions_period': None,
+                'total_disbursements_ytd': None,
+                'fec_url': 'http://docquery.fec.gov/dcdev/posted/1273093.fec',
+                'other_fed_receipts_period': None,
+                'shared_fed_activity_ytd': None,
+                'cash_on_hand_beginning_period': 0.0,
+                'total_operating_expenditures_ytd': None,
+                'non_allocated_fed_election_activity_ytd': None,
+                'debts_owed_to_committee': 0.0,
+                'pdf_url': ' http://docquery.fec.gopdf042/201810159125475042/20181015912  5475042.pdf',
+                'political_party_committee_contributions_period': None,
+                'other_political_committee_contributions_period': None,
+                'fec_file_id': 'FEC-1273093',
+                'beginning_image_number': '201810159125475042',
+                'cash_on_hand_beginning_calendar_ytd': None,
+                'coordinated_expenditures_by_party_committee_period': None,
+                'total_nonfed_transfers_period': None,
+                'loan_repayments_made_period': None,
+                'fed_candidate_contribution_refunds_period': None,
+                'individual_unitemized_contributions_period': None,
+                'fed_candidate_committee_contribution_refunds_ytd': None,
+                'total_fed_receipts_period': None,
+                'transfers_from_affiliated_party_period': None,
+                'total_contributions_ytd': None,
+                'refunded_political_party_committee_contributions_period': None,
+                'transfers_to_affiliated_committee_period': None,
+                'subtotal_summary_ytd': None,
+                'refunded_individual_contributions_period': None,
+                'transfers_from_nonfed_levin_ytd': None,
+                'other_political_committee_contributions_ytd': None,
+                'report_form': 'Form 3',
+                'total_fed_operating_expenditures_period': None,
+                'total_individual_contributions_period': None,
+                'csv_url': 'http://docquery.fec.gov/csv/093/1273093.csv',
+                'total_contribution_refunds_period': None,
+                'loans_made_ytd': None,
+                'loan_repayments_made_ytd': None,
+                'amendment_indicator': 'N',
+                'total_fed_election_activity_period': None,
+                'transfers_from_nonfed_levin_period': None,
+                'total_contributions_period': None,
+                'offsets_to_operating_expenditures_period': None,
+                'total_fed_election_activity_ytd': None,
+                'report_year': 2018,
+                'offsets_to_operating_expenditures_ytd': None,
+                'other_fed_operating_expenditures_ytd': None,
+                'total_fed_disbursements_ytd': None,
+                'cash_on_hand_close_ytd': None,
+                'most_recent_file_number': 1273093.0,
+                'shared_fed_operating_expenditures_ytd': None,
+                'total_contribution_refunds_ytd': None,
+                'total_nonfed_transfers_ytd': None,
+                'all_loans_received_period': None,
+                'debts_owed_by_committee': 0.0,
+                'shared_fed_activity_period': None,
+                'net_contributions_ytd': None,
+                'transfers_from_affiliated_party_ytd': None,
+                'coverage_start_date': '2018-07-01T00:00:00+00:00',
+                'refunded_individual_contributions_ytd': None,
+                'loan_repayments_received_ytd': None,
+                'individual_unitemized_contributions_ytd': None,
+                'end_image_number': '201810159125475048',
+                'previous_file_number': 1273093.0,
+                'independent_expenditures_ytd': None,
+                'fed_candidate_committee_contributions_ytd': None,
+                'total_fed_receipts_ytd': None,
+                'means_filed': 'e-file',
+                'committee_id': 'C00687574',
+                'amendment_chain': [1273093.0],
+                'total_fed_disbursements_period': None,
+                'cycle': 2018,
+                'transfers_from_nonfed_account_ytd': None,
+                'shared_fed_operating_expenditures_period': None,
+                'shared_nonfed_operating_expenditures_period': None,
+                'receipt_date': '2018-10-15T00:00:00',
+                'refunded_other_political_committee_contributions_period': None,
+                'most_recent': True,
+                'html_url': 'http://docquery.fec.gov/cgi-bin/forms/C00687574/127309',
+                'shared_fed_activity_nonfed_ytd': None,
+                'cash_on_hand_end_period': 0.0,
+                'report_type': 'Q3',
+                'shared_nonfed_operating_expenditures_ytd': None,
+                'subtotal_summary_page_period': None,
+                'loan_repayments_received_period': None,
+                'political_party_committee_contributions_ytd': None,
+                'file_number': 1273093,
+                'total_receipts_period': 7400.0,
+                'other_fed_receipts_ytd': None,
+                'other_disbursements_ytd': None,
+                'calendar_ytd': None,
+                'independent_expenditures_period': None,
+                'individual_itemized_contributions_ytd': None,
+                'refunded_other_political_committee_contributions_ytd': None,
+                'individual_itemized_contributions_period': None,
+                'total_receipts_ytd': None,
+                'other_fed_operating_expenditures_period': None,
+                'transfers_to_affilitated_committees_ytd': None,
+                'report_type_full': 'OCTOBER QUARTERLY',
+                'coordinated_expenditures_by_party_committee_ytd': None,
+                'total_individual_contributions_ytd': None,
+                'fed_candidate_committee_contributions_period': None,
+                'net_operating_expenditures_ytd': None,
+                'transfers_from_nonfed_account_period': None,
+                'total_fed_operating_expenditures_ytd': None,
+                'all_loans_received_ytd': None,
+                'total_operating_expenditures_period': None,
+                'other_disbursements_period': None,
+                'nonfed_share_allocated_disbursements_period': None,
+                'is_amended': False
+            }
+        ],
+        'totals': []
+    }
+
+    def test_base_case(self, load_with_nested_mock, load_cmte_financials_mock,
+                       _call_api_mock):
+        cycle = 2018
+
+        test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
+        load_with_nested_mock.return_value = (
+            test_committee,
+            [],
+            cycle
+        )
+        load_cmte_financials_mock.return_value = self.STOCK_FINANCIALS
+        committee = get_committee('C001', 2018)
+
+        assert committee['name'] == test_committee['name']
+        assert committee['committee_id'] == test_committee['committee_id']
+        assert committee['committee_type_full'] == test_committee['committee_type_full']
+        assert committee['committee_type'] == test_committee['committee_type']
+        assert committee['designation_full'] == test_committee['designation_full']
+        assert committee['street_1'] == test_committee['street_1']
+        assert committee['street_2'] == test_committee['street_2']
+        assert committee['city'] == test_committee['city']
+        assert committee['state'] == test_committee['state']
+        assert committee['zip'] == test_committee['zip']
+        assert committee['treasurer_name'] == test_committee['treasurer_name']
+        # assert committee['parent'] == test_committee['parent']
+        assert committee['cycle'] == test_committee['cycle']
+        assert committee['cycles'] == test_committee['cycles']
+        # assert committee['year'] == test_committee['year']
+        # assert committee['result_type'] == test_committee['result_type']
+        # assert committee['report_type'] == test_committee['report_type']
+        # assert committee['reports'] == test_committee['reports']
+        assert committee['context_vars'] == {
+            'cycle': 2018,
+            'timePeriod': '2017–2018',
+            'name': 'MY JOINT FUNDRAISING COMMITTEE'
+        }

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -127,7 +127,7 @@ def get_candidate(candidate_id, cycle, election_full):
         None,
     )
 
-    # If the candidate is not running in a future election, 
+    # If the candidate is not running in a future election,
     # return the most recent even eleciton year
     if not election_year:
         election_year = max(even_election_years)
@@ -269,17 +269,17 @@ def candidate(request, candidate_id):
     return render(request, 'candidates-single.jinja', candidate)
 
 
-def committee(request, committee_id):
-    # grab url query string parameters
-    cycle = request.GET.get('cycle', None)
+def get_committee(committee_id, cycle):
 
     redirect_to_previous = False if cycle else True
     committee, all_candidates, cycle = api_caller.load_with_nested('committee', committee_id, 'candidates', cycle)
 
-    # When there are multiple candidate records of various offices (H, S, P) linked to a single
-    # committee ID, we want to associate the candidate record with the matching committee type
-    # For each candidate, check if the committee type is equal to the candidate's office. If true
-    # add that candidate to the list of candidates to return
+    # When there are multiple candidate records of various offices (H, S, P)
+    # linked to a single committee ID, we want to associate the candidate record
+    # with the matching committee type
+    # For each candidate, check if the committee type is equal to
+    # the candidate's office.
+    # If true add that candidate to the list of candidates to return
     candidates = []
     for candidate in all_candidates:
         if committee['committee_type'] == candidate['office']:
@@ -304,11 +304,8 @@ def committee(request, committee_id):
 
         candidate['related_cycle'] = cycle if election_years else None
 
-
     # Load financial totals and reports for a given committee
     financials = api_caller.load_cmte_financials(committee_id, cycle=cycle)
-
-
     report_type = report_types.get(committee['committee_type'], 'pac-party')
     reports = financials['reports']
     totals = financials['totals']
@@ -346,7 +343,6 @@ def committee(request, committee_id):
         'candidates': candidates,
     }
 
-
     if financials['reports'] and financials['totals']:
         # Format the current two-year-period's totals using the process utilities
         if committee['committee_type'] == 'I':
@@ -380,6 +376,13 @@ def committee(request, committee_id):
     else:
         template_variables['has_raw_filings'] = False
 
+    return template_variables
+
+
+def committee(request, committee_id):
+    # grab url query string parameters
+    cycle = request.GET.get('cycle', None)
+    template_variables = get_committee(committee_id, cycle)
     return render(request, 'committees-single.jinja', template_variables)
 
 
@@ -504,7 +507,7 @@ def spending(request):
         'page_info': utils.page_info(top_spenders['pagination'])
     })
 
-    
+
 def feedback(request):
     if request.method == 'POST':
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -24,17 +24,14 @@ def groupby(values, keygetter):
         ret.setdefault(key, []).append(value)
     return ret
 
-election_durations = {
-    'P': 4,
-    'S': 6,
-    'H': 2,
-}
+
+election_durations = {'P': 4, 'S': 6, 'H': 2}
 
 report_types = {
     'P': 'presidential',
     'S': 'house-senate',
     'H': 'house-senate',
-    'I': 'ie-only'
+    'I': 'ie-only',
 }
 
 
@@ -47,13 +44,23 @@ def to_date(committee, cycle):
 def landing(request):
     top_candidates_raising = api_caller.load_top_candidates('-receipts', per_page=3)
 
-    return render(request, 'landing.jinja', {
-        'title': 'Campaign finance data',
-        'dates': utils.date_ranges(),
-        'top_candidates_raising': top_candidates_raising['results'] if top_candidates_raising else None,
-        'first_of_year': datetime.date(datetime.date.today().year, 1, 1).strftime('%m/%d/%Y'),
-        'last_of_year': datetime.date(datetime.date.today().year, 12, 31).strftime('%m/%d/%Y'),
-    })
+    return render(
+        request,
+        'landing.jinja',
+        {
+            'title': 'Campaign finance data',
+            'dates': utils.date_ranges(),
+            'top_candidates_raising': top_candidates_raising['results']
+            if top_candidates_raising
+            else None,
+            'first_of_year': datetime.date(datetime.date.today().year, 1, 1).strftime(
+                '%m/%d/%Y'
+            ),
+            'last_of_year': datetime.date(datetime.date.today().year, 12, 31).strftime(
+                '%m/%d/%Y'
+            ),
+        },
+    )
 
 
 def search(request):
@@ -72,17 +79,15 @@ def search(request):
         return redirect(url)
     else:
         results = api_caller.load_search_results(query)
-        return render(request, 'search-results.jinja', {
-            'query': query,
-            'title': 'Search results',
-            'results': results
-        })
+        return render(
+            request,
+            'search-results.jinja',
+            {'query': query, 'title': 'Search results', 'results': results},
+        )
 
 
 def advanced(request):
-    return render(request, 'advanced.jinja', {
-        'title': 'Advanced data'
-    })
+    return render(request, 'advanced.jinja', {'title': 'Advanced data'})
 
 
 def get_candidate(candidate_id, cycle, election_full):
@@ -92,8 +97,11 @@ def get_candidate(candidate_id, cycle, election_full):
     """
 
     candidate, committees, cycle = api_caller.load_with_nested(
-        'candidate', candidate_id, 'committees',
-        cycle=cycle, cycle_key='two_year_period',
+        'candidate',
+        candidate_id,
+        'committees',
+        cycle=cycle,
+        cycle_key='two_year_period',
         election_full=election_full,
     )
     # cycle corresponds to the two-year period for which the committee has financial activity.
@@ -101,10 +109,7 @@ def get_candidate(candidate_id, cycle, election_full):
     if election_full and cycle and cycle not in candidate['election_years']:
 
         next_cycle = next(
-            (
-                year for year in sorted(candidate['election_years'])
-                if year > cycle
-            ),
+            (year for year in sorted(candidate['election_years']) if year > cycle),
             max(candidate['election_years']),
         )
 
@@ -116,19 +121,23 @@ def get_candidate(candidate_id, cycle, election_full):
             election_full = False
         # get the next election cycle data for this candidate
         candidate, committees, cycle = api_caller.load_with_nested(
-            'candidate', candidate_id, 'committees',
-            cycle=next_cycle, cycle_key='two_year_period',
+            'candidate',
+            candidate_id,
+            'committees',
+            cycle=next_cycle,
+            cycle_key='two_year_period',
             election_full=election_full,
         )
 
     # Addresses issue#1644 - make any odd year special election an even year
     #  for displaying elections for pulldown menu in Candidate pages
     #  Using Set to ensure no duplicate years in final list
-    even_election_years = list({ year + (year % 2) for year in candidate.get('election_years', []) })
+    even_election_years = list(
+        {year + (year % 2) for year in candidate.get('election_years', [])}
+    )
 
     election_year = next(
-        (year for year in sorted(even_election_years) if year >= cycle),
-        None,
+        (year for year in sorted(even_election_years) if year >= cycle), None
     )
 
     # If the candidate is not running in a future election,
@@ -147,7 +156,7 @@ def get_candidate(candidate_id, cycle, election_full):
         'name': candidate['name'],
         'cycle': cycle,
         'electionFull': election_full,
-        'candidateID': candidate['candidate_id']
+        'candidateID': candidate['candidate_id'],
     }
 
     # In the case of when a presidential or senate candidate has filed
@@ -163,9 +172,7 @@ def get_candidate(candidate_id, cycle, election_full):
 
     # Annotate committees with most recent available cycle
     aggregate_cycles = (
-        list(range(cycle, cycle - duration, -2))
-        if election_full
-        else [cycle]
+        list(range(cycle, cycle - duration, -2)) if election_full else [cycle]
     )
     for committee in committees:
         committee['related_cycle'] = (
@@ -176,7 +183,9 @@ def get_candidate(candidate_id, cycle, election_full):
 
     # Group the committees by designation
     committee_groups = groupby(committees, lambda each: each['designation'])
-    committees_authorized = committee_groups.get('P', []) + committee_groups.get('A', [])
+    committees_authorized = committee_groups.get('P', []) + committee_groups.get(
+        'A', []
+    )
 
     committee_groups = committee_groups
     committees_authorized = committees_authorized
@@ -185,9 +194,7 @@ def get_candidate(candidate_id, cycle, election_full):
     # Get aggregate totals for the financial summary
     # And pass through the data processing utils
     aggregate = api_caller.load_candidate_totals(
-        candidate['candidate_id'],
-        cycle=max_cycle,
-        election_full=election_full,
+        candidate['candidate_id'], cycle=max_cycle, election_full=election_full
     )
     if aggregate:
         raising_summary = utils.process_raising_data(aggregate)
@@ -203,21 +210,20 @@ def get_candidate(candidate_id, cycle, election_full):
     # Get totals for the last two-year period of a cycle for showing on
     # raising and spending tabs
     two_year_totals = api_caller.load_candidate_totals(
-        candidate['candidate_id'],
-        cycle=max_cycle,
-        election_full=False
+        candidate['candidate_id'], cycle=max_cycle, election_full=False
     )
 
     # Get the statements of candidacy
     statement_of_candidacy = api_caller.load_candidate_statement_of_candidacy(
-        candidate['candidate_id'],
-        cycle=cycle
+        candidate['candidate_id'], cycle=cycle
     )
 
     if statement_of_candidacy:
         for statement in statement_of_candidacy:
             # convert string to python datetime and parse for readable output
-            statement['receipt_date'] = datetime.datetime.strptime(statement['receipt_date'], '%Y-%m-%dT%H:%M:%S')
+            statement['receipt_date'] = datetime.datetime.strptime(
+                statement['receipt_date'], '%Y-%m-%dT%H:%M:%S'
+            )
             statement['receipt_date'] = statement['receipt_date'].strftime('%m/%d/%Y')
 
     # Get all the elections
@@ -257,7 +263,7 @@ def get_candidate(candidate_id, cycle, election_full):
         'statement_of_candidacy': statement_of_candidacy,
         'elections': elections,
         'candidate': candidate,
-        'context_vars': context_vars
+        'context_vars': context_vars,
     }
 
 
@@ -285,7 +291,9 @@ def get_committee(committee_id, cycle):
     """
 
     redirect_to_previous = False if cycle else True
-    committee, all_candidates, cycle = api_caller.load_with_nested('committee', committee_id, 'candidates', cycle)
+    committee, all_candidates, cycle = api_caller.load_with_nested(
+        'committee', committee_id, 'candidates', cycle
+    )
 
     # When there are multiple candidate records of various offices (H, S, P)
     # linked to a single committee ID,
@@ -307,7 +315,9 @@ def get_committee(committee_id, cycle):
     for candidate in candidates:
         election_years = []
         for election_year in candidate['election_years']:
-            start_of_election_period = election_year - election_durations[candidate['office']]
+            start_of_election_period = (
+                election_year - election_durations[candidate['office']]
+            )
             if start_of_election_period < cycle and cycle <= election_year:
                 election_years.append(election_year)
         # For each candidate, set related_cycle to the candidate's time period
@@ -415,11 +425,11 @@ def elections_lookup(request):
     cycle = utils.current_cycle()
     cycles = utils.get_cycles(cycle + 4)
 
-    return render(request, 'election-lookup.jinja', {
-        'parent': 'data',
-        'cycles': cycles,
-        'cycle': cycle,
-    })
+    return render(
+        request,
+        'election-lookup.jinja',
+        {'parent': 'data', 'cycles': cycles, 'cycle': cycle},
+    )
 
 
 def elections(request, office, cycle, state=None, district=None):
@@ -438,36 +448,42 @@ def elections(request, office, cycle, state=None, district=None):
     if (state is not None) and (state and state.upper() not in constants.states):
         raise Http404()
 
-    #map/redirect legacy tab names to correct anchor
-    tab = request.GET.get('tab','').replace('/','')
+    # map/redirect legacy tab names to correct anchor
+    tab = request.GET.get('tab', '').replace('/', '')
     legacy_tabs = {
-         'contributions':'#individual-contributions',
-         'totals' : '#candidate-financial-totals',
-         'spending-by-others':'#independent-expenditures'
-         }
+        'contributions': '#individual-contributions',
+        'totals': '#candidate-financial-totals',
+        'spending-by-others': '#independent-expenditures',
+    }
 
     if tab in legacy_tabs.keys():
         if office == 'senate' or office == 'house':
             return redirect(
-               reverse('elections-state-district', args=(office,state,district,cycle)) + legacy_tabs[tab]
-               )
+                reverse(
+                    'elections-state-district', args=(office, state, district, cycle)
+                )
+                + legacy_tabs[tab]
+            )
         if office == 'president':
             return redirect(
-               reverse('elections-president', args=(office,cycle)) + legacy_tabs[tab]
-               )
+                reverse('elections-president', args=(office, cycle)) + legacy_tabs[tab]
+            )
 
-    return render(request, 'elections.jinja', {
-        'office': office,
-        'office_code': office[0],
-        'parent': 'data',
-        'cycle': cycle,
-        'cycles': cycles,
-        'state': state,
-        'state_full': constants.states[state.upper()] if state else None,
-        'district': district,
-        'title': utils.election_title(cycle, office, state, district),
-
-    })
+    return render(
+        request,
+        'elections.jinja',
+        {
+            'office': office,
+            'office_code': office[0],
+            'parent': 'data',
+            'cycle': cycle,
+            'cycles': cycles,
+            'state': state,
+            'state_full': constants.states[state.upper()] if state else None,
+            'district': district,
+            'title': utils.election_title(cycle, office, state, district),
+        },
+    )
 
 
 def raising(request):
@@ -480,7 +496,9 @@ def raising(request):
     elif top_category in ['party']:
         top_raisers = api_caller.load_top_parties('-receipts', cycle=cycle, per_page=10)
     else:
-        top_raisers = api_caller.load_top_candidates('-receipts', office=top_category, cycle=cycle, per_page=10)
+        top_raisers = api_caller.load_top_candidates(
+            '-receipts', office=top_category, cycle=cycle, per_page=10
+        )
 
     if cycle == datetime.datetime.today().year:
         coverage_end_date = datetime.datetime.today()
@@ -489,17 +507,21 @@ def raising(request):
 
     page_info = top_raisers['pagination']
 
-    return render(request, 'raising-bythenumbers.jinja', {
-        'parent': 'data',
-        'title': 'Raising: by the numbers',
-        'top_category': top_category,
-        'coverage_start_date': datetime.date(cycle - 1, 1, 1),
-        'coverage_end_date': coverage_end_date,
-        'cycles': cycles,
-        'cycle': cycle,
-        'top_raisers': top_raisers['results'],
-        'page_info': utils.page_info(top_raisers['pagination'])
-    })
+    return render(
+        request,
+        'raising-bythenumbers.jinja',
+        {
+            'parent': 'data',
+            'title': 'Raising: by the numbers',
+            'top_category': top_category,
+            'coverage_start_date': datetime.date(cycle - 1, 1, 1),
+            'coverage_end_date': coverage_end_date,
+            'cycles': cycles,
+            'cycle': cycle,
+            'top_raisers': top_raisers['results'],
+            'page_info': utils.page_info(top_raisers['pagination']),
+        },
+    )
 
 
 def spending(request):
@@ -508,28 +530,38 @@ def spending(request):
     cycle = request.GET.get('cycle', constants.DEFAULT_TIME_PERIOD)
 
     if top_category in ['pac']:
-        top_spenders = api_caller.load_top_pacs('-disbursements', cycle=cycle, per_page=10)
+        top_spenders = api_caller.load_top_pacs(
+            '-disbursements', cycle=cycle, per_page=10
+        )
     elif top_category in ['party']:
-        top_spenders = api_caller.load_top_parties('-disbursements', cycle=cycle, per_page=10)
+        top_spenders = api_caller.load_top_parties(
+            '-disbursements', cycle=cycle, per_page=10
+        )
     else:
-        top_spenders = api_caller.load_top_candidates('-disbursements', office=top_category, cycle=cycle, per_page=10)
+        top_spenders = api_caller.load_top_candidates(
+            '-disbursements', office=top_category, cycle=cycle, per_page=10
+        )
 
     if cycle == datetime.datetime.today().year:
         coverage_end_date = datetime.datetime.today()
     else:
         coverage_end_date = datetime.date(cycle, 12, 31)
 
-    return render(request, 'spending-bythenumbers.jinja', {
-        'parent': 'data',
-        'title': 'Spending: by the numbers',
-        'top_category': top_category,
-        'coverage_start_date': datetime.date(cycle - 1, 1, 1),
-        'coverage_end_date': coverage_end_date,
-        'cycles': cycles,
-        'cycle': cycle,
-        'top_spenders': top_spenders['results'],
-        'page_info': utils.page_info(top_spenders['pagination'])
-    })
+    return render(
+        request,
+        'spending-bythenumbers.jinja',
+        {
+            'parent': 'data',
+            'title': 'Spending: by the numbers',
+            'top_category': top_category,
+            'coverage_start_date': datetime.date(cycle - 1, 1, 1),
+            'coverage_end_date': coverage_end_date,
+            'cycles': cycles,
+            'cycle': cycle,
+            'top_spenders': top_spenders['results'],
+            'page_info': utils.page_info(top_spenders['pagination']),
+        },
+    )
 
 
 def feedback(request):
@@ -539,11 +571,24 @@ def feedback(request):
         # '{"param":"value"}'. Needs to be decoded in Python 3
         data = json.loads(request.body.decode("utf-8"))
 
-        if not any([data['action'], data['feedback'], data['about'], data['g-recaptcha-response']]):
+        if not any(
+            [
+                data['action'],
+                data['feedback'],
+                data['about'],
+                data['g-recaptcha-response'],
+            ]
+        ):
             return JsonResponse({'status': False}, status=500)
         else:
             # verify recaptcha
-            verifyRecaptcha = requests.post("https://www.google.com/recaptcha/api/siteverify", data={'secret': settings.FEC_RECAPTCHA_SECRET_KEY, 'response': data['g-recaptcha-response']})
+            verifyRecaptcha = requests.post(
+                "https://www.google.com/recaptcha/api/siteverify",
+                data={
+                    'secret': settings.FEC_RECAPTCHA_SECRET_KEY,
+                    'response': data['g-recaptcha-response'],
+                },
+            )
             recaptchaResponse = verifyRecaptcha.json()
             if not recaptchaResponse['success']:
                 # if captcha failed, return failure
@@ -552,22 +597,26 @@ def feedback(request):
                 # captcha passed, we're ready to submit the issue.
                 title = 'User feedback on ' + request.META.get('HTTP_REFERER')
 
-                body = ("## What were you trying to do and how can we improve it?\n %s \n\n"
-                        "## General feedback?\n %s \n\n"
-                        "## Tell us about yourself\n %s \n\n"
-                        "## Details\n"
-                        "* URL: %s \n"
-                        "* User Agent: %s") % (
-                            data['action'],
-                            data['feedback'],
-                            data['about'],
-                            request.META.get('HTTP_REFERER'),
-                            request.META['HTTP_USER_AGENT'])
+                body = (
+                    "## What were you trying to do and how can we improve it?\n %s \n\n"
+                    "## General feedback?\n %s \n\n"
+                    "## Tell us about yourself\n %s \n\n"
+                    "## Details\n"
+                    "* URL: %s \n"
+                    "* User Agent: %s"
+                ) % (
+                    data['action'],
+                    data['feedback'],
+                    data['about'],
+                    request.META.get('HTTP_REFERER'),
+                    request.META['HTTP_USER_AGENT'],
+                )
 
                 client = github3.login(token=settings.FEC_GITHUB_TOKEN)
-                issue = client.repository('fecgov', 'fec').create_issue(title, body=body)
+                issue = client.repository('fecgov', 'fec').create_issue(
+                    title, body=body
+                )
 
                 return JsonResponse(issue.to_json(), status=201)
     else:
         raise Http404()
-

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -359,9 +359,7 @@ def get_committee(committee_id, cycle):
         for c in sorted(committee['cycles'], reverse=True):
             financials = api_caller.load_cmte_financials(committee['committee_id'], cycle=c)
             if financials['reports']:
-                return redirect(
-                    reverse('committee-by-id', kwargs={'committee_id': committee['committee_id']}) + '?cycle=' + str(c)
-                )
+                return get_committee(committee_id, c)
 
     # If we're in the current cycle, check for raw filings in the last three days
     if cycle == utils.current_cycle():


### PR DESCRIPTION
## Summary (required)

First step for resolving #2446
- Add tests for committee page
- Refactor `get_candidate` to start again with API call/formatting instead of using `redirect` and  `reverse` - this keeps formatting separate from routing, for testing purposes.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee profile pages

Testing links from @jwchumley https://docs.google.com/spreadsheets/d/1xmDu2Ypr2tJnUjWZJcMIf_SOD7BOipCR4fGD3FmZLJ0/edit#gid=0