### PR TITLE
Fixed file an issue link on legal no results macro

### DIFF
--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -102,7 +102,7 @@
       <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources={{ '%2C'.join(fec_resources or []) }}&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
       {% endif %}
       <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
-      <li><a class="button button--standard" href="https://github.com/fegov/fec/issues">File an issue</a></li>
+      <li><a class="button button--standard" href="https://github.com/fecgov/fec/issues">File an issue</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
## Summary

_Fixed link to the "File an issue" button on the legal no results macro._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Legal global search results page

## How to test
1. Go to legal global search results page: http://localhost:8000/data/legal/search/?search_type=all&search=
2. Click on "File an issue" button, it should now go to our FEC issues repo.

