### PR TITLE
Fixed MUR number search on enforcement

### DIFF
--- a/fec/home/templates/blocks/mur_search.html
+++ b/fec/home/templates/blocks/mur_search.html
@@ -13,7 +13,7 @@
             <form action="/data/legal/search/enforcement/">
               <label for="mur_no" class="label">Find by MUR number</label>
               <div class="combo combo--search--medium combo--search--inline">
-                <input type="text" id="mur_no" name="mur_no" class="combo__input">
+                <input type="text" id="mur_no" name="case_no" class="combo__input">
                 <button class="combo__button button--search button--standard" type="submit">
                   <span class="u-visually-hidden">Search</span>
                 </button>


### PR DESCRIPTION
## Summary

- Resolves #2637 
_Updated query to use `case_no` in order for MUR number search to work._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  MUR search CMS widget

## How to test
- Go to http://localhost:8000/data/legal/search/enforcement/
- Type a MUR number like `4321`
- Check that MUR number is filtered correctly on MUR search results


