### PR TITLE
Fix districts map zoom-to-state

### DIFF
--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -142,7 +142,9 @@ ElectionMap.prototype.updateBounds = function(districts) {
   if (rule) {
     this.map.setView(rule.coords, rule.zoom);
   } else if (districts) {
-    this.map.flyToBounds(this.overlay.getBounds(), { duration: 0.15 });
+    window.setTimeout(() => {
+      this.map.flyToBounds(this.overlay.getBounds(), { duration: 0.5 });
+    }, 500);
   }
 };
 

--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -141,7 +141,7 @@ ElectionMap.prototype.updateBounds = function(districts) {
   if (rule) {
     this.map.setView(rule.coords, rule.zoom);
   } else if (districts) {
-    this.map.fitBounds(this.overlay.getBounds());
+    this.map.flyToBounds(this.overlay.getBounds(),this.opts)
   }
 };
 

--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -141,7 +141,7 @@ ElectionMap.prototype.updateBounds = function(districts) {
   if (rule) {
     this.map.setView(rule.coords, rule.zoom);
   } else if (districts) {
-    this.map.flyToBounds(this.overlay.getBounds(),this.opts)
+    this.map.flyToBounds(this.overlay.getBounds(), this.opts);
   }
 };
 

--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -76,7 +76,7 @@ ElectionMap.prototype.init = function() {
   this.map = L.map(this.elm, {
     scrollWheelZoom: false,
     draggable: false,
-    touchZoom: false,
+    touchZoom: false
   });
   this.map.on('viewreset', this.handleReset.bind(this));
   this.tileLayer = L.tileLayer.provider('Stamen.TonerLite');
@@ -142,7 +142,7 @@ ElectionMap.prototype.updateBounds = function(districts) {
   if (rule) {
     this.map.setView(rule.coords, rule.zoom);
   } else if (districts) {
-    this.map.flyToBounds(this.overlay.getBounds(), {duration:.15})
+    this.map.flyToBounds(this.overlay.getBounds(), { duration: 0.15 });
   }
 };
 

--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -76,7 +76,7 @@ ElectionMap.prototype.init = function() {
   this.map = L.map(this.elm, {
     scrollWheelZoom: false,
     draggable: false,
-    touchZoom: false
+    touchZoom: false,
   });
   this.map.on('viewreset', this.handleReset.bind(this));
   this.tileLayer = L.tileLayer.provider('Stamen.TonerLite');
@@ -125,6 +125,7 @@ ElectionMap.prototype.drawDistricts = function(districts) {
   }).addTo(this.map);
   this.updateBounds(districts);
   this.drawBackgroundDistricts(districts);
+  //this.overlay.bindPopup('popupContent').openPopup();
 };
 
 /**
@@ -141,7 +142,7 @@ ElectionMap.prototype.updateBounds = function(districts) {
   if (rule) {
     this.map.setView(rule.coords, rule.zoom);
   } else if (districts) {
-    this.map.flyToBounds(this.overlay.getBounds(), this.opts);
+    this.map.flyToBounds(this.overlay.getBounds(), {duration:.15})
   }
 };
 

--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -125,7 +125,6 @@ ElectionMap.prototype.drawDistricts = function(districts) {
   }).addTo(this.map);
   this.updateBounds(districts);
   this.drawBackgroundDistricts(districts);
-  //this.overlay.bindPopup('popupContent').openPopup();
 };
 
 /**

--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -133,6 +133,7 @@ ElectionMap.prototype.drawDistricts = function(districts) {
  * @param {array} districts - array of unique district identifiers
  */
 ElectionMap.prototype.updateBounds = function(districts) {
+  var self = this;
   var rule =
     districts &&
     _.find(boundsOverrides, function(rule, district) {
@@ -142,8 +143,8 @@ ElectionMap.prototype.updateBounds = function(districts) {
   if (rule) {
     this.map.setView(rule.coords, rule.zoom);
   } else if (districts) {
-    window.setTimeout(() => {
-      this.map.flyToBounds(this.overlay.getBounds(), { duration: 0.5 });
+    setTimeout(function() {
+      self.map.flyToBounds(self.overlay.getBounds(), { duration: 0.25 });
     }, 500);
   }
 };

--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -76,7 +76,7 @@ ElectionMap.prototype.init = function() {
   this.map = L.map(this.elm, {
     scrollWheelZoom: false,
     draggable: false,
-    touchZoom: false,
+    touchZoom: false
   });
   this.map.on('viewreset', this.handleReset.bind(this));
   this.tileLayer = L.tileLayer.provider('Stamen.TonerLite');


### PR DESCRIPTION
## Summary
Selecting states on /data/elections was inconsistent, sometimes zooming in, sometimes out

- Resolves #2447

## Impacted areas of the application
modified:   fec/static/js/modules/election-map.js
This solution uses the leaflet.js flyTo() function, using `this.overlay.getBounds(),this.opts` as arguments,  instead of fitBounds().

## Screenshots
![fly_to_zoom](https://user-images.githubusercontent.com/5572856/48244797-66517400-e3b5-11e8-97e9-a0919f6941fd.gif)


## How to test
  - Checkout and run this branch locally: `feature/fix-districts-map-zoom`
 - `npm run build`
  - go to http://127.0.0.1:8000/data/elections/ and test selecting states and districts to ensure that the map zooms into each chosen state and/or districts without zooming way out like it is on production.
  
