### PR TITLE
Add cycle and election_full query parameters to candidate name link

### DIFF
--- a/fec/fec/static/js/modules/table-columns.js
+++ b/fec/fec/static/js/modules/table-columns.js
@@ -14,7 +14,10 @@ var candidateInformationColumns = [
     render: function(data, type, row) {
       return columnHelpers.buildEntityLink(
         data,
-        helpers.buildAppUrl(['candidate', row.candidate_id]),
+        helpers.buildAppUrl(['candidate', row.candidate_id], {
+          cycle: context.election.cycle,
+          election_full: true
+        }),
         'candidate',
         { isIncumbent: row.incumbent_challenge_full === 'Incumbent' }
       );
@@ -75,7 +78,10 @@ function createElectionColumns(context) {
       render: function(data, type, row) {
         return columnHelpers.buildEntityLink(
           data,
-          helpers.buildAppUrl(['candidate', row.candidate_id]),
+          helpers.buildAppUrl(['candidate', row.candidate_id], {
+            cycle: context.election.cycle,
+            election_full: true
+          }),
           'candidate',
           { isIncumbent: row.incumbent_challenge_full === 'Incumbent' }
         );


### PR DESCRIPTION
## Summary

- Resolves #2455 
_Adds `cycle` and `election_full=true` to candidate name link query parameters. This is the link that is built in the election profile page "Candidate financial information section" and "Candidate information" section_

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Election profile pages

## How to test
- Go to any election profile page, for example: http://localhost:8000/data/elections/president/2000/
- Go to Candidate financial totals datatable and make sure that the Name column links the candidate name with the cycle and election_full query parameters added.
- Go to Candidate information datatable and make sure that the Name column links the candidate name with the cycle and election_full query parameters added.