### PR TITLE
[DO NOT MERGE - Point to next release branch first] Feature/homepage barcharts design - second pass

### DIFF
--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -179,7 +179,9 @@ TopEntities.prototype.formatData = function(result, rank) {
     rank: rank,
     party: result.party,
     party_code:
-      result.party === null || this.per_page == 3 ? '' : '[' + result.party.toUpperCase() + ']',
+      result.party === null || this.per_page == 3
+        ? ''
+        : '[' + result.party.toUpperCase() + ']',
     url: helpers.buildAppUrl(['candidate', result.candidate_id], {
       cycle: this.election_year,
       election_full: true

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -179,7 +179,7 @@ TopEntities.prototype.formatData = function(result, rank) {
     rank: rank,
     party: result.party,
     party_code:
-      result.party === null ? '' : '[' + result.party.toUpperCase() + ']',
+      result.party === null || this.per_page == 3 ? '' : '[' + result.party.toUpperCase() + ']',
     url: helpers.buildAppUrl(['candidate', result.candidate_id], {
       cycle: this.election_year,
       election_full: true

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -158,16 +158,6 @@ h3 + .simple-table {
   border-top: 2px solid $primary;
   font-family: $sans-serif;
 
-  &.chart-table-home {
-    border-top: none;
-    .simple-table__row {
-      border-bottom: 1px dotted $gray-dark;
-      .simple-table__cell {
-        font-weight:bold;
-      }
-    }
-  }
-
   .simple-table__cell {
     padding: u(.5rem 0 0 0);
   }
@@ -374,5 +364,96 @@ h3 + .simple-table {
     color: $inverse;
     border-bottom: none;
     border-right: none;
+  }
+}
+
+//Special rearrangement grid styles for homepage embedded raising-spending barcharts
+.chart-table-home {
+  border-top: none;
+
+  .simple-table__row {
+    display: grid;
+    grid-template-columns: 100% 50% 100%;
+    grid-template-rows: 30px 30px 30px;
+    grid-auto-flow: column;
+    border-bottom:0;
+    }
+
+  .simple-table__cell {
+    /* name cell */
+    grid-column: 1;
+    grid-row: 1;
+    border-bottom: 0;
+    font-weight:bold;
+  }
+
+  .simple-table__cell:nth-child(2) {
+    /* $amount cell $ */
+    grid-column: 1;
+    grid-row: 3/4;
+    border-bottom: 1px solid $gray-dark;
+    text-align: left;
+    margin-top: -9px;
+  }
+
+  .simple-table__cell:nth-child(3) {
+  /* bar cell */
+    grid-column: 1/3;
+    grid-row: 2/2;
+    padding-left: 0;
+    border-bottom: 0;
+  }
+
+  @include media($med) {
+    .simple-table__row {
+      display: grid;
+      grid-template-columns: 100% 50% 100%;
+      grid-template-rows: 30px 30px;
+      grid-auto-flow: column;
+
+    }
+    .simple-table__cell {
+      grid-column: 1;
+      grid-row: 1/3;
+      border-bottom: 1px dotted $gray-dark;
+      padding-bottom: u(7rem);
+
+       a {
+        font-size: inherit;
+        display: inline-block;
+        padding-top: 2rem;
+       }
+    }
+
+    .simple-table__cell:nth-child(2) {
+      /* $amount cell $ */
+      grid-column: auto / span 2;
+      grid-row: 2/3;
+      border-bottom: 1px dotted $gray-dark;
+      padding: u(2rem) 0 u(3rem) 0;
+      margin-top: 0;
+      font-size: inherit;
+    }
+
+    .simple-table__cell:nth-child(3) {
+    /* bar cell */
+      grid-column: 2/4;
+      grid-row: 1/2;
+      padding-left: 0;
+      border-bottom: 0;
+      padding-top: u(3rem);
+    }
+  }
+
+  @include media($lg) {
+    .simple-table__cell {
+      a {
+      font-size: 1.6rem;
+      }
+    }
+    .simple-table__cell:nth-child(2) {
+      /* $amount cell $ */
+      font-size: u(1.6rem);
+    }
   }
 }

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -377,7 +377,7 @@ h3 + .simple-table {
     grid-template-rows: 30px 30px 30px;
     grid-auto-flow: column;
     border-bottom:0;
-    }
+  }
 
   .simple-table__cell {
     /* name cell */
@@ -410,8 +410,12 @@ h3 + .simple-table {
       grid-template-columns: 100% 50% 100%;
       grid-template-rows: 30px 30px;
       grid-auto-flow: column;
-
     }
+
+    .simple-table__row:nth-child(2){
+        margin-top: u(-2rem);
+    }
+
     .simple-table__cell {
       grid-column: 1;
       grid-row: 1/3;

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -445,6 +445,7 @@ h3 + .simple-table {
     }
   }
 
+
   @include media($lg) {
     .simple-table__cell {
       a {

--- a/fec/fec/static/scss/components/_toggles.scss
+++ b/fec/fec/static/scss/components/_toggles.scss
@@ -98,6 +98,14 @@
     font-weight: normal;
     margin-bottom: -2px;
   }
+
+  &[data-toggle="home-barcharts"] {
+    @include media($med) {
+      span.button--alt{
+        min-width: u(13.5rem);
+      }
+    }
+  }
 }
 
 .toggles--small {

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -13,7 +13,7 @@
 
         <div role="row" class="simple-table__header">
           <div role="columnheader" class="simple-table__header-cell cell--40">Candidate</div>
-          <div role="columnheader" class="simple-table__header-cell cell--20 t-right-aligned js-type-label">Total <span>{{ action }}</span></div>
+          <div role="columnheader" class="simple-table__header-cell cell--20 t-left-aligned js-type-label">Total <span>{{ action }}</span></div>
           <div role="columnheader" class="simple-table__header-cell cell--40"></div>
         </div>
 

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -33,7 +33,7 @@
     </section>
   </div>
   <div class="usa-width-one-third example--primary u-padding--top--small">
-    <fieldset class="toggles u-margin--bottom" data-filter="toggle" data-filter-ignore-count="true">
+    <fieldset class="toggles u-margin--bottom" data-toggle="home-barcharts" data-filter-ignore-count="true">
       <legend class="label input__label-home t-inline-block">Data type</legend>
       <div class="row">
         <label for="switcher-receipts" class="toggle">

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -18,9 +18,9 @@
         </div>
 
         {% for datum in data %}
-        <div role="row" class="js-top-row simple-table__row">
+           <div role="row" class="js-top-row simple-table__row">
 
-        </div>
+          </div>
         {% endfor %}
         </div>
 
@@ -88,4 +88,5 @@
    type: 'receipts',
  }
 </script>
+
 {% endif %}

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -24,7 +24,7 @@
         {% endfor %}
         </div>
 
-      <div class="content__section row u-margin--top">
+      <div class="content__section row u-margin--top u-padding--top">
         <ul class="list--buttons u-float-right">
           <li class="u-padding--top--small"><a class="button button--cta button--go js-browse"  href="/data/raising-bythenumbers/">Browse top <span>raising</span> candidates</a></li>
         </ul>
@@ -49,7 +49,7 @@
 
     <div class="js-top-entities raising-spending-controls content__section" data-office="{{ office }}" data-election-year="{{ election_year }}">
       <form action="" method="GET" class="u-margin--bottom">
-        <div class="office-select u-margin--bottom">
+        <div class="office-select u-margin--bottom u-padding--top">
         <label for="top-category" class="js-type-label input__label-home label t-inline-block">How much has been <span>{{ action }}</span> by </label>
           <select id="top-category" name="top_category" class="js-office" aria-controls="top-table">
             <option value="P" {% if office == 'P' %}selected{% endif %}>Presidential candidates</option>
@@ -63,7 +63,7 @@
       </form>
       <form action="" method="get">
         <div class="row">
-          <div class="cycle-select">
+          <div class="cycle-select u-padding--top">
             <label for="election-year" class="label input__label-home">Running in</label>
             <select id="election-year" class="js-election-year" name="cycle">
               {% for each in election_years %}


### PR DESCRIPTION
## Summary

Second pass at design for raising/spending bar chart to more closely match mockup in https://github.com/fecgov/fec-cms/issues/2562
- Resolves #2562
Added section to `_table_styles scss` to use [CSS Grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) to position the chart elements according to mockup in keeping with our `mobile-first` approach.

## Impacted areas of the application
modified:   fec/static/scss/components/_table-styles.scss
modified:   home/templates/partials/raising-spending.html

## Screenshots
### Full Width:
![Screen Shot 2019-04-16 at 12 47 24 AM](https://user-images.githubusercontent.com/5572856/56182682-46b41c80-5fe1-11e9-953c-406105f2b331.png)


### Mobile first:
![Screen Shot 2019-04-16 at 12 30 04 AM](https://user-images.githubusercontent.com/5572856/56182448-449d8e00-5fe0-11e9-886e-ca28297474a2.png)

## Related PRs
https://github.com/fecgov/fec-cms/pull/2748

## How to test
- Checkout feature/homepage-embedded-apps-second-pass
- Set env var for barcharts. `export FEC_FEATURE_HOME_BARCHARTS=1`
- `npm run-build`
- View homepage raising/spending and compare to mockup in  https://github.com/fecgov/fec-cms/issues/2562
- Test different screen sizes
____

