### PR TITLE
Fix Form 4 (Host Committee) financial summary labels

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -645,6 +645,88 @@ SPENDING_FORMATTER = OrderedDict([
         {'label': 'Total federal disbursements', 'level': '2'}),
 ])
 
+HOST_RAISING_FORMATTER = OrderedDict([
+    ('receipts',  # Line 20
+        {'label': 'Total receipts', 'level': '1', 'term': 'total receipts'}),
+    ('federal_funds',  # Line 13
+        {'label': 'Federal funds', 'level': '2'}),
+    ('contributions',  # Line 14
+        {'label': 'Total Contributions to Defray Convention Expenses', 'level': '2'}),
+    ('individual_contributions',  # Line 14a
+        {'label': 'Itemized Contributions to Defray Convention Expenses', 'level': '3'}),
+    ('individual_unitemized_contributions',  # Line 14b
+        {'label': 'Unitemized Contributions to Defray Convention Expenses', 'level': '3',
+    }),
+    ('transfers_from_affiliated_party',  # Line 15
+        {'label': 'Transfers from affiliated committees', 'level': '2'}),
+    ('loans_and_loan_repayments',  # Line 16
+        {'label': 'Loans and Loan Repayments Received', 'level': '2'}),
+    ('all_loans_received',  # Line 16a
+        {'label': 'Loans Received', 'level': '3'}),
+    ('loan_repayments_received',  # Line 16b
+        {'label': 'Loan Repayments Received', 'level': '3',
+        }),
+    ('refunds_relating_convention_exp',  # Line 17
+        {'label': 'Refunds, Rebates, Returns of Deposits Relating to Convention Expenditures', 'level': '2'}),
+    ('itemized_refunds_relating_convention_exp',  # Line 17a
+        {'label': ' Itemized Refunds, Rebates, Returns of Deposits Relating to Convention', 'level': '3'}),
+    ('unitemized_refunds_relating_convention_exp',  # Line 17b
+        {'label': 'Unitemized Refunds, Rebates, Returns of Deposits Relating to Convention', 'level': '3',
+        }),
+    ('refunds_relating_convention_exp',  # Line 18
+        {'label': 'Other Refunds, Rebates, Returns of Deposits', 'level': '2'}),
+    ('itemized_refunds_relating_convention_exp',  # Line 18a
+        {'label': ' Itemized Other Refunds, Rebates, Returns of Deposits', 'level': '3'}),
+    ('unitemized_refunds_relating_convention_exp',  # Line 18b
+        {'label': 'Unitemized Other Refunds, Rebates, Returns of Deposits', 'level': '3',
+        }),
+    ('other_fed_receipts',  # Line 19
+        {'label': ' Other Income', 'level': '2'}),
+    ('itemized_other_income',  # Line 19a
+        {'label': 'Itemized Other Income', 'level': '3'}),
+    ('unitemized_other_income',  # Line 19b
+        {'label': 'Unitemized Other Income', 'level': '3',
+        }),
+
+])
+
+HOST_SPENDING_FORMATTER = OrderedDict([
+    ('disbursements',
+        {'label': 'Total disbursements', 'level': '1',
+            'term': 'total disbursements'}),
+    ('convention_exp',  # Line 21
+        {'label': 'Convention Expenditures',
+            'level': '2'}),
+    ('itemized_convention_exp',  # Line 21a
+        {'label': 'Itemized Convention Expenditures',
+            'level': '3'}),
+    ('unitemized_convention_exp',  # Line 21a
+        {'label': 'Unitemized Convention Expenditures',
+            'level': '3'}),
+    ('transfers_to_affiliated_committee',  # Line 22
+        {'label': 'Transfers to Affiliated Committees',
+            'level': '2'}),
+    ('loans_and_loan_repayments_made',  # Line 23
+        {'label': 'Loans and Loan Repayments Made',
+            'level': '2'}),
+    ('loans_made',  # Line 23a
+        {'label': 'Loans Made',
+            'level': '3'}),
+    ('loan_repayments_made',  # Line 23a
+        {'label': 'Loan Repayments Made',
+            'level': '3'}),
+    ('other_disbursements',  # Line 24
+        {'label': 'Other Disbursements',
+            'level': '2'}),
+    ('itemized_other_disb',  # Line 24a
+        {'label': 'Itemized Other Disbursements',
+            'level': '3'}),
+    ('unitemized_other_disb',  # Line 24a
+        {'label': 'Unitemized Other Disbursements',
+            'level': '3'}),
+
+])
+
 CASH_FORMATTER = OrderedDict([
     ('cash_on_hand_beginning_period', {'label': 'Beginning cash on hand', 'level': '2'}), #F3, F3P, #F3X
     ('last_cash_on_hand_end_period', {'label': 'Ending cash on hand', 'term': 'ending cash on hand', 'level': '2'}), #F3, F3P, #F3X
@@ -660,6 +742,8 @@ CASH_FORMATTER = OrderedDict([
     # ('subtotal_offsets_to_operating_expenditures', {'label': 'Offsets to operating expenditures', 'level': '3'}), #F3P
 ])
 
+
+
 IE_FORMATTER = OrderedDict([
     ('total_independent_contributions', {'label': 'Contributions received', 'level': '1'}),
     ('total_independent_expenditures', {'label': 'Independent expenditures', 'level': '1'})
@@ -669,6 +753,7 @@ INAUGURAL_FORMATTER = OrderedDict([
     ('receipts', {'label': 'Total Donations Accepted', 'level': '1'}),
     ('contribution_refunds', {'label': 'Total Donations Refunded', 'level': '1'})
 ])
+
 
 SENATE_CLASSES = {
     '1': ['AZ', 'CA', 'CT', 'DE', 'FL', 'HI', 'IN', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NJ', 'NM', 'NY', 'ND', 'OH', 'PA', 'RI', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'],

--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -246,3 +246,201 @@ class TestCommittee(TestCase):
             (85530042.0, {'label': 'Total Donations Accepted', 'level': '1'}),
             (966240.0, {'label': 'Total Donations Refunded', 'level': '1'}),
         ]
+
+    def test_host_f4_summary(
+        self, load_with_nested_mock, load_cmte_financials_mock, _call_api_mock
+    ):
+
+        cycle = 2018
+
+        test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
+        test_committee['organization_type'] = 'H'
+        load_with_nested_mock.return_value = (test_committee, [], cycle)
+        load_cmte_financials_mock.return_value = {
+            'reports': [
+                {
+                    'report_type_full': 'POST INAUGURAL SUPPLEMENT',
+                    'report_type': '90S',
+                    'report_form': 'Form 4',
+                }
+            ],
+            'totals': [
+                {
+                    'cash_on_hand_beginning_period': 503347.81,
+                    'committee_name': 'COMMITTEE FOR CHARLOTTE_CHARLOTTE DNC HOST COMMITTEE',
+                    'other_disbursements': 0.0,
+                    'last_beginning_image_number': '201610109032226424',
+                    'itemized_refunds_relating_convention_exp': 0.0,
+                    'committee_designation_full': 'Unauthorized',
+                    'refunds_relating_convention_exp': 0.0,
+                    'cycle': 2016,
+                    'committee_type_full': 'Party - Nonqualified',
+                    'individual_contributions': 0.0,
+                    'unitemized_other_disb': 0.0,
+                    'loans_and_loan_repayments_received': 0.0,
+                    'last_report_year': 2016,
+                    'itemized_other_disb': 0.0,
+                    'coverage_start_date': '2016-07-01T00:00:00+00:00',
+                    'itemized_other_income': 0.0,
+                    'itemized_convention_exp': 4500.0,
+                    'exp_subject_limits': 4500.0,
+                    'other_refunds': 0.0,
+                    'last_cash_on_hand_end_period': 498847.81,
+                    'exp_prior_years_subject_limits': 0.0,
+                    'all_loans_received': 0.0,
+                    'last_report_type_full': 'OCTOBER QUARTERLY',
+                    'loans_made': 0.0,
+                    'unitemized_other_income': 0.0,
+                    'loans_and_loan_repayments_made': 0.0,
+                    'receipts': 12345.0,
+                    'committee_id': 'C00493254',
+                    'fed_disbursements': 0.0,
+                    'committee_designation': 'U',
+                    'loan_repayments_received': 0.0,
+                    'itemized_other_refunds': 0.0,
+                    'unitemized_other_refunds': 0.0,
+                    'unitemized_refunds_relating_convention_exp': 0.0,
+                    'contributions': 0.0,
+                    'transfers_from_affiliated_party': 0.0,
+                    'coverage_end_date': '2016-09-30T00:00:00+00:00',
+                    'convention_exp': 4500.0,
+                    'individual_unitemized_contributions': 0.0,
+                    'federal_funds': 12345.0,
+                    'transfers_to_affiliated_committee': 0.0,
+                    'other_fed_receipts': 0.0,
+                    'party_full': 'DEMOCRATIC PARTY',
+                    'last_debts_owed_by_committee': 5000,
+                    'loan_repayments_made': 0.0,
+                    'unitemized_convention_exp': 0.0,
+                    'committee_type': 'X',
+                    'disbursements': 4500.0,
+                    'last_debts_owed_to_committee': 1000,
+                    'total_exp_subject_limits': None,
+                }
+            ],
+        }
+
+        committee = get_committee('C001', 2018)
+
+        assert committee['raising_summary'] == [
+            (12345.0, {'label': 'Total receipts', 'level': '1', 'term': 'total receipts'}),
+            (12345.0, {'label': 'Federal funds', 'level': '2'}),
+            (
+                0.0,
+                {
+                    'label': 'Total Contributions to Defray Convention Expenses',
+                    'level': '2',
+                },
+            ),
+            (
+                0.0,
+                {
+                    'label': 'Itemized Contributions to Defray Convention Expenses',
+                    'level': '3',
+                },
+            ),
+            (
+                0.0,
+                {
+                    'label': 'Unitemized Contributions to Defray Convention Expenses',
+                    'level': '3',
+                },
+            ),
+            (0.0, {'label': 'Transfers from affiliated committees', 'level': '2'}),
+            (0.0, {'label': 'Loans Received', 'level': '3'}),
+            (0.0, {'label': 'Loan Repayments Received', 'level': '3'}),
+            (
+                0.0,
+                {'label': 'Other Refunds, Rebates, Returns of Deposits', 'level': '2'},
+            ),
+            (
+                0.0,
+                {
+                    'label': ' Itemized Other Refunds, Rebates, Returns of Deposits',
+                    'level': '3',
+                },
+            ),
+            (
+                0.0,
+                {
+                    'label': 'Unitemized Other Refunds, Rebates, Returns of Deposits',
+                    'level': '3',
+                },
+            ),
+            (0.0, {'label': ' Other Income', 'level': '2'}),
+            (0.0, {'label': 'Itemized Other Income', 'level': '3'}),
+            (0.0, {'label': 'Unitemized Other Income', 'level': '3'}),
+        ]
+
+        assert committee['spending_summary'] == [
+            (
+                4500.0,
+                {
+                    'label': 'Total disbursements',
+                    'level': '1',
+                    'term': 'total disbursements',
+                },
+            ),
+            (4500.0, {'label': 'Convention Expenditures', 'level': '2'}),
+            (4500.0, {'label': 'Itemized Convention Expenditures', 'level': '3'}),
+            (0.0, {'label': 'Unitemized Convention Expenditures', 'level': '3'}),
+            (0.0, {'label': 'Transfers to Affiliated Committees', 'level': '2'}),
+            (0.0, {'label': 'Loans and Loan Repayments Made', 'level': '2'}),
+            (0.0, {'label': 'Loans Made', 'level': '3'}),
+            (0.0, {'label': 'Loan Repayments Made', 'level': '3'}),
+            (0.0, {'label': 'Other Disbursements', 'level': '2'}),
+            (0.0, {'label': 'Itemized Other Disbursements', 'level': '3'}),
+            (0.0, {'label': 'Unitemized Other Disbursements', 'level': '3'}),
+        ]
+
+        assert committee['cash_summary'] == [
+            (503347.81, {'label': 'Beginning cash on hand', 'level': '2'}),
+            (
+                498847.81,
+                {
+                    'label': 'Ending cash on hand',
+                    'term': 'ending cash on hand',
+                    'level': '2',
+                },
+            ),
+            (1000, {'label': 'Debts/loans owed to committee', 'level': '2'}),
+            (5000, {'label': 'Debts/loans owed by committee', 'level': '2'}),
+        ]
+
+    def test_host_f3x_summary_returns_standard_values(
+        self, load_with_nested_mock, load_cmte_financials_mock, _call_api_mock
+    ):
+        cycle = 2018
+
+        test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
+        test_committee['organization_type'] = 'H'
+        load_with_nested_mock.return_value = (test_committee, [], cycle)
+        load_cmte_financials_mock.return_value = self.STOCK_FINANCIALS
+        committee = get_committee('C001', 2018)
+
+        assert committee['name'] == test_committee['name']
+        assert committee['committee_id'] == test_committee['committee_id']
+        assert committee['committee_type_full'] == test_committee['committee_type_full']
+        assert committee['committee_type'] == test_committee['committee_type']
+        assert committee['designation_full'] == test_committee['designation_full']
+        assert committee['street_1'] == test_committee['street_1']
+        assert committee['street_2'] == test_committee['street_2']
+        assert committee['city'] == test_committee['city']
+        assert committee['state'] == test_committee['state']
+        assert committee['zip'] == test_committee['zip']
+        assert committee['treasurer_name'] == test_committee['treasurer_name']
+        assert committee['parent'] == 'data'
+        assert committee['cycle'] == test_committee['cycle']
+        assert committee['cycles'] == test_committee['cycles']
+        assert committee['year'] == test_committee['cycle']
+        assert committee['result_type'] == 'committees'
+        assert committee['report_type'] == 'pac-party'
+        assert committee['reports'] == self.STOCK_FINANCIALS['reports']
+        assert committee['party_full'] == test_committee['party_full']
+        assert committee['context_vars'] == {
+            'cycle': 2018,
+            'timePeriod': '2017–2018',
+            'name': 'MY JOINT FUNDRAISING COMMITTEE',
+        }
+        assert committee['totals'] == []
+        assert committee['candidates'] == []

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -154,6 +154,14 @@ def process_inaugural_data(totals):
     return financial_summary_processor(totals, constants.INAUGURAL_FORMATTER)
 
 
+def process_host_raising_data(totals):
+    return financial_summary_processor(totals, constants.HOST_RAISING_FORMATTER)
+
+
+def process_host_spending_data(totals):
+    return financial_summary_processor(totals, constants.HOST_SPENDING_FORMATTER)
+
+
 def get_next_senate_elections(current_cycle):
     """
     Returns an dictionary of senate classes in chronological order

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -376,6 +376,20 @@ def get_committee(committee_id, cycle):
             template_variables['inaugural_summary'] = utils.process_inaugural_data(
                 financials['totals'][0]
             )
+        # Host Committees that file on Form 4
+        elif (
+            committee['organization_type'] == 'H'
+            and financials['reports'][0]['report_form'] == 'Form 4'
+        ):
+            template_variables['raising_summary'] = utils.process_host_raising_data(
+                financials['totals'][0]
+            )
+            template_variables['spending_summary'] = utils.process_host_spending_data(
+                financials['totals'][0]
+            )
+            template_variables['cash_summary'] = utils.process_cash_data(
+                financials['totals'][0]
+            )
         else:
             # All other committees have three tables
             template_variables['raising_summary'] = utils.process_raising_data(


### PR DESCRIPTION
## Summary (required)

- Resolves #2446 (Part 2)
Change labels for F4 filer financial summary

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee profile pages for host committees that file on Form 4

Point to `dev` API if this PR has been merged: https://github.com/fecgov/openFEC/pull/3458 or follow the steps in the PR to point to your local API. Take a look at http://localhost:8000/data/committee/C00493254/ if pointing to local API/DB, or use the test data here https://docs.google.com/spreadsheets/d/1xmDu2Ypr2tJnUjWZJcMIf_SOD7BOipCR4fGD3FmZLJ0/edit#gid=1956073211 if it's been merged.

## Screenshots

<img width="732" alt="screen shot 2018-10-25 at 2 08 05 pm" src="https://user-images.githubusercontent.com/31420082/47520892-761e7380-d85f-11e8-8578-aacada09a7a3.png">
<img width="761" alt="screen shot 2018-10-25 at 2 08 11 pm" src="https://user-images.githubusercontent.com/31420082/47520894-7880cd80-d85f-11e8-81c1-64345da12493.png">

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fec-cms `feature/add-f13-f4-summaries-2` | https://github.com/fecgov/fec-cms/pull/2465
openFEC `feature/add-form-4-fields` | https://github.com/fecgov/openFEC/pull/3458


