### PR TITLE
Add html/link capability to core and custom table_blocks

### DIFF
--- a/fec/home/blocks.py
+++ b/fec/home/blocks.py
@@ -7,8 +7,7 @@ from wagtail.snippets.blocks import SnippetChooserBlock
 
 """options for wagtail default table_block """
 core_table_options = {
-
-    'renderer': 'html',
+    'renderer': 'html'
 }
 
 class ThumbnailBlock(blocks.StructBlock):
@@ -146,14 +145,13 @@ class CustomTableBlock(blocks.StructBlock):
     Typicallyused for Statistical Press Release tables
     """
     custom_table_options = {
-    'startRows': 7,
-    'startCols': 6,
-    'colHeaders': True,
-    'rowHeaders': True,
-    'height': 108,
-    'language': 'en',
-    'renderer': 'html',
-
+        'startRows': 7,
+        'startCols': 6,
+        'colHeaders': True,
+        'rowHeaders': True,
+        'height': 108,
+        'language': 'en',
+        'renderer': 'html'
     }
 
     custom_table = blocks.StreamBlock([

--- a/fec/home/blocks.py
+++ b/fec/home/blocks.py
@@ -5,6 +5,12 @@ from wagtail.documents.blocks import DocumentChooserBlock
 from wagtail.contrib.table_block.blocks import TableBlock
 from wagtail.snippets.blocks import SnippetChooserBlock
 
+"""options for wagtail default table_block """
+core_table_options = {
+
+    'renderer': 'html',
+}
+
 class ThumbnailBlock(blocks.StructBlock):
     """A block that combines a thumbnail and a caption,
         both of which link to a URL"""
@@ -146,6 +152,8 @@ class CustomTableBlock(blocks.StructBlock):
     'rowHeaders': True,
     'height': 108,
     'language': 'en',
+    'renderer': 'html',
+
     }
 
     custom_table = blocks.StreamBlock([
@@ -187,7 +195,7 @@ class ResourceBlock(blocks.StructBlock):
         ('fec_jobs', CareersBlock()),
         ('mur_search', MURSearchBlock()),
         ('audit_search', AuditSearchBlock()),
-        ('table', TableBlock()),
+        ('table', TableBlock(table_options=core_table_options)),
         ('custom_table', CustomTableBlock()),
         ('html', blocks.RawHTMLBlock()),
         ('reporting_example_cards', ReportingExampleCards()),

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -49,6 +49,11 @@ from home.blocks import (ThumbnailBlock, AsideLinkBlock,
                          CustomTableBlock, ReportingExampleCards, InternalButtonBlock,
                          ExternalButtonBlock, SnippetChooserBlock, ExampleImage)
 
+"""options for wagtail default table_block """
+core_table_options = {
+
+    'renderer': 'html',
+}
 
 stream_factory = functools.partial(
     StreamField,
@@ -57,7 +62,7 @@ stream_factory = functools.partial(
         ('paragraph', blocks.RichTextBlock()),
         ('html', blocks.RawHTMLBlock()),
         ('image', ImageChooserBlock()),
-        ('table', TableBlock()),
+        ('table', TableBlock(table_options=core_table_options)),
         ('custom_table', CustomTableBlock()),
         ('contact', ContactInfoBlock())
     ],
@@ -582,7 +587,7 @@ class CustomPage(Page):
         ('html', blocks.RawHTMLBlock()),
         ('example_image', ExampleImage()),
         ('image', ImageChooserBlock()),
-        ('table', TableBlock()),
+        ('table', TableBlock(table_options=core_table_options)),
         ('example_paragraph', ExampleParagraph()),
         ('example_forms', ExampleForms()),
         ('reporting_example_cards', ReportingExampleCards()),


### PR DESCRIPTION
## Summary (required)
Adds the  ability to add html (specifically, links) to core (Wagtail default) and custom table_blocks. 

- Resolves: There is no issue for this but resolves first wishlist item on the below doc:
"Tables: no github issue. Need the ability to add links within table cells (without manually html coding)- SORELY NEEDED"
https://docs.google.com/document/d/1HM1-SaxAL-pVhzwQY8ZP-1uA8bVlbAxwFhqW4f-3lAo/edit

## Impacted areas of the application
List general components of the application that this PR will affect:
Added html renderer option for core and custom tables in models.py and blocks.py
modified:   home/blocks.py
modified:   home/models.py

## Screenshots
![links-to_tables](https://user-images.githubusercontent.com/5572856/56012042-8d8bd480-5cb8-11e9-939c-ae2a22293a43.gif)

## How to test
- Checkout `feature/add-html-link-capability-to-tableblocks`
- Login to Wagtail admin and create a child page of `CustomPage` type
- In the `body` section choose `Table`
- Create an html link in a cell : `<a href="http...etc`
- Click away form the cell to see the link created.
- Double-click back in the cell to open the link  for editing. (see gif screenshot above)
- Publish or preview the page to test the lnk live
- Works for absolute and relative links

-To test `custom_table_block`, you can create a `ResoucePage` where the `Sections` section has Custom Table option

____

