### PR TITLE
Show robots.txt in all environments except production

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -22,9 +22,6 @@ FEC_API_KEY = env.get_credential('FEC_WEB_API_KEY')
 FEC_API_VERSION = env.get_credential('FEC_API_VERSION', 'v1')
 FEC_API_KEY_PUBLIC = env.get_credential('FEC_WEB_API_KEY_PUBLIC', '')
 
-# Disables crawling for all of our environments except for production
-FEC_CMS_ROBOTS = True
-
 FEC_RECAPTCHA_SECRET_KEY = env.get_credential('FEC_RECAPTCHA_SECRET_KEY')
 FEC_GITHUB_TOKEN = env.get_credential('FEC_GITHUB_TOKEN')
 

--- a/fec/fec/settings/dev.py
+++ b/fec/fec/settings/dev.py
@@ -1,5 +1,6 @@
 from .base import *  # noqa
 
+# These settings are for local development only.
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/fec/fec/settings/production.py
+++ b/fec/fec/settings/production.py
@@ -3,6 +3,9 @@ from .env import env
 
 SECRET_KEY = env.get_credential('DJANGO_SECRET_KEY')
 
+# These settings are used for all public environments:
+# dev, stage, feature, and production
+
 DEBUG = False
 TEMPLATE_DEBUG = False
 

--- a/fec/fec/settings/production.py
+++ b/fec/fec/settings/production.py
@@ -9,9 +9,6 @@ SECRET_KEY = env.get_credential('DJANGO_SECRET_KEY')
 DEBUG = False
 TEMPLATE_DEBUG = False
 
-# Allows search crawling in production only
-FEC_CMS_ROBOTS = False
-
 SESSION_COOKIE_SECURE = True
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_SECURE = True

--- a/fec/fec/tests/test_robots.py
+++ b/fec/fec/tests/test_robots.py
@@ -1,6 +1,5 @@
 import sys
 from django.test import TestCase
-from django.test import override_settings
 from django.conf import settings
 from django.core.urlresolvers import clear_url_caches
 from importlib import reload, import_module
@@ -20,13 +19,13 @@ class TestRobots(TestCase):
 
     def test_robots_txt_returns_200_stage(self):
 
-        with override_settings(**{'FEC_CMS_ENVIRONMENT': 'STAGING'}):
+        with self.settings(FEC_CMS_ENVIRONMENT='STAGING'):
             response = self.client.get('/robots.txt')
             self.assertEqual(response.status_code, 200)
 
     def test_robots_txt_throws_404(self):
 
-        with override_settings(**{'FEC_CMS_ENVIRONMENT': 'PRODUCTION'}):
+        with self.settings(FEC_CMS_ENVIRONMENT='PRODUCTION'):
             reload_url_conf()
             response = self.client.get('/robots.txt')
             self.assertEqual(response.status_code, 404)

--- a/fec/fec/tests/test_robots.py
+++ b/fec/fec/tests/test_robots.py
@@ -1,0 +1,32 @@
+import sys
+from django.test import TestCase
+from django.test import override_settings
+from django.conf import settings
+from django.core.urlresolvers import clear_url_caches
+from importlib import reload, import_module
+
+
+# URLs need to be reloaded with new settings
+def reload_url_conf():
+    clear_url_caches()
+    urlconf = settings.ROOT_URLCONF
+    if urlconf in sys.modules:
+        reload(sys.modules[urlconf])
+    else:
+        import_module(urlconf)
+
+
+class TestRobots(TestCase):
+
+    def test_robots_txt_returns_200_stage(self):
+
+        with override_settings(**{'FEC_CMS_ENVIRONMENT': 'STAGING'}):
+            response = self.client.get('/robots.txt')
+            self.assertEqual(response.status_code, 200)
+
+    def test_robots_txt_throws_404(self):
+
+        with override_settings(**{'FEC_CMS_ENVIRONMENT': 'PRODUCTION'}):
+            reload_url_conf()
+            response = self.client.get('/robots.txt')
+            self.assertEqual(response.status_code, 404)

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -39,7 +39,8 @@ if settings.FEC_CMS_ENVIRONMENT != 'LOCAL':
     #admin/login always must come before admin/, so place at beginning of list
     urlpatterns.insert(0,url(r'^admin/login', uaa_views.login, name='login'))
 
-if settings.FEC_CMS_ROBOTS:
+
+if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION':
     urlpatterns += url(
         r'^robots\.txt$',
         TemplateView.as_view(


### PR DESCRIPTION
## Summary (required)

Resolves #2517: Show robots.txt in all environments except production
- Add tests
- Simplify logic
- Clarify Django settings files

## Impacted areas of the application
List general components of the application that this PR will affect:

-  https://fec-dev-proxy.app.cloud.gov/robots.txt
- https://stage.fec.gov/robots.txt
- https://fec-feature-cms.app.cloud.gov/robots.txt (edited)

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/fix-robots | https://github.com/fecgov/fec-cms/pull/1893

## How to test

I tested this with a manual deploy to the `dev` space 
<img width="499" alt="screen shot 2018-11-20 at 7 26 26 pm" src="https://user-images.githubusercontent.com/31420082/48811119-4184c700-ecfa-11e8-9133-df3d3899cb69.png">
