### PR TITLE
Removed cycle greater than 2006 limitation on candidate and committee…

### DIFF
--- a/fec/data/templates/macros/tables.jinja
+++ b/fec/data/templates/macros/tables.jinja
@@ -34,16 +34,16 @@ case 3: for committe profile page.
 not 'type' object, so use 'link' to check for 'independent-expenditures' and 'party-coordinated-expenditure'
 #}
 
-        {% if item[1]['type'] and cycle|int > 2006 and committee_id|count < 9 %}
+        {% if item[1]['type'] and committee_id|count < 9 %}
           <a href="/data/{{ item[1]['type']['link'] }}/?{% for id in committee_id -%}committee_id={{ id }}&{%- endfor %}two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
           </a>
-        {% elif item[1]['type'] and cycle|int > 2006 and committee_id|count == 9 %}
+        {% elif item[1]['type'] and committee_id|count == 9 %}
           <a href="/data/{{ item[1]['type']['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
           </a>
 
-        {% elif (item[1]['link']=="independent-expenditures" or item[1]['link'] == "party-coordinated-expenditures")and cycle|int > 2006 and committee_id|count == 9 %}
+        {% elif (item[1]['link']=="independent-expenditures" or item[1]['link'] == "party-coordinated-expenditures") and committee_id|count == 9 %}
           <a href="/data/{{ item[1]['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}">
             {{ item[0]|currency }}
           </a>


### PR DESCRIPTION
## Summary (required)

Removed the the condition that restrict on transaction level data prior to cycle 2006 clickable.

- Resolves Issue #2401  - [Missing links to transaction level data pre-2006: Candidate and committee profile pages](https://github.com/fecgov/fec-cms/issues/2401)
_Include a summary of proposed changes._

## Impacted areas of the application
Candidate and Committee summary pages.(line item links on the financial summary )

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/20324717/49180769-9db3a080-f323-11e8-9ecf-af0252567a7c.png)
After:
![image](https://user-images.githubusercontent.com/20324717/49180839-d784a700-f323-11e8-83a6-8938afb0ed73.png)


## How to test
Pull down feature/missing_links_to_transactions to your local environment
Run you local fec-cms with api locally.
http://localhost:8000/data/candidate/S6MT00162/?cycle=2006&election_full=true
http://localhost:8000/data/candidate/S6MT00162/?cycle=2006&election_full=true

