### PR TITLE
Implement data table descriptions

### DIFF
--- a/fec/data/templates/partials/advanced/filings-reports.jinja
+++ b/fec/data/templates/partials/advanced/filings-reports.jinja
@@ -8,18 +8,21 @@
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/filings">All filings</a></h4>
+          <p>Search for reports, statements, and filings submitted by committees and filers. Search by committee name, candidate, receipt date, form type and more.</p>
         </div>
       </li>
       <li>
           <i class="icon i-magnifying-glass icon--absolute--left"></i>
           <div class="content__section--indent-left">
             <h4><a href="/data/reports/presidential/?is_amended=false">Presidential committee reports</a></h4>
+            <p>Search financial disclosure reports filed by presidential committees on Form 3P. Search by committee name, candidate, amount of financial activity and report name.</p>
         </div>
       </li>
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/reports/house-senate">House and Senate committee reports</a></h4>
+          <p class ="u-margin--bottom">Search financial disclosure reports filed by House and Senate committees on the Form 3. Search by committee name, candidate, amount of financial activity and report name.</p>
           <div class="js-accordion accordion--neutral" data-content-prefix="house-senate">
             <button type="button" class="js-accordion-trigger accordion__button">Download this data as .CSV to use on your own</button>
             <div class="accordion__content">
@@ -38,6 +41,7 @@
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/reports/pac-party">PAC and party committee reports</a></h4>
+          <p>Search financial disclosure reports filed by political action committees (PACs) and party committees on Form 3X. Search by committee name, amount of financial activity and report name.</p>
         </div>
       </li>
       <li>

--- a/fec/data/templates/partials/advanced/loans-debts.jinja
+++ b/fec/data/templates/partials/advanced/loans-debts.jinja
@@ -7,6 +7,7 @@
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/loans">Loans</a></h4>
+          <p>Search loans owed by or to committees. Search by committee, loaner’s name, date the loan was incurred, original loan amount and payments made.</p>
         </div>
       </li>
       <li>

--- a/fec/data/templates/partials/advanced/raising.jinja
+++ b/fec/data/templates/partials/advanced/raising.jinja
@@ -3,6 +3,7 @@
 
 <section class="row" id="raising" aria-hidden="false" role="tabpanel">
   <h2>Raising</h2>
+  <p>Receipts are anything of value, like money, services or property.</p>
   <h3>Search or browse data</h3>
   <div class="content__section--ruled-responsive t-sans">
     <ul>
@@ -10,7 +11,7 @@
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/receipts/">All receipts</a></h4>
-          <p>Receipts are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
+          <p>Search candidate and committee receipt data by contributor, amount and date.</p>
         </div>
       </li>
       <li>

--- a/fec/data/templates/partials/advanced/spending.jinja
+++ b/fec/data/templates/partials/advanced/spending.jinja
@@ -43,14 +43,14 @@
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/party-coordinated-expenditures/">Party coordinated expenditures</a></h4>
-          <p>Search <span class="term" data-term="party coordinated expenditures" title="Click to define" tabindex="0">party coordinated expenditures</span> by specific national or state party committee, candidate and payee.</p>
+          <p>Search <span class="term" data-term="coordinated party expenditure" title="Click to define" tabindex="0">party coordinated expenditures</span> by specific national or state party committee, candidate and payee.</p>
         </div>
       </li>
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/electioneering-communications/">Electioneering communications</a></h4>
-          <p class ="u-margin--bottom">Search <span class="term" data-term="electioneering communications">electioneering communications</span> by the spender, candidate mentioned, date, or amount spent.</p>
+          <p class ="u-margin--bottom">Search <span class="term" data-term="electioneering communication">electioneering communications</span> by the spender, candidate mentioned, date, or amount spent.</p>
           <div class="js-accordion accordion--neutral" data-content-prefix="electioneering-communications">
             <button type="button" class="js-accordion-trigger accordion__button">Download this data as .CSV to use on your own</button>
             <div class="accordion__content">

--- a/fec/data/templates/partials/advanced/spending.jinja
+++ b/fec/data/templates/partials/advanced/spending.jinja
@@ -42,14 +42,15 @@
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
-          <h4 class="u-padding--bottom"><a href="/data/party-coordinated-expenditures/">Party coordinated expenditures</a></h4>
+          <h4><a href="/data/party-coordinated-expenditures/">Party coordinated expenditures</a></h4>
+          <p>Search <span class="term" data-term="party coordinated expenditures" title="Click to define" tabindex="0">party coordinated expenditures</span> by specific national or state party committee, candidate and payee.</p>
         </div>
       </li>
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/electioneering-communications/">Electioneering communications</a></h4>
-          <p class ="u-margin--bottom">Search electioneering communications for communications that support or oppose specific candidates. Search by date and amount spent.</p>
+          <p class ="u-margin--bottom">Search <span class="term" data-term="electioneering communications">electioneering communications</span> by the spender, candidate mentioned, date, or amount spent.</p>
           <div class="js-accordion accordion--neutral" data-content-prefix="electioneering-communications">
             <button type="button" class="js-accordion-trigger accordion__button">Download this data as .CSV to use on your own</button>
             <div class="accordion__content">


### PR DESCRIPTION
## Summary
Add datatable descriptions and glossary links(where applicable) to adv data page templates

- Resolves #2426
      
## Impacted areas of the application
 modified:   data/templates/partials/advanced/filings-reports.jinja
 modified:   data/templates/partials/advanced/loans-debts.jinja
 modified:   data/templates/partials/advanced/raising.jinja
 modified:   data/templates/partials/advanced/spending.jinja

## How to test
  - checkout  `feature/implement-datatable-descriptions-adv-data`
  - Go to http://127.0.0.1:8000/data/advanced/?tab=raising, (and other appllciable tabs) to verify changes in issue  #2426 have been made


