### PR TITLE
[MERGE WITH GIT FLOW] Fix candidate filing pages for missing amendment chain

### DIFF
--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -392,6 +392,7 @@ function amendmentVersionDescription(row) {
   // and F1N & F2 that are filed as N but are not originals
   if (
     row.amendment_indicator === API.amendment_indicator_new &&
+    row.amendment_chain != null &&
     row.amendment_chain.length === 1
   ) {
     description = ' Original';


### PR DESCRIPTION
## Summary (required)

- Resolves #2504

Fix candidate filing pages for missing amendment chain. In rare occasions like [this filing](http://docquery.fec.gov/pdf/569/201701209041436569/201701209041436569.pdf), a F99 will get coded as a F2 and won't have an amendment chain. This PR checks for an amendment chain before trying to check its length. 

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate filings page

## Screenshots

### Before

<img width="1375" alt="screen shot 2018-11-13 at 12 19 52 pm" src="https://user-images.githubusercontent.com/31420082/48430938-744d1f00-e73e-11e8-8b23-b82c23ba26c1.png">

<img width="830" alt="screen shot 2018-11-13 at 12 29 21 pm" src="https://user-images.githubusercontent.com/31420082/48431467-c8a4ce80-e73f-11e8-9c58-3b0641ca6b93.png">


### After
<img width="1395" alt="screen shot 2018-11-13 at 12 21 20 pm" src="https://user-images.githubusercontent.com/31420082/48431015-a6f71780-e73e-11e8-823f-845c3c70999e.png">
<img width="1095" alt="screen shot 2018-11-13 at 12 29 04 pm" src="https://user-images.githubusercontent.com/31420082/48431476-cd698280-e73f-11e8-8c49-06f4cea687d3.png">



## Related PRs

https://github.com/fecgov/fec-cms/pull/2410

## How to test

Filings should load:
http://localhost:8000/data/candidate/P80001571/?tab=filings
http://localhost:8000/data/filings/?data_type=processed&candidate_id=P80001571
