### PR TITLE
Restore color coded district icons on data/elections

### DIFF
--- a/fec/fec/static/img/i-map--primary.svg
+++ b/fec/fec/static/img/i-map--primary.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="16px" height="22px" viewBox="0 0 16 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
+    <title>i-map--primary</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Simple-Copy" sketch:type="MSArtboardGroup" transform="translate(-261.000000, -920.000000)" fill="#022C53">
+            <path d="M268.836735,941.661538 C268.836735,941.661538 261,932.609046 261,928.123077 C261,923.637446 264.508898,920 268.836735,920 C273.164571,920 276.673469,923.637446 276.673469,928.123077 C276.673469,932.609046 268.836735,941.661538 268.836735,941.661538 L268.836735,941.661538 Z M268.836735,923.775995 C266.520666,923.775995 264.642857,925.722416 264.642857,928.12311 C264.642857,930.523805 266.520666,932.470497 268.836735,932.470497 C271.152804,932.470497 273.030612,930.523805 273.030612,928.12311 C273.030612,925.722416 271.152804,923.775995 268.836735,923.775995 L268.836735,923.775995 Z" id="i-map--primary" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## Summary
Color coded marker icon for districts was missing on `data/elections`

- Resolves #2485

### [How to test &#187;](#how-to-test)
## Impacted areas of the application
Effects district search results for all states on [data/elections](https://www.fec.gov/data/elections/?state=&cycle=2018&election_full=true)
**new-file:**  fec/static/img/i-map--primary.svg

## Screenshots
<img width="1116" alt="screen shot 2018-10-31 at 12 36 02 am" src="https://user-images.githubusercontent.com/5572856/47885039-85766180-de09-11e8-8bc5-ac2dd14191a0.png">
<a id="how-to-test"></a> 
<hr/>

## How to test
  - checkout and run this branch locally : `fix/restore-color-coded-district-icon`
  - Go to http://127.0.0.1:8000/data/elections/?cycle=2018&state=CO
  - Make sure color coded icons show up in search results as in screenshot above, spot-check that color coding matches the color on the map for that district

