### PR TITLE
Enable sort on employer and occupation columns

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -90,7 +90,7 @@ var employerColumns = [
   {
     data: 'total',
     className: 'all',
-    orderable: false,
+    orderable: true,
     orderSequence: ['desc', 'asc'],
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],
@@ -117,7 +117,7 @@ var occupationColumns = [
   {
     data: 'total',
     className: 'all',
-    orderable: false,
+    orderable: true,
     orderSequence: ['desc', 'asc'],
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/fec-cms/issues/2242
Made the`Total contributed` column  sortable on both Employer and Occupations tabs.

## Impacted areas of the application
On committee profile pages, under Raising, on the Individual contributions table, the sort function now works on both Employer and Occupation tab.

## How to test
Production (without sort):
https://www.fec.gov/data/committee/C00431445/?tab=raising#individual-contribution-transactions

Local (with sort): 
http://localhost:8000/data/committee/C00431445/?tab=raising#individual-contribution-transactions
`Total contributed` column is now sortable on both `Employer` and `Occupation` tabs 