### PR TITLE
Changing the label for the cycle <select>

### DIFF
--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -2,7 +2,7 @@
 {% set cycle = cycle | int %}
 {% if cycles %}
   <div class="cycle-select js-cycle-select">
-    <label for="{{ id }}" class="label cycle-select__label">Election</label>
+    <label for="{{ id }}" class="label cycle-select__label">Two-Year Period</label>
     <select
         id="{{ id }}"
         class="{{ class }} js-cycle"


### PR DESCRIPTION
https://github.com/fecgov/fec-cms/issues/2588

## Summary (required)
I changed the label for the election cycle <select> from "Election" to "Two-Year Period" (both are capped with css).

- Resolves #2588 

## Impacted areas of the application
It's a tiny change to the text in the label.

-  

## How to test
The label can be reviewed at
/data/raising-bythenumbers/
/data/spending-bythenumbers/
____

