### PR TITLE
Admin fines datatable page v2

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -69,7 +69,7 @@ def load_search_results(query, query_type=None):
 def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwargs):
     filters = dict((key, value) for key, value in kwargs.items() if value)
 
-    if query or query_type in ['advisory_opinions', 'murs', 'adrs', 'admin-fines']:
+    if query or query_type in ['advisory_opinions', 'murs', 'adrs', 'admin_fines']:
         filters['hits_returned'] = limit
         filters['type'] = query_type
         filters['from_hit'] = offset

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -69,7 +69,7 @@ def load_search_results(query, query_type=None):
 def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwargs):
     filters = dict((key, value) for key, value in kwargs.items() if value)
 
-    if query or query_type in ['advisory_opinions', 'murs', 'adrs']:
+    if query or query_type in ['advisory_opinions', 'murs', 'adrs', 'admin-fines']:
         filters['hits_returned'] = limit
         filters['type'] = query_type
         filters['from_hit'] = offset
@@ -95,6 +95,9 @@ def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwa
 
     if 'adrs' in results:
         results['adrs_returned'] = len(results['adrs'])
+
+    if 'admin_fines' in results:
+        results['admin_fines_returned'] = len(results['admin_fines'])
 
     return results
 

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -46,6 +46,7 @@ FEATURES = {
     'radform': bool(env.get_credential('FEC_FEATURE_RADFORM', '')),
     'linecharts': bool(env.get_credential('FEC_FEATURE_LINECHARTS', '')),
     'adrs': bool(env.get_credential('FEC_FEATURE_ADRS', '')),
+    'afs': bool(env.get_credential('FEC_FEATURE_AFS', '')),
 }
 
 ENVIRONMENTS = {

--- a/fec/legal/templates/legal-search-results-afs.jinja
+++ b/fec/legal/templates/legal-search-results-afs.jinja
@@ -1,0 +1,47 @@
+{% extends "layouts/legal-doc-search-results.jinja" %}
+{% import 'macros/legal.jinja' as legal %}
+{% set document_type_display_name = 'Administrative fines' %}
+
+{% block header %}
+<header class="page-header slab slab--primary">
+  {{ breadcrumb.breadcrumbs('Search results', [('/legal-resources', 'Legal resources'), ('/legal-resources/enforcement', 'Enforcement')]) }}
+</header>
+{% endblock %}
+
+{% block filters %}
+  {{ legal.keyword_search(result_type, query) }}
+  <div class="filter">
+    <label class="label" for="case_no">Administrative fine number</label>
+    <input id="case_no" name="case_no" type="text" value="{{ case_no }}">
+  </div>
+  <div class="filter">
+    <label class="label" for="case_respondents">Administrative fine respondents</label>
+    <input id="case_respondents" name="case_respondents" type="text" value="{{ case_respondents }}">
+  </div>
+  <div class="filter">
+    <button type="submit" class="button button--cta">Apply filters</button>
+  </div>
+{% endblock %}
+
+{% block message %}
+<div class="data-container__tags">
+  <div class="row">
+    <h3 class="tags__title">Viewing <span class="tags__count">{{ results.total_admin_fines }}</span>  filtered results for:</h3>
+  </div>
+</div>
+<div class="message message--info u-no-margin-top">
+  <p>You can search all FEC administrative fine cases using keywords, administrative fine case numbers, names of respondents and more. For additional search filters, you can still search Administrative fine cases using our legacy <a href="http://eqs.fec.gov">FEC Enforcement Query System</a>.</p>
+</div>
+{% endblock %}
+
+{% block results %}
+{% with results=results %}
+
+{% include 'partials/legal-search-results-afs.jinja' %}
+{% endwith %}
+
+{% with results=results %}
+{% include 'partials/legal-pagination.jinja' %}
+{% endwith %}
+
+{% endblock %}

--- a/fec/legal/templates/legal-search-results-afs.jinja
+++ b/fec/legal/templates/legal-search-results-afs.jinja
@@ -15,10 +15,6 @@
     <input id="case_no" name="case_no" type="text" value="{{ case_no }}">
   </div>
   <div class="filter">
-    <label class="label" for="case_respondents">Administrative fine respondents</label>
-    <input id="case_respondents" name="case_respondents" type="text" value="{{ case_respondents }}">
-  </div>
-  <div class="filter">
     <button type="submit" class="button button--cta">Apply filters</button>
   </div>
 {% endblock %}

--- a/fec/legal/templates/legal-search-results-afs.jinja
+++ b/fec/legal/templates/legal-search-results-afs.jinja
@@ -30,7 +30,7 @@
   </div>
 </div>
 <div class="message message--info u-no-margin-top">
-  <p>You can search all FEC administrative fine cases using keywords, administrative fine case numbers, names of respondents and more. For additional search filters, you can still search Administrative fine cases using our legacy <a href="http://eqs.fec.gov">FEC Enforcement Query System</a>.</p>
+  <p>You can search all FEC administrative fine cases using keywords, administrative fine case numbers, names of respondents and more. For additional search filters, you can still search administrative fine cases using our legacy <a href="http://eqs.fec.gov">FEC Enforcement Query System</a>.</p>
 </div>
 {% endblock %}
 

--- a/fec/legal/templates/legal-search-results-afs.jinja
+++ b/fec/legal/templates/legal-search-results-afs.jinja
@@ -15,6 +15,10 @@
     <input id="case_no" name="case_no" type="text" value="{{ case_no }}">
   </div>
   <div class="filter">
+    <label class="label" for="name">Committee name</label>
+    <input id="af_name" name="af_name" type="text" value="{{ af_name }}">
+  </div>
+  <div class="filter">
     <button type="submit" class="button button--cta">Apply filters</button>
   </div>
 {% endblock %}

--- a/fec/legal/templates/partials/legal-search-results-afs.jinja
+++ b/fec/legal/templates/partials/legal-search-results-afs.jinja
@@ -1,0 +1,44 @@
+<table class="simple-table simple-table--display">
+  <thead>
+    <tr class="simple-table__header">
+      <th class="simple-table__header-cell cell--50">Case</th>
+      <th class="simple-table__header-cell">Report year, type</th>
+      <th class="simple-table__header-cell">Closed date</th>
+      <th class="simple-table__header-cell">Final civil penalty or fine</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for admin_fine in results.admin_fines %}
+    <tr class="simple-table__row">
+      <td class="simple-table__cell">
+        <div class="t-sans">
+          <i class="icon i-folder icon--inline--left"></i>
+          <a class="t-bold" title="{{ admin_fine.name }}" href="/data/legal/administrative-fine/{{ admin_fine.no }}">AF #{{ admin_fine.no }}</a><br />
+            {{ admin_fine.name.upper() }}
+          {% if admin_fine.highlights %}
+            <div class="t-sans u-padding--top">Keyword match:</div>
+            <div class="legal-search-result__hit u-padding--left">
+              {% for highlight in admin_fine.highlights %}
+                <span class="t-serif">
+                    {{ highlight|safe }} &hellip;
+                </span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </div>
+      </td>
+      <td class="simple-table__cell">
+        <div class="t-sans">
+            {{ admin_fine.report_year }}, {{ admin_fine.report_type }}
+        </div>
+      </td>
+      <td class="simple-table__cell">
+        <div class="t-sans">{{ admin_fine.final_determination_date | date(fmt='%m/%d/%Y') }}</div>
+      </td>
+      <td class="simple-table__cell">
+          <div class="t-sans">{{ "${:,.2f}".format(admin_fine.final_determination_amount) }}</div>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/fec/legal/urls.py
+++ b/fec/legal/urls.py
@@ -28,3 +28,8 @@ if settings.FEATURES['adrs']:
         r'^data/legal/search/adrs/$', views.legal_doc_search_adr
     ),
 
