### PR TITLE
Rename section to 'Contributions from committees to candidates & independent expenditures'

### DIFF
--- a/fec/data/templates/partials/advanced/bulk-data.jinja
+++ b/fec/data/templates/partials/advanced/bulk-data.jinja
@@ -192,7 +192,7 @@
         <p class="icon-download--inline--left"><a href="/files/bulk-downloads/data_dictionaries/indiv_header_file.csv">Header file</a></p>
         <p>The individual contributions file contains each contribution from an individual to a federal committee. It includes the ID number of the committee receiving the contribution, the name, city, state, zip code, and place of business of the contributor along with the date and amount of the contribution.</p>
       </div>
-      <button type="button" class="js-accordion-trigger accordion__button">Contributions to candidates</button>
+      <button type="button" class="js-accordion-trigger accordion__button">Contributions from committees to candidates & independent expenditures</button>
       <div class="accordion__content">
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">


### PR DESCRIPTION
## Summary (required)

- Resolves #2522 

Rename  'Contributions to committees' section to 'Contributions from committees to candidates & independent expenditures'

## Impacted areas of the application
List general components of the application that this PR will affect:

-  https://www.fec.gov/data/advanced/?tab=bulk-data

## Screenshots

### Before

![screen shot 2018-11-21 at 12 09 29 pm](https://user-images.githubusercontent.com/31420082/48857261-6fafe880-ed86-11e8-8f30-e09673291257.png)

### After
<img width="885" alt="screen shot 2018-11-30 at 4 44 08 pm" src="https://user-images.githubusercontent.com/31420082/49316555-4ea27280-f4bf-11e8-8e86-800eeddabed4.png">

## How to test
http://localhost:8000/data/advanced/?tab=bulk-data
