### PR TITLE
show null data in datatables by default

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -637,7 +637,7 @@ DataTable.prototype.isPending = function() {
 };
 
 DataTable.prototype.buildUrl = function(data, paginate) {
-  var query = _.extend({ sort_hide_null: true }, this.filters || {});
+  var query = _.extend({ sort_hide_null: false }, this.filters || {});
   paginate = typeof paginate === 'undefined' ? true : paginate;
   query.sort = mapSort(data.order, this.opts.columns);
 

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -149,7 +149,7 @@ describe('data table', function() {
       var url = this.table.buildUrl(data);
       var expected = helpers.buildUrl(
         ['path', 'to', 'endpoint'],
-        {sort_hide_null: 'true', party: 'DFL', sort: '-office', per_page: 30, page: 3, extra: 'true'}
+        {sort_hide_null: 'false', party: 'DFL', sort: '-office', per_page: 30, page: 3, extra: 'true'}
       );
       expect(URI(url).equals(expected)).to.be.true;
     });


### PR DESCRIPTION
## Summary (required)

- Resolves #2481 
_Shows nulls in datatables by default. Null values will no longer be hidden, which means that these rows will now be filterable and searchable_

**Future improvement**
A corresponding API fix will need to be made to make the display better by always sorting nulls last. Issue logged here: https://github.com/fecgov/openFEC/issues/3470

## Impacted areas of the application, how to test
List general components of the application that this PR will affect:

- Check datatables (below is not a list of all the datatables, but a list of tables that now shows nulls on first load): 
     - [ ] IEs - http://localhost:8000/data/independent-expenditures/?data_type=processed&is_notice=true
     - [ ] Party coordinated - http://localhost:8000/data/party-coordinated-expenditures/
     - [ ] ECs - http://localhost:8000/data/electioneering-communications/
     - [ ] Communication costs - http://localhost:8000/data/communication-costs/
     - [ ] Loans - http://localhost:8000/data/loans/
     - [ ] Candidates - http://localhost:8000/data/candidates/?has_raised_funds=true
     - [ ] Candidates for President - http://localhost:8000/data/candidates/president/?election_year=2020&cycle=2020&election_full=true
     - [ ] Candidates for Senate - http://localhost:8000/data/candidates/senate/?election_year=2018&cycle=2018&election_full=true
     - [ ] Candidates for House - http://localhost:8000/data/candidates/house/
     - [ ] Committees - http://localhost:8000/data/committees/
     - [ ] RFAIs - http://localhost:8000/data/filings/?data_type=processed&form_type=RFAI
     - [ ] All filings - http://localhost:8000/data/filings/?data_type=processed
     - [ ] House and Senate committee reports - http://localhost:8000/data/reports/house-senate/?data_type=processed

## Screenshots

### This is an example of the committees datatable and what it will show on first load
![screen shot 2018-11-01 at 9 43 47 am](https://user-images.githubusercontent.com/12799132/47855369-d01cbd00-ddba-11e8-9aca-0d257d374662.png)
