### PR TITLE
Change page-relative links to site-relative

### DIFF
--- a/fec/data/templates/partials/browse-data/bulk-data.jinja
+++ b/fec/data/templates/partials/browse-data/bulk-data.jinja
@@ -64,7 +64,7 @@
           </ul>
           <p class="u-margin--top"><a href="/campaign-finance-data/candidate-master-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
         </div>
-        <p class="icon-download--inline--left"><a href="files/bulk-downloads/data_dictionaries/cn_header_file.csv">Header file</a></p>
+        <p class="icon-download--inline--left"><a href="/files/bulk-downloads/data_dictionaries/cn_header_file.csv">Header file</a></p>
         <p>The candidate master file contains one record for each candidate who has either registered with the Federal Election Commission or appeared on a ballot list prepared by a state elections office.</p>
       </div>
       <button type="button" class="js-accordion-trigger accordion__button">Candidate-committee linkages</button>
@@ -141,7 +141,7 @@
           </ul>
           <p class="u-margin--top"><a href="/campaign-finance-data/committee-master-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
         </div>
-        <p class="icon-download--inline--left"><a href="files/bulk-downloads/data_dictionaries/cm_header_file.csv">Header file</a></p>
+        <p class="icon-download--inline--left"><a href="/files/bulk-downloads/data_dictionaries/cm_header_file.csv">Header file</a></p>
         <p>The committee master file contains one record for each committee registered with the Federal Election Commission. This includes federal political action committees and party committees, campaign committees for presidential, house and senate candidates, as well as groups or organizations who are spending money for or against candidates for federal office.</p>
       </div>
       <button type="button" class="js-accordion-trigger accordion__button">PAC summary</button>

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -36,7 +36,7 @@
         <div class="content__section--indent-left">
           <h4><a href="/data/candidates/president/">Presidential candidates</a></h4>
           <p>Search presidential <span class="term" data-term="candidate" title="Click to define" tabindex="0">candidate</span> data including money raised, money spent, cash on hand and debt.</p>
-          <p><a href="/press/resources-journalists/presidential-public-funding/">Find which candidates have applied for presidential public funding</a> &#187; </p>
+          <p><a href="/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/#reports-and-resources">Find which candidates have applied for presidential public funding</a> &#187; </p>
         </div>
       </li>
       <li>

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -36,7 +36,7 @@
         <div class="content__section--indent-left">
           <h4><a href="/data/candidates/president/">Presidential candidates</a></h4>
           <p>Search presidential <span class="term" data-term="candidate" title="Click to define" tabindex="0">candidate</span> data including money raised, money spent, cash on hand and debt.</p>
-          <p><a href="press/resources-journalists/presidential-public-funding/">Find which candidates have applied for presidential public funding</a> &#187; </p>
+          <p><a href="/press/resources-journalists/presidential-public-funding/">Find which candidates have applied for presidential public funding</a> &#187; </p>
         </div>
       </li>
       <li>


### PR DESCRIPTION
## Summary
Fixed a link that was page-relative (and breaking) as well as a couple others I found while checking the rest of the site for the same issue.

- Resolves #2742 

## Impacted areas of the application
/data/browse-data/?tab=candidates, the "Find which candidates" link.
Additionally, two orphaned links in /data/templates/partials/browse-data/build-data.jinja.

## Screenshots
The updated href in the status bar:
![image](https://user-images.githubusercontent.com/26720877/55103421-c021b480-509e-11e9-95b8-d5c678bf2e21.png)

## Related PRs
none

## How to test
- Pull the branch
- Go to http://localhost:8000/data/browse-data/?tab=candidates
- Check the "Find which candidates" link's href

For the other two links, verify that `/files/bulk-downloads/data_dictionaries/cm_header_file.csv` and `/files/bulk-downloads/data_dictionaries/cn_header_file.csv` exist

____
