### PR TITLE
Fixed election search page layout

### DIFF
--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -63,7 +63,7 @@
     <div class="grid--2-wide grid--flex">
       <div class="grid__item">
         <h2>Compare candidates</h2>
-        <div id="election-lookup">
+        <div id="election-lookup" class="search--election-mini">
           <div class="usa-width-one-half">
             <form action="/data/elections" class="content__section">
               <div class="search-controls__state">

--- a/fec/fec/static/scss/components/_search-controls.scss
+++ b/fec/fec/static/scss/components/_search-controls.scss
@@ -270,7 +270,7 @@
       }
     }
   }
-  #election-lookup {
+  #election-lookup.search--election-mini {
     display: flex;
     flex-wrap: wrap;
 
@@ -393,7 +393,7 @@
     }
   }
 
-  #election-lookup {
+  #election-lookup.search--election-mini {
     flex-wrap: initial;
 
     .usa-width-one-half:first-child {


### PR DESCRIPTION
## Summary

_Election search page layout was falling out of alignment, so this PR creates a separate `.search--election-mini` class for elections the data landing page layout_

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Data landing page

## How to test
- Go to [data landing page](http://localhost:8000/data/) to make sure election search proportions are correct.
- Check the [homepage election search](http://localhost:8000) feature and [elections lookup main](http://localhost:8000/data/elections/) page to make sure styles did not change. 

