### PR TITLE
Make breadcrumbs render proper color based on parent section

### DIFF
--- a/fec/fec/templates/partials/breadcrumbs.html
+++ b/fec/fec/templates/partials/breadcrumbs.html
@@ -1,4 +1,4 @@
-<nav class="page-header page-header--{{ style }}">
+<nav class="page-header page-header--{% if "/legal-resources/" in request.path or "/campaign-finance-data/" in request.path %}primary{% elif self.breadcrumb_style %}{{ self.breadcrumb_style }} {% else %}secondary{% endif %}">
   <ul class="breadcrumbs">
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     {% for link in links %}

--- a/fec/fec/templates/partials/breadcrumbs.html
+++ b/fec/fec/templates/partials/breadcrumbs.html
@@ -1,4 +1,4 @@
-<nav class="page-header page-header--{% if "/legal-resources/" in request.path or "/campaign-finance-data/" in request.path or "/introduction-campaign-finance/" in request.path %}primary{% elif self.breadcrumb_style %}{{ self.breadcrumb_style }} {% else %}secondary{% endif %}">
+<nav class="page-header page-header--{% if "/legal-resources/" in request.path or "/campaign-finance-data/" in request.path or "/introduction-campaign-finance/" in request.path %}primary {% else %}secondary{% endif %}">
   <ul class="breadcrumbs">
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     {% for link in links %}

--- a/fec/fec/templates/partials/breadcrumbs.html
+++ b/fec/fec/templates/partials/breadcrumbs.html
@@ -1,4 +1,4 @@
-<nav class="page-header page-header--{% if "/legal-resources/" in request.path or "/campaign-finance-data/" in request.path %}primary{% elif self.breadcrumb_style %}{{ self.breadcrumb_style }} {% else %}secondary{% endif %}">
+<nav class="page-header page-header--{% if "/legal-resources/" in request.path or "/campaign-finance-data/" in request.path or "/introduction-campaign-finance/" in request.path %}primary{% elif self.breadcrumb_style %}{{ self.breadcrumb_style }} {% else %}secondary{% endif %}">
   <ul class="breadcrumbs">
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     {% for link in links %}

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -899,6 +899,7 @@ class ResourcePage(Page):
                                 help_text='If this is a report, add a category',
                                 blank=True,
                                 null=True)
+    #breadcrumb_style removed from promote-panel in favor of controlling breadcrumbs by parent section
     breadcrumb_style = models.CharField(max_length=255,
         choices=[('primary', 'Blue'), ('secondary', 'Red')],
         default='primary')
@@ -921,7 +922,6 @@ class ResourcePage(Page):
     ]
 
     promote_panels = Page.promote_panels + [
-        FieldPanel('breadcrumb_style'),
         FieldPanel('category'),
         FieldPanel('date')
     ]

--- a/fec/home/templates/home/resource_page.html
+++ b/fec/home/templates/home/resource_page.html
@@ -5,7 +5,7 @@
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
 
 {% block breadcrumbs %}
-  {% include 'partials/breadcrumbs.html' with page=self links=self.get_ancestors style=self.breadcrumb_style %}
+  {% include 'partials/breadcrumbs.html' with page=self links=self.get_ancestors style='' %}
 {% endblock %}
 
 {% block intro %}

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/2762-red-blue-breadcrumbs-custom-template'),
+    #('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),
+    ('feature', lambda _, branch: branch == 'feature/2762-red-blue-breadcrumbs-custom-template'),
 )
 
 


### PR DESCRIPTION
## Summary (required)
Resolves #2762

Added conditional statement to breadcrumbs.html that forces breadcrumb style based on parent-page type.
- All page-types published with a parent of  `legal-resources` , `campaign-finance-data` , and `introduction-campaign-finance`  will have blue breadcrumb style.
- All other page-types published NOT in the three sections above have red breadcrumb style
- Removed the  `breadcrumb-style checkbox` on the ResuorcePage "promote tab"  and the template tag ( `...style=self.breadcrumb_style %}` ) referring to this in the ResourcePage template

## Impacted areas of the application
modified:   fec/templates/partials/breadcrumbs.html
modified:   home/templates/home/resource_page.html
modified:   /home/models.py

## How to test
- Checkout `feature/2762-red-blue-breadcrumbs-custom-template`
- Login to Wagtail admin and navigate from the left sidebar Pages > Home > Legal resources 
   - click on  Legal: Regulations
   - Create a child page of type `CustomPage`
   - Preview it to confirm that the breadcrumb style is blue
- Navigate to Pages > Home
   - Click on `campaign-finance`
   - Create a child page of page type `CustomPage`
   - Preview it to confirm that the breadcrumb style is blue
- Spot check data description pages in the accordions on http://127.0.0.1:8000/data/browse-data/ to confirm that they have blue breadcrumbs
- Spot check pages NOT in  `legal-resources` , `campaign-finance-data` , and `introduction-campaign-finance`  to confirm they have red breadcrumbs





