### PR TITLE
Feature/2744 aggregate totals box

### DIFF
--- a/fec/data/templates/macros/aggregate-totals.jinja
+++ b/fec/data/templates/macros/aggregate-totals.jinja
@@ -1,6 +1,6 @@
 {% macro build_block(dataObj={}) %}
-  {% do dataObj.update({"target": "#aggregate-totals-block-1"}) %}
-    <aside id="aggregate-totals-block-1" class="aggregate-totals-block js-not-loaded">
+  {% do dataObj.update({"target": "#aggregate-totals-block"}) %}
+    <aside id="aggregate-totals-block" class="aggregate-totals-block" style="display: none">
       <h1 class="value"></h1>
       <h2 class="description"></h2>
     </aside>

--- a/fec/data/templates/macros/aggregate-totals.jinja
+++ b/fec/data/templates/macros/aggregate-totals.jinja
@@ -1,8 +1,0 @@
-{% macro build_block(dataObj={}) %}
-  {% do dataObj.update({"target": "#aggregate-totals-block"}) %}
-    <aside id="aggregate-totals-block" class="aggregate-totals-block" style="display: none">
-      <h1 class="value"></h1>
-      <h2 class="description"></h2>
-    </aside>
-    <script defer data-obj="{{ dataObj }}" src="{{ asset_for_js('modules/aggregate-totals.js') }}"></script>
-{% endmacro %}

