### PR TITLE
Remove setTimout function-elections map

### DIFF
--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -142,9 +142,7 @@ ElectionMap.prototype.updateBounds = function(districts) {
   if (rule) {
     this.map.setView(rule.coords, rule.zoom);
   } else if (districts) {
-    setTimeout(function() {
-      self.map.flyToBounds(self.overlay.getBounds(), { duration: 0.25 });
-    }, 500);
+    self.map.flyToBounds(self.overlay.getBounds(), { duration: 0.25 });
   }
 };
 


### PR DESCRIPTION
## Summary
Remove setTimeout function so zipcode zoom/color works properly
The setTimout error was added to remove console error, but then causes problems with the zipcode search function.( There exists a console error on production, so this still represents a step forward and the current console error will be researched.)

- Related issue #2447
- Related PR #2502

## Impacted areas of the application
modified:   fec/static/js/modules/election-map.js

## How to test
  - Checkout and run this branch locally: `feature/fix-districts-map-zoom`
 - `npm run build`
  - go to http://127.0.0.1:8000/data/elections/ and select states and districts,  then enter a zipcode and see that it zooms to that zipcode with district colored.