### PR TITLE
Fix custom table block rendering

### DIFF
--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -265,7 +265,7 @@ h3 + .simple-table {
 
 .custom-table {
   box-shadow: -10px 0 20px -10px $gray-medium inset;
-  overflow-x: scroll;
+  overflow-x: auto;
   display: block;
   margin-bottom: u(1rem);
 

--- a/fec/home/blocks.py
+++ b/fec/home/blocks.py
@@ -155,6 +155,9 @@ class CustomTableBlock(blocks.StructBlock):
         ('footnote', blocks.CharBlock(required=False))
     ])
 
+    class Meta:
+        template = 'blocks/custom_table.html'
+
 class ExampleImage(blocks.StructBlock):
     """Creates an example module with an image and a caption, side-by-side
     Typically used for showing reporting Examples
@@ -245,6 +248,3 @@ class ExampleForms(blocks.StructBlock):
     class Meta:
         template = 'blocks/example-forms.html'
         icon = 'doc-empty'
-
-    class Meta:
-        template = 'blocks/custom_table.html'


### PR DESCRIPTION
## Summary (required)
- Template for `custom_table block` was misplaced in `blockys.py`, causing improper rendering of custom table, specifically on statistical press releases (and anywhere else this block is used). 

- Also noticed that an empty scrollbar was appearing at bottom of custom table even when there was no overflow of content, so fixed this by changing `overflow-x:scroll` on custom-table in `_table-styles.scss` to `overflow-x:auto`

 Resolves #2746
Move custom table block template into the proper location on blocks.py. 

## Impacted areas of the application
	modified:   fec/static/scss/components/_table-styles.scss
	modified:   home/blocks.py

## Screenshots
![custom-table-fix](https://user-images.githubusercontent.com/5572856/55740912-15908680-59fa-11e9-8dc2-daf43b463473.gif)


## Related PRs
List related PRs against other branches:

## How to test
  - checkout `feature/2746-fix-custom-table-template-rendering`
  - run npm run build-sass
  - Check statistical press release pages, like
    http://127.0.0.1:8000/updates/statistical-summary-15-month-campaign-activity-2017-2018-election-cycle/
...to confirm that the words "custom_table" no longer shows above the table and that the horizontal scroll bar does not show up until screen is sized to cause overflow of table. See scrnsht above