### PR TITLE
Fix active candidate flag for Raising/Spending visualizations

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -353,7 +353,7 @@ def load_top_candidates(sort, office=None, election_year=constants.DEFAULT_ELECT
         sort_hide_null=True,
         election_year=election_year,
         election_full=True,
-        active_candidates=True,
+        is_active_candidate=True,
         office=office,
         sort=sort,
         per_page=per_page,

--- a/fec/fec/static/js/modules/aggregate-totals.js
+++ b/fec/fec/static/js/modules/aggregate-totals.js
@@ -139,7 +139,7 @@ AggregateTotals.prototype.init = function() {
   this.baseQuery = {
     office: '',
     per_page: 20,
-    active_candidates: false,
+    is_active_candidate: true,
     sort_null_only: false,
     sort_hide_null: false,
     sort_nulls_last: false,

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -44,7 +44,7 @@ TopEntities.prototype.init = function() {
     election_year: this.election_year,
     election_full: true,
     office: this.office,
-    active_candidates: true,
+    is_active_candidate: true,
     page: 1
   };
   this.maxValue = Number(
@@ -262,7 +262,7 @@ TopEntities.prototype.handleTypeChange = function(e) {
     election_year: this.election_year,
     election_full: true,
     office: this.office,
-    active_candidates: true
+    is_active_candidate: true
   };
 
   this.currentQuery = baseQuery;

--- a/fec/fec/tests/js/top-entities-breakdown.js
+++ b/fec/fec/tests/js/top-entities-breakdown.js
@@ -86,7 +86,7 @@ describe('Top entities breakdown', function() {
         election_year: 2012,
         election_full: true,
         office: 'S',
-        active_candidates: true,
+        is_active_candidate: true,
         page: 1
       });
     });
@@ -119,7 +119,7 @@ describe('Top entities breakdown', function() {
           election_year: 2016,
           election_full: true,
           office: 'P',
-          active_candidates: true,
+          is_active_candidate: true,
           page: 1
         });
       });


### PR DESCRIPTION
## Summary

- Resolves #2841 
_Corrects active candidate flag, now uses `is_active_candidate` attribute for /candidates/totals and /candidates/totals/by_office for aggregates._

## Impacted areas of the application
List general components of the application that this PR will affect:

- Raising/spending by the numbers pages
- Aggregate totals on raising/spending by the numbers

## Screenshots

![Screen Shot 2019-04-17 at 11 26 52 AM](https://user-images.githubusercontent.com/12799132/56300319-bd493b00-6103-11e9-8d43-01e0192832a5.png)

## How to test
1. Go to Raising by the numbers and Spending by the numbers pages to make sure that the ajax calls are all using the `is_active_candidate=true` flag
2. Make sure that Al Franken is not in the list of candidates running in 2020 Senate.
