### PR TITLE
Fix disappearing dropdown

### DIFF
--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -228,7 +228,6 @@ Dropdown.prototype.selectItem = function($input) {
         .focus();
     }
   } else {
-    this.removePanel();
     this.$selected.find('input[type="checkbox"]').focus();
   }
 };

--- a/fec/fec/tests/js/dropdowns.js
+++ b/fec/fec/tests/js/dropdowns.js
@@ -143,14 +143,6 @@ describe('dropdown', function() {
       expect(document.activeElement).to.equal($('#A').get(0));
     });
 
-    it('calls remove on selecting the last item', function() {
-      sinon.spy(this.dropdown, 'removePanel');
-      this.dropdown.selectItem($('#A'));
-      expect(this.dropdown.removePanel).to.have.not.been.called;
-      this.dropdown.selectItem($('#B'));
-      expect(this.dropdown.removePanel).to.have.been.called;
-    });
-
     it('removes the panel', function() {
       this.dropdown.removePanel();
       expect(this.dropdown.$body.find('.dropdown__panel').length).to.equal(0);


### PR DESCRIPTION
## Summary (required)
Currently, once you choose all the checklist items in a filter dropdown, the dropdown disappears. Although there is a legitimate UX argument for this behavior, the fact that it does not reappear in the  unlikely (but possible edge-case ) event that the user removes all chosen filters means the user ultimately no longer has access to those filters. This PR makes the dropdowns persist, regardless of filters chosen.

Resolves: #2117

## Impacted areas of the application
fec/static/js/modules/dropdowns.js

## How to test:
- Checkout and un this branch
- Make sure a checklist-dropdown does not disappear after choosing all the items and  adding them to the selected filters list above.
- http://127.0.0.1:8000/data/disbursements/ is a good one to test because it has a two-item dropdown.

# Screenshots
![dropdown-disappear](https://user-images.githubusercontent.com/5572856/47459680-c4256f80-d7aa-11e8-90d8-be812c0963ce.gif)
