### PR TITLE
Remove double slashes from spending urls

### DIFF
--- a/fec/fec/static/js/modules/other-spending-totals.js
+++ b/fec/fec/static/js/modules/other-spending-totals.js
@@ -8,9 +8,9 @@ var _ = require('underscore');
 var helpers = require('../modules/helpers');
 
 var pathMap = {
-  independentExpenditures: '/schedules/schedule_e/by_candidate/',
-  communicationCosts: '/communication_costs/by_candidate/',
-  electioneering: '/electioneering/by_candidate/'
+  independentExpenditures: ['schedules', 'schedule_e', 'by_candidate'],
+  communicationCosts: ['communication_costs', 'by_candidate'],
+  electioneering: ['electioneering', 'by_candidate']
 };
 
 function OtherSpendingTotals(type) {


### PR DESCRIPTION


## Summary (required)

- Resolves issue found in testing: **Remove double slashes from spending urls**
- `helpers.buildUrl` is expecting the format `['elections', 'search']`
- URL was being formatted as localhost:5000/v1//schedules...

## Impacted areas of the application
List general components of the application that this PR will affect:

"Spending by others to support or oppose" tab: http://localhost:8000/data/candidate/P80001571/?tab=other-spending&cycle=2016&election_full=false

## Screenshots

## Before
<img width="1096" alt="screen shot 2019-02-26 at 3 19 46 pm" src="https://user-images.githubusercontent.com/31420082/53443577-015c7100-39da-11e9-8de9-9f94cbed8efc.png">

## After
<img width="1096" alt="screen shot 2019-02-26 at 3 18 32 pm" src="https://user-images.githubusercontent.com/31420082/53443585-04eff800-39da-11e9-9ba6-94936ecca02f.png">

