### PR TITLE
Modify financial summary display for Inaugural committees

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -665,6 +665,11 @@ IE_FORMATTER = OrderedDict([
     ('total_independent_expenditures', {'label': 'Independent expenditures', 'level': '1'})
 ])
 
+INAUGURAL_FORMATTER = OrderedDict([
+    ('receipts', {'label': 'Total Donations Accepted', 'level': '1'}),
+    ('contribution_refunds', {'label': 'Total Donations Refunded', 'level': '1'})
+])
+
 SENATE_CLASSES = {
     '1': ['AZ', 'CA', 'CT', 'DE', 'FL', 'HI', 'IN', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NJ', 'NM', 'NY', 'ND', 'OH', 'PA', 'RI', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'],
     '2': ['AL', 'AK', 'AR', 'CO', 'DE', 'GA', 'ID', 'IL', 'IA', 'KS', 'KY', 'LA', 'ME', 'MA', 'MI', 'MN', 'MS', 'MT', 'NE', 'NH', 'NJ', 'NM', 'NC', 'OK', 'OR', 'RI', 'SC', 'SD', 'TN', 'TX', 'VA', 'WV', 'WY'],

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -16,6 +16,16 @@
           </div>
           {{ tables.summary(ie_summary) }}
         </div>
+      <!-- Inaugural Committees -->
+      {% elif organization_type == 'I' %}
+        <div class="entity__figure">
+          <div class="row">
+            <div class="tag__category">
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
+            </div>
+          </div>
+          {{ tables.summary(inaugural_summary) }}
+        </div>
       {% else %}
         <div class="entity__figure entity__figure--narrow" id="total-raised">
           <div class="heading--section heading--with-action">

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -150,6 +150,10 @@ def process_ie_data(totals):
     return financial_summary_processor(totals, constants.IE_FORMATTER)
 
 
+def process_inaugural_data(totals):
+    return financial_summary_processor(totals, constants.INAUGURAL_FORMATTER)
+
+
 def get_next_senate_elections(current_cycle):
     """
     Returns an dictionary of senate classes in chronological order

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -342,6 +342,7 @@ def get_committee(committee_id, cycle):
         'committee_id': committee_id,
         'committee_type_full': committee['committee_type_full'],
         'committee_type': committee['committee_type'],
+        'organization_type': committee['organization_type'],
         'designation_full': committee['designation_full'],
         'street_1': committee['street_1'],
         'street_2': committee['street_2'],
@@ -368,6 +369,11 @@ def get_committee(committee_id, cycle):
         if committee['committee_type'] == 'I':
             # IE-only committees have very little data, so they just get this one
             template_variables['ie_summary'] = utils.process_ie_data(
+                financials['totals'][0]
+            )
+        # Inaugural Committees
+        elif committee['organization_type'] == 'I':
+            template_variables['inaugural_summary'] = utils.process_inaugural_data(
                 financials['totals'][0]
             )
         else:


### PR DESCRIPTION
## Summary (required)

- Resolves #2446 
Modify financial summary display for Inaugural committees. 

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Inaugural committee financial summaries

Test with http://127.0.0.1:8000/data/committee/C00540005/?tab=summary and point to `dev` API

More test data: https://docs.google.com/spreadsheets/d/1xmDu2Ypr2tJnUjWZJcMIf_SOD7BOipCR4fGD3FmZLJ0/edit#gid=1956073211

## Screenshots
<img width="1380" alt="screen shot 2018-10-24 at 8 46 31 am" src="https://user-images.githubusercontent.com/31420082/47431209-5e64c380-d769-11e8-9e2d-f2432802e83a.png">


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
`https://github.com/fecgov/openFEC/pull/3432` | https://github.com/fecgov/openFEC/pull/3432
