### PR TITLE
Upgrade django-storages to 1.7.1

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -264,6 +264,7 @@ if FEC_CMS_ENVIRONMENT != 'LOCAL':
     AWS_S3_REGION_NAME = env.get_credential('region')
     AWS_S3_CUSTOM_DOMAIN = env.get_credential('CMS_AWS_CUSTOM_DOMAIN')
     AWS_S3_FILE_OVERWRITE = False
+    AWS_DEFAULT_ACL = None
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_LOCATION = 'cms-content'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ python-dateutil==2.6.0
 
 # Content import
 beautifulsoup4==4.5.1
-django-storages==1.5.2
+django-storages==1.7.1
 boto3==1.7.21
 
 cg-django-uaa==1.3.0


### PR DESCRIPTION
## Summary (required)

Resolves #2457 
- Upgrade django-storages to 1.7.1
- Default to using the bucket's ACL per django-storages warning:
From Django-storages:
> "The default behavior of S3Boto3Storage is insecure and will change
 in django-storages 2.0. By default files and new buckets are saved
 with an ACL of 'public-read' (globally publicly readable). Version 2.0 will
 default to using the bucket's ACL. To opt into the new behavior set
 `AWS_DEFAULT_ACL = None`

 See https://github.com/jschneier/django-storages/blob/master/storages/backends/s3boto3.py#L280-L287

## Impacted areas of the application
List general components of the application that this PR will affect:

-  S3 storage
- Wagtail image and document upload
## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/714-s3-files-uploads | https://github.com/fecgov/fec-cms/pull/747: Capability to upload documents and images from Wagtail to s3


## How to test

Might need to do a manual deploy to `dev` to test wagtail file uploads
