### PR TITLE
Add spender committee type filter into disbursements page.

### DIFF
--- a/fec/data/templates/partials/disbursements-filter.jinja
+++ b/fec/data/templates/partials/disbursements-filter.jinja
@@ -29,7 +29,7 @@ Filter disbursements
   {{ date.partition_field('date', 'Disbursement date', dates ) }}
 </div>
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
-  <button type="button" class="js-accordion-trigger accordion__button">Spender details</button>
+  <button type="button" class="js-accordion-trigger accordion__button">Recipient details</button>
   <div class="accordion__content">
     {{ text.field('recipient_city', 'City') }}
     {{ states.field('recipient_state')}}
@@ -52,6 +52,10 @@ Filter disbursements
     <div class="message message--info message--small">
       <span class="t-block">Disbursements are reported periodically, according to the filer's reporting schedule. Disbursements are updated as they’re processed— that time can vary.</span>
     </div>
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Spender committee type</button>
+  <div class="accordion__content">
+    {% include 'partials/filters/spender-committee-types.jinja' %}
   </div>
 </div>
 {% endblock %}

--- a/fec/data/templates/partials/filters/spender-committee-types.jinja
+++ b/fec/data/templates/partials/filters/spender-committee-types.jinja
@@ -1,0 +1,151 @@
+<div class="filter">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox">
+    <legend class="label" for="committee_type">Authorized committees</legend>
+    <ul class="dropdown__selected">
+      <li>
+        <input id="committee-type-checkbox-P" type="checkbox" name="spender_committee_type" value="P">
+        <label class="dropdown__value" for="committee-type-checkbox-P">Presidential</label>
+      </li>
+      <li>
+        <input id="committee-type-checkbox-S" type="checkbox" name="spender_committee_type" value="S">
+        <label class="dropdown__value" for="committee-type-checkbox-S">Senate</label>
+      </li>
+      <li>
+        <input id="committee-type-checkbox-H" type="checkbox" name="spender_committee_type" value="H">
+        <label class="dropdown__value" for="committee-type-checkbox-H">House</label>
+      </li>
+    </ul>
+  </fieldset>
+</div>
+
+<div class="filter">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox">
+    <legend class="label" for="committee_type">Independent expenditure committees</legend>
+    <ul class="dropdown__selected">
+      <li>
+        <input id="committee-type-checkbox-O" type="checkbox" name="spender_committee_type" value="O">
+        <label class="dropdown__value" for="committee-type-checkbox-O">Super PAC (independent expenditure only)</label>
+      </li>
+    </ul>
+    <div class="dropdown">
+      <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
+      <div id="ie-dropdown" class="dropdown__panel" aria-hidden="true">
+      <ul class="dropdown__list">
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-U" type="checkbox" name="spender_committee_type" value="U">
+          <label class="dropdown__value" for="committee-type-checkbox-U">Single candidate independent expenditure</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-I" type="checkbox" name="spender_committee_type" value="I">
+          <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditure filer (not a committee)</label>
+        </li>
+      </ul>
+    </div>
+  </div>
+</fieldset>
+</div>
+
+<div class="filter">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox">
+    <legend class="label" for="committee_type">PACs</legend>
+    <ul class="dropdown__selected"></ul>
+    <div class="dropdown">
+      <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
+      <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
+      <ul class="dropdown__list">
+        <li class="dropdown__item">
+          <input id="designation-checkbox-B" type="checkbox" name="designation" value="B">
+          <label class="dropdown__value" for="designation-checkbox-B">Lobbyist/Registrant PAC</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="designation-checkbox-D" type="checkbox" name="designation" value="D">
+          <label class="dropdown__value" for="designation-checkbox-D">Leadership PAC</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-N" type="checkbox" name="spender_committee_type" value="N">
+          <label class="dropdown__value" for="committee-type-checkbox-N">PAC - nonqualified</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-Q" type="checkbox" name="spender_committee_type" value="Q">
+          <label class="dropdown__value" for="committee-type-checkbox-Q">PAC - qualified</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-V" type="checkbox" name="spender_committee_type" value="V">
+          <label class="dropdown__value" for="committee-type-checkbox-V">PAC with non-contribution account - nonqualified</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-W" type="checkbox" name="spender_committee_type" value="W">
+          <label class="dropdown__value" for="committee-type-checkbox-W">PAC with non-contribution account - qualified</label>
+        </li>
+        <li class="dropdown__subhead">Separate segregated funds</li>
+        <li class="dropdown__item">
+          <input id="org-type-checkbox-C" name="organization_type" type="checkbox" value="C">
+          <label class="dropdown__value" for="org-type-checkbox-C">Corporation</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="org-type-checkbox-L" name="organization_type" type="checkbox" value="L">
+          <label class="dropdown__value" for="org-type-checkbox-L">Labor organization</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="org-type-checkbox-M" name="organization_type" type="checkbox" value="M">
+          <label class="dropdown__value" for="org-type-checkbox-M">Membership organization</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="org-type-checkbox-T" name="organization_type" type="checkbox" value="T">
+          <label class="dropdown__value" for="org-type-checkbox-T">Trade association</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="org-type-checkbox-V" name="organization_type" type="checkbox" value="V">
+          <label class="dropdown__value" for="org-type-checkbox-V">Cooperative</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="org-type-checkbox-W" name="organization_type" type="checkbox" value="W">
+          <label class="dropdown__value" for="org-type-checkbox-W">Corporation without capital stock</label>
+        </li>
+      </ul>
+    </div>
+  </fieldset>
+</div>
+
+
+<div class="filter">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox">
+    <legend class="label" for="committee_type">Other committees</legend>
+    <ul class="dropdown__selected">
+      <li>
+        <input id="designation-checkbox-J" type="checkbox" name="designation" value="J">
+        <label class="dropdown__value" for="designation-checkbox-J">Joint fundraising committee</label>
+      </li>
+    </ul>
+    <div class="dropdown">
+      <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
+      <div id="other-dropdown" class="dropdown__panel" aria-hidden="true">
+      <ul class="dropdown__list">
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-C" type="checkbox" name="spender_committee_type" value="C">
+          <label class="dropdown__value" for="committee-type-checkbox-C">Communication cost</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-D" type="checkbox" name="spender_committee_type" value="D">
+          <label class="dropdown__value" for="committee-type-checkbox-D">Delegate committee</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-E" type="checkbox" name="spender_committee_type" value="E">
+          <label class="dropdown__value" for="committee-type-checkbox-E">Electioneering communication</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-X" type="checkbox" name="spender_committee_type" value="X">
+          <label class="dropdown__value" for="committee-type-checkbox-X">Party - nonqualified</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-Y" type="checkbox" name="spender_committee_type" value="Y">
+          <label class="dropdown__value" for="committee-type-checkbox-Y">Party - qualified</label>
+        </li>
+        <li class="dropdown__item">
+          <input id="committee-type-checkbox-Z" type="checkbox" name="spender_committee_type" value="Z">
+          <label class="dropdown__value" for="committee-type-checkbox-Z">National party nonfederal account</label>
+        </li>
+      </ul>
+    </div>
+  </fieldset>
+</div>


