### PR TITLE
Update the sale-or-use of FEC data link

### DIFF
--- a/fec/data/templates/browse-data.jinja
+++ b/fec/data/templates/browse-data.jinja
@@ -173,7 +173,7 @@
     <div class="container">
       <div class="usa-width-one-half">
         <p class="t-sans">Anyone can inspect and copy reports and statements filed by political committees. But the names and addresses of individual contributors may not be sold or used for commercial purposes or to solicit contributions or donations.</p>
-        <p class="t-sans u-no-margin"><a href="{{ TRANSITION_URL }}/pages/brochures/saleuse.shtml">Read more about the sale and use of FEC data</a>.</p>
+        <p class="t-sans u-no-margin"><a href="https://www.fec.gov/updates/sale-or-use-contributor-information/">Read more about the sale or use of FEC data</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
Tiny update for the text and href of the data-use link at the bottom of /data/landing.

- Resolves #2718 

## Impacted areas of the application
Only touched data/templates/browse-data.jinja

## Screenshots
The text on the page and the link at the bottom of the window (status bar):
![image](https://user-images.githubusercontent.com/26720877/55099457-14746680-5096-11e9-82c1-ba473efeef92.png)


## Related PRs
none


## How to test
- Pull the branch.
- Go to http://localhost:8000/data/browse-data/
- Check the "Read more about the sale…" link just above the site footer.
____

