### PR TITLE
Update Django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.15
+Django==1.11.20
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary
Updated requirements.txt to install the (currently) most recent 1.11 version of Django, 1.11.20, from 1.11.15.

- Resolves #2624 

## Impacted areas of the application
Technically the entire Django system is affected but the changes were tiny and we're only using one of the features updated by 1.11.16-1.11.20 (release notes: [1.11.16](https://docs.djangoproject.com/en/2.1/releases/1.11.16/), [1.11.17](https://docs.djangoproject.com/en/2.1/releases/1.11.17/), [1.11.18](https://docs.djangoproject.com/en/2.1/releases/1.11.18/), [1.11.19](https://docs.djangoproject.com/en/2.1/releases/1.11.19/), [1.11.20](https://docs.djangoproject.com/en/2.1/releases/1.11.20/)).

(We're using contrib.admin in base.py and it's using django.utils.numberformat.format(), which was fixed in 1.11.19. That's as close as we got to being affected by anything between 1.11.15 and 1.11.20.)

## Screenshots
None—purely a back-end change

## Related PRs
None

## How to test
- In the fec-cms root directory, run `pip install -r requirements.txt`, which should remove the current version of Django and upgrade to 1.11.20.
- To double-check that the correct version of Django is installed, run `python`, `import django`, and `django.VERSION`; it should read `(1, 11, 20, 'final', 0)`.
- Run `exit()`.
- Go back into fec-cms/fec and runserver like normal.
- Check localhost. There should be no visible difference from before the update.

____

