### PR TITLE
Upgrade CMS to cflinuxfs3

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -1,5 +1,5 @@
 ---
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 routes:
   - route: fec-dev-cms.app.cloud.gov

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -1,5 +1,5 @@
 ---
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 routes:
   - route: fec-feature-cms.app.cloud.gov

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,5 +1,5 @@
 ---
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 routes:
   - route: fec-prod-cms.app.cloud.gov

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -1,5 +1,5 @@
 ---
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 routes:
   - route: fec-stage-cms.app.cloud.gov

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gunicorn==19.7.1
 gevent==1.2.1
 lxml==4.2.5
 newrelic==2.82.0.62
-psycopg2==2.7.1
+psycopg2==2.7.3.2
 requests==2.20.1
 slacker==0.8.6
 whitenoise==2.0.3

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,8 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/2654-upgrade-to-cflinuxfs3'),
+    #('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),
 )

--- a/tasks.py
+++ b/tasks.py
@@ -74,8 +74,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'feature/2654-upgrade-to-cflinuxfs3'),
-    #('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),
 )


### PR DESCRIPTION
## Summary

- Resolves #2654 
_This upgrades CMS to `cflinuxfs3` stack and psycopg2 to v2.7.3.2._

We tested together by deploying manually to the CMS dev environment to make sure the deploy was successful. It succeeded without incident.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Database connections and ubuntu stack