### PR TITLE
Fix raising / spending overview link

### DIFF
--- a/fec/data/templates/partials/browse-data/raising.jinja
+++ b/fec/data/templates/partials/browse-data/raising.jinja
@@ -41,7 +41,7 @@
         </div>
       </li>
       <li>
-        <section class="content__section" style="padding-top: 3rem;">
+        <section class="content__section" id="raising-overview" style="padding-top: 3rem;">
           <div class="heading--section heading--with-action" style="border: none;padding: 0">
             <h3 class="heading__left">Cumulative amount raised by committees</h3>
             <div class="heading__right">

--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -100,7 +100,7 @@
         </div>
       </li>
       <li>
-        <section class="content__section" style="padding-top: 3rem;">
+        <section class="content__section" id="spending-overview" style="padding-top: 3rem;">
           <div class="heading--section heading--with-action" style="border: none;padding: 0">
             <h3 class="heading__left">Cumulative amount spent by committees</h3>
             <div class="heading__right">

--- a/fec/data/templates/raising-bythenumbers.jinja
+++ b/fec/data/templates/raising-bythenumbers.jinja
@@ -11,7 +11,7 @@
 
 {% block sidebar %}
 <nav class="sidebar sidebar--breakdown sidebar--left side-nav js-sticky-side" data-sticky-container="options">
-  <a class="sidebar__title" href="/data/#raising">&lsaquo; Raising overview</a>
+  <a class="sidebar__title" href="/data/browse-data/?tab=raising#raising-overview">&lsaquo; Raising overview</a>
   <ul class="sidebar__content js-toc">
     <li class="side-nav__item"><a class="side-nav__link" href="#top-raisers">Top raising candidates</a></li>
     <li class="side-nav__item"><span class="side-nav__link is-disabled">Where contributions come from</span></li>

--- a/fec/data/templates/spending-bythenumbers.jinja
+++ b/fec/data/templates/spending-bythenumbers.jinja
@@ -11,7 +11,7 @@
 
 {% block sidebar %}
 <nav class="sidebar sidebar--breakdown sidebar--left side-nav js-sticky-side" data-sticky-container="options">
-  <a class="sidebar__title" href="/data/#spending">&lsaquo; Spending overview</a>
+  <a class="sidebar__title" href="/data/browse-data/?tab=spending#spending-overview">&lsaquo; Spending overview</a>
   <ul class="sidebar__content js-toc">
     <li class="side-nav__item"><a class="side-nav__link" href="#top-spenders">Top spending candidates</a></li>
     <li class="side-nav__item"><span class="side-nav__link is-disabled">Where contributions come from</span></li>


### PR DESCRIPTION
## Summary

_Fixed link for "Raising overview" and "Spending overview" navigation buttons to link to the raising browse data and spending browse data section._

## Impacted areas of the application
List general components of the application that this PR will affect:

- raising-bythenumbers
- spending-bythenumbers

## Screenshots

![Screen Shot 2019-03-25 at 12 51 15 PM](https://user-images.githubusercontent.com/12799132/54938421-b8c2a580-4efc-11e9-8179-f2b4b5915a85.png)
![Screen Shot 2019-03-25 at 12 51 02 PM](https://user-images.githubusercontent.com/12799132/54938422-b8c2a580-4efc-11e9-86aa-0432edbbe25a.png)

## How to test
1. Go to http://localhost:8000/data/raising-bythenumbers/ and make sure raising overview link goes to the raising line chart
2. Go to http://localhost:8000/data/spending-bythenumbers/ and make sure spending overview link goes to the spending line chart
