### PR TITLE
Add closing parenthesis for Super PAC label

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -237,7 +237,7 @@ pac_party_types = OrderedDict([
     ('Y', 'Party - qualified'),
     ('Z', 'National party nonfederal account'),
     ('U', 'Single candidate independent expenditure'),
-    ('O', 'Super PAC (independent expenditure only'),
+    ('O', 'Super PAC (independent expenditure only)'),
     ('I', 'Independent expenditor (person or group)')
 ])
 


### PR DESCRIPTION
## Summary (required)

Resolves #2104: Missing parenthesis on https://www.fec.gov/data/reports/pac-party/
- Add closing parenthesis for Super PAC label

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee type label on https://www.fec.gov/data/reports/pac-party/

## Screenshots

![screen shot 2018-11-21 at 12 31 29 pm](https://user-images.githubusercontent.com/31420082/48858657-ee5a5500-ed89-11e8-9301-5af40e196632.png)



## How to test
Check out committee type dropdown: http://localhost:8000/data/reports/pac-party/?two_year_transaction_period=2018&data_type=processed&min_receipt_date=01%2F01%2F2017&max_receipt_date=11%2F21%2F2018
