### PR TITLE
[DO NOT MERGE UNTIL 04/12 WITH GITFLOW] Add fec-notify accordion to filings-reports tab

### DIFF
--- a/fec/data/templates/partials/browse-data/filings-reports.jinja
+++ b/fec/data/templates/partials/browse-data/filings-reports.jinja
@@ -1,7 +1,16 @@
 <section class="row" id="filings" aria-hidden="true" role="tabpanel">
   <h2>Filings and reports</h2>
   <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and filing candidate or committee.</p>
-  <h3>Search or browse data</h3>
+  <div class="js-accordion accordion--neutral u-margin--bottom" data-content-prefix="fec-notify">
+    <button type="button" class="js-accordion-trigger accordion__button">Get notified when a candidate or committee submits a new filing
+    </button>
+    <div class="accordion__content">
+      <p>Subscribe to individual candidates and committees to be notified immediately by email of new filing submissions, as well as Requests for Additional Information the FEC sends to filers.</p>
+      <p class="u-margin--bottom"><a class="button button--cta button--go" href="https://fecnotify.fec.gov/fecnotify/register/">Subscribe</a></p>
+      <a href="https://fecnotify.fec.gov/fecnotify/login/">Already subscribed? Log in</a>
+    </div>
+  </div>
+  <h3 class="u-padding--top">Search or browse data</h3>
   <div class="content__section--ruled t-sans">
     <ul>
       <li>

--- a/fec/data/templates/partials/browse-data/filings-reports.jinja
+++ b/fec/data/templates/partials/browse-data/filings-reports.jinja
@@ -2,7 +2,7 @@
   <h2>Filings and reports</h2>
   <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and filing candidate or committee.</p>
   <div class="js-accordion accordion--neutral u-margin--bottom" data-content-prefix="fec-notify">
-    <button type="button" class="js-accordion-trigger accordion__button">Get notified when a candidate or committee submits a new filing
+    <button type="button" class="js-accordion-trigger accordion__button email__button">Get notified when a candidate or committee submits a new filing
     </button>
     <div class="accordion__content">
       <p>Subscribe to individual candidates and committees to be notified immediately by email of new filing submissions, as well as Requests for Additional Information the FEC sends to filers.</p>

--- a/fec/fec/static/scss/components/_accordions.scss
+++ b/fec/fec/static/scss/components/_accordions.scss
@@ -45,6 +45,14 @@
     @include u-icon-bg($minus-circle, $primary);
     border-bottom: none;
   }
+
+  &.email__button {
+    &::before {
+      content:'';
+      @extend .button--envelope
+
+    }
+  }
 }
 
 .accordion__content {

--- a/fec/fec/static/scss/components/_accordions.scss
+++ b/fec/fec/static/scss/components/_accordions.scss
@@ -47,10 +47,11 @@
   }
 
   &.email__button {
+    padding: u(1rem 4rem 1rem 1rem);
     &::before {
       content:'';
-      @extend .button--envelope
-
+      @extend .button--envelope;
+      padding: u(1rem 0rem 1rem 0);
     }
   }
 }


### PR DESCRIPTION
## Summary
Add fec-notify accordion to filings-reports tab

**Do not merge until E-Filing team releases FEC Notify-- slated for release Friday, April 12, 2019**
Although there will be a new master branch (deploy date 04/09)  by the time this is merged (@04/12), it is unlikely that the simple changes here would conflict with any commits to that new master.

- Resolves #2777 

## Impacted areas of the application
modified:   data/templates/partials/browse-data/filings-reports.jinja
                  static/scss/components/_accordions.scss

## Screenshots
<img width="1019" alt="Screen Shot 2019-04-10 at 2 17 02 PM" src="https://user-images.githubusercontent.com/5572856/55903318-655a8380-5b9b-11e9-8324-9fba05df4efd.png">

## How to test
-  Checkout  hotfix/fec-notify-subscription-accordion
-  Test first accordion and links therein on http://127.0.0.1:8000/data/browse-data/?tab=filings

To merge with git flow, see `Step 2: For the hotfix reviewer` on t[his google doc](https://docs.google.com/document/d/1PUfmRMCkD4PaTt8D94pKdth-YlxAZJEWOZ1Id3ebq9s/edit#heading=h.63s57i1wrsoz).