### PR TITLE
Fix logic for full cycle candidate committee totals (Part 2)

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -4,7 +4,7 @@ import operator
 from data import utils
 
 START_YEAR = 1979
-END_YEAR = 2018
+END_YEAR = 2020
 DEFAULT_TIME_PERIOD = 2018  # Change after final YE report (1/31/19)
 DEFAULT_ELECTION_YEAR = 2020  # Change after election day (11/3/20)
 DEFAULT_PRESIDENTIAL_YEAR = 2020

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -5,8 +5,21 @@ import datetime
 from data import constants
 
 
-def current_cycle():
-    year = datetime.datetime.now().year
+def current_cycle(delayed_start=False):
+    """
+    Calculate the current cycle from the calendar date,
+    except when `delayed_start` is True - in that case,
+    don't roll over to the next cycle
+    until April 15th of the next year.
+
+    Example: on 1/20/19, current_cycle should be 2018 because we don't have
+    2020 data yet. On 4/15/19 (April Quarterly deadline), roll over to 2020
+    """
+    if delayed_start:
+        date = datetime.date.today() + datetime.timedelta(-104)
+    else:
+        date = datetime.date.today()
+    year = date.year
     return year + year % 2
 
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -163,7 +163,8 @@ def get_candidate(candidate_id, cycle, election_full):
     # the cycle for itemized tables. Because these are only in 2-year chunks,
     # the cycle should never be beyond the one we're in.
     cycles = [cycle for cycle in candidate['cycles'] if cycle <= utils.current_cycle()]
-    max_cycle = cycle if cycle <= utils.current_cycle() else utils.current_cycle()
+    # New transactions will appear after the Q1 - around 4/15/19
+    max_cycle = cycle if cycle <= constants.DEFAULT_TIME_PERIOD else constants.DEFAULT_TIME_PERIOD
     show_full_election = election_full if cycle <= utils.current_cycle() else False
 
     # Annotate committees with most recent available cycle
@@ -188,7 +189,7 @@ def get_candidate(candidate_id, cycle, election_full):
     # Get aggregate totals for the financial summary
     # And pass through the data processing utils
     aggregate = api_caller.load_candidate_totals(
-        candidate['candidate_id'], cycle=max_cycle, election_full=election_full
+        candidate['candidate_id'], cycle=cycle, election_full=election_full
     )
     if aggregate:
         raising_summary = utils.process_raising_data(aggregate)

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -163,8 +163,8 @@ def get_candidate(candidate_id, cycle, election_full):
     # the cycle for itemized tables. Because these are only in 2-year chunks,
     # the cycle should never be beyond the one we're in.
     cycles = [cycle for cycle in candidate['cycles'] if cycle <= utils.current_cycle()]
-    # New transactions will appear after the Q1 - around 4/15/19
-    max_cycle = cycle if cycle <= constants.DEFAULT_TIME_PERIOD else constants.DEFAULT_TIME_PERIOD
+    # New transactions will appear after the Q1 of a new election year - this delays the rollover to a new cycle by 104 days
+    max_cycle = cycle if cycle <= utils.current_cycle(delayed_start=True) else utils.current_cycle(delayed_start=True)
     show_full_election = election_full if cycle <= utils.current_cycle() else False
 
     # Annotate committees with most recent available cycle

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -164,7 +164,11 @@ def get_candidate(candidate_id, cycle, election_full):
     # the cycle should never be beyond the one we're in.
     cycles = [cycle for cycle in candidate['cycles'] if cycle <= utils.current_cycle()]
     # New transactions will appear after the Q1 of a new election year - this delays the rollover to a new cycle by 104 days
-    max_cycle = cycle if cycle <= utils.current_cycle(delayed_start=True) else utils.current_cycle(delayed_start=True)
+    max_cycle = (
+        cycle
+        if cycle <= utils.current_cycle(delayed_start=True)
+        else utils.current_cycle(delayed_start=True)
+    )
     show_full_election = election_full if cycle <= utils.current_cycle() else False
 
     # Annotate committees with most recent available cycle


### PR DESCRIPTION
## Summary (required)

Resolves #2631 along with API PR (Part 1): https://github.com/fecgov/openFEC/pull/3561
- Pass election year to API for full election totals
- Add 2020 to available transaction date ranges
- Delay new two-year period for candidate committees until Q1 (4/15/19)

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile pages, all-years total. Transaction data tables date range options.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
`feature/fix-2020-totals` (openFEC) | https://github.com/fecgov/openFEC/pull/3561

## How to test
- If https://github.com/fecgov/openFEC/pull/3561 hasn't been merged to `dev`, run local API on `feature/fix-2020-totals` branch
Compare 2-year/all-year totals to production:
- 2020 senate: 
http://localhost:8000/data/candidate/S6IL00151 
http://localhost:8000/data/candidate/S4NJ00185
http://localhost:8000/data/candidate/S2TX00106
- 2022 senate:
http://localhost:8000/data/candidate/S4PA00121/
http://localhost:8000/data/candidate/S6CA00584/
- 2018/24 senate (check 2018 data):
http://localhost:8000/data/candidate/S8FL00273/?cycle=2018&election_full=true
http://localhost:8000/data/candidate/S8TX00285/
http://localhost:8000/data/candidate/S6MO00305/
- 2020 presidential:
http://localhost:8000/data/candidate/P80001571/
http://localhost:8000/data/candidate/P00006213/
http://localhost:8000/data/candidate/P00006486/
- 2018 House:  `H8CA05035` (2 year periods only - no 2020 data yet)

