### PR TITLE
2222 Add "other filers" option to hard coded page

### DIFF
--- a/fec/home/templates/home/candidate-and-committee-services/guides.html
+++ b/fec/home/templates/home/candidate-and-committee-services/guides.html
@@ -56,6 +56,14 @@
               aria-controls="cand-comm-guides-political-action-committees"
               href="#cand-comm-guides-political-action-committees">Political action committees (PACs)</a>
         </li>
+        <li class="side-nav__item" role="presentation">
+          <a class="side-nav__link"
+              role="tab"
+              data-name="other-filers"
+              tabindex="0"
+              aria-controls="cand-comm-guides-other-filers"
+              href="#cand-comm-guides-other-filers">Other filers</a>
+        </li>
       </ul>
     </nav>
     <div class="main__content--right-full">
@@ -160,6 +168,25 @@
             <span class="label">PDF Guide</span>
             <a class="t-sans" href="/resources/cms-content/documents/nongui.pdf">Nonconnected committees campaign guide</a>
           </div>
+        </div>
+      </section>
+
+      <section id="cand-comm-guides-other-filers" role="tabpanel" aria-hidden="true" aria-labelledby="other-filers">
+        <h2><a href="/help-candidates-and-committees/other-filers/">Other filers</a></h2>
+        <p>Every person, group of persons or organization, other than a political committee, that makes certain communications may be required to file certain disclosure forms with the FEC, as well as comply with disclaimer requirements for specific types of communications.</p>
+        <div class="grid grid--2-wide">
+          <div class="grid__item">
+            <ul class="t-sans list--spacious">
+              <li><a href="/help-candidates-and-committees/other-filers/#independent-expenditures-by-persons-other-than-political-committees">Independent expenditure by persons other than political committees</a> &#187;</li>
+              <li><a href="/help-candidates-and-committees/other-filers/#express-advocacy-communications-to-restricted-class-by-corporations-labor-organizations-and-membership-organizations">Express advocacy communications to restricted class by corporations, labor organizations and membership organizations</a> &#187;</li>
+              <li><a href="/help-candidates-and-committees/other-filers/#electioneering-communications">Electioneering communications</a> &#187;</li>
+            </ul>
+          </div>
+          <!-- <div class="grid__item">
+            <img src="{% static 'img/thumbnail--pdf-guide.png' %}" alt="Icon representing a large PDF file">
+            <span class="label">PDF Guide</span>
+            <a class="t-sans" href="/resources/cms-content/documents/nongui.pdf">Nonconnected committees campaign guide</a>
+          </div> -->
         </div>
       </section>
     </div>

--- a/fec/home/templates/home/candidate-and-committee-services/guides.html
+++ b/fec/home/templates/home/candidate-and-committee-services/guides.html
@@ -182,11 +182,6 @@
               <li><a href="/help-candidates-and-committees/other-filers/#electioneering-communications">Electioneering communications</a> &#187;</li>
             </ul>
           </div>
-          <!-- <div class="grid__item">
-            <img src="{% static 'img/thumbnail--pdf-guide.png' %}" alt="Icon representing a large PDF file">
-            <span class="label">PDF Guide</span>
-            <a class="t-sans" href="/resources/cms-content/documents/nongui.pdf">Nonconnected committees campaign guide</a>
-          </div> -->
         </div>
       </section>
     </div>

--- a/fec/home/templates/home/candidate-and-committee-services/guides.html
+++ b/fec/home/templates/home/candidate-and-committee-services/guides.html
@@ -172,7 +172,7 @@
       </section>
 
       <section id="cand-comm-guides-other-filers" role="tabpanel" aria-hidden="true" aria-labelledby="other-filers">
-        <h2><a href="/help-candidates-and-committees/other-filers/">Other filers</a></h2>
+        <h2>Other filers</h2>
         <p>Every person, group of persons or organization, other than a political committee, that makes certain communications may be required to file certain disclosure forms with the FEC, as well as comply with disclaimer requirements for specific types of communications.</p>
         <div class="grid grid--2-wide">
           <div class="grid__item">


### PR DESCRIPTION
## Summary
Adding Other filers to /help-candidates-and-committees/guides

- Resolves # [2222](https://github.com/fecgov/fec-cms/issues/2222)
Added an Other filers option at the bottom of the left column (in fec/home/templates/home/candidate-and-committee-services/guides.html)
And added another tabpanel at the bottom for the Other filers content

## Impacted areas of the application
This section will link to the [new Other filers page](https://www.fec.gov/help-candidates-and-committees/other-filers) and to various places on it


## Screenshots
![image](https://user-images.githubusercontent.com/26720877/52086955-2fcf6380-2576-11e9-892a-ae2c24fd8cb1.png)
![image](https://user-images.githubusercontent.com/26720877/52087007-4ecdf580-2576-11e9-8151-126a9bee05f8.png)
![image](https://user-images.githubusercontent.com/26720877/52087073-7b820d00-2576-11e9-9f5c-10bd51fc62fd.png)


## How to test
- Go to http://localhost:8000/help-candidates-and-committees/guides/
- Verify that "Other filers" (capped) is at the bottom of the left column
- Click "Other filers"
- Verify that the main content has changed to the [content for Other filers](https://docs.google.com/document/d/1_76eBAtftxN4pNEq6RE1JtpAZYlJLSb1O2K1zY3p0Xw/edit)
- Verify that the new content goes away when other sections are selected

The links should work on dev but may not work on localhost yet.
This section has a title that's also a link and we haven't done that for any of the other sections. Do we typically handle that a different way?
____

