### PR TITLE
Change button hrefs from transition to dates-and-deadlines

### DIFF
--- a/fec/data/templates/partials/elections/election-data-and-compliance-tab.jinja
+++ b/fec/data/templates/partials/elections/election-data-and-compliance-tab.jinja
@@ -85,7 +85,7 @@
                 'Quarterly / monthly filing and pre-/post-election reports',
                 [{
                   'text': 'Reporting deadlines and notices',
-                  'href': 'https://transition.fec.gov/info/report_dates_'+cycle|string+'.shtml'
+                  'href': 'https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/'
                 }]
               )
             }}
@@ -224,7 +224,7 @@
               '24- and 48-hour report periods',
               [{
                 'text': 'Independent expenditure deadlines',
-                'href': 'https://transition.fec.gov/info/charts_ie_dates_'+cycle|string+'.shtml'+ie,
+                'href': 'https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/',
               }]
             )
           }}
@@ -310,7 +310,7 @@
                 '30- and 60-day report periods',
                 [{
                   'text': 'Electioneering communication deadlines',
-                  'href': 'https://transition.fec.gov/info/charts_ec_dates_'+cycle|string+'.shtml'+ec,
+                  'href': 'https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/',
                 }]
               )
             }}

--- a/fec/data/templates/partials/elections/election-data-and-compliance-tab.jinja
+++ b/fec/data/templates/partials/elections/election-data-and-compliance-tab.jinja
@@ -95,10 +95,10 @@
                 'Quarterly filing and pre-/post-election reports',
                 [{
                   'text': 'Convention and Primary deadlines',
-                  'href': 'https://transition.fec.gov/info/charts_primary_dates_'+cycle|string+'.shtml'+cp
+                  'href': 'https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/'
                 },{
                   'text': 'General deadlines',
-                  'href': 'https://transition.fec.gov/info/report_dates_'+cycle|string+'.shtml#general'
+                  'href': 'https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/'
                 }]
               )
             }}


### PR DESCRIPTION
## Summary
- Resolves # [2671](https://github.com/fecgov/fec-cms/issues/2671)
Updated the button links on https://www.fec.gov/data/elections/president/2020

## Impacted areas of the application
Only the Jinja template was updated but it may affect https://www.fec.gov/data/elections/president/*. Luckily, the links were made more generic so as not to require updates every year. Also, the buttons no longer link to transition.

## Screenshots
Skipping the screenshots as there was no visible change, only URL changes
Some shots showing the URLs in the address bar and the button HREF in the status bar at the bottom of the window:
![image](https://user-images.githubusercontent.com/26720877/53817535-9fe55680-3f33-11e9-9a3c-a191d17693fd.png)
![image](https://user-images.githubusercontent.com/26720877/53817612-d58a3f80-3f33-11e9-964d-6ee4181c57c0.png)
![image](https://user-images.githubusercontent.com/26720877/53817626-de7b1100-3f33-11e9-8e16-ab1b2287af73.png)
![image](https://user-images.githubusercontent.com/26720877/53817639-e89d0f80-3f33-11e9-886c-f796a0cf4e8d.png)
![image](https://user-images.githubusercontent.com/26720877/53817650-ecc92d00-3f33-11e9-81dc-c17f1774b54d.png)
![image](https://user-images.githubusercontent.com/26720877/53817664-f3f03b00-3f33-11e9-9ec4-b6c856024f0a.png)
![image](https://user-images.githubusercontent.com/26720877/53817668-f8b4ef00-3f33-11e9-8469-b00342405f00.png)
![image](https://user-images.githubusercontent.com/26720877/53817698-0ff3dc80-3f34-11e9-8dc4-1596a7cd35a3.png)
![image](https://user-images.githubusercontent.com/26720877/53817704-14b89080-3f34-11e9-8da2-18205cc51236.png)
![image](https://user-images.githubusercontent.com/26720877/53817716-1bdf9e80-3f34-11e9-93d0-ef266bc0138b.png)
![image](https://user-images.githubusercontent.com/26720877/53817721-21d57f80-3f34-11e9-9f41-b333c17cf484.png)



## Related PRs
No related PRs, though there will be additional work to add the redirects specified in the To-do list in the ticket.

## How to test
For these pages, verify the dark blue buttons' href values go to the new address—both the subdomain and the paths.
- http://localhost:8000/data/elections/president/2020/
- http://localhost:8000/data/elections/house/VA/11/2020/
- http://localhost:8000/data/elections/house/MD/05/2020/
- http://localhost:8000/data/elections/senate/VA/2020/
(any district/area will work—these are just examples)
____

