### PR TITLE
Consistent  menu bar indicator

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -50,6 +50,7 @@ def landing(request):
         request,
         'landing.jinja',
         {
+            'parent':'data',
             'title': 'Campaign finance data',
             'dates': utils.date_ranges(),
             'top_candidates_raising': top_candidates_raising['results']
@@ -89,7 +90,7 @@ def search(request):
 
 
 def browse_data(request):
-    return render(request, 'browse-data.jinja', {'title': 'Browse data'})
+    return render(request, 'browse-data.jinja', {'title': 'Browse data', 'parent': 'data'})
 
 
 def get_candidate(candidate_id, cycle, election_full):

--- a/fec/fec/templates/partials/breadcrumbs.html
+++ b/fec/fec/templates/partials/breadcrumbs.html
@@ -1,4 +1,4 @@
-<nav class="page-header page-header--{% if "/legal-resources/" in request.path or "/campaign-finance-data/" in request.path or "/introduction-campaign-finance/" in request.path %}primary {% else %}secondary{% endif %}">
+<nav class="page-header page-header--{% if "/legal-resources/" in request.path or "/campaign-finance-data/" in request.path or "/introduction-campaign-finance/" in request.path %}primary{% else %}secondary{% endif %}">
   <ul class="breadcrumbs">
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     {% for link in links %}

--- a/fec/fec/templates/partials/navigation/navigation.html
+++ b/fec/fec/templates/partials/navigation/navigation.html
@@ -28,7 +28,7 @@
         </a>
       </li>
       <li class="site-nav__item" data-submenu="data">
-        <a class="site-nav__link" href="/data" tabindex="0">
+        <a class="site-nav__link {% if self.content_section == 'data' or parent == 'data' %}is-parent{% endif %}" href="/data" tabindex="0">
           <span class="site-nav__link__title">
           Campaign finance data</span>
         </a>
@@ -41,7 +41,7 @@
         {% include 'partials/navigation/nav-help.html' %}
       </li>
       <li class="site-nav__item" data-submenu="legal">
-        <a href="/legal-resources" tabindex="0" class="site-nav__link {% if self.content_section == 'legal' %}is-parent{% endif %}">
+        <a href="/legal-resources" tabindex="0" class="site-nav__link {% if self.content_section == 'legal' or parent == 'legal' %}is-parent{% endif %}">
           <span class="site-nav__link__title">Legal resources</span>
         </a>
         {% include 'partials/navigation/nav-legal.html' %}

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -83,7 +83,6 @@ def get_content_section(page):
     }
 
     ancestors = page.get_ancestors()
-
     content_sections = [
         slugs.get(ancestor.slug) for ancestor in ancestors
         if slugs.get(ancestor.slug) != None
@@ -92,6 +91,17 @@ def get_content_section(page):
         return content_sections[0]
     else:
         return ''
+
+
+
+    # content_sections = [
+    #     slugs.get(ancestor.slug) for ancestor in ancestors
+    #     if slugs.get(ancestor.slug) != None
+    # ]
+    # if len(content_sections):
+    #     return content_sections[0]
+    # else:
+    #     return ''
 
 class UniqueModel(models.Model):
     """Abstract base class for unique pages."""
@@ -127,7 +137,8 @@ class ContentPage(Page):
         index.SearchField('body')
     ]
 
-    #Default content section for determining the active nav
+    """Returns no content section so the active nav can be set in the page-type \
+    that extends the ContentPage model """
     @property
     def content_section(self):
        return ''
@@ -354,7 +365,7 @@ class RecordPage(ContentPage):
 
     @property
     def content_section(self):
-        return 'about'
+        return get_content_section(self)
 
     @property
     def get_update_type(self):

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -79,11 +79,11 @@ def get_content_section(page):
         'legal-resources': 'legal',
         'about':'about',
         'campaign-finance-data': 'data',
-        'data':'data'
-
-
+        'data':'data',
     }
+
     ancestors = page.get_ancestors()
+
     content_sections = [
         slugs.get(ancestor.slug) for ancestor in ancestors
         if slugs.get(ancestor.slug) != None
@@ -127,10 +127,11 @@ class ContentPage(Page):
         index.SearchField('body')
     ]
 
-    # Default content section for determining the active nav
+    #Default content section for determining the active nav
     @property
     def content_section(self):
