### PR TITLE
Fix candidate page 404 errors due to missing district

### DIFF
--- a/fec/data/templates/candidates-single.jinja
+++ b/fec/data/templates/candidates-single.jinja
@@ -116,9 +116,11 @@
               <li><a href="#other">Other documents filed</a></li>
             </ul>
         </li>
+        {% if get_election_url(candidate, election_year, district) %}
         <li class="side-nav__item">
           <a class="button button--cta u-margin--top t-left-aligned button--two-candidates u-full-width" href="{{ get_election_url(candidate, election_year, district) }}">Compare to<br>opposing candidates</a>
         </li>
+        {% endif %}
       </ul>
     </nav>
 

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -53,8 +53,8 @@
       </table>
 
       <div class="usa-width-one-fourth">
+        {% if get_election_url(candidate, election_year, district) %}
         <div class="card">
-          {% if get_election_url(candidate, election_year, district) %}
           <a href="{{ get_election_url(candidate, election_year, district) }}">
             <div class="card__image__container">
               <img class="icon--complex" src="/static/img/i-elections--primary.svg" alt="Icon representing elections">
@@ -63,8 +63,8 @@
               View all candidates in the {% if election_year %}{{ election_year }} {% endif %}{% if constants.states[state] %}{{ constants.states[state] }}{% endif %} {% if office == 'P' %}Presidential{% else %}{{ office_full }}{% endif %}{% if office_full == 'House' %} District {{ district|strip_zero_pad }}{% endif %} election
             </div>
           </a>
-          {% endif %}
         </div>
+        {% endif %}
       </div>
     </div>
 

--- a/fec/data/templatetags/filters.py
+++ b/fec/data/templatetags/filters.py
@@ -67,9 +67,15 @@ def nullify(value, *nulls):
 def get_election_url(candidate, cycle, district=None):
     if cycle:
         if candidate['office'] == 'H':
-            district_url = '/' + str(candidate['state']) + '/' + candidate['district']
+            if candidate.get('state') and candidate.get('district'):
+                district_url = '/' + str(candidate['state']) + '/' + candidate['district']
+            else:
+                return None
         elif candidate['office'] == 'S':
-            district_url = '/' + str(candidate['state'])
+            if candidate.get('state'):
+                district_url = '/' + str(candidate['state'])
+            else:
+                return None
         else:
             district_url = ''
 
@@ -101,7 +107,9 @@ def strip_zero_pad(number):
     Removes leading 0's for display purposes
     Commonly used for congressional districts
     '''
-    return number.lstrip("0")
+    if number:
+        return number.lstrip("0")
+    return "None"
 
 
 def date_filter(value, fmt='%m/%d/%Y'):

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -187,8 +187,6 @@ def get_candidate(candidate_id, cycle, election_full):
         'A', []
     )
 
-    committee_groups = committee_groups
-    committees_authorized = committees_authorized
     committee_ids = [committee['committee_id'] for committee in committees_authorized]
 
     # Get aggregate totals for the financial summary
@@ -204,8 +202,6 @@ def get_candidate(candidate_id, cycle, election_full):
         raising_summary = None
         spending_summary = None
         cash_summary = None
-
-    aggregate = aggregate
 
     # Get totals for the last two-year period of a cycle for showing on
     # raising and spending tabs


### PR DESCRIPTION
## Summary (required)

Found while testing #2463
- Resolves #2499: Fix candidate page 404 errors due to missing district
- Fix candidate page 404 errors due to missing district. 
- Only show compare button if link can be generated
- Hide grey box if compare link can't be generated
- (code cleanup) Remove variable self-assignment

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile pages

## Screenshots

### Before
<img width="715" alt="screen shot 2018-11-08 at 4 26 35 pm" src="https://user-images.githubusercontent.com/31420082/48228406-15b92700-e373-11e8-8668-cb602f6c5b0c.png">
<img width="316" alt="screen shot 2018-11-08 at 4 31 59 pm" src="https://user-images.githubusercontent.com/31420082/48228699-f242ac00-e373-11e8-8749-132e5a9efc2e.png">
<img width="864" alt="screen shot 2018-11-08 at 4 29 33 pm" src="https://user-images.githubusercontent.com/31420082/48228703-f53d9c80-e373-11e8-84a7-c0ba52b01a4e.png">

### After
<img width="896" alt="screen shot 2018-11-08 at 4 18 31 pm" src="https://user-images.githubusercontent.com/31420082/48228089-36cd4800-e372-11e8-9434-ff68ef85c309.png">
<img width="867" alt="screen shot 2018-11-08 at 4 20 40 pm" src="https://user-images.githubusercontent.com/31420082/48228160-6bd99a80-e372-11e8-8768-05c361cce889.png">


## How to test
- Point to `dev` API
- These pages should load:
http://localhost:8000/data/candidate/H0CA00116/?tab=summary
http://localhost:8000/data/candidate/H0CA00116/?tab=about-candidate