### PR TITLE
Add download only API key to CMS 

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -20,6 +20,7 @@
     API_LOCATION = '{{ FEC_API_URL }}';
     API_VERSION = 'v1';
     API_KEY = '{{ FEC_API_KEY }}';
+    DOWNLOAD_API_KEY = '{{ FEC_DOWNLOAD_API_KEY }}';
     DEFAULT_TIME_PERIOD = '2018';
     START_YEAR = '1979';
     END_YEAR = '2018';

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -21,6 +21,7 @@ FEC_API_URL = env.get_credential('FEC_API_URL', 'http://localhost:5000')
 FEC_API_KEY = env.get_credential('FEC_WEB_API_KEY')
 FEC_API_VERSION = env.get_credential('FEC_API_VERSION', 'v1')
 FEC_API_KEY_PUBLIC = env.get_credential('FEC_WEB_API_KEY_PUBLIC', '')
+FEC_DOWNLOAD_API_KEY = env.get_credential('FEC_DOWNLOAD_API_KEY', '')
 
 FEC_RECAPTCHA_SECRET_KEY = env.get_credential('FEC_RECAPTCHA_SECRET_KEY')
 FEC_GITHUB_TOKEN = env.get_credential('FEC_GITHUB_TOKEN')
@@ -138,6 +139,7 @@ TEMPLATES = [
                 'constants': constants,
                 'CANONICAL_BASE': CANONICAL_BASE,
                 'FEC_API_KEY': FEC_API_KEY,
+                'FEC_DOWNLOAD_API_KEY': FEC_DOWNLOAD_API_KEY,
                 'FEC_API_KEY_PUBLIC': FEC_API_KEY_PUBLIC,
                 'FEC_API_URL': FEC_API_URL,
                 'WEBMANAGER_EMAIL': WEBMANAGER_EMAIL,

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -285,11 +285,15 @@ function buildAppUrl(path, query) {
 }
 
 function buildUrl(path, query) {
-  return URI(API_LOCATION)
+  var uri = URI(API_LOCATION)
     .path(Array.prototype.concat(API_VERSION, path, '').join('/'))
-    .addQuery({ api_key: API_KEY })
-    .addQuery(query)
-    .toString();
+    .addQuery({ api_key: API_KEY });
+
+  if (query.api_key) {
+    // if query provides api_key, use that.
+    uri.removeQuery('api_key');
+  }
+  return uri.addQuery(query).toString();
 }
 
 function buildTableQuery(context) {

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -624,7 +624,7 @@ DataTable.prototype.fetch = function(data, callback) {
 };
 
 DataTable.prototype.export = function() {
-  var url = this.buildUrl(this.api.ajax.params(), false);
+  var url = this.buildUrl(this.api.ajax.params(), false, true);
   download.download(url, false, true);
   this.disableExport({ message: DOWNLOAD_MESSAGES.pending });
 };
@@ -634,7 +634,7 @@ DataTable.prototype.isPending = function() {
   return download.isPending(url);
 };
 
-DataTable.prototype.buildUrl = function(data, paginate) {
+DataTable.prototype.buildUrl = function(data, paginate, download) {
   var query = _.extend(
     { sort_hide_null: false, sort_nulls_last: true }, // eslint-disable-line camelcase
     this.filters || {}
@@ -644,6 +644,11 @@ DataTable.prototype.buildUrl = function(data, paginate) {
 
   if (paginate) {
     query = _.extend(query, this.paginator.mapQuery(data, query));
+  }
+  if (download) {
+    query = _.extend(query, {
+      api_key: window.DOWNLOAD_API_KEY
+    });
   }
 
   return helpers.buildUrl(


### PR DESCRIPTION
## Summary

- Resolves #2833 
- Add FEC_DOWNLOAD_API_KEY as environment variable for data templates
- Add DOWNLOAD_API_KEY as a parameter to the download query
- Remove default api_key if a separate api_key is defined in the query

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Export button when querying /download/ API calls

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/limit-downloads-access | https://github.com/fecgov/openFEC/pull/3695

## How to test
1. Set FEC_DOWNLOAD_API_KEY as environment variables
2. Test exporting a dataset like the candidates data: http://localhost:8000/data/candidates/. The `/download/` api call should only contain the `api_key` defined inside FEC_DOWNLOAD_API_KEY
3. Make sure all other client side API calls still uses the default key defined in FEC_WEB_API_KEY