--- a/fec/data/templates/macros/bythenumbers.jinja
+++ b/fec/data/templates/macros/bythenumbers.jinja
@@ -1,5 +1,3 @@
-{% import "macros/aggregate-totals.jinja" as aggTotals %}
-
 {% macro top_entities(
   election_years,
   election_year,
@@ -36,7 +34,7 @@
       </select>
   </form>
   {% if FEATURES.aggregatetotals %}
-  {{ aggTotals.build_block({"election_year": election_year, "office": office, "action": action, "year_control": "#election-year", "office_control": "#top-category"}) }}
+  <script defer data-election-year="{{ election_year }}" data-office="{{ office }}" data-action="{{ action }}" data-year-control="#election-year" data-office-control="#top-category" src="{{ asset_for_js('modules/aggregate-totals.js') }}"></script>
   {% endif %}
   <span class="t-sans js-dates"></span>
   <div class="chart-table simple-table--responsive js-top-table" id="top-table" aria-live="polite" role="grid">

--- a/fec/fec/static/js/modules/aggregate-totals.js
+++ b/fec/fec/static/js/modules/aggregate-totals.js
@@ -36,12 +36,12 @@ AggregateTotals.prototype.displayUpdatedData = function(queryResponse) {
 
   // If this is the first build
   if (this.animVars.stepCount == 0) {
-    this.animVars.stepCount = Math.ceil(Math.random() * 5) + 1; // How many animation steps should we have?
+    this.animVars.stepCount = Math.ceil(Math.random() * 10) + 5; // How many animation steps should we have? (random(1-11) + 5)
     this.animVars.value =
       this.action == 'raised'
         ? queryResponse.results[0].total_receipts
         : queryResponse.results[0].total_disbursements;
-    this.animVars.stepAmount = Math.random() * 10; // How much should each step increment?
+    this.animVars.stepAmount = Math.random() * 100 + 123.456; // How much should each step increment? (random(1-11) + 20)
     this.animVars.startingValue =
       this.animVars.value - this.animVars.stepAmount * this.animVars.stepCount; // Considering this.animVars.stepAmount, where should we start the animation?
 
@@ -69,7 +69,7 @@ AggregateTotals.prototype.displayUpdatedData = function(queryResponse) {
     let anim_tempVal =
       this.animVars.startingValue +
       this.animVars.stepCurrent * this.animVars.stepAmount; // How much this step should display
-    let anim_delay = this.animVars.stepCurrent * 750; // How long this step should wait from the start
+    let anim_delay = this.animVars.stepCurrent * 250; // How long this step should wait from the start
     let instance = this; // The calling instance
     setTimeout(function() {
       let valString =

--- a/fec/fec/static/js/modules/aggregate-totals.js
+++ b/fec/fec/static/js/modules/aggregate-totals.js
@@ -3,8 +3,16 @@
 const $ = require('jquery');
 const helpers = require('./helpers');
 
+const doInitialNumberBuild = false;
 /**
- * Handles the functionality for the aggregate totals box(es)
+ * Handles the functionality for the aggregate totals box(es).
+ * Loads, creates an <aside> with {@link init}, then makes itself visible (with {@link displayUpdatedData}) after it has some data to show.
+ * @param {String} office - Required. Can be set through data-office for the <script> or collected from the target specified with data-office-control.
+ * @param {String} election_year - Required. Can be set through data-election-year for the <script> or collected from the target specied with data-year-control.
+ * @param {String} officeControl - Required. Set with data-office-control on <script> but not required if data-office is set.
+ * @param {String} yearControl - Required. Set with data-year-control on <script> but not required if data-election-year is set.
+ * @param {String} action - Required. Can be 'raised' or 'spending'? 'spent'?
+ * @param {Boolean} doInitialNumberBuild - Should we animate the first value or just display it and be done? Default: false.
  */
 function AggregateTotals() {
   this.scriptElement; // The <script>
@@ -18,64 +26,84 @@ function AggregateTotals() {
   this.basePath = ['candidates', 'totals', 'by_office'];
   this.baseQuery; // Vars for data load
   this.animVars = {
-    value: 0, // This instance's current value, only used for animation
-    stepCount: 0
+    valueTotal: 0, // This instance's current value, only used for animation
+    valueTemp: 0,
+    stepCount: 0,
+    interval: null
   };
 
   this.init();
 }
 /**
  * Called by {@link loadData} to parse and display the data
- * @param Response queryResponse - The successful API reply
+ * @param {Response} queryResponse - The successful API reply
  */
 AggregateTotals.prototype.displayUpdatedData = function(queryResponse) {
-  console.log('TESTING - query response:');
-  console.log(queryResponse);
+  // Get the office value from the <script>
   this.baseQuery.office = queryResponse.results[0].office;
-  this.baseQuery.election_year = queryResponse.results[0].election_year;
+  // Get the office value from the <script>, but scrub it
+  this.baseQuery.election_year = scrubElectionYear(
+    queryResponse.results[0].election_year,
+    this.baseQuery.office
+  );
 
   // If this is the first build
   if (this.animVars.stepCount == 0) {
-    this.animVars.stepCount = Math.ceil(Math.random() * 10) + 5; // How many animation steps should we have? (random(1-11) + 5)
-    this.animVars.value =
+    this.animVars.stepCount = 1;
+    this.animVars.valueTotal =
       this.action == 'raised'
         ? queryResponse.results[0].total_receipts
         : queryResponse.results[0].total_disbursements;
-    this.animVars.stepAmount = Math.random() * 100 + 123.456; // How much should each step increment? (random(1-11) + 20)
-    this.animVars.startingValue =
-      this.animVars.value - this.animVars.stepAmount * this.animVars.stepCount; // Considering this.animVars.stepAmount, where should we start the animation?
+
+    // Save the first value for subsequent animations
+    this.animVars.valueTemp = this.animVars.valueTotal;
+
+    // If we don't want to animate the first build,
+    if (!doInitialNumberBuild) {
+      this.displayValue(this, this.animVars.valueTotal);
+    }
+
+    // Otherwise, build the initial animation steps
+    else {
+      this.animVars.stepCount = Math.ceil(Math.random() * 10) + 8; // How many animation steps should we have? (random(1-11) + 8)
+
+      this.animVars.stepAmount = Math.random() * 5 + 5; // How much should each step increment? (random(1-6) + 5)
+      this.animVars.startingValue =
+        this.animVars.valueTotal -
+        this.animVars.stepAmount * this.animVars.stepCount; // Considering this.animVars.stepAmount, where should we start the animation?
+
+      // Save the first value for subsequent animations
+      this.animVars.valueTemp = this.animVars.valueTotal;
+
+      // Animating numbers can be messy, and it was here
+      // We're going to set the animation as a series of setTimeout updates
+      // We're going to jump by stepAmount every anim_delay ms for stepCurrent steps
+      // This will handle from $0 where we're jumping from just ~$100 back as well as on control change where we may be jumping up or down by $1B
+      for (
+        this.animVars.stepCurrent = 0;
+        this.animVars.stepCurrent <= this.animVars.stepCount;
+        this.animVars.stepCurrent++
+      ) {
+        let anim_tempVal =
+          this.animVars.startingValue +
+          this.animVars.stepCurrent * this.animVars.stepAmount; // How much this step should display
+        let anim_delay = this.animVars.stepCurrent * 125; // How long this step should wait from the start
+        let instance = this; // The calling instance
+        setTimeout(function() {
+          instance.displayValue(instance, anim_tempVal);
+        }, anim_delay);
+      }
+    }
 
     // Otherwise, only update the steps values
   } else {
-    this.animVars.startingValue = this.animVars.value;
-    this.animVars.value =
+    this.animVars.startingValue = this.animVars.valueTotal;
+    this.animVars.valueTotal =
       this.action == 'raised'
         ? queryResponse.results[0].total_receipts
         : queryResponse.results[0].total_disbursements;
-    this.animVars.stepAmount =
-      (this.animVars.value - this.animVars.startingValue) /
-      this.animVars.stepCount;
-  }
 
-  // Animating numbers can be messy and it was here
-  // We're going to set the animation as a series of setTimeout updates
-  // We're going to jump by stepAmount every anim_delay ms for stepCurrent steps
-  // This will handle from $0 where we're jumping from just ~$100 back as well as on control change where we may be jumping up or down by $1B
-  for (
-    this.animVars.stepCurrent = 0;
-    this.animVars.stepCurrent <= this.animVars.stepCount;
-    this.animVars.stepCurrent++
-  ) {
-    let anim_tempVal =
-      this.animVars.startingValue +
-      this.animVars.stepCurrent * this.animVars.stepAmount; // How much this step should display
-    let anim_delay = this.animVars.stepCurrent * 250; // How long this step should wait from the start
-    let instance = this; // The calling instance
-    setTimeout(function() {
-      let valString =
-        '$' + anim_tempVal.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,'); // Format for US dollars and cents
-      instance.valueField.innerHTML = valString; // Display this value
-    }, anim_delay);
+    this.startAnimation();
   }
 
   // TODO: let's lean on other sources here
@@ -84,7 +112,7 @@ AggregateTotals.prototype.displayUpdatedData = function(queryResponse) {
     S: 'Senate',
     H: 'House'
   };
-  // Set the description
+  // Set the description text
   this.descriptionField.innerHTML =
     'Total ' +
     this.action +
@@ -136,7 +164,10 @@ AggregateTotals.prototype.init = function() {
       String(this.scriptElement.dataset['yearControl'])
     );
     $(this.yearControl).on('change', this.handleElectionYearChange.bind(this));
-    this.baseQuery.election_year = $(this.yearControl).val();
+    this.baseQuery.election_year = scrubElectionYear(
+      $(this.yearControl).val(),
+      this.baseQuery.office
+    );
 
     // alternatively, we can use a hard-coded single value, too
   } else if (this.scriptElement.dataset['electionYear']) {
@@ -152,7 +183,7 @@ AggregateTotals.prototype.init = function() {
   // If we're missing something, stop here
   if (!allSet && this.action) return;
 
-  // Make the <aside> for the html doc and give it its attributes
+  // Make the <aside> for the dom and give it its attributes
   this.element = document.createElement('aside');
   this.element.setAttribute(
     'id',
@@ -179,27 +210,142 @@ AggregateTotals.prototype.init = function() {
 
 /**
  * Starts the data load, called by {@link init}
- * @param Object query - The data object for the query, {@link baseQuery}
+ * @param {Object} query - The data object for the query, {@link baseQuery}
  */
 AggregateTotals.prototype.loadData = function(query) {
-  console.log('TESTING - loading data query:');
-  console.log(query);
-  let self = this;
+  let instance = this;
   $.getJSON(helpers.buildUrl(this.basePath, query)).done(response => {
-    self.displayUpdatedData(response);
+    instance.displayUpdatedData(response);
   });
 };
 
+/**
+ * Event handler for when the office control is changed.
+ * The target is specified in <script data-office-control />
+ * @param Event e - the change event
+ */
 AggregateTotals.prototype.handleOfficeChange = function(e) {
   e.preventDefault();
   this.baseQuery.office = e.target.value; // Save the updated value
   this.loadData(this.baseQuery); // Reload the data
 };
 
+/**
+ * Event handler for when the election year control changes.
+ * The target is specified in <script data-year-control />
+ * @param {Event} e - The change event
+ */
 AggregateTotals.prototype.handleElectionYearChange = function(e) {
   e.preventDefault();
   this.baseQuery.election_year = e.target.value; // Save the updated value
   this.loadData(this.baseQuery); // Reload the data
 };
+
+/**
+ * Formats the given value and puts it into the dom element.
+ * @param {Element} instance - The dom element whose valueField will hold the text
+ * @param {Number} passedValue - The number to format and plug into the element
+ */
+AggregateTotals.prototype.displayValue = function(instance, passedValue) {
+  let valString =
+    '$' + passedValue.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,'); // Format for US dollars and cents
+  instance.valueField.innerHTML = valString;
+};
+
+/**
+ * Starts the timers to update the displayed value from one to the next (not part of the initial display)
+ * Called by {@link displayUpdatedData} when the displayed value should changed.
+ */
+AggregateTotals.prototype.startAnimation = function() {
+  let instance = this;
+  // If there's an existing interval, clear it
+  if (instance.animVars.interval) clearInterval(instance.animVars.interval);
+  instance.animVars.interval = setInterval(function() {
+    let nextVal = getNextValue(
+      instance.animVars.valueTemp,
+      instance.animVars.valueTotal
+    );
+    instance.animVars.valueTemp = nextVal; // Save for next loop
+    instance.displayValue(instance, nextVal); // Update the element
+
+    // If our values match, we can stop the animations
+    if (instance.animVars.valueTemp == instance.animVars.valueTotal) {
+      clearInterval(instance.animVars.interval);
+    }
+  }, 25);
+};
+
+/**
+ * Returns the next value to step from `currentValue` to `goalValue`, when animating each place from current to goal.
+ * e.g. changes the ones position from current toward goal, then changes the tens position value from current toward goal, then hundreds, thousands, etc.
+ * @param {*} currentValue
+ * @param {*} goalValue
+ * @returns {Number} - The next value, one step more from currentValue toward goalValue
+ */
+function getNextValue(currentValue, goalValue) {
+  // Convert the values to strings to split them apart into arrays
+  // Multiplying by 100 to get rid of the decimal
+  let currentValArr = Math.round(currentValue * 100)
+    .toString()
+    .split('');
+  let goalValArr = Math.round(goalValue * 100)
+    .toString()
+    .split('');
+
+  // Reversing them will make it easier for us to loop starting with 1-cents, then 10-cents, then 1-dollars, 10-dollars, etc.
+  currentValArr.reverse();
+  goalValArr.reverse();
+
+  // Let's add leading zeroes so the lengths are the same
+  while (goalValArr.length < currentValArr.length) {
+    goalValArr.push('0');
+  }
+  while (currentValArr.length < goalValArr.length) {
+    currentValArr.push('0');
+  }
+
+  for (let i = 0; i < goalValArr.length; i++) {
+    let currentDigitVal = parseInt(currentValArr[i], 10);
+    let goalDigitVal = parseInt(goalValArr[i], 10);
+
+    if (currentDigitVal == goalDigitVal) {
+      // do nothing, just loop
+    } else {
+      // The new digit is one lower than the current one if the goal is lower, but one higher if the goal is higher
+      if (currentDigitVal > goalDigitVal) currentDigitVal--;
+      else if (currentDigitVal < goalDigitVal) currentDigitVal++;
+
+      currentValArr[i] = currentDigitVal.toString();
+
+      // Reverse the array back to normal (no longer need goalValArr)
+      currentValArr.reverse();
+
+      // Make it back into a number
+      // Dividing by 100 to add the decimal back
+      let newTempVal = parseInt(currentValArr.join(''), 10) / 100;
+      newTempVal = Number(newTempVal.toFixed(2));
+      return newTempVal;
+    }
+  }
+  // If there's some kind of error, just return the goal
+  return goalValue;
+}
+
+/**
+ * Returns the next valid election cycle, particularly for presidential races
+ * @param {String, Number} year - The year to scrub / correct
+ * @param {String} office - The office of that cycle
+ * @returns {Number} - Either `office` or the next valid election year
+ */
+function scrubElectionYear(year, office) {
+  let toReturn = year;
+  if (office.toLowerCase() == 'p') {
+    toReturn = parseInt(toReturn);
+    // If election year isn't cleanly divisble by four,
+    // we need to increment it by the difference between its modulus and four
+    if (toReturn % 4) toReturn += 4 - (toReturn % 4);
+  }
+  return toReturn;
+}
 
 new AggregateTotals();

--- a/fec/fec/static/js/modules/aggregate-totals.js
+++ b/fec/fec/static/js/modules/aggregate-totals.js
@@ -7,49 +7,78 @@ const helpers = require('./helpers');
  * Handles the functionality for the aggregate totals box(es)
  */
 function AggregateTotals() {
-  this.scriptElement; // the <script>
-  this.element; // the HTML element of this box
-  this.descriptionField; // the HTML element that holds the explanation
-  this.valueField; // the HTML element that holds the value
+  this.scriptElement; // The <script>
+  this.element; // The HTML element of this box
+  this.descriptionField; // The HTML element that holds the explanation
+  this.valueField; // The HTML element that holds the value
+  this.action;
+  this.officeControl;
+  this.yearControl;
 
   this.basePath = ['candidates', 'totals', 'by_office'];
-  this.election_year; // this instance's current election year
-  this.office; // this instance's current office var
-  this.queryObj; // 
-  this.value; // this instance's current value
+  // this.year; // This instance's current election year
+  // this.office; // This instance's current office var
+  this.baseQuery; // Object for data load
+  this.animVars = {
+    value: 0, // This instance's current value, only used for animation
+    stepCount: 0
+  }
 
   this.init();
 }
 /**
  * Called by {@link loadData} to parse and display the data
- * @param Response queryResponse - the successful API reply
+ * @param Response queryResponse - The successful API reply
  */
-AggregateTotals.prototype.buildElement = function(queryResponse) {
-  this.value = queryResponse.results[0].total_disbursements;
-  this.office = queryResponse.results[0].office; // (Again, in case it's changed)
-  this.year = queryResponse.results[0].election_year;
+AggregateTotals.prototype.displayUpdatedData = function(queryResponse) {
+  console.log('TESTING - query response:');
+  console.log(queryResponse);
+  this.baseQuery.office = queryResponse.results[0].office;
+  this.baseQuery.election_year = queryResponse.results[0].election_year;
 
-  let stepCount = Math.ceil(Math.random() * 5) + 1; // How many animation steps should we have?
-  let stepAmount = Math.random() * 10; // How much should each step increment?
-  let startingValue = this.value - stepAmount * stepCount; // Considering stepAmount, where should we start the animation?
+  // If this is the first build
+  if (this.animVars.stepCount == 0) {
+    this.animVars.stepCount = Math.ceil(Math.random() * 5) + 1; // How many animation steps should we have?
+    this.animVars.value = this.action == 'raised' ? queryResponse.results[0].total_receipts : queryResponse.results[0].total_disbursements;
+    this.animVars.stepAmount = Math.random() * 10; // How much should each step increment?
+    this.animVars.startingValue = this.animVars.value - this.animVars.stepAmount * this.animVars.stepCount; // Considering this.animVars.stepAmount, where should we start the animation?
 
-  for (let stepCurrent = 0; stepCurrent <= stepCount; stepCurrent++) {
-    let tempVal = startingValue + stepCurrent * stepAmount; // How much this step should display
-    let delay = stepCurrent * 750; // How long this step should wait from the start
+  // Otherwise, only update the steps values
+  } else {
+    this.animVars.startingValue = this.animVars.value;
+    this.animVars.value = this.action == 'raised' ? queryResponse.results[0].total_receipts : queryResponse.results[0].total_disbursements;
+    this.animVars.stepAmount = (this.animVars.value - this.animVars.startingValue) / this.animVars.stepCount;
+  }
+
+  // Animating numbers can be messy and it was here
+  // We're going to set the animation as a series of setTimeout updates
+  // We're going to jump by stepAmount every anim_delay ms for stepCurrent steps
+  // This will handle from $0 where we're jumping from just ~$100 back as well as on control change where we may be jumping up or down by $1B
+  for (this.animVars.stepCurrent = 0; this.animVars.stepCurrent <= this.animVars.stepCount; this.animVars.stepCurrent++) {
+    let anim_tempVal = this.animVars.startingValue + this.animVars.stepCurrent * this.animVars.stepAmount; // How much this step should display
+    let anim_delay = this.animVars.stepCurrent * 750; // How long this step should wait from the start
     let instance = this; // The calling instance
     setTimeout(function() {
       let valString =
-        '$' + tempVal.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,'); // Format for US dollars and cents
+        '$' + anim_tempVal.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,'); // Format for US dollars and cents
       instance.valueField.innerHTML = valString; // Display this value
-    }, delay);
+    }, anim_delay);
   }
 
+  // TODO: let's lean on other sources here
+  let officeDefs = {
+    P: 'Presidential',
+    S: 'Senate',
+    H: 'House'
+  }
+  // Set the description
   this.descriptionField.innerHTML =
-    'Total raised by all ' +
-    this.office +
+    'Total ' + this.action + ' by all ' +
+    officeDefs[this.baseQuery.office] +
     ' candidates running in ' +
-    this.year;
+    this.baseQuery.election_year;
 
+  // Start the opening animation
   $(this.element).slideDown();
 };
 
@@ -58,52 +87,101 @@ AggregateTotals.prototype.buildElement = function(queryResponse) {
  */
 AggregateTotals.prototype.init = function() {
   this.scriptElement = document.currentScript; // The <script> on the page
-  var dataObjStr = String(this.scriptElement.dataset.obj); // Grab the data-obj param
-  dataObjStr = dataObjStr.replace(/'/g, '"'); // Convert the single quotes to double to be JSON-friendlier
-  this.dataObj = JSON.parse('[' + dataObjStr + ']')[0]; // And make it into a usable object, but only the first element
-  // this.dataObj = this.dataObj[0]; // 
 
-  this.office = this.dataObj.office;
-  this.election_year = this.dataObj.election_year;
-
-  this.element = document.querySelector(String(this.dataObj.target));
-
-  $(this.element).slideUp(0);
-
-  this.valueField = document.querySelector(
-    String(this.dataObj.target) + ' .value'
-  );
-  this.descriptionField = document.querySelector(
-    String(this.dataObj.target) + ' .description'
-  );
-
-  this.queryObj = {
-    office: this.office,
+  this.baseQuery = {
+    office: '',
     per_page: 20,
     active_candidates: false,
     sort_null_only: false,
     sort_hide_null: false,
     sort_nulls_last: false,
     page: 1,
-    election_year: this.election_year
+    election_year: 2020
   };
 
-  this.loadData(this.queryObj);
+  let allSet = true;
+  // If we have a control for the office value, let's work with that
+  if (this.scriptElement.dataset['officeControl']) {
+    this.officeControl = document.querySelector(String(this.scriptElement.dataset['officeControl']));
+    $(this.officeControl).on('change', this.handleOfficeChange.bind(this));
+    this.baseQuery.office = $(this.officeControl).val();
+
+  // alternatively, we can use a hard-coded single value, too
+  } else if (this.scriptElement.dataset.office) {
+    this.baseQuery.office = this.scriptElement.dataset.office;
+
+  // without one of those, we can't do anything
+  } else allSet = false;
+
+  // If we have a control for the year value, let's work with that
+  if (this.scriptElement.dataset['yearControl']) {
+    this.yearControl = document.querySelector(String(this.scriptElement.dataset['yearControl']));
+    $(this.yearControl).on('change', this.handleElectionYearChange.bind(this));
+    this.baseQuery.election_year = $(this.yearControl).val();
+  
+  // alternatively, we can use a hard-coded single value, too
+  } else if (this.scriptElement.dataset['electionYear']) {
+    this.baseQuery.election_year = this.scriptElement.dataset['electionYear'];
+  
+  // without one of those, we can't do anything
+  } else allSet = false;
+
+  // Should we look at receipts or disbursements?
+  this.action = this.scriptElement.dataset['action'];
+  if (!this.action) allSet = false;
+
+  // If we're missing something, stop here
+  if (!allSet && this.action) return;
+
+  // Make the <aside> for the html doc and give it its attributes
+  this.element = document.createElement('aside');
+  this.element.setAttribute('id', "fec_at_" + Math.floor(Math.random() * 10000)); // Random so we can have multiple on a page, if needed
+  this.element.setAttribute('class', 'aggregate-totals-block');
+  // Create the value element
+  this.valueField = document.createElement('h1');
+  this.valueField.setAttribute('class', 'value');
+  // Create the description element
+  this.descriptionField = document.createElement('h2');
+  this.descriptionField.setAttribute('class', 'description')
+  // Put the value and description in the <aside>
+  this.element.appendChild(this.valueField);
+  this.element.appendChild(this.descriptionField);
+  // It's not visible yet, but let's make sure it doesn't show up until we have something to show
+  $(this.element).slideUp(0);
+  // Put it in the page right before this <script>
+  $(this.element).insertBefore(this.scriptElement);
+
+  // Start the initial data load
+  this.loadData(this.baseQuery);
 };
 
 /**
  * Starts the data load, called by {@link init}
- * @param Object query - The data object for the query, {@link queryObj}
+ * @param Object query - The data object for the query, {@link baseQuery}
  */
 AggregateTotals.prototype.loadData = function(query) {
+  console.log('TESTING - loading data query:');
+  console.log(query);
   let self = this;
   $.getJSON(helpers.buildUrl(this.basePath, query))
     .done(response => {
-      self.buildElement(response);
+      self.displayUpdatedData(response);
     })
     .fail((jqxhr, textStatus, error) => {
       // FAIL SILENTY
     });
 };
+
+AggregateTotals.prototype.handleOfficeChange = function(e) {
+  e.preventDefault();
+  this.baseQuery.office = e.target.value; // Save the updated value
+  this.loadData(this.baseQuery); // Reload the data
+}
+
+AggregateTotals.prototype.handleElectionYearChange = function(e) {
+  e.preventDefault();
+  this.baseQuery.election_year = e.target.value; // Save the updated value
+  this.loadData(this.baseQuery); // Reload the data
+}
 
 new AggregateTotals();

--- a/fec/fec/static/js/modules/aggregate-totals.js
+++ b/fec/fec/static/js/modules/aggregate-totals.js
@@ -259,8 +259,11 @@ AggregateTotals.prototype.displayValue = function(instance, passedValue) {
 AggregateTotals.prototype.startAnimation = function() {
   let instance = this;
   // If there's an existing interval, clear it
-  if (instance.animVars.interval) clearInterval(instance.animVars.interval);
-  instance.animVars.interval = setInterval(function() {
+  if (instance.animVars.interval) {
+    window.clearInterval(instance.animVars.interval);
+  }
+  instance.animVars.interval = window.setInterval(function() {
+    console.log('tick');
     let nextVal = getNextValue(
       instance.animVars.valueTemp,
       instance.animVars.valueTotal
@@ -270,7 +273,7 @@ AggregateTotals.prototype.startAnimation = function() {
 
     // If our values match, we can stop the animations
     if (instance.animVars.valueTemp == instance.animVars.valueTotal) {
-      clearInterval(instance.animVars.interval);
+      window.clearInterval(instance.animVars.interval);
     }
   }, 25);
 };

--- a/fec/fec/static/js/modules/aggregate-totals.js
+++ b/fec/fec/static/js/modules/aggregate-totals.js
@@ -16,13 +16,11 @@ function AggregateTotals() {
   this.yearControl;
 
   this.basePath = ['candidates', 'totals', 'by_office'];
-  // this.year; // This instance's current election year
-  // this.office; // This instance's current office var
-  this.baseQuery; // Object for data load
+  this.baseQuery; // Vars for data load
   this.animVars = {
     value: 0, // This instance's current value, only used for animation
     stepCount: 0
-  }
+  };
 
   this.init();
 }
@@ -39,23 +37,38 @@ AggregateTotals.prototype.displayUpdatedData = function(queryResponse) {
   // If this is the first build
   if (this.animVars.stepCount == 0) {
     this.animVars.stepCount = Math.ceil(Math.random() * 5) + 1; // How many animation steps should we have?
-    this.animVars.value = this.action == 'raised' ? queryResponse.results[0].total_receipts : queryResponse.results[0].total_disbursements;
+    this.animVars.value =
+      this.action == 'raised'
+        ? queryResponse.results[0].total_receipts
+        : queryResponse.results[0].total_disbursements;
     this.animVars.stepAmount = Math.random() * 10; // How much should each step increment?
-    this.animVars.startingValue = this.animVars.value - this.animVars.stepAmount * this.animVars.stepCount; // Considering this.animVars.stepAmount, where should we start the animation?
+    this.animVars.startingValue =
+      this.animVars.value - this.animVars.stepAmount * this.animVars.stepCount; // Considering this.animVars.stepAmount, where should we start the animation?
 
-  // Otherwise, only update the steps values
+    // Otherwise, only update the steps values
   } else {
     this.animVars.startingValue = this.animVars.value;
-    this.animVars.value = this.action == 'raised' ? queryResponse.results[0].total_receipts : queryResponse.results[0].total_disbursements;
-    this.animVars.stepAmount = (this.animVars.value - this.animVars.startingValue) / this.animVars.stepCount;
+    this.animVars.value =
+      this.action == 'raised'
+        ? queryResponse.results[0].total_receipts
+        : queryResponse.results[0].total_disbursements;
+    this.animVars.stepAmount =
+      (this.animVars.value - this.animVars.startingValue) /
+      this.animVars.stepCount;
   }
 
   // Animating numbers can be messy and it was here
   // We're going to set the animation as a series of setTimeout updates
   // We're going to jump by stepAmount every anim_delay ms for stepCurrent steps
   // This will handle from $0 where we're jumping from just ~$100 back as well as on control change where we may be jumping up or down by $1B
-  for (this.animVars.stepCurrent = 0; this.animVars.stepCurrent <= this.animVars.stepCount; this.animVars.stepCurrent++) {
-    let anim_tempVal = this.animVars.startingValue + this.animVars.stepCurrent * this.animVars.stepAmount; // How much this step should display
+  for (
+    this.animVars.stepCurrent = 0;
+    this.animVars.stepCurrent <= this.animVars.stepCount;
+    this.animVars.stepCurrent++
+  ) {
+    let anim_tempVal =
+      this.animVars.startingValue +
+      this.animVars.stepCurrent * this.animVars.stepAmount; // How much this step should display
     let anim_delay = this.animVars.stepCurrent * 750; // How long this step should wait from the start
     let instance = this; // The calling instance
     setTimeout(function() {
@@ -70,10 +83,12 @@ AggregateTotals.prototype.displayUpdatedData = function(queryResponse) {
     P: 'Presidential',
     S: 'Senate',
     H: 'House'
-  }
+  };
   // Set the description
   this.descriptionField.innerHTML =
-    'Total ' + this.action + ' by all ' +
+    'Total ' +
+    this.action +
+    ' by all ' +
     officeDefs[this.baseQuery.office] +
     ' candidates running in ' +
     this.baseQuery.election_year;
@@ -102,28 +117,32 @@ AggregateTotals.prototype.init = function() {
   let allSet = true;
   // If we have a control for the office value, let's work with that
   if (this.scriptElement.dataset['officeControl']) {
-    this.officeControl = document.querySelector(String(this.scriptElement.dataset['officeControl']));
+    this.officeControl = document.querySelector(
+      String(this.scriptElement.dataset['officeControl'])
+    );
     $(this.officeControl).on('change', this.handleOfficeChange.bind(this));
     this.baseQuery.office = $(this.officeControl).val();
 
-  // alternatively, we can use a hard-coded single value, too
+    // alternatively, we can use a hard-coded single value, too
   } else if (this.scriptElement.dataset.office) {
     this.baseQuery.office = this.scriptElement.dataset.office;
 
-  // without one of those, we can't do anything
+    // without one of those, we can't do anything
   } else allSet = false;
 
   // If we have a control for the year value, let's work with that
   if (this.scriptElement.dataset['yearControl']) {
-    this.yearControl = document.querySelector(String(this.scriptElement.dataset['yearControl']));
+    this.yearControl = document.querySelector(
+      String(this.scriptElement.dataset['yearControl'])
+    );
     $(this.yearControl).on('change', this.handleElectionYearChange.bind(this));
     this.baseQuery.election_year = $(this.yearControl).val();
-  
-  // alternatively, we can use a hard-coded single value, too
+
+    // alternatively, we can use a hard-coded single value, too
   } else if (this.scriptElement.dataset['electionYear']) {
     this.baseQuery.election_year = this.scriptElement.dataset['electionYear'];
-  
-  // without one of those, we can't do anything
+
+    // without one of those, we can't do anything
   } else allSet = false;
 
   // Should we look at receipts or disbursements?
@@ -135,14 +154,17 @@ AggregateTotals.prototype.init = function() {
 
   // Make the <aside> for the html doc and give it its attributes
   this.element = document.createElement('aside');
-  this.element.setAttribute('id', "fec_at_" + Math.floor(Math.random() * 10000)); // Random so we can have multiple on a page, if needed
+  this.element.setAttribute(
+    'id',
+    'fec_at_' + Math.floor(Math.random() * 10000)
+  ); // Random so we can have multiple on a page, if needed
   this.element.setAttribute('class', 'aggregate-totals-block');
   // Create the value element
   this.valueField = document.createElement('h1');
   this.valueField.setAttribute('class', 'value');
   // Create the description element
   this.descriptionField = document.createElement('h2');
-  this.descriptionField.setAttribute('class', 'description')
+  this.descriptionField.setAttribute('class', 'description');
   // Put the value and description in the <aside>
   this.element.appendChild(this.valueField);
   this.element.appendChild(this.descriptionField);
@@ -163,25 +185,21 @@ AggregateTotals.prototype.loadData = function(query) {
   console.log('TESTING - loading data query:');
   console.log(query);
   let self = this;
-  $.getJSON(helpers.buildUrl(this.basePath, query))
-    .done(response => {
-      self.displayUpdatedData(response);
-    })
-    .fail((jqxhr, textStatus, error) => {
-      // FAIL SILENTY
-    });
+  $.getJSON(helpers.buildUrl(this.basePath, query)).done(response => {
+    self.displayUpdatedData(response);
+  });
 };
 
 AggregateTotals.prototype.handleOfficeChange = function(e) {
   e.preventDefault();
   this.baseQuery.office = e.target.value; // Save the updated value
   this.loadData(this.baseQuery); // Reload the data
-}
+};
 
 AggregateTotals.prototype.handleElectionYearChange = function(e) {
   e.preventDefault();
   this.baseQuery.election_year = e.target.value; // Save the updated value
   this.loadData(this.baseQuery); // Reload the data
-}
+};
 
 new AggregateTotals();

--- a/fec/fec/static/js/modules/aggregate-totals.js
+++ b/fec/fec/static/js/modules/aggregate-totals.js
@@ -263,7 +263,6 @@ AggregateTotals.prototype.startAnimation = function() {
     window.clearInterval(instance.animVars.interval);
   }
   instance.animVars.interval = window.setInterval(function() {
-    console.log('tick');
     let nextVal = getNextValue(
       instance.animVars.valueTemp,
       instance.animVars.valueTotal

--- a/fec/fec/static/scss/components/_aggregate-totals-block.scss
+++ b/fec/fec/static/scss/components/_aggregate-totals-block.scss
@@ -25,18 +25,17 @@
     padding: 2rem;
 
     h1 {
-      flex-grow: 4;
-      margin: 0 0 0 .6rem;
+      margin: 0 0 0 1rem;
       order: 1;
       text-align: right;
+      width: 60%
     }
     h2 {
-      flex-grow: 1;
       font-size: u(1.4rem);
-      margin-left: .6rem;
+      margin-left: 1rem;
       order: 2;
       text-align: left;
-      width: 30%;
+      width: 40%;
     }
   }
 }

--- a/fec/webpack.config.js
+++ b/fec/webpack.config.js
@@ -88,6 +88,14 @@ module.exports = [
         {
           test: /\.hbs/,
           use: ['handlebars-template-loader', 'cache-loader']
+        },
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: 'babel-loader',
+          options: {
+            presets: ['latest']
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary
Adding the aggregate totals box!

- Resolves #2744 

Removed the macro for aggregate-totals-box from an earlier commit.
Simplified how the module is included in data/templates/macros/bythenumbers.jinja.

## Impacted areas of the application
- The new box can be seen on the raising and spending bythenumbers pages.
- It has its own css—its scss was added to static/scss/data-landing.scss
- Its JavaScript is isolated but has a new entry in webpack.config.js

## Screenshots
![image](https://user-images.githubusercontent.com/26720877/55028773-f5ff6400-4fde-11e9-88a1-2e3cfccc5e3a.png)
![image](https://user-images.githubusercontent.com/26720877/55028821-0ca5bb00-4fdf-11e9-9064-c7dcb374395c.png)
![image](https://user-images.githubusercontent.com/26720877/55028842-1af3d700-4fdf-11e9-91c6-16523bcea524.png)

## Related PRs
branch | PR
------ | ------ 
feature/2562/embed-bar-charts-election-map-homepage | #2748 

## How to test
- Set the feature flag environment variable `FEC_FEATURE_AGGR_TOTS=1`
- Go to either [raising](http://localhost:8000/data/raising-bythenumbers/) or [spending](http://localhost:8000/data/spending-bythenumbers) bythenumbers.
- The aggregate totals box should only appear after the rest of the page has loaded and only if there's data to display (give it about a second).
- When the animation is complete, check the console log to make sure the query response results total_disbursements (or total_receipts) match the dollar figure on the screen at the end of the animation.
- Change a pull-down, let the animation tick, compare the value with the console values.
- Change the other pull-down, let the animation play, compare the value again.
- Make sure the description text updates for each pull-down change.

Notes:
- The number of animation steps/ticks is randomized each time the page is loaded but they should remain the same through each pull-down change.
- The value increment for the first animation (effectively building from $0) should be <$100 per animation step/timer tick.
- The value increment for subsequent animations should be whatever it takes to get from the previous value to the new value in this session's number of steps (e.g., if there are three steps, each one should be a third of the difference between the previous and next values.). These steps could be negative when moving from a larger to a smaller value.
____

