### PR TITLE
Add data.json file for data.gov

### DIFF
--- a/fec/fec/templates/data.json
+++ b/fec/fec/templates/data.json
@@ -12,12 +12,12 @@
             "modified": "R/P2W",
             "publisher": {
                 "@type": "org:Organization",
-                "name": "Federal Election Commission",
+                "name": "Federal Election Commission"
             },
             "contactPoint": {
                 "@type": "vcard:Contact",
                 "fn": "Open Source",
-                "hasEmail": "mailto:apiinfo@fec.gov",
+                "hasEmail": "mailto:apiinfo@fec.gov"
             },
             "identifier": "https://api.open.fec.gov/",
             "accessLevel": "public",
@@ -31,9 +31,9 @@
                     "describedBy": "https://api.open.fec.gov/swagger/",
                     "describedByType": "application/swagger+json",
                     "format": "API",
-                    "title": "OpenFEC REST API",
+                    "title": "OpenFEC REST API"
                 }
-            ],
+            ]
         }
-    ],
+    ]
 }

--- a/fec/fec/templates/data.json
+++ b/fec/fec/templates/data.json
@@ -1,38 +1,38 @@
 {
-"conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
-"describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
-"@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
-"@type": "dcat:Catalog",
-"dataset": [
-    {
-        "@type": "dcat:Dataset",
-        "title": "FEC API",
-        "description": "The FEC is A RESTful web service supporting full-text and field-specific searches on federal campaign finance data.",
-        "keyword": ["campaign", "finance", "FEC", "elections"],
-        "modified": "R/P2W",
-        "publisher": {
-          "@type": "org:Organization",
-          "name": "Federal Election Commission"
-        },
-        "contactPoint": {
-          "@type": "vcard:Contact",
-          "fn": "Open Source",
-          "hasEmail": "mailto:apiinfo@fec.gov"
-        },
-        "identifier": "https://api.open.fec.gov/",
-        "accessLevel": "public",
-        "bureauCode": ["360:00"],
-        "programCode": ["000:000"],
-        "distribution": [
-            {
-                "accessURL": "https://api.open.fec.gov",
-                "description": "A fully queryable REST API with JSON output",
-                "describedBy": "https://api.open.fec.gov/swagger/",
-                "describedByType": "application/swagger+json",
-                "format": "API",
-                "title": "OpenFEC REST API"
-            }
-        ]
-    }
-]
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@type": "dcat:Catalog",
+    "dataset": [
+        {
+            "@type": "dcat:Dataset",
+            "title": "FEC API",
+            "description": "The FEC is A RESTful web service supporting full-text and field-specific searches on federal campaign finance data.",
+            "keyword": ["campaign", "finance", "FEC", "elections"],
+            "modified": "R/P2W",
+            "publisher": {
+                "@type": "org:Organization",
+                "name": "Federal Election Commission",
+            },
+            "contactPoint": {
+                "@type": "vcard:Contact",
+                "fn": "Open Source",
+                "hasEmail": "mailto:apiinfo@fec.gov",
+            },
+            "identifier": "https://api.open.fec.gov/",
+            "accessLevel": "public",
+            "bureauCode": ["360:00"],
+            "programCode": ["000:000"],
+            "distribution": [
+                {
+                    "accessURL": "https://api.open.fec.gov",
+                    "description": "A fully queryable REST API with JSON output",
+                    "describedBy": "https://api.open.fec.gov/swagger/",
+                    "describedByType": "application/swagger+json",
+                    "format": "API",
+                    "title": "OpenFEC REST API",
+                }
+            ],
+        }
+    ],
 }

--- a/fec/fec/templates/data.json
+++ b/fec/fec/templates/data.json
@@ -1,0 +1,38 @@
+{
+"conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+"describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+"@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+"@type": "dcat:Catalog",
+"dataset": [
+    {
+        "@type": "dcat:Dataset",
+        "title": "FEC API",
+        "description": "The FEC is A RESTful web service supporting full-text and field-specific searches on federal campaign finance data.",
+        "keyword": ["campaign", "finance", "FEC", "elections"],
+        "modified": "R/P2W",
+        "publisher": {
+          "@type": "org:Organization",
+          "name": "Federal Election Commission"
+        },
+        "contactPoint": {
+          "@type": "vcard:Contact",
+          "fn": "Open Source",
+          "hasEmail": "mailto:apiinfo@fec.gov"
+        },
+        "identifier": "https://api.open.fec.gov/",
+        "accessLevel": "public",
+        "bureauCode": ["360:00"],
+        "programCode": ["000:000"],
+        "distribution": [
+            {
+                "accessURL": "https://api.open.fec.gov",
+                "description": "A fully queryable REST API with JSON output",
+                "describedBy": "https://api.open.fec.gov/swagger/",
+                "describedByType": "application/swagger+json",
+                "format": "API",
+                "title": "OpenFEC REST API"
+            }
+        ]
+    }
+]
+}

--- a/fec/fec/templates/data.json
+++ b/fec/fec/templates/data.json
@@ -23,6 +23,7 @@
             "accessLevel": "public",
             "bureauCode": ["360:00"],
             "programCode": ["000:000"],
