### PR TITLE
[MERGE WITH GITFLOW] Hotfix for rendering bugs and responsive issues with home bar charts

### DIFF
--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -196,7 +196,7 @@ TopEntities.prototype.formatData = function(result, rank) {
 TopEntities.prototype.drawBars = function() {
   var maxValue = this.maxValue;
   this.$table.find('.value-bar').each(function() {
-    var width = Number(this.getAttribute('data-value')) / maxValue;
+    var width = Number(this.getAttribute('data-value')) / maxValue || 0;
     this.style.width = String(width * 100) + '%';
   });
 };

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -14,6 +14,7 @@ function TopEntities(elm, type) {
   this.per_page = this.$elm.data('perpage');
 
   this.$table = this.$elm.find('.js-top-table');
+
   this.$dates = this.$elm.find('.js-dates');
   this.$previous = this.$elm.find('.js-previous');
   this.$next = this.$elm.find('.js-next');
@@ -163,7 +164,10 @@ TopEntities.prototype.populateTable = function(response) {
   // Set max value if it's the first page
   if (response.pagination.page === 1) {
     if (response.results.length > 0) {
-      self.maxValue = response.results[0].receipts;
+      self.maxValue =
+        this.type == 'receipts'
+          ? response.results[0].receipts
+          : response.results[0].disbursements;
     }
     self.$previous.addClass('is-disabled');
   }

--- a/fec/fec/static/scss/components/_breakdowns.scss
+++ b/fec/fec/static/scss/components/_breakdowns.scss
@@ -25,3 +25,7 @@
   margin: 0;
 
 }
+.bar-container {
+      margin-left: 0;
+      background: $gray-lightest;
+    }

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -164,7 +164,7 @@ h3 + .simple-table {
 
     .bar-container {
       margin-left: 0;
-      background: $gray-medium;
+      background: $gray-light;
     }
 
     .simple-table__row {
@@ -187,8 +187,11 @@ h3 + .simple-table {
 
       .t-right-aligned {
         text-align: left;
-
       }
+    }
+
+    .simple-table__header-cell:nth-child(2) {
+      text-align: left;
     }
   }
 

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -164,6 +164,7 @@ h3 + .simple-table {
 
     .bar-container {
       margin-left: 0;
+      background: $gray-medium;
     }
 
     .simple-table__row {
@@ -173,10 +174,15 @@ h3 + .simple-table {
         content: '';
         display: block;
         height: 1rem;
-        border-bottom: 1px solid $gray-dark;
+        border-bottom: 1px solid $gray-medium;
       }
       .simple-table__cell {
         font-weight:bold;
+      }
+
+      .simple-table__cell:nth-child(2) {
+      /* $amount cell $ */
+      font-weight:normal;
       }
 
       .t-right-aligned {
@@ -231,7 +237,7 @@ h3 + .simple-table {
           display: none;
         }
         .simple-table__cell {
-          border-bottom: 1px dotted $gray-dark;
+          border-bottom: 1px solid $gray-medium;
         }
       }
     }
@@ -421,3 +427,8 @@ h3 + .simple-table {
     border-right: none;
   }
 }
+
+//for home barchart-full width on mobile
+.breakdowns-home {
+   width: 100%;
+  }

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -158,12 +158,30 @@ h3 + .simple-table {
   border-top: 2px solid $primary;
   font-family: $sans-serif;
 
+  // For homepage barcharts
   &.chart-table-home {
     border-top: none;
+
+    .bar-container {
+      margin-left: 0;
+    }
+
     .simple-table__row {
-      border-bottom: 1px dotted $gray-dark;
+      border-bottom: 0;
+
+      &:after {
+        content: '';
+        display: block;
+        height: 1rem;
+        border-bottom: 1px solid $gray-dark;
+      }
       .simple-table__cell {
         font-weight:bold;
+      }
+
+      .t-right-aligned {
+        text-align: left;
+
       }
     }
   }
@@ -197,6 +215,33 @@ h3 + .simple-table {
       // Left padding for bar cells
       &:last-of-type {
         padding-left: u(1rem);
+      }
+    }
+
+    // For homepage barcharts
+    &.chart-table-home {
+
+      .bar-container {
+        margin-left: u(2rem);
+      }
+
+      .simple-table__row {
+
+        &:after {
+          display: none;
+        }
+        .simple-table__cell {
+          border-bottom: 1px dotted $gray-dark;
+        }
+      }
+    }
+  }
+
+  @include media($lg) {
+    &.chart-table-home {
+
+      .bar-container {
+        margin-left: 0;
       }
     }
   }

--- a/fec/fec/static/scss/components/_toggles.scss
+++ b/fec/fec/static/scss/components/_toggles.scss
@@ -98,6 +98,35 @@
     font-weight: normal;
     margin-bottom: -2px;
   }
+
+  &[data-toggle="home-barcharts"] {
+    .button--alt{
+      min-width: u(13.5rem);
+    }
+    label.toggle {
+        float:none;
+      }
+    @include media($med) {
+      .button-first {
+        border-radius: 4px 4px 0 0 !important;
+      }
+      .button-last {
+        border-radius:0 0  4px 4px !important;
+      }
+
+    }
+    @include media($lg) {
+     label.toggle {
+        float:left;
+      }
+      .button-first {
+        border-radius: 4px 0 0 4px !important;
+      }
+      .button-last {
+        border-radius:0 4px 4px 0 !important;
+      }
+    }
+  }
 }
 
 .toggles--small {

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -6,7 +6,7 @@
 <section class="usa-grid-full">
   <p class="t-bold u-padding--top">Learn how much individual candidates have raised and spent for presidential, Senate and House elections.</p>
   <div class="usa-width-two-thirds grid--flex">
-    <section id="raising-breakdowns">
+    <section id="raising-breakdowns" class="breakdowns-home">
        <div class="js-top-entities" data-office="{{ office }}" data-election-year="{{ election_year }}" data-perpage="3">
 
        <div class="chart-table chart-table-home simple-table--responsive js-top-table" id="top-table" aria-live="polite" role="grid">
@@ -33,16 +33,16 @@
     </section>
   </div>
   <div class="usa-width-one-third example--primary u-padding--top--small">
-    <fieldset class="toggles u-margin--bottom" data-filter="toggle" data-filter-ignore-count="true">
+    <fieldset class="toggles u-margin--bottom" data-toggle="home-barcharts" data-filter-ignore-count="true">
       <legend class="label input__label-home t-inline-block">Data type</legend>
       <div class="row">
         <label for="switcher-receipts" class="toggle">
           <input type="radio" class="js-chart-toggle" value="receipts" id="switcher-receipts" checked name="data_type" data-prefix="raising"  aria-controls="processed-message" tabindex="0">
-          <span class="button--alt">Money raised</span>
+          <span class="button--alt button-first">Money raised</span>
         </label>
         <label for="switcher-disbursements" class="toggle">
           <input type="radio" class="js-chart-toggle" value="disbursements" id="switcher-disbursements" name="data_type" data-prefix="spending" aria-controls="processed-message" tabindex="0">
-          <span class="button--alt">Money spent</span>
+          <span class="button--alt button-last">Money spent</span>
         </label>
       </div>
     </fieldset>


### PR DESCRIPTION
## Summary 
This is a hotfix to fix responsive issues and rendering bugs with the homepage bar charts. 

## Impacted areas of the application
Home page raising/spending bar charts

## Screenshots
**Currently on production**

<img width="364" alt="Screen Shot 2019-04-19 at 12 25 54 AM" src="https://user-images.githubusercontent.com/5572856/56405312-d0f6bd80-6239-11e9-995d-2f82c81909e4.png">

**This hotfix**

<img width="378" alt="Screen Shot 2019-04-18 at 10 22 55 PM" src="https://user-images.githubusercontent.com/5572856/56405325-db18bc00-6239-11e9-842e-5c6e73763755.png">

### Also fixes this:
![med-size-bug](https://user-images.githubusercontent.com/5572856/56405698-72324380-623b-11e9-8951-ede9f6c976be.png)

## Related PRs
#2835
#2748

## How to test
Checkout and run hot fix branch and test that above bugs are fixed at small/med screen sizes
____

