### PR TITLE
Feature/2562/embed bar charts election map homepage

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -48,6 +48,8 @@ FEATURES = {
     'adrs': bool(env.get_credential('FEC_FEATURE_ADRS', '')),
     'afs': bool(env.get_credential('FEC_FEATURE_AFS', '')),
     'aggregatetotals': bool(env.get_credential('FEC_FEATURE_AGGR_TOTS', '')),
+    'map': bool(env.get_credential('FEC_FEATURE_HOME_MAP', '')),
+    'barcharts': bool(env.get_credential('FEC_FEATURE_HOME_BARCHARTS', '')),
 }
 
 ENVIRONMENTS = {

--- a/fec/fec/static/js/modules/filters/multi-filter.js
+++ b/fec/fec/static/js/modules/filters/multi-filter.js
@@ -6,7 +6,7 @@ var CheckboxFilter = require('./checkbox-filter').CheckboxFilter;
 
 /* MultiFilters used when there are multiple filters that share the
  * same name attribute
-*/
+ */
 
 function MultiFilter(elm) {
   Filter.call(this, elm);

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -27,7 +27,7 @@ function TopEntities(elm, type) {
   this.$elm
     .find('.js-next')
     .on('click', this.handlePagination.bind(this, 'next'));
-  $('.js-chart-toggle').on('change', this.handleTypeChange.bind(this))
+  $('.js-chart-toggle').on('change', this.handleTypeChange.bind(this));
 }
 
 TopEntities.prototype.init = function() {
@@ -255,7 +255,7 @@ TopEntities.prototype.handleTypeChange = function(e) {
 
   var baseQuery = {
     sort: '-' + this.type,
-    per_page: 10,
+    per_page: this.per_page,
     sort_hide_null: true,
     election_year: this.election_year,
     election_full: true,
@@ -263,16 +263,18 @@ TopEntities.prototype.handleTypeChange = function(e) {
     active_candidates: true
   };
 
+  this.currentQuery = baseQuery;
+
   this.loadData(this.currentQuery);
   this.updateCoverageDateRange();
 
-  $('a.js-browse').attr({
-    'href':"/data/"+this.type
-  }).html('Browse top '+this.prefix+' candidates')
+  $('a.js-browse')
+    .attr({
+      href: '/data/' + this.type
+    })
+    .html('Browse top ' + this.prefix + ' candidates');
 
-  $('.js-type-label span').html(this.action)
-
+  $('.js-type-label span').html(this.action);
 };
-
 
 module.exports = { TopEntities: TopEntities };

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -84,7 +84,8 @@ TopEntities.prototype.handleOfficeChange = function(e) {
   this.office = e.target.value;
 
   this.currentQuery = Object.assign({}, this.currentQuery, {
-    office: this.office
+    office: this.office,
+    page: 1
   });
   this.updateElectionYearOptions(this.office);
   this.updateCoverageDateRange();

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -153,7 +153,7 @@ TopEntities.prototype.populateTable = function(response) {
   var index = 1;
   var rankBase = (response.pagination.page - 1) * 10; // So that page 2 starts at 11
   response.results.forEach(function(result) {
-    var rank = rankBase + index;
+    var rank = self.per_page==3 ? '' :rankBase + index +'.';
     var data = self.formatData(result, rank);
     self.$table.append(TOP_ROW(data));
     index++;

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -153,7 +153,7 @@ TopEntities.prototype.populateTable = function(response) {
   var index = 1;
   var rankBase = (response.pagination.page - 1) * 10; // So that page 2 starts at 11
   response.results.forEach(function(result) {
-    var rank = self.per_page==3 ? '' :rankBase + index +'.';
+    var rank = self.per_page == 3 ? '' : rankBase + index + '.';
     var data = self.formatData(result, rank);
     self.$table.append(TOP_ROW(data));
     index++;

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -271,7 +271,7 @@ TopEntities.prototype.handleTypeChange = function(e) {
 
   $('a.js-browse')
     .attr({
-      href: '/data/' + this.type
+      href: '/data/'+this.prefix+'-bythenumbers/'
     })
     .html('Browse top ' + this.prefix + ' candidates');
 

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -271,7 +271,7 @@ TopEntities.prototype.handleTypeChange = function(e) {
 
   $('a.js-browse')
     .attr({
-      href: '/data/'+this.prefix+'-bythenumbers/'
+      href: '/data/' + this.prefix + '-bythenumbers/'
     })
     .html('Browse top ' + this.prefix + ' candidates');
 

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -11,6 +11,7 @@ function TopEntities(elm, type) {
   this.type = type;
   this.office = this.$elm.data('office');
   this.election_year = this.$elm.data('election-year');
+  this.per_page = this.$elm.data('perpage');
 
   this.$table = this.$elm.find('.js-top-table');
   this.$dates = this.$elm.find('.js-dates');
@@ -26,6 +27,7 @@ function TopEntities(elm, type) {
   this.$elm
     .find('.js-next')
     .on('click', this.handlePagination.bind(this, 'next'));
+  $('.js-chart-toggle').on('change', this.handleTypeChange.bind(this))
 }
 
 TopEntities.prototype.init = function() {
@@ -37,7 +39,7 @@ TopEntities.prototype.init = function() {
 
   var baseQuery = {
     sort: '-' + this.type,
-    per_page: 10,
+    per_page: this.per_page || 10,
     sort_hide_null: true,
     election_year: this.election_year,
     election_full: true,
@@ -244,5 +246,33 @@ TopEntities.prototype.pushStateToURL = function(keyValPairsObj) {
   window.history.pushState(query, search, search || window.location.pathname);
   // analytics.pageView();
 };
+
+TopEntities.prototype.handleTypeChange = function(e) {
+  this.type = e.target.value;
+  this.basePath = ['candidates', 'totals'];
+  this.prefix = $(e.target).data('prefix');
+  this.action = this.type == 'receipts' ? 'raised' : 'spent';
+
+  var baseQuery = {
+    sort: '-' + this.type,
+    per_page: 10,
+    sort_hide_null: true,
+    election_year: this.election_year,
+    election_full: true,
+    office: this.office,
+    active_candidates: true
+  };
+
+  this.loadData(this.currentQuery);
+  this.updateCoverageDateRange();
+
+  $('a.js-browse').attr({
+    'href':"/data/"+this.type
+  }).html('Browse top '+this.prefix+' candidates')
+
+  $('.js-type-label span').html(this.action)
+
+};
+
 
 module.exports = { TopEntities: TopEntities };

--- a/fec/fec/static/js/templates/top-entity-row.hbs
+++ b/fec/fec/static/js/templates/top-entity-row.hbs
@@ -1,5 +1,5 @@
 <div role="row" class="simple-table__row js-top-row">
-  <div class="simple-table__cell">{{ rank }}. <a href="{{ url }}">{{ name }}</a>
+  <div class="simple-table__cell">{{ rank }} <a href="{{ url }}">{{ name }}</a>
   {{#if party_code}}
     {{ party_code }}
   {{/if}}

--- a/fec/fec/static/js/vendor/beautify-html.js
+++ b/fec/fec/static/js/vendor/beautify-html.js
@@ -192,8 +192,8 @@
       typeof options.extra_liners == 'object' && options.extra_liners
         ? options.extra_liners.concat()
         : typeof options.extra_liners === 'string'
-          ? options.extra_liners.split(',')
-          : 'head,body,/html'.split(',');
+        ? options.extra_liners.split(',')
+        : 'head,body,/html'.split(',');
     eol = options.eol ? options.eol : '\n';
 
     if (options.indent_with_tabs) {

--- a/fec/fec/static/scss/components/_breakdowns.scss
+++ b/fec/fec/static/scss/components/_breakdowns.scss
@@ -17,4 +17,11 @@
 .breakdown__title {
   line-height: u(3.4rem);
   margin: 0;
+
+}
+
+.input__label-home {
+  line-height: u(2.5rem);
+  margin: 0;
+
 }

--- a/fec/fec/static/scss/components/_buttons.scss
+++ b/fec/fec/static/scss/components/_buttons.scss
@@ -68,6 +68,9 @@
     border-color: $bright-blue;
     color: $primary;
   }
+  span {
+    color:$inverse;
+  }
 }
 
 .button--alt {

--- a/fec/fec/static/scss/components/_icon-headings.scss
+++ b/fec/fec/static/scss/components/_icon-headings.scss
@@ -197,6 +197,14 @@
     float: left;
     margin-right: u(1.5rem);
   }
+
+  &.primary{
+    &::before {
+      @include u-icon-circle($direction-sign, $primary, $inverse, 4.5rem);
+      background-size: u(4rem);
+      }
+  }
+
 }
 
 .icon-heading--shield-circle {
@@ -275,6 +283,31 @@
     float: left;
     margin-right: u(1.5rem);
   }
+
+  &.primary{
+    &::before {
+      @include u-icon-circle($financial-document, $primary, $inverse, 4.5rem);
+      background-size: 40%;
+      }
+  }
+}
+
+.icon-heading--election-circle {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($election, $inverse, $secondary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+
+  &.primary{
+    &::before {
+      @include u-icon-circle($election, $primary, $inverse, 4.5rem);
+      background-size: 40%;
+      }
+  }
 }
 
 .icon-heading--graph-circle,
@@ -286,7 +319,10 @@
 .icon-heading--magnifying-glass-circle,
 .icon-heading--question-bubble-circle,
 .icon-heading--individual-contributions-circle,
-.icon-heading--person-location-circle
+.icon-heading--person-location-circle,
+.icon-heading--direction-sign-circle,
+.icon-heading--financial-document,
+.icon-heading--election-circle
  {
   border-bottom: none;
   display: table;

--- a/fec/fec/static/scss/components/_maps.scss
+++ b/fec/fec/static/scss/components/_maps.scss
@@ -27,6 +27,10 @@
   height: u(24rem);
 }
 
+.election-map--home {
+  height: u(26rem);
+}
+
 .choropleths {
   position: relative;
 }

--- a/fec/fec/static/scss/components/_search-controls.scss
+++ b/fec/fec/static/scss/components/_search-controls.scss
@@ -126,6 +126,31 @@
   }
 }
 
+//For home-page embedded election map form fields
+.election-search-home {
+  .search-controls__zip {
+  @include span-columns(6);
+  margin-bottom: u(1rem);
+
+  input {
+    width: 100%;
+  }
+}
+
+}
+
+.raising-spending-controls {
+  .office-select {
+    @include span-columns(10);
+    select {
+     width:100%;
+   }
+  }
+  .cycle-select {
+    @include span-columns(6);
+  }
+}
+
  //for keyword-options modals on AO, MUR, Statues searches
 .keyword-modal{
   .modal__tips, modal__form {
@@ -340,9 +365,4 @@
   }
 }
 
-select#top-category {
-  min-width: 15em;
-}
-select#election-year {
-  min-width: 6.5em;
-}
+

--- a/fec/fec/static/scss/components/_search-controls.scss
+++ b/fec/fec/static/scss/components/_search-controls.scss
@@ -153,7 +153,7 @@
 
  //for keyword-options modals on AO, MUR, Statues searches
 .keyword-modal{
-  .modal__tips, modal__form {
+  .modal__tips, .modal__form {
     display:table-row;
     width:100%;
   }

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -158,6 +158,16 @@ h3 + .simple-table {
   border-top: 2px solid $primary;
   font-family: $sans-serif;
 
+  &.chart-table-home {
+    border-top: none;
+    .simple-table__row {
+      border-bottom: 1px dotted $gray-dark;
+      .simple-table__cell {
+        font-weight:bold;
+      }
+    }
+  }
+
   .simple-table__cell {
     padding: u(.5rem 0 0 0);
   }

--- a/fec/fec/static/scss/layout/_layout.scss
+++ b/fec/fec/static/scss/layout/_layout.scss
@@ -136,8 +136,16 @@
   padding-top: u(2rem);
 }
 
+.u-padding--top--small {
+  padding-top: u(.5rem) !important;
+}
+
 .u-padding--bottom {
   padding-bottom: u(2rem);
+}
+
+.u-padding--bottom--small {
+  padding-bottom: u(.5rem) !important;
 }
 
 .u-padding--left {

--- a/fec/fec/static/scss/layout/_slabs.scss
+++ b/fec/fec/static/scss/layout/_slabs.scss
@@ -39,6 +39,10 @@
   padding: u(4rem 0);
 }
 
+.slab--spacious-margin {
+  margin: u(3rem 0);
+}
+
 .slab--inline {
   border-radius: 4px;
   margin: u(2rem 0);
@@ -53,6 +57,11 @@
     @include span-columns(10);
     padding-left: u(2rem);
   }
+}
+
+.slab--ruled {
+  border-top: 2px solid $inverse;
+  border-bottom: 2px solid $inverse;
 }
 
 // Reset all slab colors on print

--- a/fec/fec/static/scss/layout/_slabs.scss
+++ b/fec/fec/static/scss/layout/_slabs.scss
@@ -18,6 +18,9 @@
 // Neutral gray background with base accents and type (default)
 .slab--neutral {
   @include u-bg--neutral();
+  a:hover {
+    border-bottom: 2px solid ;
+  }
 }
 
 // Primary background with primary-contrast accents and type

--- a/fec/fec/static/scss/layout/_slabs.scss
+++ b/fec/fec/static/scss/layout/_slabs.scss
@@ -18,9 +18,6 @@
 // Neutral gray background with base accents and type (default)
 .slab--neutral {
   @include u-bg--neutral();
-  a:hover {
-    border-bottom: 2px solid ;
-  }
 }
 
 // Primary background with primary-contrast accents and type

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -1,0 +1,178 @@
+{% load static compress wagtailuserbar %}
+{% load filters %}
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html lang="en"> <![endif]-->
+<!--[if IE 7]>         <html lang="en"> <![endif]-->
+<!--[if IE 8]>         <html lang="en"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en"> <!--<![endif]-->
+  <head>
+    {% include './partials/meta-tags.html' %}
+
+    <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }} | FEC {% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
+
+    {% block css %}
+    <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
+    {% endblock %}
+  </head>
+
+  <body class="{% block body_class %}{% endblock %}">
+    <!--[if lt IE 10]>
+    <div style="background-color: #212121; padding: 10px">
+      <h2 style="color: #ffffff">Your browser is outdated</h2>
+      <p style="color: #ffffff; font-size: 16px;">You're using an older version of Internet Explorer. Please update or switch to another browser like Chrome, Firefox, or Safari for a better experience.</p>
+      <p style="color: #ffffff; font-size: 16px;"><a style="color: #ffffff; text-decoration: underline" target="_blank" href="http://browsehappy.com/">Learn how to update your browser.</a></p>
+      <p style="color: #ffffff; font-size: 16px;">You can still access an archive of the old FEC.gov at <a style="color: #ffffff; text-decoration: underline" href="http://classic.fec.gov">classic.fec.gov</a></p>
+    </div>
+    <![endif]-->
+    {% wagtailuserbar %}
+    <a href="#main" class="skip-nav">skip navigation</a>
+    {% if self.title == "Homepage" or self.title == "Home" %}
+    <header class="site-header site-header--homepage">
+      <div class="masthead">
+        <div class="homepage-seal">
+          <img src="{% static 'img/seal.svg' %}" alt="FEC logo">
+        </div>
+        <div class="disclaimer">
+          <span class="disclaimer__right">An official website of the U.S. government <img src="{% static 'img/us_flag_small.png' %}" class="flag" alt="US flag signifying that this is a United States Federal Government website"></span>
+        </div>
+        <div class="site-title--print"></div>
+        <a title="Home" href="/" class="site-title" rel="home"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
+        <ul class="utility-nav list--flat">
+          <li class="utility-nav__item"><a href="/calendar/">Calendar</a></li>
+          <li class="utility-nav__item">
+            <a class="js-glossary-toggle glossary__toggle">Glossary</a>
+          </li>
+          <li class="utility-nav__search">
+            <form accept-charset="UTF-8" action="/search" class="combo" method="get" role="search">
+              <input type="hidden" name="type" value="candidates">
+              <input type="hidden" name="type" value="committees">
+              <input type="hidden" name="type" value="site">
+              <label class="u-visually-hidden" for="query">Search</label>
+              <input
+                class="js-site-search combo__input"
+                autocomplete="off"
+                id="query"
+                name="query"
+                type="text"
+                aria-label="Search FEC.gov">
+              <button type="submit" class="button--standard combo__button button--search">
+                <span class="u-visually-hidden">Search</span>
+              </button>
+            </form>
+          </li>
+        </ul>
+      </div>
+      {% include 'partials/navigation/navigation.html' %}
+    </header>
+    {% else %}
+    <header class="site-header">
+      <div class="masthead">
+        <div class="disclaimer">
+          <span class="disclaimer__right">An official website of the United States Government <img src="{% static 'img/us_flag_small.png' %}"  alt="US flag signifying that this is a United States Federal Government website"></span>
+        </div>
+        <div class="site-title--print"></div>
+        <a title="Home" href="/" class="site-title" rel="home"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
+        <ul class="utility-nav list--flat">
+          <li class="utility-nav__item{% if self.content_section == 'calendar' %} is-active{% endif %}"><a href="/calendar/">Calendar</a></li>
+          <li class="utility-nav__item"><a class="js-glossary-toggle glossary__toggle">Glossary</a></li>
+          <li class="utility-nav__search">
+            <form accept-charset="UTF-8" action="/search" id="search_form" class="combo" method="get" role="search">
+              <input type="hidden" name="type" value="candidates">
+              <input type="hidden" name="type" value="committees">
+              <input type="hidden" name="type" value="site">
+              <label class="u-visually-hidden" for="query">Search</label>
+              <input
+                class="js-site-search combo__input"
+                autocomplete="off"
+                id="query"
+                name="query"
+                type="text"
+                aria-label="Search FEC.gov">
+              <button type="submit" class="button--standard combo__button button--search">
+                <span class="u-visually-hidden">Search</span>
+              </button>
+            </form>
+          </li>
+        </ul>
+      </div>
+      {% include 'partials/navigation/navigation.html' %}
+    </header>
+    {% endif %}
+
+    <main id="main">
+      {% block content %}{% endblock %}
+    </main>
+
+    {% include 'partials/footer-navigation.html' %}
+    <footer class="footer">
+      <div class="container">
+        <div class="seal">
+          <img class="seal__img" width="140" height="140" src="{% static "img/seal--inverse.svg" %}" alt="Seal of the Federal Election Commission | United States of America">
+          <p class="address__title">Federal Election Commission</p>
+        </div>
+
+        <div class="address">
+          <ul class="social-media">
+            <li>
+              <div class="i icon--twitter">
+                <a href="https://twitter.com/fec"><span class="u-visually-hidden">The FEC's Twitter page</span></a>
+              </div>
+            </li>
+            <li>
+              <div class="i icon--youtube">
+                <a href="https://www.youtube.com/user/FECTube"><span class="u-visually-hidden">The FEC's YouTube page</span></a>
+              </div>
+            </li>
+          </ul>
+
+          <p>1050 First Street, NE<br>
+          Washington, DC 20463</p>
+
+          <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank">
+            <button class="button--standard button--envelope">Sign up for FECMail</button>
+          </a>
+        </div>
+      </div>
+    </footer>
+
+    {% include './partials/glossary.html' %}
+
+    {% csrf_token %}
+
+    <script>
+      window.BASE_PATH = '/data';
+      window.FEC_APP_URL = '{{ settings.FEC_APP_URL }}';
+      window.API_LOCATION = '{{ settings.FEC_API_URL }}';
+      window.API_VERSION = '{{ settings.FEC_API_VERSION }}';
+      window.API_KEY = '{{ settings.FEC_API_KEY_PUBLIC }}';
+      window.TRANSITION_URL = '{{ settings.FEC_TRANSITION_URL }}';
+      window.CANONICAL_BASE = '{{ settings.CANONICAL_BASE }}'
+    </script>
+
+
+    {# Global javascript #}
+    <script type="text/javascript" src="{% asset_for_js 'vendor.js' %}"></script>
+    <script type="text/javascript" src="{% asset_for_js 'init.js' %}"></script>
+    <script type="text/javascript" src='https://www.google.com/recaptcha/api.js'></script>
+
+    {% block extra_js %}
+    {# Override this in templates to add extra javascript #}
+    {% endblock %}
+
+    {% if not settings.DEBUG %}
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('set', 'anonymizeIp', true);
+      ga('set', 'forceSSL', true);
+      ga('create', 'UA-48605964-22', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+    <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
+    {% endif %}
+  </body>
+</html>

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -12,6 +12,7 @@
 
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% asset_for_css 'elections.css' %}" />
     {% endblock %}
   </head>
 
@@ -95,7 +96,7 @@
           </li>
         </ul>
       </div>
-      {% include 'partials/navigation/navigation.html' %}
+      {% include 'partials/navigation/navigation.html' %
     </header>
     {% endif %}
 
@@ -155,6 +156,7 @@
     <script type="text/javascript" src="{% asset_for_js 'init.js' %}"></script>
     <script type="text/javascript" src='https://www.google.com/recaptcha/api.js'></script>
 
+
     {% block extra_js %}
     {# Override this in templates to add extra javascript #}
     {% endblock %}
@@ -173,6 +175,7 @@
     </script>
 
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
+
     {% endif %}
   </body>
 </html>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -1,6 +1,8 @@
-{% extends "base.html" %}
+{% extends "home_base.html" %}
 {% load wagtailcore_tags %}
 {% load staticfiles %}
+{% load top_entities %}
+{% load elections_lookup %}
 {% load home_page %}
 {% load filters %}
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
@@ -56,27 +58,31 @@
 
   <section class="slab slab--home slab--neutral">
     <div class="container">
-      <h2 class="heading--section u-margin--bottom">Get started</h2>
-      <ul class="grid grid--3-wide grid--flex t-sans">
-        <li class="grid__item grid__item--with-img grid__item--with-button">
-          <img src="{% static 'img/feature--candidate-support.jpg' %}" alt="">
-          <h4>Find out how individuals can support federal candidates</h4>
-          <p class="t-note t-normal t-sans">Including making contributions, volunteering, internet activities and filing complaints</p>
-          <a class="button button--cta button--go" href="/introduction-campaign-finance/understanding-ways-support-federal-candidates/">Start learning</a>
-        <li class="grid__item grid__item--with-img grid__item--with-button">
-          <img src="{% static 'img/feature--compare-candidates.jpg' %}" alt="">
-          <h4>Explore financial data for current and past elections and the candidates in those races</h4>
-          <a class="button button--cta button--go" href="/data/#compare-candidates-in-an-election">Compare candidates</a>
-        </li>
-        <li class="grid__item grid__item--with-img grid__item--with-button">
-          <img src="{% static 'img/feature--contributions.jpg' %}" alt="">
-          <h4>Learn about how much contributors can give to different types of committees</h4>
-          <a class="button button--cta button--go" href="/help-candidates-and-committees/candidate-taking-receipts/contribution-limits-candidates/">Get the contribution limits</a>
-        </li>
-      </ul>
+
+    {% elections_lookup request %}
+
+      <div class="grid grid--3-wide grid--no-border slab--spacious-margin slab--ruled u-padding--top">
+        <div class="grid__item">
+          <div class="icon-heading icon-heading--direction-sign-circle primary">
+            <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/understanding-ways-support-federal-candidates/">Understand ways to support federal candidates</a></p>
+          </div>
+        </div>
+        <div class="grid__item">
+          <div class="icon-heading icon-heading--financial-document primary">
+            <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/how-to-research-public-records/">Learn more about using the FEC's campaign finance data</a></p>
+          </div>
+        </div>
+        <div class="grid__item">
+          <div class="icon-heading icon-heading--election-circle primary">
+            <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/election-and-voting-information/">Find election and voting information</a></p>
+          </div>
+        </div>
+      </div>
+
+    {% raising request %}
+
     </div>
   </section>
-
   <section class="slab">
     <div class="container">
       <h1>Commissioners</h1>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -74,7 +74,7 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading icon-heading--election-circle primary">
-            <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/election-and-voting-information/">Find election results and voting information</a></p>
+            <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/election-and-voting-information/">Find election resultsand voting information</a></p>
           </div>
         </div>
       </div>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -157,4 +157,20 @@
 <script src="{% asset_for_js 'bythenumbers.js' %}"></script>
 <script src="{% asset_for_js 'dataviz-common.js' %}"></script>
 <script src="{% asset_for_js 'election-lookup.js' %}"></script>
+<script>
+  //remove competing/cofusing querystrings on homepage
+  $(function(){
+    function cleanURI(){
+      let uri = window.location.toString();
+      const clean_uri = uri.substring(0, uri.indexOf("?"));
+      if (uri.indexOf("?") > 0) {
+        window.history.replaceState({}, document.title, clean_uri);
+      }
+    }
+    $('body').on('change ', 'input, select', function(){
+      cleanURI()
+    })
+  cleanURI()
+  });
+</script>
 {% endblock %}

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -74,7 +74,7 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading icon-heading--election-circle primary">
-            <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/election-and-voting-information/">Find election and voting information</a></p>
+            <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/election-and-voting-information/">Find election results and voting information</a></p>
           </div>
         </div>
       </div>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -158,19 +158,22 @@
 <script src="{% asset_for_js 'dataviz-common.js' %}"></script>
 <script src="{% asset_for_js 'election-lookup.js' %}"></script>
 <script>
-  //remove competing/cofusing querystrings on homepage
+  //remove competing/confusing querystrings on homepage
   $(function(){
+    cleanURI()
     function cleanURI(){
-      let uri = window.location.toString();
-      const clean_uri = uri.substring(0, uri.indexOf("?"));
-      if (uri.indexOf("?") > 0) {
-        window.history.replaceState({}, document.title, clean_uri);
+      const uri = window.location.toString();
+      if (uri.indexOf('?') > 0) {
+        window.history.replaceState({}, document.title, location.href.split('?')[0]);
       }
     }
-    $('body').on('change ', 'input, select', function(){
-      cleanURI()
+    $('#main').on('change ', 'input, select', function(){
+      cleanURI();
     })
-  cleanURI()
+    //handle Chrome insconsistency with History API
+    $('.js-office').val('P');
+    $('.js-election-year').val('2020')
+    $('.js-chart-toggle').filter('[value=receipts]').prop('checked', true)
   });
 </script>
 {% endblock %}

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -79,7 +79,7 @@
         </div>
       </div>
 
-    {% raising request %}
+    {% raising_spending request %}
 
     </div>
   </section>
@@ -151,9 +151,10 @@
       </div>
     </div>
   </section>
-
 {% endblock %}
 
 {% block extra_js %}
-  <script type="text/javascript" src="{% asset_for_js 'home.js' %}"></script>
+<script src="{% asset_for_js 'bythenumbers.js' %}"></script>
+<script src="{% asset_for_js 'dataviz-common.js' %}"></script>
+<script src="{% asset_for_js 'election-lookup.js' %}"></script>
 {% endblock %}

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -74,7 +74,7 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading icon-heading--election-circle primary">
-            <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/election-and-voting-information/">Find election resultsand voting information</a></p>
+            <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/election-and-voting-information/">Find election results and voting information</a></p>
           </div>
         </div>
       </div>

--- a/fec/home/templates/partials/elections-lookup.html
+++ b/fec/home/templates/partials/elections-lookup.html
@@ -1,0 +1,90 @@
+{% if FEATURES.map %}
+{% load wagtailcore_tags %}
+{% load filters %}
+
+
+
+<link rel="stylesheet" type="text/css" href="{% asset_for_css 'elections.css' %}" />
+
+<h2 class="heading--section">Compare candidates in an election</h2>
+<div class="grid grid--2-wide grid--flex" id="election-lookup">
+  <div class="grid__item">
+    <div class="election-map election-map--small u-margin--top">
+      <!--map renders here -->
+    </div>
+  </div>
+  <div class="grid__item example--primary search-controls election-search-home">
+    <p class="t-bold">Learn about candidates running in a particular state or district for past or upcoming elections.</p>
+    <form action="/data/elections">
+      <div class="row u-margin--bottom">
+        <div class="search-controls__zip">
+          <label for="zip" class="label input__label-home">Find by ZIP code</label>
+          <input type="text" inputmode="numeric" id="zip" name="zip" class="combo__input">
+        </div>
+        <div class="search-controls__submit search-controls__no-label">
+          <button type="submit" class="button--search--text button--standard">Search</button>
+        </div>
+      </div>
+      <div class="row">
+        <div class="search-controls__state">
+          <label for="state" class="label input__label-home">State</label>
+          <select id="state" name="state" aria-label="Select a state">
+            <option value="">Select state</option>
+            {% for value, label in states.items %}
+            <option value="{{ value }}">{{ label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="search-controls__district">
+          <label for="District" class="label input__label-home">District <span class="label__optional">(optional)</span></label>
+          <select id="district" name="district" aria-label="Select a district" class="select--alt">
+            <option value="">Select district</option>
+            <option value="S">Senate</option>
+            <optgroup label="House">
+              {% for value in range %}
+
+              {% comment %}
+              {% for value in range|districts(100) %}
+              {% with formatted = '{0:02d}'.format(value) %}
+              {% endcomment %}
+
+              <option value="{{ value.normalize }}">{{ value.normalize }}</option>
+
+              {% comment %}
+              {% endwith %}
+              {% endcomment %}
+
+              {% endfor %}
+            </optgroup>
+          </select>
+        </div>
+        <div class="search-controls__submit search-controls__no-label">
+         <button type="submit" class="button--search--text button--standard">Search</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>
+
+
+<script>
+var context = {
+  election: {
+    cycle: '{{ cycle }}',
+    state: '{{ state|default_if_none:"" }}'
+  }
+};
+
+  API_LOCATION = '{{ API_LOCATION }}';
+  API_VERSION = '{{ API_VERSION }}';
+  FEC_APP_URL = '{{ FEC_APP_URL }}';
+  BASE_PATH = '{{ BASE_PATH }}';
+  API_KEY = '{{ API_KEY }}';
+  CANONICAL_BASE = '{{ CANONICAL_BASE }}';
+  BASE_URL = '{{ BASE_URL }}';
+</script>
+
+<script type="text/javascript" src="{% asset_for_js 'vendor.js' %}"></script>
+<script src="{% asset_for_js 'dataviz-common.js' %}"></script>
+<script src="{% asset_for_js 'election-lookup.js' %}"></script>
+{% endif %}

--- a/fec/home/templates/partials/elections-lookup.html
+++ b/fec/home/templates/partials/elections-lookup.html
@@ -2,10 +2,6 @@
 {% load wagtailcore_tags %}
 {% load filters %}
 
-
-
-<link rel="stylesheet" type="text/css" href="{% asset_for_css 'elections.css' %}" />
-
 <h2 class="heading--section">Compare candidates in an election</h2>
 <div class="grid grid--2-wide grid--flex" id="election-lookup">
   <div class="grid__item">
@@ -75,16 +71,8 @@ var context = {
   }
 };
 
-  API_LOCATION = '{{ API_LOCATION }}';
-  API_VERSION = '{{ API_VERSION }}';
-  FEC_APP_URL = '{{ FEC_APP_URL }}';
-  BASE_PATH = '{{ BASE_PATH }}';
-  API_KEY = '{{ API_KEY }}';
-  CANONICAL_BASE = '{{ CANONICAL_BASE }}';
-  BASE_URL = '{{ BASE_URL }}';
+
 </script>
 
-<script type="text/javascript" src="{% asset_for_js 'vendor.js' %}"></script>
-<script src="{% asset_for_js 'dataviz-common.js' %}"></script>
-<script src="{% asset_for_js 'election-lookup.js' %}"></script>
+
 {% endif %}

--- a/fec/home/templates/partials/elections-lookup.html
+++ b/fec/home/templates/partials/elections-lookup.html
@@ -3,13 +3,13 @@
 {% load filters %}
 
 <h2 class="heading--section">Compare candidates in an election</h2>
-<div class="grid grid--2-wide grid--flex" id="election-lookup">
-  <div class="grid__item">
-    <div class="election-map election-map--small u-margin--top">
+<div class="grid grid--2-wide grid--flex u-padding--top" id="election-lookup">
+  <div class="grid__item u-margin--bottom">
+    <div class="election-map election-map--home">
       <!--map renders here -->
     </div>
   </div>
-  <div class="grid__item example--primary search-controls election-search-home">
+  <div class="grid__item example--primary u-margin--bottom search-controls election-search-home">
     <p class="t-bold">Learn about candidates running in a particular state or district for past or upcoming elections.</p>
     <form action="/data/elections">
       <div class="row u-margin--bottom">

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -1,0 +1,105 @@
+{% if FEATURES.barcharts %}
+{% load wagtailcore_tags %}
+{% load filters %}
+
+    <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% asset_for_css 'data-landing.css' %}">
+
+<h2 class="heading--section u-margin--bottom">Who is raising and spending the most</h2>
+<section class="usa-grid-full">
+  <p class="t-bold">Learn how much individual candidates have raised and spent for presidential, Senate and House elections.</p>
+  <div class="usa-width-two-thirds grid--flex">
+    <section id="raising-breakdowns">
+       <div class="js-top-entities" data-office="{{ office }}" data-election-year="{{ election_year }}" data-perpage="3">
+
+       <div class="chart-table chart-table-home simple-table--responsive js-top-table" id="top-table" aria-live="polite" role="grid">
+
+        <div role="row" class="simple-table__header">
+          <div role="columnheader" class="simple-table__header-cell cell--40">Name</div>
+          <div role="columnheader" class="simple-table__header-cell cell--20 t-right-aligned js-type-label">Total <span>{{ action }}</span></div>
+          <div role="columnheader" class="simple-table__header-cell cell--40"></div>
+        </div>
+
+        {% for datum in data %}
+        <div role="row" class="js-top-row simple-table__row">
+
+        </div>
+        {% endfor %}
+        </div>
+
+      <div class="content__section row u-margin--top">
+        <ul class="list--buttons u-float-right">
+          <li><a class="button button--standard button--table js-browse"  href="/data/receipts">Explore top <span>raising</span> candidates</a></li>
+        </ul>
+      </div>
+     </div>
+    </section>
+  </div>
+  <div class="usa-width-one-third example--primary">
+    <fieldset class="toggles u-margin--bottom" data-filter="toggle" data-filter-ignore-count="true">
+      <legend class="label input__label-home t-inline-block">Data type</legend>
+      <div class="row">
+        <label for="switcher-receipts" class="toggle">
+          <input type="radio" class="js-chart-toggle" value="receipts" id="switcher-receipts" checked name="data_type" data-prefix="raising"  aria-controls="processed-message" tabindex="0">
+          <span class="button--alt">Money raised</span>
+        </label>
+        <label for="switcher-disbursements" class="toggle">
+          <input type="radio" class="js-chart-toggle" value="disbursements" id="switcher-disbursements" name="data_type" data-prefix="spending" aria-controls="processed-message" tabindex="0">
+          <span class="button--alt">Money spent</span>
+        </label>
+      </div>
+    </fieldset>
+
+    <div class="js-top-entities raising-spending-controls content__section" data-office="{{ office }}" data-election-year="{{ election_year }}">
+      <form action="" method="GET" class="u-margin--bottom">
+        <div class="office-select u-margin--bottom">
+        <label for="top-category" class="js-type-label input__label-home label t-inline-block">How much has been <span>{{ action }}</span> by </label>
+          <select id="top-category" name="top_category" class="js-office" aria-controls="top-table">
+            <option value="P" {% if office == 'P' %}selected{% endif %}>Presidential candidates</option>
+            <option value="S" {% if office == 'S' %}selected{% endif %}>Senate candidates</option>
+            <option value="H" {% if office == 'H' %}selected{% endif %}>House candidates</option>
+          </select>
+        </div>
+          <noscript>
+            <button type="submit" class="button button--cta">Submit</button>
+          </noscript>
+      </form>
+      <form action="" method="get">
+        <div class="row">
+          <div class="cycle-select">
+            <label for="election-year" class="label input__label-home">Running in</label>
+            <select id="election-year" class="js-election-year" name="cycle">
+              {% for each in election_years %}
+                <option
+                    value="{{ each }}"
+                    {% if election_year == each %}selected{% endif %}
+                  >{{ each }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        <noscript>
+          <button type="submit" class="button button--cta">Submit</button>
+        </noscript>
+      </form>
+    </div>
+  </div>
+</section>
+
+ <script type="text/javascript">
+ var context = {
+   type: 'receipts'
+ }
+
+API_LOCATION = '{{ API_LOCATION }}';
+API_VERSION = '{{ API_VERSION }}';
+FEC_APP_URL = '{{ FEC_APP_URL }}';
+BASE_PATH = '{{ BASE_PATH }}';
+API_KEY = '{{ API_KEY }}';
+CANONICAL_BASE = '{{ CANONICAL_BASE }}';
+BASE_URL = '{{ BASE_URL }}';
+</script>
+
+<script type="text/javascript" src="{% asset_for_js 'vendor.js' %}"></script>
+<script src="{% asset_for_js 'bythenumbers.js' %}"></script>
+{% endif %}

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -12,7 +12,7 @@
        <div class="chart-table chart-table-home simple-table--responsive js-top-table" id="top-table" aria-live="polite" role="grid">
 
         <div role="row" class="simple-table__header">
-          <div role="columnheader" class="simple-table__header-cell cell--40">Name</div>
+          <div role="columnheader" class="simple-table__header-cell cell--40">Candidate</div>
           <div role="columnheader" class="simple-table__header-cell cell--20 t-right-aligned js-type-label">Total <span>{{ action }}</span></div>
           <div role="columnheader" class="simple-table__header-cell cell--40"></div>
         </div>
@@ -85,7 +85,7 @@
 
  <script type="text/javascript">
  var context = {
-   type: 'receipts'
+   type: 'receipts',
  }
 </script>
 {% endif %}

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -2,9 +2,9 @@
 {% load wagtailcore_tags %}
 {% load filters %}
 
-<h2 class="heading--section u-margin--bottom">Who is raising and spending the most</h2>
+<h2 class="heading--section">Who is raising and spending the most</h2>
 <section class="usa-grid-full">
-  <p class="t-bold">Learn how much individual candidates have raised and spent for presidential, Senate and House elections.</p>
+  <p class="t-bold u-padding--top">Learn how much individual candidates have raised and spent for presidential, Senate and House elections.</p>
   <div class="usa-width-two-thirds grid--flex">
     <section id="raising-breakdowns">
        <div class="js-top-entities" data-office="{{ office }}" data-election-year="{{ election_year }}" data-perpage="3">
@@ -24,15 +24,15 @@
         {% endfor %}
         </div>
 
-      <div class="content__section row u-margin--top">
+      <div class="content__section row u-padding--top">
         <ul class="list--buttons u-float-right">
-          <li><a class="button button button--go js-browse"  href="/data/raising-bythenumbers/">Explore top <span>raising</span> candidates</a></li>
+          <li><a class="button button--cta button--go js-browse"  href="/data/raising-bythenumbers/">Explore top <span>raising</span> candidates</a></li>
         </ul>
       </div>
      </div>
     </section>
   </div>
-  <div class="usa-width-one-third example--primary">
+  <div class="usa-width-one-third example--primary u-padding--top--small">
     <fieldset class="toggles u-margin--bottom" data-filter="toggle" data-filter-ignore-count="true">
       <legend class="label input__label-home t-inline-block">Data type</legend>
       <div class="row">

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -24,9 +24,9 @@
         {% endfor %}
         </div>
 
-      <div class="content__section row u-padding--top">
+      <div class="content__section row u-margin--top">
         <ul class="list--buttons u-float-right">
-          <li><a class="button button--cta button--go js-browse"  href="/data/raising-bythenumbers/">Explore top <span>raising</span> candidates</a></li>
+          <li class="u-padding--top--small"><a class="button button--cta button--go js-browse"  href="/data/raising-bythenumbers/">Browse top <span>raising</span> candidates</a></li>
         </ul>
       </div>
      </div>

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -29,7 +29,7 @@
 
       <div class="content__section row u-margin--top">
         <ul class="list--buttons u-float-right">
-          <li><a class="button button--standard button--table js-browse"  href="/data/receipts">Explore top <span>raising</span> candidates</a></li>
+          <li><a class="button button button--go js-browse"  href="/data/raising-bythenumbers/">Explore top <span>raising</span> candidates</a></li>
         </ul>
       </div>
      </div>

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -2,9 +2,6 @@
 {% load wagtailcore_tags %}
 {% load filters %}
 
-    <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
-    <link rel="stylesheet" type="text/css" href="{% asset_for_css 'data-landing.css' %}">
-
 <h2 class="heading--section u-margin--bottom">Who is raising and spending the most</h2>
 <section class="usa-grid-full">
   <p class="t-bold">Learn how much individual candidates have raised and spent for presidential, Senate and House elections.</p>
@@ -90,16 +87,5 @@
  var context = {
    type: 'receipts'
  }
-
-API_LOCATION = '{{ API_LOCATION }}';
-API_VERSION = '{{ API_VERSION }}';
-FEC_APP_URL = '{{ FEC_APP_URL }}';
-BASE_PATH = '{{ BASE_PATH }}';
-API_KEY = '{{ API_KEY }}';
-CANONICAL_BASE = '{{ CANONICAL_BASE }}';
-BASE_URL = '{{ BASE_URL }}';
 </script>
-
-<script type="text/javascript" src="{% asset_for_js 'vendor.js' %}"></script>
-<script src="{% asset_for_js 'bythenumbers.js' %}"></script>
 {% endif %}

--- a/fec/home/templatetags/elections_lookup.py
+++ b/fec/home/templatetags/elections_lookup.py
@@ -1,0 +1,18 @@
+from django import template
+from data import constants
+
+from django.conf import settings
+from data import constants
+from data import utils
+
+register = template.Library()
+
+@register.inclusion_tag('partials/elections-lookup.html')
+def elections_lookup(request):
+
+    cycle = constants.DEFAULT_ELECTION_YEAR
+    cycles = utils.get_cycles(cycle + 4)
+    FEATURES = settings.FEATURES
+    states = constants.states
+
+    return {'parent': 'data', 'cycles': cycles, 'cycle': cycle, 'states':states, 'FEATURES': FEATURES}

--- a/fec/home/templatetags/top_entities.py
+++ b/fec/home/templatetags/top_entities.py
@@ -1,6 +1,7 @@
 from django import template
 from data import constants
 
+import datetime
 from django.conf import settings
 from data import constants
 from data import utils
@@ -9,7 +10,7 @@ register = template.Library()
 
 
 @register.inclusion_tag('partials/raising-spending.html')
-def raising(request):
+def raising_spending(request):
     office = request.GET.get('office', 'P')
 
     election_year = int(request.GET.get('election_year', constants.DEFAULT_ELECTION_YEAR))

--- a/fec/home/templatetags/top_entities.py
+++ b/fec/home/templatetags/top_entities.py
@@ -8,7 +8,6 @@ from data import utils
 
 register = template.Library()
 
-
 @register.inclusion_tag('partials/raising-spending.html')
 def raising_spending(request):
     office = request.GET.get('office', 'P')
@@ -21,14 +20,6 @@ def raising_spending(request):
     FEATURES = settings.FEATURES
 
     return {
-    #'parent': 'data',
-    'API_KEY':settings.FEC_API_KEY_PUBLIC,
-    'BASE_URL': settings.CANONICAL_BASE,
-    'BASE_PATH': '/data',
-    'FEC_APP_URL': settings.FEC_APP_URL,
-    'API_LOCATION':settings.FEC_API_URL,
-    'API_VERSION' :settings.FEC_API_VERSION,
-    'CANONICAL_BASE': settings.CANONICAL_BASE,
     'name_field':'name',
     'id_field:' :'candidate_id',
     'candidate' :'candidate_id',

--- a/fec/home/templatetags/top_entities.py
+++ b/fec/home/templatetags/top_entities.py
@@ -1,0 +1,40 @@
+from django import template
+from data import constants
+
+from django.conf import settings
+from data import constants
+from data import utils
+
+register = template.Library()
+
+
+@register.inclusion_tag('partials/raising-spending.html')
+def raising(request):
+    office = request.GET.get('office', 'P')
+
+    election_year = int(request.GET.get('election_year', constants.DEFAULT_ELECTION_YEAR))
+
+    max_election_year = utils.current_cycle() + 4
+    election_years = utils.get_cycles(max_election_year)
+
+    FEATURES = settings.FEATURES
+
+    return {
+    #'parent': 'data',
+    'API_KEY':settings.FEC_API_KEY_PUBLIC,
+    'BASE_URL': settings.CANONICAL_BASE,
+    'BASE_PATH': '/data',
+    'FEC_APP_URL': settings.FEC_APP_URL,
+    'API_LOCATION':settings.FEC_API_URL,
+    'API_VERSION' :settings.FEC_API_VERSION,
+    'CANONICAL_BASE': settings.CANONICAL_BASE,
+    'name_field':'name',
+    'id_field:' :'candidate_id',
+    'candidate' :'candidate_id',
+    'action': 'raised',
+    'title': 'Raising: by the numbers',
+    'election_years': election_years,
+    'election_year': election_year,
+    'office': office,
+    'FEATURES':FEATURES
+    }


### PR DESCRIPTION
## Summary
Embed bar charts and election map in homepage


- Resolves #2562
- Replaces WIP PR: #2715

Please not that this iteration of the home `/templates/home/home_page.html` extends  a new template called `home_base.html` instead of the  `base.html` which is extended by most of the other pages in home. This is done in order to Set the `BASE_PATH` variables  to `/data` ( it is set to  `/ ` in `base.html` )

## Impacted areas of the application
List general components of the application that this PR will affect:

**Modifies files**:    
        modified:   /settings/base.py
	modified:   fec/static/js/modules/top-entities.js
	modified:   fec/static/scss/components/_breakdowns.scss
	modified:   fec/static/scss/components/_icon-headings.scss
	modified:   fec/static/scss/components/_search-controls.scss
	modified:   fec/static/scss/components/_table-styles.scss
	modified:   fec/static/scss/layout/_slabs.scss
	modified:   home/templates/home/home_page.html

**New Files:**
	fec/templates/home_base.html
	home/templates/partials/elections-lookup.html
	home/templates/partials/raising-spending.html
	home/templatetags/elections_lookup.py
	home/templatetags/top_entities.py

## Screenshots

<kbd>

![embeds_scrnsht](https://user-images.githubusercontent.com/5572856/54502792-d1cac580-4902-11e9-8a5e-ecb863e2306d.jpg)


</kbd>


## Related PRs
List related PRs against other branches:

## How to test
Include any information that may be helpful to the reviewer(s).
  - Run npm `run-build`
 - Set feature flags in your shell session or in your bash profile to map and barcharts:
 `FEC_FEATURE_HOME_BARCHARTS=1` , `FEC_FEATURE_HOME_MAP=1`
- Visit http://127.0.0.1:8000/ and test the embedded map and barchart apps
- This branch is based on the new develop branch with node upgrade, so if you have not pulled the new develop (and updated your environment), you may need to follow some of the how-to-test  steps here  to get this to work:  https://github.com/fecgov/fec-cms/pull/2733

**For future reference, should we need to make data apps available to home templates:**
Because the data app uses jinja ( .jinja) templates and the home app uses django (.html) templates, making the bar-charts and election-map available to the homepage involves recreating the logic in views/macros in data as templatetags/inclusion-tags in home. There are other ways of doing this, but I am fairly confident that this is the most efficient way. 

We have discussed making the templates uniform, using either Jinja or  Django templates sitewide. I cannot remember which was the recommendation by @xtine at  18F. Once this is done, sharing content across the apps would be simpler. 

