### PR TITLE
[MERGE BEFORE RELEASE] Raising-Spending barcharts - disable non-pres election years for Safari-and-IPhone

### DIFF
--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -103,9 +103,11 @@ TopEntities.prototype.updateElectionYearOptions = function(office) {
     // only show presential options
     $('#election-year option').each(function() {
       var optValue = parseInt($(this).val());
-      // hide all of the non-presidential election years
+      // hide all of the non-presidential election years/disable for Safari
       if (optValue % 4 !== 0) {
-        $(this).hide();
+        $(this)
+          .hide()
+          .prop('disabled', true);
       } else {
         // track the nearest future presidential election
         if (optValue > currentYear) {
@@ -122,8 +124,10 @@ TopEntities.prototype.updateElectionYearOptions = function(office) {
         .change();
     }
   } else {
-    // show all options!
-    $('#election-year option').show();
+    // show all options/enable for Safari!
+    $('#election-year option')
+      .show()
+      .prop('disabled', false);
   }
 };
 


### PR DESCRIPTION
## Summary
- Fixes Raising/Spending barcharts bug on IPhone and Safari desktop which was showing non-presidential years as select option for presidential  searches. If a non-pres years was chosen, it would present the user with  a meaningless, zero-sum bar chart.
-  Adds `disabled(true/false)` property to accommodate Safari Desktop/Mobile's lack of support for hide/show --- or any JS or CSS display property manipulation on `select options`

```
if (optValue % 4 !== 0) {
$(this).hide().prop('disabled', true);
...
else {
$('#election-year option').show().prop('disabled', false);
}
```
So I think the best solution is to `hide/show` and `disable/enable` them. This way Chrome and FF do not show the options, while Safari/IPhone show them as disabled and unclickable.

**BTW:** If we REALLY needed to remove the presidential options completely from view, this actually  works using `jQuery wrap(), unwrap()` but I did not think it was worthwhile to wrap it in them in all browsers just to accommodate one:
```
if (optValue % 4 !== 0) {
$(this)
.hide()
.wrap( "<span style='visibility:hidden'></span>" )

    ...

else {
$('#election-year option')
.show()
.unwrap("span")
}

(we have to keep the show/hide in here to trigger the default-to-2020 expression when switching from H/S to P while on non pres year)
```
<hr>
Because of Safari's vigilant adherence to  its user-agent stylesheets for select options, we have no ability to  enhance UX by adding conditional CSS to more clearly delineate visible, yet disabled options. 

- Resolves #2851

## Impacted areas of the application
modified:   fec/static/js/modules/top-entities.js_
Impacts stand-alone and home raising/spending barcharts 

## Screenshots
### IPhone:
![ezgif com-resize](https://user-images.githubusercontent.com/5572856/56552611-d285f580-6559-11e9-87fb-ab401a823226.gif)
### Safari:
![Apr-22-2019 22-46-55](https://user-images.githubusercontent.com/5572856/56552379-175d5c80-6559-11e9-810b-4f47b4865fb6.gif)

## Related PRs
#2848 : Hotfix for rendering bugs and responsive issues with home bar charts 

## How to test
Checkout feature/disable-non-pres-elections-choice-safari-and-iphone
Run npm run buld
Test in Safari to make sure that non-pres-years are disabled for presidential searches and available for house/senate searches

Note:  I tested this on IPhone by pointing iPhone to local servers IP address and temporarily setting ALLOWED_HOSTS to ['*'] in settings/dev.py. I think you also need to have your Mac and your iphone using the same WIFI network to do this. 
____

