### PR TITLE
Change test for non-filer filter

### DIFF
--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -16,6 +16,11 @@ from home.models import (CommissionerPage, DigestPage, MeetingPage,
 
 
 def replace_dash(string):
+    # Leave the dash in place for non-filer publications
+    # This matches what's in the database
+    # Seems to have been a problem testing for the hyphenated version, I suspect the hyphen is escaped
+    if all(x in string for x in ['non', 'filer', 'publications']):
+        return "non-filer publications"
     return string.replace("-", " ")
 
 

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -18,7 +18,8 @@ from home.models import (CommissionerPage, DigestPage, MeetingPage,
 def replace_dash(string):
     # Leave the dash in place for non-filer publications
     # This matches what's in the database
-    # Seems to have been a problem testing for the hyphenated version, I suspect the hyphen is escaped
+    # Seems to have been a problem testing for the hyphenated version,
+    # suspect the hyphen is escaped or encoded
     if all(x in string for x in ['non', 'filer', 'publications']):
         return "non-filer publications"
     return string.replace("-", " ")


### PR DESCRIPTION
## Summary
Updated the filter test for "non-filer publications". The dash in the category isn't triggering the former `if` so we'll test for the words, assuming the punctuation is escaped or otherwise encoded.

- Resolves #2745 

## Impacted areas of the application
At least /fec/home/views.py as seen in http://localhost:8000/updates/?update_type=press-release&category=non-filer-publications

## Screenshots
![image](https://user-images.githubusercontent.com/26720877/54712276-4596e900-4b22-11e9-8c6d-ed3de55b7f63.png)

## Related PRs
https://github.com/fecgov/fec-cms/pull/2528

## How to test
- Pull the branch
- Go to http://localhost:8000/updates/?update_type=press-release&category=non-filer-publications
- Check that there are results
- Change the Press Release Subjects to something else, confirm results
- Change back to Non-filer publications, confirm results
- Check any other place this component may be used (if any)
____