+            "licence": "https://github.com/fecgov/FEC/blob/master/LICENSE.md",
             "distribution": [
                 {
                     "accessURL": "https://api.open.fec.gov",

--- a/fec/fec/tests/test_static_files.py
+++ b/fec/fec/tests/test_static_files.py
@@ -1,0 +1,29 @@
+from django.test import Client, TestCase
+import pytest
+
+
+class TestStaticFiles(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_data_json_renders(self):
+        response = self.client.get('/data.json')
+        self.assertEqual(response.status_code, 200)
+
+    def test_data_json_valid(self):
+        response = self.client.get('/data.json')
+        try:
+            response.json()
+        except Exception as e:
+            pytest.fail("Data.json is not valid json: {0}".format(e))
+
+    def test_code_json_renders(self):
+        response = self.client.get('/code.json')
+        self.assertEqual(response.status_code, 200)
+
+    def test_code_json_valid(self):
+        response = self.client.get('/code.json')
+        try:
+            response.json()
+        except Exception as e:
+            pytest.fail("Data.json is not valid json: {0}".format(e))

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -32,8 +32,18 @@ urlpatterns = [
     url(r'', include('data.urls')),  # URLs for /data
     url(r'', include('legal.urls')),  # URLs for legal pages
     url(r'', include(wagtail_urls)),
-    url(r'^code\.json$', TemplateView.as_view(template_name='code.json')),
-    url(r'^data\.json$', TemplateView.as_view(template_name='data.json')),
+    url(
+        r'^code\.json$',
+        TemplateView.as_view(
+            template_name='code.json', content_type="application/json"
+        ),
+    ),
+    url(
+        r'^data\.json$',
+        TemplateView.as_view(
+            template_name='data.json', content_type="application/json"
+        ),
+    ),
 ]
 
 if settings.FEC_CMS_ENVIRONMENT != 'LOCAL':

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -14,7 +14,11 @@ from search import views as search_views
 
 
 urlpatterns = [
-    url(r'^documents/(\d+)/(.*)$', home_views.serve_wagtail_doc, name='wagtaildocs_serve'),
+    url(
+        r'^documents/(\d+)/(.*)$',
+        home_views.serve_wagtail_doc,
+        name='wagtaildocs_serve',
+    ),
     url(r'^auth/', include(uaa_urls)),
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^calendar/$', home_views.calendar),
@@ -28,30 +32,21 @@ urlpatterns = [
     url(r'', include('data.urls')),  # URLs for /data
     url(r'', include('legal.urls')),  # URLs for legal pages
     url(r'', include(wagtail_urls)),
-    url(r'^code\.json$',
-        TemplateView.as_view(
-            template_name='code.json'
-        )
-    ),
-    url(r'^data\.json$',
-        TemplateView.as_view(
-            template_name='data.json'
-        )
-    ),
+    url(r'^code\.json$', TemplateView.as_view(template_name='code.json')),
+    url(r'^data\.json$', TemplateView.as_view(template_name='data.json')),
 ]
 
 if settings.FEC_CMS_ENVIRONMENT != 'LOCAL':
-    #admin/login always must come before admin/, so place at beginning of list
-    urlpatterns.insert(0,url(r'^admin/login', uaa_views.login, name='login'))
+    # admin/login always must come before admin/, so place at beginning of list
+    urlpatterns.insert(0, url(r'^admin/login', uaa_views.login, name='login'))
 
 if settings.FEC_CMS_ROBOTS:
-    urlpatterns += url(
-        r'^robots\.txt$',
-        TemplateView.as_view(
-            template_name='robots.txt',
-            content_type='text/plain'
+    urlpatterns += (
+        url(
+            r'^robots\.txt$',
+            TemplateView.as_view(template_name='robots.txt', content_type='text/plain'),
         ),
-    ),
+    )
 
 
 if settings.DEBUG:
@@ -62,5 +57,5 @@ if settings.DEBUG:
     urlpatterns += staticfiles_urlpatterns()
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
-    #hide django-admin unless DEBUG=True
-    urlpatterns.insert(1,url(r'^django-admin/', include(admin.site.urls)))
+    # hide django-admin unless DEBUG=True
+    urlpatterns.insert(1, url(r'^django-admin/', include(admin.site.urls)))

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -57,7 +57,7 @@ if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION':
             template_name='robots.txt',
             content_type='text/plain'
         ),
-    )
+    ),
 
 
 if settings.DEBUG:

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -32,7 +32,12 @@ urlpatterns = [
         TemplateView.as_view(
             template_name='code.json'
         )
-    )
+    ),
+    url(r'^data\.json$',
+        TemplateView.as_view(
+            template_name='data.json'
+        )
+    ),
 ]
 
 if settings.FEC_CMS_ENVIRONMENT != 'LOCAL':


### PR DESCRIPTION
## Summary (required)

Partial resolution for #2362: Add FEC API to data.gov
- Add data.json file to root directory (www.fec.gov/data.json) for data.gov harvesting process.
- Add tests for code.json and data.json files

## Related PRs

branch | PR
------ | ------
`feature/add-codegov-json`| https://github.com/fecgov/fec-cms/pull/2260: Add code.json file to root directory for code.gov open source inventory

## How to test
- http://localhost:8000/data.json should display data.json metadata file. 
- Validate with https://labs.data.gov/dashboard/validate. Schema is here: https://project-open-data.cio.gov/v1.1/schema/#modified