### PR TITLE
Handle over-limit downloads

### DIFF
--- a/fec/fec/static/js/modules/download.js
+++ b/fec/fec/static/js/modules/download.js
@@ -194,7 +194,7 @@ DownloadItem.prototype.handleServerError = function(xhr) {
   } else {
     this.$body.html(
       '<div class="message message--alert message--mini">' +
-        'Sorry, there was a server error. Please try again later.' +
+        'Sorry, you have either exceeded your maximum downloads for the hour or encountered a server error. Please try again later.' +
         '</div>'
     );
   }

--- a/fec/fec/static/js/modules/download.js
+++ b/fec/fec/static/js/modules/download.js
@@ -157,7 +157,7 @@ DownloadItem.prototype.handleSuccess = function(response) {
 
 DownloadItem.prototype.handleError = function(xhr, textStatus) {
   if (textStatus === 'error') {
-    this.handleServerError();
+    this.handleServerError(xhr);
   } else if (textStatus !== 'abort') {
     this.schedule();
   } else if (xhr.status === 403) {
@@ -182,14 +182,22 @@ DownloadItem.prototype.close = function() {
   this.container.subtract();
 };
 
-DownloadItem.prototype.handleServerError = function() {
+DownloadItem.prototype.handleServerError = function(xhr) {
   // This is how we handle a 500 server error
   // First, display a message
-  this.$body.html(
-    '<div class="message message--alert message--mini">' +
-      'Sorry, there was a server error. Please try again later.' +
-      '</div>'
-  );
+  if (xhr.status === 429) {
+    this.$body.html(
+      '<div class="message message--alert message--mini">' +
+        'Sorry, you have exceeded your maximum downloads for the hour. Please try again later.' +
+        '</div>'
+    );
+  } else {
+    this.$body.html(
+      '<div class="message message--alert message--mini">' +
+        'Sorry, there was a server error. Please try again later.' +
+        '</div>'
+    );
+  }
 
   // Clear all traces of the downloadUrl
   window.clearTimeout(this.timeout);

--- a/tasks.py
+++ b/tasks.py
@@ -73,8 +73,7 @@ def _detect_space(repo, branch=None, yes=False):
 
 DEPLOY_RULES = (
     ('prod', _detect_prod),
-    #('stage', lambda _, branch: branch.startswith('release')),
-    ('stage', lambda _, branch: branch == 'feature/handle-over-limit-downloads'),
+    ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     #('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),

--- a/tasks.py
+++ b/tasks.py
@@ -73,7 +73,8 @@ def _detect_space(repo, branch=None, yes=False):
 
 DEPLOY_RULES = (
     ('prod', _detect_prod),
-    ('stage', lambda _, branch: branch.startswith('release')),
+    #('stage', lambda _, branch: branch.startswith('release')),
+    ('stage', lambda _, branch: branch == 'feature/handle-over-limit-downloads'),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     #('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),


### PR DESCRIPTION
## Summary

- Resolves #2842 
_Add specific 429 over rate limit error message when a post request is received. This will only work on first 429 error with a POST xhr call. Otherwise, print a generic error message that also warns of over rate limits when there is an error._

Also see this detailed explanation about error message handling for downloads: https://github.com/fecgov/fec-cms/issues/2842#issuecomment-497367683

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Datatable page downloads

## Screenshots
Below you will see that the initial error may give you the 429 error message. The subsequent request gives you the generic error message.

<img width="752" alt="Screen Shot 2019-05-30 at 12 31 04 PM" src="https://user-images.githubusercontent.com/12799132/58648173-1e555880-82d7-11e9-8446-e9f5436ac954.png">

## How to test
- Check out this branch and `npm run build`
- Query stage space for FEC_DOWNLOAD_API_KEY and set it in your environment
- Change FEC_API_URL to point to stage
- `./manage.py runserver`
- Check a datatable page, like candidates http://localhost:8000/data/candidates
- Do a bunch of exports until you hit the rate limit for the stage API. Right now it's set to 25 hits per IP per hour.
- Check error messages and make sure you're getting either the updated generic error message, seen in the screenshot above, or the exceeded limit error message, also seen in screenshot above.
____

