### PR TITLE
FEC-CMS : Add snyk vulnerability links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-## Develop
+**Develop**
 [![CircleCI](https://circleci.com/gh/fecgov/fec-cms.svg?style=svg)](https://circleci.com/gh/fecgov/fec-cms)
 [![Test Coverage](https://img.shields.io/codecov/c/github/fecgov/fec-cms/develop.svg)](https://codecov.io/github/fecgov/fec-cms)
+**package.json**
+[![[Known Vulnerabilities]](https://snyk.io/test/github/fecgov/fec-cms/badge.svg)](https://snyk.io/test/github/fecgov/fec-cms?targetFile=package.json)
+**requirements.txt**
+[![[Known Vulnerabilities]](https://snyk.io/test/github/fecgov/fec-cms/badge.svg)](https://snyk.io/test/github/fecgov/fec-cms?targetFile=requirements.txt)
 
-## Master
+**Master**
 [![Test Coverage](https://img.shields.io/codecov/c/github/fecgov/fec-cms/master.svg)](https://codecov.io/github/fecgov/fec-cms)
 
-## Snyk vulnerabilities
-**package.json**
-[![[Known Vulnerabilities]](https://snyk.io/test/github/fecgov/fec-cms/badge.svg?targetFile=package.json)](https://snyk.io/test/github/fecgov/fec-cms?targetFile=package.json)
-**requirements.txt**
-[![[Known Vulnerabilities]](https://snyk.io/test/github/fecgov/fec-cms/badge.svg?targetFile=requirements.txt)](https://snyk.io/test/github/fecgov/fec-cms?targetFile=requirements.txt)
+
+
 
 ## Campaign finance for everyone
 The Federal Election Commission (FEC) releases information to the public about

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-**Develop**
+## Develop
 [![CircleCI](https://circleci.com/gh/fecgov/fec-cms.svg?style=svg)](https://circleci.com/gh/fecgov/fec-cms)
 [![Test Coverage](https://img.shields.io/codecov/c/github/fecgov/fec-cms/develop.svg)](https://codecov.io/github/fecgov/fec-cms)
 
-**Master**
-[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/fec-cms/badge.svg)](https://snyk.io/test/github/fecgov/fec-cms)
+## Master
 [![Test Coverage](https://img.shields.io/codecov/c/github/fecgov/fec-cms/master.svg)](https://codecov.io/github/fecgov/fec-cms)
+
+## Snyk vulnerabilities
+**package.json**
+[![[Known Vulnerabilities]](https://snyk.io/test/github/fecgov/fec-cms/badge.svg?targetFile=package.json)](https://snyk.io/test/github/fecgov/fec-cms?targetFile=package.json)
+**requirements.txt**
+[![[Known Vulnerabilities]](https://snyk.io/test/github/fecgov/fec-cms/badge.svg?targetFile=requirements.txt)](https://snyk.io/test/github/fecgov/fec-cms?targetFile=requirements.txt)
 
 ## Campaign finance for everyone
 The Federal Election Commission (FEC) releases information to the public about


### PR DESCRIPTION
## Summary (required)

- Resolves #https://github.com/fecgov/openfec/issues/3547

_Include a summary of proposed changes._
In README.md file, added two new sync vulnerability links. These links will display the count of vulnerabilites found in `package.json` and `requirements.txt file` off the `develop` branch

## How to test
Verify  vulnerabilities count in the Snyk app link( https://snyk.io/org/fecgov/projects) vs new links added on `fec-cms` README.md file. Make sure the count matches and the links are not broken.
