### PR TITLE
Remove reaction box feedback from site

### DIFF
--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -224,7 +224,6 @@
            </li>
          </ul>
       </div>
-      {{ reaction.reaction_box('raised', 'landing') }}
     </section>
     <section class="content__section" id="spending">
       <h3 class="u-no-margin">Spending</h3>
@@ -259,7 +258,6 @@
           </li>
         </ul>
       </div>
-      {{ reaction.reaction_box('spent', 'landing') }}
     </section>
   </div>
   {% endif %}

--- a/fec/data/templates/partials/advanced/raising.jinja
+++ b/fec/data/templates/partials/advanced/raising.jinja
@@ -87,11 +87,6 @@
           </div>
         </div>
       </li>
-      <li>
-        <section class="content__section">
-          {{ reaction.reaction_box('raised', 'advanced') }}
-        </section>
-      </li>
       {% endif %}
     </ul>
   </div>

--- a/fec/data/templates/partials/advanced/spending.jinja
+++ b/fec/data/templates/partials/advanced/spending.jinja
@@ -145,11 +145,6 @@
           </div>
         </div>
       </li>
-      <li>
-        <section class="content__section">
-          {{ reaction.reaction_box('spent', 'advanced') }}
-        </section>
-      </li>
       {% endif %}
     </ul>
   </div>


### PR DESCRIPTION
## Summary

_This removes the reaction box feedback feature from the data landing page, raising page, and spending page. The reaction box needed to be removed after 1 months time, which has been reached._

## How to test
Make sure the reaction box feature no longer appears on the following pages

-  http://localhost:8000/data/
- http://localhost:8000/data/advanced/?tab=raising
- http://localhost:8000/data/advanced/?tab=spending