### PR TITLE
Add other filers button to h4cc landing page

### DIFF
--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -35,7 +35,7 @@
         <a href="/help-candidates-and-committees/guides/?tab=political-party-committees">
           <aside class="card card--horizontal card--secondary">
             <div class="card__image__container">
-              <span class="card__icon i-notebook"><span class="u-visually-hidden">Icon of a training screen</span></span>
+              <span class="card__icon i-notebook"><span class="u-visually-hidden">Icon representing a notebook</span></span>
             </div>
             <div class="card__content">
               Political party committees
@@ -47,7 +47,7 @@
         <a href="/help-candidates-and-committees/guides/?tab=corporations-and-labor-organizations">
           <aside class="card card--horizontal card--secondary">
             <div class="card__image__container">
-              <span class="card__icon i-notebook"><span class="u-visually-hidden">Icon of a candidate</span></span>
+              <span class="card__icon i-notebook"><span class="u-visually-hidden">Icon representing a notebook</span></span>
             </div>
             <div class="card__content">
               Corporations and labor organizations
@@ -59,7 +59,7 @@
         <a href="/help-candidates-and-committees/guides/?tab=political-action-committees">
           <aside class="card card--horizontal card--secondary">
             <div class="card__image__container">
-              <span class="card__icon i-notebook"><span class="u-visually-hidden">Icon of a candidate</span></span>
+              <span class="card__icon i-notebook"><span class="u-visually-hidden">Icon representing a notebook</span></span>
             </div>
             <div class="card__content">
               Political action committees (PACs)
@@ -71,7 +71,7 @@
         <a href="/help-candidates-and-committees/guides/?tab=other-filers">
           <aside class="card card--horizontal card--secondary">
             <div class="card__image__container">
-              <span class="card__icon i-notebook"><span class="u-visually-hidden">Icon of a candidate</span></span>
+              <span class="card__icon i-notebook"><span class="u-visually-hidden">Icon representing a notebook</span></span>
             </div>
             <div class="card__content">
               Other filers

--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -18,7 +18,7 @@
 <div class="container main">
   <div class="container">
     <h2>Guides</h2>
-    <div class="grid grid--4-wide">
+    <div class="grid grid--3-wide">
       <div class="grid__item">
         <a href="/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees">
           <aside class="card card--horizontal card--secondary">
@@ -63,6 +63,18 @@
             </div>
             <div class="card__content">
               Political action committees (PACs)
+            </div>
+          </aside>
+        </a>
+      </div>
+      <div class="grid__item">
+        <a href="/help-candidates-and-committees/guides/?tab=other-filers">
+          <aside class="card card--horizontal card--secondary">
+            <div class="card__image__container">
+              <span class="card__icon i-notebook"><span class="u-visually-hidden">Icon of a candidate</span></span>
+            </div>
+            <div class="card__content">
+              Other filers
             </div>
           </aside>
         </a>


### PR DESCRIPTION
## Summary

As part of the other filers ticket here: https://github.com/fecgov/fec-cms/issues/2222#issuecomment-435034634, we needed to add the other filers button to the Help for candidates and committees landing page.

Test on this page: http://localhost:8000/help-candidates-and-committees/

## Impacted areas of the application
List general components of the application that this PR will affect:
-  Help for candidates and committees landing page

## Screenshots

![screen shot 2019-02-05 at 1 58 37 pm](https://user-images.githubusercontent.com/12799132/52297192-2a935f80-294e-11e9-8e30-5a77655d5875.png)