### PR TITLE
Use cache key prefix for finer control of cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,9 @@ jobs:
 
       - restore_cache:
           keys:
-          - fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+          - v1-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
-          - fec-cms-dependencies-
+          - v1-fec-cms-dependencies-
 
       - run:
           name: Install python dependencies
@@ -61,7 +61,7 @@ jobs:
           paths:
             - ./.env
             - ./node_modules
-          key: fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+          key: v1-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
 
       - run:
           name: Ensure database is available


### PR DESCRIPTION
I believe the build on `stage` was weird because Circle was caching dependencies. This change forces Circle to get fresh dependencies for the production deploy.

Use cache key prefix for finer control of cache. See the tip under https://circleci.com/docs/2.0/configuration-reference/#save_cache: "Given the immutability of caches, it might be helpful to start all your cache keys with a version prefix v1-.... That way you will be able to regenerate all your caches just by incrementing the version in this prefix."
