### PR TITLE
[WIP] NPM lint fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
     'clearTimeout': true,
     'ga': true,
     'grecaptcha': true,
-    'navigator': true
+    'navigator': true,
   },
   "extends": [
     "plugin:react/recommended",
@@ -20,6 +20,7 @@
     'no-useless-escape': [0],
     'prettier/prettier': 'error',
   },
+  'parser': 'babel-eslint',
   'parserOptions': {
       'ecmaVersion': 6,
       'sourceType': 'module',

--- a/.jshintrc
+++ b/.jshintrc
@@ -5,6 +5,7 @@
   "camelcase": true,
   "curly": true,
   "expr": true,
+  "esversion": 6,
   "forin": true,
   "immed": true,
   "latedef": "nofunc",

--- a/fec/fec/static/js/modules/analytics.js
+++ b/fec/fec/static/js/modules/analytics.js
@@ -15,7 +15,7 @@ function trackerExists() {
 
 /* Initialize a non Digital Analytics Program GA tracker
  * This tracker's name is "nonDAP", so all commands will need to be prefixed
-*/
+ */
 function init() {
   if (!trackerExists()) {
     (function(i, s, o, g, r, a, m) {

--- a/fec/fec/static/js/modules/filters/multi-filter.js
+++ b/fec/fec/static/js/modules/filters/multi-filter.js
@@ -6,7 +6,7 @@ var CheckboxFilter = require('./checkbox-filter').CheckboxFilter;
 
 /* MultiFilters used when there are multiple filters that share the
  * same name attribute
-*/
+ */
 
 function MultiFilter(elm) {
   Filter.call(this, elm);

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -330,14 +330,14 @@ function getTimePeriod(electionYear, cycle, electionFull, office) {
 }
 
 /*
-* zeroPad: used to add decimals to numbers in order to right-align them
-* It does so by getting the width of a container element, measuring the length
-* of an item, and then appending decimals until the item is as long as the container
-*
-* @param container: a selector for the item to use as the maxWidth
-* @param item: a selector for the items whose width we will equalize
-* @param appendee (optional): what to append the decimal to
-*/
+ * zeroPad: used to add decimals to numbers in order to right-align them
+ * It does so by getting the width of a container element, measuring the length
+ * of an item, and then appending decimals until the item is as long as the container
+ *
+ * @param container: a selector for the item to use as the maxWidth
+ * @param item: a selector for the items whose width we will equalize
+ * @param appendee (optional): what to append the decimal to
+ */
 
 function zeroPad(container, item, appendee) {
   // Subtract 2 so if it's close we don't go over

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -669,10 +669,10 @@ DataTable.prototype.fetchSuccess = function(resp) {
         this.newCount.toLocaleString('en-US') +
         '</span>'
       : this.newCount > 500000
-        ? 'about <span class="tags__count">' +
-          this.newCount.toLocaleString('en-US') +
-          '</span>'
-        : '<span class="tags__count">0</span>';
+      ? 'about <span class="tags__count">' +
+        this.newCount.toLocaleString('en-US') +
+        '</span>'
+      : '<span class="tags__count">0</span>';
   this.$widgets.find('.js-count').html(countHTML);
 
   filterSuccessUpdates(changeCount);

--- a/fec/fec/static/js/vendor/beautify-html.js
+++ b/fec/fec/static/js/vendor/beautify-html.js
@@ -192,8 +192,8 @@
       typeof options.extra_liners == 'object' && options.extra_liners
         ? options.extra_liners.concat()
         : typeof options.extra_liners === 'string'
-          ? options.extra_liners.split(',')
-          : 'head,body,/html'.split(',');
+        ? options.extra_liners.split(',')
+        : 'head,body,/html'.split(',');
     eol = options.eol ? options.eol : '\n';
 
     if (options.indent_with_tabs) {


### PR DESCRIPTION
## Summary

_Added babel-eslint parser to eslint, added esversion 6 to jshint, linted files._

This change will allow for eslint to parse ES6 without unexpected token errors. See this thread for more: https://stackoverflow.com/questions/36001552/eslint-parsing-error-unexpected-token. Also adds ES6 to jshint. 

**To do:**
Fix these two errors:
```
$ npm run lint

> fec-cms@1.0.0 lint fec-cms
> eslint --quiet ./fec/fec/static/js/**/*.js

/fec-cms/fec/fec/static/js/modules/accessibility.js
  3:11  error  'require' is defined but never used  no-unused-vars

/fec-cms/fec/fec/static/js/pages/data-browse-data.js
  3:20  error  'ga' is defined but never used  no-unused-vars
```

## How to test
- In the project, do `npm run lint` and check for any errors. 
