### PR TITLE
Fix spelling of Pennsylvania

### DIFF
--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -78,7 +78,7 @@
           <div class="js-accordion accordion--neutral pa-message" data-content-prefix="pa-redistricting">
             <button type="button" class="js-accordion-trigger accordion__button" aria-controls="pa-redistricting-content-0" aria-expanded="false">Information about 2018 Pennsylvania redistricting</button>
             <div class="accordion__content" id="pa-redistricting-content-0" aria-hidden="true">
-                <p>On February 19, 2018, Pennsylvania's Supreme Court released a new congressional map for Pennsylvannia. Some candidates subsequently amended their registration forms to reflect new district numbers. Candidates are listed using
+                <p>On February 19, 2018, Pennsylvania's Supreme Court released a new congressional map for Pennsylvania. Some candidates subsequently amended their registration forms to reflect new district numbers. Candidates are listed using
                     information from their registration forms and may be running in different districts than in the past.</p>
             </div>
           </div>

--- a/fec/data/templates/partials/elections/election-data-and-compliance-tab.jinja
+++ b/fec/data/templates/partials/elections/election-data-and-compliance-tab.jinja
@@ -28,7 +28,7 @@
     {% include 'partials/elections/election-profile-cards.jinja' %}
     {% if state == 'PA' and office == 'house' and cycle == 2018 %}
     <div class="message message--info">
-        <p>On February 19, 2018, Pennsylvania's Supreme Court released a new congressional map for Pennsylvannia. Some candidates subsequently amended their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may be running in different districts than in the past.</p>
+        <p>On February 19, 2018, Pennsylvania's Supreme Court released a new congressional map for Pennsylvania. Some candidates subsequently amended their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may be running in different districts than in the past.</p>
     </div>
     {% endif %}
     <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">


### PR DESCRIPTION
## Summary (required)

- Resolves #2595 
Fix spelling of Pennsylvania on PA special election banner

## Impacted areas of the application
List general components of the application that this PR will affect:

- Banner on all 2018 PA house election profile pages 
 (ie https://www.fec.gov/data/elections/house/PA/17/2018/)
- Info accordion on https://www.fec.gov/data/elections/?cycle=2018&state=PA

## Screenshots

### Before
<img width="1129" alt="screen shot 2018-12-19 at 2 34 22 pm" src="https://user-images.githubusercontent.com/31420082/50243623-9bc98400-039b-11e9-9081-5f20a530810e.png">
<img width="1111" alt="screen shot 2018-12-19 at 2 35 18 pm" src="https://user-images.githubusercontent.com/31420082/50243634-a3892880-039b-11e9-8856-9d184465be4c.png">

### After
<img width="476" alt="screen shot 2018-12-19 at 2 38 39 pm" src="https://user-images.githubusercontent.com/31420082/50243738-f82ca380-039b-11e9-83ce-5d8fa4b6c9d2.png">

<img width="923" alt="screen shot 2018-12-19 at 2 39 05 pm" src="https://user-images.githubusercontent.com/31420082/50243735-f662e000-039b-11e9-9e2f-f2be264071d9.png">

## How to test

- http://localhost:8000/data/elections/house/PA/01/2018/
- http://localhost:8000/data/elections/?cycle=2018&state=PA