### PR TITLE
Update image of FECA compilation

### DIFF
--- a/fec/legal/templates/legal-statutes-landing.jinja
+++ b/fec/legal/templates/legal-statutes-landing.jinja
@@ -50,7 +50,7 @@
       <li>
         <p>Access the FEC’s compilation of statutes. That PDF contains Title 52, Subtitle III, Title 26, Subtitle H and additional provisions of the U.S. Code that aren’t enforced by FEC but are relevant to people involved in federal elections.</p>
         <div class="grid grid--2-wide">
-          {{ document.thumbnail("Federal Election Campaign Laws by the FEC", "https://www.fec.gov/resources/cms-content/documents/feca.pdf", img="img/thumbnail--feca.jpg", size="2.58MB") }}
+          {{ document.thumbnail("Federal Election Campaign Laws by the FEC", "https://www.fec.gov/resources/cms-content/documents/feca.pdf", img="/resources/cms-content/images/thumbnail--feca.original.jpg", size="2.58MB") }}
         </div>
       </li>
       <li>


### PR DESCRIPTION
- Resolves #[_2859_]

Updates the image of the FECA compilation  "Federal Election Campaign Laws" to look like the current 2019 edition's cover.

See on https://www.fec.gov/data/legal/statutes/

## Screenshots
Before: 
![image](https://user-images.githubusercontent.com/24437369/57036430-455e3300-6c22-11e9-9f2d-fa576b2416db.png)

After: image should look like 
![image](https://user-images.githubusercontent.com/24437369/57036457-53ac4f00-6c22-11e9-9553-338b47eb4e94.png)

## How to test
Verify that image used matches the second picture.
