### PR TITLE
Add CommitteeID column to committees datapage.

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -327,7 +327,7 @@ table_columns = OrderedDict([
     ('candidates-office-president', ['Name', 'Party', 'Receipts', 'Disbursements']),
     ('candidates-office-senate', ['Name', 'Party', 'State', 'Receipts', 'Disbursements']),
     ('candidates-office-house', ['Name', 'Party', 'State', 'District', 'Receipts', 'Disbursements']),
-    ('committees', ['Name', 'Treasurer', 'Type', 'Designation', 'First filing date']),
+    ('committees', ['Name', 'Committee ID', 'Treasurer', 'Type', 'Designation', 'First filing date']),
     ('communication-costs', ['Committee', 'Support/Oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Description', 'Disbursement date', 'Amount']),
     ('electioneering-communications', ['Spender', 'Candidate mentioned','Number of candidates', 'Amount per candidate', 'Date', 'Disbursement amount' ]),

--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -208,6 +208,7 @@ var committees = [
       }
     }
   },
+  { data: 'committee_id', orderable: false, className: 'all' },
   { data: 'treasurer_name', className: 'min-desktop hide-panel' },
   { data: 'committee_type_full', className: 'min-tablet hide-panel' },
   { data: 'designation_full', className: 'min-tablet hide-panel' },


### PR DESCRIPTION
## Summary 

- Resolves https://github.com/fecgov/fec-cms/issues/2361
Added `Committee ID` column to Committees datapage.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committees datapage

## Screenshots
In Production(Before fix)
![screen shot 2018-11-28 at 9 51 14 pm](https://user-images.githubusercontent.com/11650355/49196317-8347ea00-f358-11e8-8f8d-35349d8f66c4.png)


In Local env(After fix)

![screen shot 2018-11-28 at 9 53 44 pm](https://user-images.githubusercontent.com/11650355/49196324-893dcb00-f358-11e8-9768-7375b8b6686c.png)


## How to test

  - checkout the branch `feature/add-cmteid-to-committees-datatable`
  - Committee ID column should appear here :http://localhost:8000/data/committees/

