### PR TITLE
Sort nulls last in data tables

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -637,7 +637,10 @@ DataTable.prototype.isPending = function() {
 };
 
 DataTable.prototype.buildUrl = function(data, paginate) {
-  var query = _.extend({ sort_hide_null: false }, this.filters || {});
+  var query = _.extend(
+    { sort_hide_null: false, sort_nulls_last: true },
+    this.filters || {}
+  );
   paginate = typeof paginate === 'undefined' ? true : paginate;
   query.sort = mapSort(data.order, this.opts.columns);
 

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -149,7 +149,8 @@ describe('data table', function() {
       var url = this.table.buildUrl(data);
       var expected = helpers.buildUrl(
         ['path', 'to', 'endpoint'],
-        {sort_hide_null: 'false', party: 'DFL', sort: '-office', per_page: 30, page: 3, extra: 'true'}
+        {sort_hide_null: 'false', sort_nulls_last: 'true', party: 'DFL',
+        sort: '-office', per_page: 30, page: 3, extra: 'true'}
       );
       expect(URI(url).equals(expected)).to.be.true;
     });


### PR DESCRIPTION
## Summary (required)

- Follow-up front-end task for https://github.com/fecgov/openFEC/issues/3470 and Resolves #2481 

Because we can't know where null values belong, we should always sort nulls last (at the bottom, on the last pages) in data tables.

## Impacted areas of the application, how to test
List general components of the application that this PR will affect:

- Point to `dev` API 

- Check datatables (below is not a list of all the datatables, but a list of tables that were showing nulls on first load). They should all show nulls at the end.
     - [ ] IEs - http://localhost:8000/data/independent-expenditures/?data_type=processed&is_notice=true
     - [ ] Party coordinated - http://localhost:8000/data/party-coordinated-expenditures/
     - [ ] Loans - http://localhost:8000/data/loans/
     - [ ] Candidates - http://localhost:8000/data/candidates/?has_raised_funds=true
     - [ ] Committees - http://localhost:8000/data/committees/
     - [ ] RFAIs - http://localhost:8000/data/filings/?data_type=processed&form_type=RFAI
     - [ ] All filings - http://localhost:8000/data/filings/?data_type=processed
     - [ ] House and Senate committee reports - http://localhost:8000/data/reports/house-senate/?data_type=processed
