### PR TITLE
[HOTFIX - Merge with gitflow] Specifies IE11 in meta tags

### DIFF
--- a/fec/data/templates/partials/meta-tags.jinja
+++ b/fec/data/templates/partials/meta-tags.jinja
@@ -5,7 +5,7 @@
 {% endif %}
 
 <meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE10">
+<meta http-equiv="X-UA-Compatible" content="IE=11">
 <meta name="description" content="{{ description }}">
 
 <!-- Mobile Specific Metas

--- a/fec/fec/templates/partials/meta-tags.html
+++ b/fec/fec/templates/partials/meta-tags.html
@@ -2,7 +2,7 @@
 {% load filters %}
 
 <meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta http-equiv="X-UA-Compatible" content="IE=11">
 <meta name="description" content="{% if self.search_description %}{{ self.search_description }}{% else %}{{ self.content_section | get_meta_description }}{% endif %}">
 
 <!-- Mobile Specific Metas


### PR DESCRIPTION
## Summary

- Resolves #2778 
_Default to IE 11 browsers to resolve datatable issues._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Datatable related pages

## How to test
- Go to the dev site, this branch is currently deployed there, data pages should function