### PR TITLE
Fix breaking text on H4CC mega-menu (Safari)

### DIFF
--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -97,6 +97,7 @@
   margin-bottom: u(1.5rem);
   padding-left: u(2rem);
   line-height:1.2;
+  break-inside: avoid;
 
   &:first-of-type {
   }


### PR DESCRIPTION
## Summary
"Dates and deadlines" was breaking up across two columns in the H4CC mega-menu **in Safari desktop and mobile browsers**. Adding `break-inside:avoid` to the `mega__item` class fixes this.

- Resolves #2564

## Impacted areas of the application
modified:   fec/static/scss/components/_mega-menu.scss

## How to test
Checkout and this branch: fix/breaking-text-mega-menu
Run `npm run build` or just `npm run build-sass` 
View site in Safari browser to see that "Dates and deadlines" appears as expected 
____

