### PR TITLE
Update GPO links to statute PDFs

### DIFF
--- a/fec/legal/templates/legal-statutes-landing.jinja
+++ b/fec/legal/templates/legal-statutes-landing.jinja
@@ -50,14 +50,14 @@
       <li>
         <p>Access the FEC’s compilation of statutes. That PDF contains Title 52, Subtitle III, Title 26, Subtitle H and additional provisions of the U.S. Code that aren’t enforced by FEC but are relevant to people involved in federal elections.</p>
         <div class="grid grid--2-wide">
-          {{ document.thumbnail("Federal Election Campaign Laws by the FEC", "https://www.fec.gov/resources/cms-content/documents/feca.pdf", img="img/thumbnail--feca.jpg", size="1.7MB") }}
+          {{ document.thumbnail("Federal Election Campaign Laws by the FEC", "https://www.fec.gov/resources/cms-content/documents/feca.pdf", img="img/thumbnail--feca.jpg", size="2.58MB") }}
         </div>
       </li>
       <li>
         <p>Access the Government Printing Office (GPO) version of Title 52, Subtitle III and Title 26, Subtitle H.</p>
         <div class="grid grid--2-wide">
-          {{ document.thumbnail("Title 52, Voting and Elections, GPO", "https://www.gpo.gov/fdsys/pkg/USCODE-2015-title52/pdf/USCODE-2015-title52-subtitleIII.pdf", img="img/thumbnail--title52.jpg", size="387KB") }}
-          {{ document.thumbnail("Title 26, Internal Revenue Code, GPO", "https://www.gpo.gov/fdsys/pkg/USCODE-2015-title26/pdf/USCODE-2015-title26-subtitleH.pdf", img="img/thumbnail--title26.jpg", size="215KB") }}
+          {{ document.thumbnail("Title 52, Voting and Elections, GPO", "https://www.govinfo.gov/content/pkg/USCODE-2017-title52/pdf/USCODE-2017-title52-subtitleIII-chap301.pdf", img="img/thumbnail--title52.jpg", size="395KB") }}
+          {{ document.thumbnail("Title 26, Internal Revenue Code, GPO", "https://www.govinfo.gov/content/pkg/USCODE-2017-title26/pdf/USCODE-2017-title26-subtitleH.pdf", img="img/thumbnail--title26.jpg", size="197KB") }}
         </div>
       </li>
   </div>


### PR DESCRIPTION
Updates file sizes for the FEC PDF file (new version uploaded) and the 2017 versions available on GPO's website that we link on the legal resource statutes page at https://www.fec.gov/data/legal/statutes/

Specifically:
The 2019 edition of the gray book has been uploaded to https://www.fec.gov/resources/cms-content/documents/feca.pdf

Latest files from govinfo.gov for:
Title 52: 
Link to: https://www.govinfo.gov/content/pkg/USCODE-2017-title52/pdf/USCODE-2017-title52-subtitleIII-chap301.pdf

Title 26: 
https://www.govinfo.gov/content/pkg/USCODE-2017-title26/pdf/USCODE-2017-title26-subtitleH.pdf

- Resolves # [2459]


## Screenshots

File sizes:
![image](https://user-images.githubusercontent.com/24437369/52800152-2e5b6c00-3049-11e9-879f-95315bdd632d.png)


## How to test
Include any information that may be helpful to the reviewer(s).
- [ ] Ensure links on https://www.fec.gov/data/legal/statutes/ work.
- [ ] Doublecheck file sizes were changed (compare to screenshot).

