### PR TITLE
Election profile page: Fix "Individual contributions" section for future candidates

### DIFF
--- a/fec/fec/static/js/modules/maps.js
+++ b/fec/fec/static/js/modules/maps.js
@@ -316,7 +316,12 @@ function appendStateMap($parent, results, cached) {
 function drawStateMap($container, candidateId, cached) {
   var url = helpers.buildUrl(
     ['schedules', 'schedule_a', 'by_state', 'by_candidate'],
-    { cycle: context.election.cycle, candidate_id: candidateId, per_page: 99 }
+    {
+      cycle: context.election.cycle,
+      candidate_id: candidateId,
+      per_page: 99,
+      election_full: true
+    }
   );
   var $map = $container.find('.state-map-choropleth');
   $map.html('');

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -810,8 +810,8 @@ function refreshTables(e, context) {
     });
 
   if (selected.length > 0) {
-    drawSizeTable(selected, context);
-    drawStateTable(selected, context);
+    drawContributionsBySizeTable(selected, context);
+    drawContributionsByStateTable(selected, context);
   }
 
   if (e) {
@@ -893,7 +893,8 @@ var drawTableOpts = {
   pagingType: 'simple'
 };
 
-function drawSizeTable(selected, context) {
+// For election profile page "Individual contributions to candidates"
+function drawContributionsBySizeTable(selected, context) {
   var $table = $('table[data-type="by-size"]');
   var primary = _.object(
     _.map(selected, function(result) {
@@ -929,7 +930,8 @@ function drawSizeTable(selected, context) {
   });
 }
 
-function drawStateTable(selected, context) {
+// For election profile page "Individual contributions to candidates"
+function drawContributionsByStateTable(selected, context) {
   var $table = $('table[data-type="by-state"]');
   var primary = _.object(
     _.map(selected, function(result) {

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -878,17 +878,6 @@ function destroyTable($table) {
   }
 }
 
-function buildUrl(selected, context, path) {
-  var query = {
-    cycle: context.election.cycle,
-    candidate_id: _.pluck(selected, 'candidate_id'),
-    per_page: 0,
-    election_full: true
-  };
-
-  return helpers.buildUrl(path, query);
-}
-
 var drawTableOpts = {
   autoWidth: false,
   destroy: true,
@@ -911,14 +900,17 @@ function drawSizeTable(selected, context) {
       return [result.candidate_id, result];
     })
   );
-  $.getJSON(
-    buildUrl(selected, context, [
-      'schedules',
-      'schedule_a',
-      'by_size',
-      'by_candidate'
-    ])
-  ).done(function(response) {
+  var query = {
+    cycle: context.election.cycle,
+    candidate_id: _.pluck(selected, 'candidate_id'),
+    per_page: 0,
+    election_full: true
+  };
+  var url = helpers.buildUrl(
+    ['schedules', 'schedule_a', 'by_size', 'by_candidate'],
+    query
+  );
+  $.getJSON(url).done(function(response) {
     var data = mapSize(response, primary);
     destroyTable($table);
     $table.dataTable(
@@ -944,14 +936,17 @@ function drawStateTable(selected, context) {
       return [result.candidate_id, result];
     })
   );
-  $.getJSON(
-    buildUrl(selected, context, [
-      'schedules',
-      'schedule_a',
-      'by_state',
-      'by_candidate'
-    ])
-  ).done(function(response) {
+  var query = {
+    cycle: context.election.cycle,
+    candidate_id: _.pluck(selected, 'candidate_id'),
+    per_page: 0,
+    election_full: true
+  };
+  var url = helpers.buildUrl(
+    ['schedules', 'schedule_a', 'by_state', 'by_candidate'],
+    query
+  );
+  $.getJSON(url).done(function(response) {
     var data = mapState(response, primary);
     // Populate headers with correct text
     var headerLabels = ['State'].concat(_.pluck(selected, 'candidate_name'));

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -882,7 +882,8 @@ function buildUrl(selected, context, path) {
   var query = {
     cycle: context.election.cycle,
     candidate_id: _.pluck(selected, 'candidate_id'),
-    per_page: 0
+    per_page: 0,
+    election_full: true
   };
 
   return helpers.buildUrl(path, query);


### PR DESCRIPTION
## Summary (required)

- Resolves #2544: Fix "Individual contributions" section for future candidates
- Pass `election_full=true` for comparison table & map
## Impacted areas of the application
List general components of the application that this PR will affect:

-  Election profile pages of future presidential and senate candidates

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/31420082/49117462-c037b200-f26e-11e8-92c5-88ae22bf9c80.png)
<img width="1007" alt="screen shot 2018-11-27 at 6 08 17 pm" src="https://user-images.githubusercontent.com/31420082/49117688-903cde80-f26f-11e8-804e-974cf3a648cd.png">


### After
<img width="974" alt="screen shot 2018-11-27 at 6 06 49 pm" src="https://user-images.githubusercontent.com/31420082/49117693-9632bf80-f26f-11e8-8f44-6b29dc07c5f5.png">
<img width="1016" alt="screen shot 2018-11-27 at 6 08 47 pm" src="https://user-images.githubusercontent.com/31420082/49117697-9af77380-f26f-11e8-9c08-0c7e6370188a.png">


## Related PRs
https://github.com/fecgov/fec-cms/pull/2254: Add future elections to election search & profile pages (This related PR missed the "Individual contributions" section)

## How to test
Include any information that may be helpful to the reviewer(s).
- http://localhost:8000/data/elections/senate/CA/2022/#individual-contributions
- http://localhost:8000/data/elections/president/2020/#individual-contributions
