### PR TITLE
Corrected ADR closing date label

### DIFF
--- a/fec/legal/templates/legal-adr.jinja
+++ b/fec/legal/templates/legal-adr.jinja
@@ -90,7 +90,7 @@
       </div>
       <div class="legal-adr__property">
         <p>
-          <strong>OPENING DATE:</strong> {{ adr.close_date | date(fmt='%m/%d/%Y') }}
+          <strong>CLOSING DATE:</strong> {{ adr.close_date | date(fmt='%m/%d/%Y') }}
         </p>
       </div>
       <div class="legal-adr__property">


### PR DESCRIPTION
## Summary

_On the ADR canonical page, the "Closing date" label was incorrectly labeled as "Opening date". This corrects the label_

## How to test:
- [x] Go to any canonical page, like this one: http://localhost:8000/data/legal/alternative-dispute-resolution/848/
- [x] Make sure there is an opening date and closing date label. Should not have 2 opening date labels.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  ADR canonical page