### PR TITLE
[HOTFIX - Merge with gitflow] Adds additional reaction box validation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
     'setTimeout': true,
     'clearTimeout': true,
     'ga': true,
-    'grecaptcha': true
+    'grecaptcha': true,
+    'navigator': true
   },
   "extends": [
     "plugin:react/recommended",

--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
 
 
     # Feedback Tool
+    url(r'^data/issue/reaction/$', views.reactionFeedback),
     url(r'^data/issue/$', views.feedback),
 
     # Datatables

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -524,7 +524,6 @@ def feedback(request):
             else:
                 # captcha passed, we're ready to submit the issue.
                 title = 'User feedback on ' + request.META.get('HTTP_REFERER')
-
                 body = ("## What were you trying to do and how can we improve it?\n %s \n\n"
                         "## General feedback?\n %s \n\n"
                         "## Tell us about yourself\n %s \n\n"
@@ -536,6 +535,56 @@ def feedback(request):
                             data['about'],
                             request.META.get('HTTP_REFERER'),
                             request.META['HTTP_USER_AGENT'])
+
+                client = github3.login(token=settings.FEC_GITHUB_TOKEN)
+                issue = client.repository('fecgov', 'fec').create_issue(title, body=body)
+
+                return JsonResponse(issue.to_json(), status=201)
+    else:
+        raise Http404()
+
+def reactionFeedback(request):
+    if request.method == 'POST':
+
+        # json.loads() is expecting a string in JSON format:
+        # '{"param":"value"}'. Needs to be decoded in Python 3
+        data = json.loads(request.body.decode("utf-8"))
+
+        if not all(
+            [
+                data['name'],
+                data['location'],
+                data['reaction'],
+                data['g-recaptcha-response'],
+                data['userAgent'],
+            ]
+        ) :
+            # the required fields were not provided, return error.
+            return JsonResponse({'status': False}, status=500)
+        else:
+            # verify recaptcha
+            verifyRecaptcha = requests.post("https://www.google.com/recaptcha/api/siteverify", data={'secret': settings.FEC_RECAPTCHA_SECRET_KEY, 'response': data['g-recaptcha-response']})
+            recaptchaResponse = verifyRecaptcha.json()
+            if not recaptchaResponse['success']:
+                # if captcha failed, return failure
+                return JsonResponse({'status': False}, status=500)
+            else:
+                # captcha passed, we're ready to submit the issue.
+                title = 'User feedback on ' + request.META.get('HTTP_REFERER')
+                body = (
+                    "## What were you trying to do and how can we improve it?\n %s \n\n"
+                    "## General feedback?\n %s \n\n"
+                    "## Tell us about yourself\n %s \n\n"
+                    "## Details\n"
+                    "* URL: %s \n"
+                    "* User Agent: %s"
+                ) % (
+                    "\nChart Name: " + data['name'] + "\nChart Location: " + data['location'],
+                    data['feedback'],
+                    "\nThe reaction to the chart is: " + data['reaction'],
+                    request.META.get('HTTP_REFERER'),
+                    data['userAgent'],
+                )
 
                 client = github3.login(token=settings.FEC_GITHUB_TOKEN)
                 issue = client.repository('fecgov', 'fec').create_issue(title, body=body)

--- a/fec/fec/static/js/modules/reaction-box.js
+++ b/fec/fec/static/js/modules/reaction-box.js
@@ -25,7 +25,7 @@ function ReactionBox(selector) {
   this.name = this.$element.data('name');
   this.location = this.$element.data('location');
   this.path = window ? window.location.pathname : null;
-  this.url = helpers.buildAppUrl(['issue']);
+  this.url = helpers.buildAppUrl(['issue', 'reaction']);
 
   this.$element.on('click', '.js-reaction', this.submitReaction.bind(this));
   this.$element.on('click', '.js-reset', this.handleReset.bind(this));
@@ -71,17 +71,15 @@ ReactionBox.prototype.handleSubmit = function(token) {
       }
     }
   });
-
+  
   var chartLocation = this.path || this.location;
-  var action =
-    '\nChart Name: ' + this.name + '\nChart Location: ' + chartLocation;
-  var about = '\nThe reaction to the chart is: ' + this.reaction;
-  var feedback = '\n' + this.$textarea.val();
 
   var data = {
-    action: action,
-    about: about,
-    feedback: feedback
+    name: this.name ? this.name : '',
+    location: chartLocation ? chartLocation : '',
+    reaction: this.reaction ? this.reaction : '',
+    feedback: this.$textarea.val(),
+    userAgent: navigator.userAgent
   };
   // explicitly set token as g-recaptcha-response
   data['g-recaptcha-response'] = token;

--- a/fec/fec/static/js/modules/reaction-box.js
+++ b/fec/fec/static/js/modules/reaction-box.js
@@ -71,7 +71,6 @@ ReactionBox.prototype.handleSubmit = function(token) {
       }
     }
   });
-  
   var chartLocation = this.path || this.location;
 
   var data = {


### PR DESCRIPTION
## Summary

- Resolves #2470 
Requires name, location, reaction, recaptcha response, and user agent to be defined. If it is not, return error.

## How to test
- Check out the branch and `npm run build`
- `./manage.py runserver`
- Submit reaction boxes below line charts for:
    - [x] Data landing: http://localhost:8000/data/
    - [x] Advanced data raising: http://localhost:8000/data/advanced?tab=raising
    - [x] Advanced data spending: http://localhost:8000/data/advanced?tab=spending

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Reaction feedback box

## Screenshots

<img width="972" alt="screen shot 2018-10-26 at 3 09 41 pm" src="https://user-images.githubusercontent.com/12799132/47587524-31fba380-d931-11e8-8db6-c631f833f5b9.png">