### PR TITLE
Add optional label for cycle_select

### DIFF
--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -1,8 +1,8 @@
-{% macro cycle_select(cycles, cycle=none, duration=2, location='query', id='cycle-select', class='', range=False) %}
+{% macro cycle_select(cycles, cycle=none, duration=2, location='query', id='cycle-select', class='', range=False, label='Election') %}
 {% set cycle = cycle | int %}
 {% if cycles %}
   <div class="cycle-select js-cycle-select">
-    <label for="{{ id }}" class="label cycle-select__label">Two-Year Period</label>
+    <label for="{{ id }}" class="label cycle-select__label">{{ label }}</label>
     <select
         id="{{ id }}"
         class="{{ class }} js-cycle"

--- a/fec/data/templates/raising-bythenumbers.jinja
+++ b/fec/data/templates/raising-bythenumbers.jinja
@@ -12,7 +12,7 @@
 
 {% block sidebar %}
 <form action="" method="get" class="breakdown-cycle">
-  {{ select.cycle_select(cycles, cycle, location='form', range=True) }}
+  {{ select.cycle_select(cycles, cycle, location='form', range=True, label='Two-Year Period') }}
   <noscript>
     <button type="submit" class="button button--cta">Submit</button>
   </noscript>

--- a/fec/data/templates/spending-bythenumbers.jinja
+++ b/fec/data/templates/spending-bythenumbers.jinja
@@ -12,7 +12,7 @@
 
 {% block sidebar %}
 <form action="" method="get" class="breakdown-cycle">
-  {{ select.cycle_select(cycles, cycle, location='form', range=True) }}
+  {{ select.cycle_select(cycles, cycle, location='form', range=True, label='Two-Year Period') }}
   <noscript>
     <button type="submit" class="button button--cta">Submit</button>
   </noscript>


### PR DESCRIPTION
## Summary (required)
Part 2 to resolve #2588
Resolves an issue found while testing. We should keep the "election" label for `cycle_select` on election search, election profile, candidate, and committee profile pages. This PR adds an optional `label` argument to `cycle_select` macro so we can relabel the dropdown when needed.

## Impacted areas of the application
List general components of the application that this PR will affect:

Anywhere that uses `cycle_select`:
- Election profile pages
- Candidate/committee profile pages
- Raising/Spending charts

## Screenshots

## After
<img width="493" alt="screen shot 2018-12-17 at 10 57 25 am" src="https://user-images.githubusercontent.com/31420082/50098773-97aa3480-01ea-11e9-92e1-246eb7995776.png">
<img width="506" alt="screen shot 2018-12-17 at 10 57 06 am" src="https://user-images.githubusercontent.com/31420082/50098778-9973f800-01ea-11e9-845f-426bef3b668d.png">

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
2588-relabel-election-to-twoyear-period | #2590

## How to test
- Election search page cycle dropdown should be labeled "Election": http://localhost:8000/data/elections/
- Raising/Spending date range dropdown should be labeled "Two-year period": http://localhost:8000/data/spending-bythenumbers/
http://localhost:8000/data/raising-bythenumbers/
