### PR TITLE
Polyfill ES6-object-assign for homepage apps

### DIFF
--- a/fec/fec/static/js/object-assign-polyfill.js
+++ b/fec/fec/static/js/object-assign-polyfill.js
@@ -1,0 +1,29 @@
+if (typeof Object.assign != 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, "assign", {
+    value: function assign(target, varArgs) { // .length of function is 2
+      'use strict';
+      if (target == null) { // TypeError if undefined or null
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource != null) { // Skip over if undefined or null
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    },
+    writable: true,
+    configurable: true
+  });
+}

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -154,6 +154,7 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="{% asset_for_js 'object-assign-polyfill.js' %}"></script>
 <script src="{% asset_for_js 'home.js' %}"></script>
 <script src="{% asset_for_js 'bythenumbers.js' %}"></script>
 <script src="{% asset_for_js 'dataviz-common.js' %}"></script>


### PR DESCRIPTION
## Summary
Dropdowns on Home barcharts do not work  in Internet Explorer 11 on FEC-issued MS Surface, some other Windows 7/10 machines  and some Android browsers. This is because  some versions of IE 11 and some Android browsers  lack  support for `ES6  object-assign`. "Versions" of IE11 refers to the WIndows Build Pack and possibly other configurations on the machine on which it is running. 

The standalone barcharts, however, do work here because they reside in /data and get the a polyfill through that build process. Including the polyfill in the same way to /home throws an error:
 ``` 
Uncaught SyntaxError: Unexpected string...
    import 'babel-polyfill';
```
I was unable to resolve the error by editing `webpack.config` , so I just include a separate polyfill for the homepage only. 

@rfultz likely knows how to include this polyfill in the build without error in /home. If so, I  could use that technique and would like to pair on editing `webpack.config` (or whatever else needs to be edited).  Otherwise, the solution in this PR works with one new file and one line of code. 

- Resolves #2868

## Impacted areas of the application
new file:   fec/static/js/object-assign-polyfill.js
modified:   home/templates/home/home_page.html

## How to test
This has been tested on the Android browser and works now.
- Test this on the [feature space](https://fec-feature-cms.app.cloud.gov/)  in Internet Explorer on your MS Surface (Or other IE environment where it does not work on prod, currently) 
  - Confirm (in IE) that when changing the  `HOW MUCH HAS BEEN RAISED BY` and `RUNNING IN` dropdowns, the barchart updates. 
https://fec-feature-cms.app.cloud.gov/

--OR--
- Checkout and run, `feature/object-assign-polyfill-for-homepage`
- Test Locally by pointing your MS Surface to your local servers IP address: [WIKI instructions here &#187;](https://github.com/fecgov/fec-cms/wiki/Testing-a-dev-branch-on-iPhone,-Internet-Explorer-WIndows,-Android)
- Confirm (in IE) that when changing the  `HOW MUCH HAS BEEN RAISED BY` and `RUNNING IN` dropdowns, the barchart updates. 


