### PR TITLE
Refer to SERS for archived hearing pages and files

### DIFF
--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -109,7 +109,7 @@
           </section>
           <section id="meetings-hearings" role="tabpanel" aria-hidden="true" aria-labelledby="hearings">
             <h2>Public hearings</h2>
-            <p>The Commission periodically holds public hearings at its headquarters in Washington, DC. These hearings offer interested persons an opportunity to testify concerning proposed regulations and other matters that come before the Commission.</p>
+            <p>The Commission periodically holds public hearings at its headquarters in Washington, DC. These hearings offer interested persons an opportunity to testify concerning proposed regulations and other matters that come before the Commission. This page lists upcoming public hearings as well as those held from 2005 through the present. Use <a href="http://sers.fec.gov/fosers/">SERS</a> to search for all archived rulemaking hearings.</p>
             <div class="filters--horizontal">
                <form action="" id="hearings_form" method="get" class="js-form-nav container">
                   <div class="filter">


### PR DESCRIPTION
## Summary (required)
 Resolves #2514: Add language to hearings page to refer people to SERS for archived hearings

- Add this sentence to the end of the description at the top of https://www.fec.gov/meetings/?tab=hearings:
>This page lists upcoming public hearings as well as those held from 2005 through the present. Use SERS to search for all archived rulemaking hearings.
- Add the link to SERS in that sentence so that it points to http://sers.fec.gov/fosers/
(note that https doesn't currently work with SERS - @patphongs is looking into it)
<img width="261" alt="screen shot 2018-11-21 at 9 32 53 am" src="https://user-images.githubusercontent.com/31420082/48848307-99124980-ed71-11e8-8eab-a2043ddb234a.png">

## Impacted areas of the application
List general components of the application that this PR will affect:

-  http://localhost:8000/meetings/?tab=hearings

## Screenshots

<img width="780" alt="screen shot 2018-11-21 at 9 36 25 am" src="https://user-images.githubusercontent.com/31420082/48848398-cc54d880-ed71-11e8-88cb-c142c86836ea.png">