### PR DESCRIPTION
## Summary (required)
This PR depends on api PR 3449 [https://github.com/fecgov/openFEC/pull/3449](https://github.com/fecgov/openFEC/pull/3449) which has been merged to develop branch on openFEC already and works well.
The api PR should release first, then this cms PR.

- Resolves # [_2128_] [https://github.com/fecgov/fec-cms/issues/2128](https://github.com/fecgov/fec-cms/issues/2128)


_Include a summary of proposed changes._
1)Change Disbursements filter label from `Spender details` to `Recipient details`
2)Add new `Spender committee type filter`

_How to test it_
1)checkout branch: feature/add_disbursement_spender_cmte_tp_filter
2)setup api point to dev
export DATABASE_URL=postgresql://:@/cfdm_cms_test
export FEC_API_URL=https://fec-dev-api.app.cloud.gov
export FEC_WEB_API_KEY=
export FEC_WEB_API_KEY_PUBLIC=
export FEC_CMS_ENVIRONMENT=LOCAL

3)play with spender committee type filter
[http://127.0.0.1:8000/data/disbursements/?data_type=processed&two_year_transaction_period=2018&min_date=01%2F01%2F2017&max_date=10%2F22%2F2018](http://127.0.0.1:8000/data/disbursements/?data_type=processed&two_year_transaction_period=2018&min_date=01%2F01%2F2017&max_date=10%2F22%2F2018)


## Impacted areas of the application
Disbursements page.

## Screenshots
![image](https://user-images.githubusercontent.com/24395751/47298092-e2da0980-d5e4-11e8-9db1-5eefc1a53a7d.png)


## related branch
[feature/add_spender_committee_type_filter](feature/add_spender_committee_type_filter)
Thanks John worked on this, the source code will save for reference in the future.

## related Issue
[https://github.com/fecgov/fec-cms/issues/2117](https://github.com/fecgov/fec-cms/issues/2117)
committee type filter: Dropdown filter disappears after options are selected then deselected