### PR TITLE
Restyle tooltip so content is visibly contained within

### DIFF
--- a/fec/fec/static/js/modules/maps.js
+++ b/fec/fec/static/js/modules/maps.js
@@ -185,7 +185,17 @@ function stateTooltips(svg, path, results) {
 function moveTooltip(tooltip) {
   var x = d3.event.pageX - tooltip[0][0].offsetWidth / 2;
   var y = d3.event.pageY - tooltip[0][0].offsetHeight;
-  tooltip.style('left', x + 'px').style('top', y + 'px');
+
+  var bottomPointerHeight = '.8rem';
+
+  var contentHeight = $('#map-tooltip .tooltip__title').innerHeight();
+  contentHeight += $('#map-tooltip .tooltip__value').innerHeight();
+  contentHeight += 30; // (padding)
+
+  tooltip
+    .style('left', x + 'px')
+    .style('top', 'calc(' + y + 'px - ' + bottomPointerHeight + ')')
+    .style('height', contentHeight + 'px');
 }
 
 function highlightState($parent, state) {

--- a/fec/fec/static/js/templates/calendar/events.hbs
+++ b/fec/fec/static/js/templates/calendar/events.hbs
@@ -34,7 +34,7 @@
               <span class="tooltip__trigger-text" aria-describedby="category-tooltip-{{@index}}">{{ toUpperCase category }}</span>
               <div class="tooltip__container">
                 <button class="tooltip__trigger"><span class="u-visually-hidden">Show tooltip</span></button>
-                <div class="tooltip tooltip--under" role="tooltip" id="category-tooltip-{{@index}}">
+                <div class="tooltip tooltip--under tooltip--right" role="tooltip" id="category-tooltip-{{@index}}">
                   <div class="tooltip__content">
                     {{{ tooltipContent }}}
                   </div>

--- a/fec/fec/static/scss/components/_tooltips.scss
+++ b/fec/fec/static/scss/components/_tooltips.scss
@@ -84,7 +84,7 @@
 
 // When the tooltip is above the content. Puts the arrow at the bottom center of the tooltip
 .tooltip--above {
-  width: u(12rem);
+  min-width: u(12rem);
   $bottom: u(1.5rem);
   left: u(-4rem);
   bottom: calc(100% + #{$bottom});
@@ -94,7 +94,7 @@
     bottom: u(-1rem);
     content: '';
     display: block;
-    left: u(4.2rem);
+    left: calc(50% - 1rem);
     position: absolute;
   }
 
@@ -103,7 +103,7 @@
     content: '';
     display: block;
     position: absolute;
-    left: u(4.4rem);
+    left: calc(50% - .8rem);
     bottom: u(-.7rem);
   }
 
@@ -180,28 +180,10 @@
 
 // When the tooltip is above the content. Puts the arrow at the bottom center of the tooltip
 .tooltip--above {
-  width: u(12rem);
+  min-width: u(12rem);
   $bottom: u(1.5rem);
   left: u(-4rem);
   bottom: calc(100% + #{$bottom});
-
-  &::before {
-    @include triangle(2rem, $primary, down);
-    bottom: u(-1rem);
-    content: '';
-    display: block;
-    left: u(4.2rem);
-    position: absolute;
-  }
-
-  &::after {
-    @include triangle(1.6rem, $inverse, down);
-    content: '';
-    display: block;
-    position: absolute;
-    left: u(4.4rem);
-    bottom: u(-.7rem);
-  }
 
   &.tooltip--left {
     width: u(30rem);
@@ -284,7 +266,7 @@
   }
 
   .tooltip__title {
-    line-height: u(4rem);
+    line-height: u(2rem);
     padding-left: u(1rem);
     float: left;
   }


### PR DESCRIPTION
## Summary
Being absolutely positioned, the tooltip was ignoring the size of its content.

- Resolves # [2644](https://github.com/fecgov/fec-cms/issues/2644)

## Impacted areas of the application
The changes should only affect the map tooltips, and only with tooltips that appear above the pointer but we should make sure we check maps and tooltips elsewhere on the site.

`fec/fec/static/js/modules/maps.js`:

- Expanded js to set tooltip height to accommodate that of its content + padding.
- Adjusted the vertical distance between the tooltip point and the pointer so the tooltip no longer appears under the pointer.

`fec/fec/static/scss/components/_tooltips.scss`:

- Adjusted tooltip `width` settings to be `min-width` so wider content (like "Pennsylvania") don't overflow the right edge of the tooltip
- Horizontally centered the downward arrow (it has two pieces, the `:before` and the `:after`) under the tooltip rather than leave it hard-coded a specific distance from the left
- Removed a duplicated chunk of code for `.tooltip--above &::before` (and `after`)
- Decreased the `line-height` of the larger/title text in the tooltip from 4rem to 2rem because the distance between title lines was greater than the distance between the title and the value/text under it

## Screenshots
Current (with the pointer over the northwestern point of Washington)
![before](https://user-images.githubusercontent.com/26720877/52282623-d2993080-292e-11e9-8fa3-cc56ce6b619a.png)
Proposed (with the pointer in the same place)
![after](https://user-images.githubusercontent.com/26720877/52282651-e17fe300-292e-11e9-8efa-a2dbd7a0ee32.png)

## How to test
- Find a [candidate page on localhost](http://localhost:8000/data/candidate/S2MA00170/?cycle=2018&election_full=true&tab=raising)
- Choose Raising from the left nav
- Scroll down to Individual Contributions
- Choose the State tab
- Move your cursor over the map, back and forth over the states, especially those with names of different widths (I think Iowa and Massachusetts are the extremes)
- The tooltip text should appear inside the tooltip box and the widths and tooltip position should adjust properly
- **Check the maps and tooltips elsewhere on the site, including tooltips with two-line titles**
- **Double-check functionality on IE, older browsers, and touch devices**
- **Test in Safari after it's on dev**

____