### PR TITLE
Update upcoming election to 2020, remove unused API call

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -5,9 +5,10 @@ from data import utils
 
 START_YEAR = 1979
 END_YEAR = 2018
-DEFAULT_TIME_PERIOD = 2018
+DEFAULT_TIME_PERIOD = 2018  # Change after final YE report (1/31/19)
+DEFAULT_ELECTION_CYCLE = 2020  # Change after election day (11/3/20)
 DEFAULT_PRESIDENTIAL_YEAR = 2020
-DISTRICT_MAP_CUTOFF = 2018 # The year we show district maps for on election pages
+DISTRICT_MAP_CUTOFF = 2018  # The year we show district maps for on election pages
 
 states = OrderedDict([
     ('AL', 'Alabama'),

--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -6,7 +6,7 @@ from data import utils
 START_YEAR = 1979
 END_YEAR = 2018
 DEFAULT_TIME_PERIOD = 2018  # Change after final YE report (1/31/19)
-DEFAULT_ELECTION_CYCLE = 2020  # Change after election day (11/3/20)
+DEFAULT_ELECTION_YEAR = 2020  # Change after election day (11/3/20)
 DEFAULT_PRESIDENTIAL_YEAR = 2020
 DISTRICT_MAP_CUTOFF = 2018  # The year we show district maps for on election pages
 

--- a/fec/data/templates/macros/filters/election-filter.jinja
+++ b/fec/data/templates/macros/filters/election-filter.jinja
@@ -1,11 +1,11 @@
 {% macro full_cycle(name, title, cycle_name, full_name, office) %}
   {% if office == 'president' %}
     {% set duration = 4 %}
-    {% set years = range(2020, 1976, -4) %}
+    {% set years = range(constants.DEFAULT_PRESIDENTIAL_YEAR, 1976, -4) %}
     {% set default_cycle = constants.DEFAULT_PRESIDENTIAL_YEAR %}
   {% elif office == 'senate' %}
     {% set duration = 6 %}
-    {% set years = range(2022, 1976, -2) %}
+    {% set years = range(constants.DEFAULT_ELECTION_CYCLE + 4, 1976, -2) %}
     {% set default_cycle = constants.DEFAULT_ELECTION_CYCLE %}
   {% endif %}
   <div

--- a/fec/data/templates/macros/filters/election-filter.jinja
+++ b/fec/data/templates/macros/filters/election-filter.jinja
@@ -5,8 +5,8 @@
     {% set default_cycle = constants.DEFAULT_PRESIDENTIAL_YEAR %}
   {% elif office == 'senate' %}
     {% set duration = 6 %}
-    {% set years = range(constants.DEFAULT_ELECTION_CYCLE + 4, 1976, -2) %}
-    {% set default_cycle = constants.DEFAULT_ELECTION_CYCLE %}
+    {% set years = range(constants.DEFAULT_ELECTION_YEAR + 4, 1976, -2) %}
+    {% set default_cycle = constants.DEFAULT_ELECTION_YEAR %}
   {% endif %}
   <div
       id="{{ name }}-field"

--- a/fec/data/templates/macros/filters/election-filter.jinja
+++ b/fec/data/templates/macros/filters/election-filter.jinja
@@ -6,7 +6,7 @@
   {% elif office == 'senate' %}
     {% set duration = 6 %}
     {% set years = range(2022, 1976, -2) %}
-    {% set default_cycle = constants.DEFAULT_TIME_PERIOD %}
+    {% set default_cycle = constants.DEFAULT_ELECTION_CYCLE %}
   {% endif %}
   <div
       id="{{ name }}-field"

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -438,7 +438,7 @@ def committee(request, committee_id):
 
 def elections_lookup(request):
 
-    cycle = utils.current_cycle()
+    cycle = constants.DEFAULT_ELECTION_CYCLE
     cycles = utils.get_cycles(cycle + 4)
 
     return render(

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -434,7 +434,7 @@ def committee(request, committee_id):
 
 def elections_lookup(request):
 
-    cycle = constants.DEFAULT_ELECTION_CYCLE
+    cycle = constants.DEFAULT_ELECTION_YEAR
     cycles = utils.get_cycles(cycle + 4)
 
     return render(

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -42,7 +42,6 @@ def to_date(committee, cycle):
 
 
 def landing(request):
-    top_candidates_raising = api_caller.load_top_candidates('-receipts', per_page=3)
 
     return render(
         request,
@@ -50,9 +49,6 @@ def landing(request):
         {
             'title': 'Campaign finance data',
             'dates': utils.date_ranges(),
-            'top_candidates_raising': top_candidates_raising['results']
-            if top_candidates_raising
-            else None,
             'first_of_year': datetime.date(datetime.date.today().year, 1, 1).strftime(
                 '%m/%d/%Y'
             ),


### PR DESCRIPTION
## Summary (required)

Resolves #2587 
- Set next election cycle to 2020 for election search and senate data tables, keep financial time period at 2018 (we won't have 2-year time period data for 2020 until we receive the 2018 YE on 1/31/19)
- Use constants to determine current and future elections for senate and presidential candidate data tables
- Remove unused API call for top candidates on data landing page for performance improvement

## Impacted areas of the application
List general components of the application that this PR will affect:

- "Election" dropdown on https://www.fec.gov/data/elections/
- "Election year" dropdown on https://www.fec.gov/data/candidates/senate/
- Removed unused API call for https://www.fec.gov/data/

## Screenshots

## Before
<img width="1007" alt="screen shot 2018-12-14 at 9 36 49 am" src="https://user-images.githubusercontent.com/31420082/50009074-0df92d80-ff84-11e8-9803-4bda22bcb68f.png">
<img width="783" alt="screen shot 2018-12-14 at 9 39 54 am" src="https://user-images.githubusercontent.com/31420082/50009158-4862ca80-ff84-11e8-9bfb-6b72d25d41c5.png">


## After
<img width="269" alt="screen shot 2018-12-19 at 3 09 36 pm" src="https://user-images.githubusercontent.com/31420082/50245620-f31e2300-03a0-11e9-8b00-68b1222ab6d9.png">

<img width="296" alt="screen shot 2018-12-19 at 3 15 12 pm" src="https://user-images.githubusercontent.com/31420082/50245612-f1545f80-03a0-11e9-94a8-5b31d62ddc53.png">
<img width="295" alt="screen shot 2018-12-19 at 3 15 23 pm" src="https://user-images.githubusercontent.com/31420082/50245611-ef8a9c00-03a0-11e9-9de7-8cc5da2c0317.png">

## How to test
- http://localhost:8000/data/elections/?state=&cycle=2020&election_full=true
- http://localhost:8000/data/candidates/senate/
- http://localhost:8000/data/candidates/president/
- http://localhost:8000/data/ (should be no change)