### PR TITLE
Remove closed meeting from homepage events

### DIFF
--- a/fec/fec/static/js/modules/home-events.js
+++ b/fec/fec/static/js/modules/home-events.js
@@ -16,7 +16,7 @@ var eventsTemplate = require('../templates/homepage/events-and-deadlines.hbs');
 // and need to match API parameter `calendar_category_id`
 
 var updates = {
-  '.js-next-commission-meeting': ['32', '39', '40'],
+  '.js-next-commission-meeting': ['32', '40'],
   '.js-next-filing-deadline': ['21', '25', '26', '27'],
   '.js-next-training-or-conference': ['33', '34'],
   '.js-next-public-comment-deadline': ['23']

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -32,7 +32,7 @@
       </div>
       <ul class="grid grid--4-wide grid--flex t-sans">
         <li class="grid__item grid__item--with-button">
-          <div class="t-bold">Next commission meeting:</div>
+          <div class="t-bold">Next open commission meeting:</div>
           <div class="js-next-commission-meeting"></div>
           <a class="button button--alt button--updates" href="/meetings">All meetings</a>
         <li class="grid__item grid__item--with-button">


### PR DESCRIPTION
## Summary

- Resolves #2416 
_This removes the exec closed meetings from the homepage display._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Homepage meetings section

## Screenshot
<img width="246" alt="screen shot 2018-10-19 at 6 22 06 pm" src="https://user-images.githubusercontent.com/12799132/47246477-fceccf80-d3cb-11e8-96f1-2b24b9769aba.png">