-        return ''
+       return ''
+
 '''
 class Person(User):
     objects = User()
@@ -353,7 +354,7 @@ class RecordPage(ContentPage):
 
     @property
     def content_section(self):
-        return ''
+        return 'about'
 
     @property
     def get_update_type(self):
@@ -392,7 +393,7 @@ class DigestPage(ContentPage):
 
     @property
     def content_section(self):
-        return ''
+        return 'about'
 
     @property
     def get_update_type(self):
@@ -453,7 +454,7 @@ class PressReleasePage(ContentPage):
 
     @property
     def content_section(self):
-        return ''
+        return 'about'
 
     @property
     def get_update_type(self):
@@ -517,7 +518,7 @@ class TipsForTreasurersPage(ContentPage):
 
     @property
     def content_section(self):
-        return ''
+        return 'about'
 
     @property
     def get_author_office(self):
@@ -705,7 +706,6 @@ class DocumentPage(ContentPage):
         # Return the file extension of file_url
         return self.file_url.rsplit('.', 1)[1].upper()
 
-
 class DocumentFeedPage(ContentPage):
     subpage_types = ['DocumentPage', 'ResourcePage']
     intro = StreamField([
@@ -720,7 +720,7 @@ class DocumentFeedPage(ContentPage):
 
     @property
     def content_section(self):
-        return ''
+        return get_content_section(self)
 
     @property
     def category_filters(self):
@@ -1117,6 +1117,7 @@ class MeetingPage(Page):
     @property
     def get_update_type(self):
         return constants.update_types['commission-meeting']
+
     @property
     def content_section(self):
         return 'about'

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -76,7 +76,12 @@ def get_content_section(page):
     """
     slugs = {
         'help-candidates-and-committees': 'help',
-        'legal-resources': 'legal'
+        'legal-resources': 'legal',
+        'about':'about',
+        'campaign-finance-data': 'data',
+        'data':'data'
+
+
     }
     ancestors = page.get_ancestors()
     content_sections = [
@@ -739,7 +744,7 @@ class ReportsLandingPage(ContentPage, UniqueModel):
 
     @property
     def content_section(self):
-        return ''
+        return 'about'
 
 
 class AboutLandingPage(Page):
@@ -754,7 +759,9 @@ class AboutLandingPage(Page):
         StreamFieldPanel('hero'),
         StreamFieldPanel('sections')
     ]
-
+    @property
+    def content_section(self):
+        return 'about'
 
 class CommissionerPage(Page):
     first_name = models.CharField(max_length=255, default='', blank=False)
@@ -1110,6 +1117,9 @@ class MeetingPage(Page):
     @property
     def get_update_type(self):
         return constants.update_types['commission-meeting']
+    @property
+    def content_section(self):
+        return 'about'
 
 
 class ReportingExamplePage(Page):
@@ -1176,3 +1186,6 @@ class ContactPage(Page):
         StreamFieldPanel('services'),
     ]
 
+    @property
+    def content_section(self):
+        return 'about'

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -171,7 +171,7 @@ def updates(request):
     except EmptyPage:
         updates = paginator.page(paginator.num_pages)
 
-    page_context = {"title": "Latest updates"}
+    page_context = {"title": "Latest updates", "content_section" : "about"}
 
     category_list = list(map(replace_space, category_list))
 
@@ -365,7 +365,7 @@ def index_meetings(request):
     except EmptyPage:
         executive_sessions = executive_paginator.page(executive_paginator.num_pages)
 
-    page_context = {"title": "Commission meetings"}
+    page_context = {"content_section": "about","title": "Commission meetings"}
 
     return render(
         request,
@@ -387,7 +387,7 @@ def index_meetings(request):
 
 
 def guides(request):
-    page_context = {"content_section": "guides", "title": "Guides"}
+    page_context = {"content_section": "help", "title": "Guides"}
     return render(
         request,
         "home/candidate-and-committee-services/guides.html",


### PR DESCRIPTION
## Summary
Make menu bar indicators consistent site-wide

- Resolves #2760

## Impacted areas of the application
modified: home/models.py
modified: partials/navigation.html
modified: home/views.py
modified: data/views.py


## How to test
- checkout `feature/2760-fix-menu-bar-indicator` or see `https://fec-feature-cms.app.cloud.gov`
- Test that menu bar indicator shows the proper parent section for all pages
- A few pages at the root level that have no parent section and will not get indicator: Example: `test-- new-features-our-design-team/` and `/freedom-information-act/`

