### PR TITLE
fix/spacing-on-home-slab

### DIFF
--- a/fec/home/templates/partials/elections-lookup.html
+++ b/fec/home/templates/partials/elections-lookup.html
@@ -2,7 +2,7 @@
 {% load wagtailcore_tags %}
 {% load filters %}
 
-<h2 class="heading--section">Compare candidates in an election</h2>
+<h2 class="heading--section u-padding--top">Compare candidates in an election</h2>
 <div class="grid grid--2-wide grid--flex u-padding--top" id="election-lookup">
   <div class="grid__item u-margin--bottom">
     <div class="election-map election-map--home">


### PR DESCRIPTION
## Summary
This is a PR to release/public-20190326.
Per @JonellaCulmer's Slack request, fixing slab spacing that is unequal when only one app is present on home page. 

_Include a summary of proposed changes.
modified:   home/templates/partials/elections-lookup.html

Related PRs/Issues:
Original 03/26 release PR: https://github.com/fecgov/fec-cms/pull/2751
Original homepage embed maps/barcharts PR: https://github.com/fecgov/fec-cms/pull/2748
Homepage embed maps/barcharts issue: https://github.com/fecgov/fec-cms/issues/2562


## How to test
- Turn off  FEC_FEATURE_HOME_BARCHARTS `unset FEC_FEATURE_HOME_BARCHARTS` in your terminal or in your bash profile.
- Make sure that vertical padding on top and bottom of the homepage grey slab that contains the election map is equal

____

