### PR TITLE
[MERGE WITH GITFLOW] Hotfix-Handle party-null values in barcharts

### DIFF
--- a/fec/data/templates/macros/bythenumbers.jinja
+++ b/fec/data/templates/macros/bythenumbers.jinja
@@ -53,7 +53,7 @@
       <div role="gridcell" class="simple-table__cell">{{ loop.index }}.
         <a href="/data/{{ route }}/{{ datum[id_field] }}/?cycle={{ cycle }}&election_full=false" title="{{ datum[name_field] }}">{{ datum[name_field] }}</a>
         {% if datum.party %}
-          [{{ datum.party | truncate(1, end='') | upper }}]
+          [{{ datum.party | upper }}]
         {% endif %}
       </div>
       <div class="simple-table__cell t-right-aligned">{{ datum[value_field] | currency }}</div>

--- a/fec/data/templates/raising-bythenumbers.jinja
+++ b/fec/data/templates/raising-bythenumbers.jinja
@@ -51,6 +51,7 @@
         <li>Senate and House committees: Form 3, Line 16, Column A</li>
         <li>PACs and party committees: Form 3X, Line 20, Column A</li>
       </ul>
+       <p><a href="/campaign-finance-data/party-code-descriptions/">See a list of political party abbreviations.</a></p>
     </div>
   </div>
 </div>

--- a/fec/data/templates/spending-bythenumbers.jinja
+++ b/fec/data/templates/spending-bythenumbers.jinja
@@ -51,6 +51,7 @@
         <li>Senate and House committees: Form 3, Line 22, Column A</li>
         <li>PACs and party committees: Form 3X, Line 31, Column A</li>
       </ul>
+      <p><a href="/campaign-finance-data/party-code-descriptions/">See a list of political party abbreviations.</a></p>
     </div>
   </div>
 </div>

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -167,7 +167,8 @@ TopEntities.prototype.formatData = function(result, rank) {
       value: result[this.type],
       rank: rank,
       party: result.party,
-      party_code: '[' + result.party.charAt('0').toUpperCase() + ']',
+      party_code:
+        result.party === null ? '' : '[' + result.party.toUpperCase() + ']',
       url: helpers.buildAppUrl(['candidate', result.candidate_id], {
         cycle: this.cycle,
         election_full: false

--- a/fec/fec/tests/js/top-entities-breakdown.js
+++ b/fec/fec/tests/js/top-entities-breakdown.js
@@ -241,7 +241,7 @@ describe('Top entities breakdown', function() {
             value: 2000,
             rank: 1,
             party: 'dem',
-            party_code: '[D]',
+            party_code: '[DEM]',
             url: '//candidate/1234/?cycle=2016&election_full=false'
           });
         });


### PR DESCRIPTION
## Summary (required)
- Fix the fact that candidates with `"party": null` in their data break rendering from their number to the end of that page because the JS that truncates it to one-character/uppercase cannot act on a non-string like `null`.

- Show the full, uppercase abbreviation for  candidates that have a party declaration in their data, instead of showing the one-letter that  we are now (from page 2 on)

- Show nothing for  each candidate with  `"party":null` 

(Aside: All the party abbreviations in the data are already uppercase.  I am not  sure why the code needs to ensure uppercase, unless their is some legacy code that is inconsistent. So I am leaving it in for now.)

- Resolves #2694
-Related PR: https://github.com/fecgov/fec-cms/pull/2695



## Impacted areas of the application
modified:   data/templates/macros/bythenumbers.jinja
modified:   data/templates/spending-bythenumbers.jinja
modified:   data/templates/raiding-bythenumbers.jinja
modified:   fec/static/js/modules/top-entities.js
modified:   fec/tests/js/top-entities-breakdown.js


## Screenshots
<img width="1228" alt="screen shot 2019-02-24 at 11 04 48 pm" src="https://user-images.githubusercontent.com/5572856/53313701-a830f800-3888-11e9-92ca-68903c70ee50.png">


## Related PRs
List related PRs against other branches:

## How to test
 - `npm run build`
  - Go to: http://127.0.0.1:8000/data/raising-bythenumbers/
  - Check to see that items 11-20 show up (currently on  prod only item 11 shows and the rest of he page failed to render)
 -And check that Julian Castro has nothing next to his name for a party.
 - Go to: http://127.0.0.1:8000/data/spending-bythenumbers/
 - Check that items 21-30 show up (on prod only items 21-27 show)
  -Again check that Julian Castro has nothing next to his name for a party.
 - Test the line charts work OK at the bottom of http://127.0.0.1:8000/data/browse-data/?tab=raising AND http://127.0.0.1:8000/data/browse-data/?tab=spending. This is the other chart that uses the JS file modified. 
Note: You may have to set the env var for `FEC_FEATURE_LINECHARTS=1` to see line charts locally

- Test link to abbreviation descriptions at the bottom of the Methodology  modal.
____