+if settings.FEATURES['afs']:
+    urlpatterns += url(
+        r'^data/legal/search/admin_fines/$', views.legal_doc_search_af
+    ),
+

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -149,6 +149,24 @@ def legal_doc_search_adr(request):
         'query': query
     })
 
+def legal_doc_search_af(request):
+    results = {}
+    query = request.GET.get('search', '')
+    offset = request.GET.get('offset', 0)
+    case_no = request.GET.get('case_no', '')
+    case_respondents = request.GET.get('case_respondents', '')
+    af_election_cycles = request.GET.get('af_election_cycles', '')
+
+    results = api_caller.load_legal_search_results(query, 'admin_fines', offset=offset, case_no=case_no, case_respondents=case_respondents)
+
+    return render(request, 'legal-search-results-afs.jinja', {
+        'parent': 'legal',
+        'results': results,
+        'result_type': 'admin_fines',
+        'case_no': case_no,
+        'case_respondents': case_respondents,
+        'query': query
+    })
 
 def legal_doc_search_regulations(request):
     results = {}

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -154,17 +154,17 @@ def legal_doc_search_af(request):
     query = request.GET.get('search', '')
     offset = request.GET.get('offset', 0)
     case_no = request.GET.get('case_no', '')
-    case_respondents = request.GET.get('case_respondents', '')
+    af_name = request.GET.get('af_name', '')
     af_election_cycles = request.GET.get('af_election_cycles', '')
 
-    results = api_caller.load_legal_search_results(query, 'admin_fines', offset=offset, case_no=case_no, case_respondents=case_respondents)
+    results = api_caller.load_legal_search_results(query, 'admin_fines', offset=offset, case_no=case_no, af_name=af_name)
 
     return render(request, 'legal-search-results-afs.jinja', {
         'parent': 'legal',
         'results': results,
         'result_type': 'admin_fines',
         'case_no': case_no,
-        'case_respondents': case_respondents,
+        'af_name': af_name,
         'query': query
     })
 


### PR DESCRIPTION
## Summary

- Resolves #2438 
_This adds Admin fines datatable page to the enforcement legal features._

## How to test
1. `vi ~/.bash_profile` and insert this feature flag for ADRs `export FEC_FEATURE_AFS=true`
2. Open a new terminal window and run the branch
3. Go to http://localhost:8000/data/legal/search/admin_fines/ to test the page. At this point, none of the canonical Admin fine links will work since that is phase 2 of the development for this feature.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Enforcement Admin fines datatable page
## Screenshots

![screen shot 2018-11-26 at 8 20 35 am](https://user-images.githubusercontent.com/12799132/49016518-5c20cb00-f154-11e8-8b88-1b5b557e4887.png)