### PR TITLE
Add task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task-issue.md
+++ b/.github/ISSUE_TEMPLATE/task-issue.md
@@ -1,0 +1,30 @@
+---
+name: Task issue
+about: Template to help guide task related issues
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Summary
+**What we're after:**
+_Briefly describe the goal or user story for this issue. Be sure to add any dependencies down below if there are any._
+
+### Related issues
+
+_List any relevant related issue(s)_
+- #[issue_number]
+- #[issue_number]
+
+### Completion criteria
+
+_List action items that need to be done to complete this task. List in checklist formatting._
+- [ ] First item to complete
+- [ ] Second item to complete
+- [ ] Follow-up tasks such as set up redirect, create new issue
+- [ ] etc
+
+### Future work
+
+_Other future work that may be needed following this issue's completion._

--- a/.github/ISSUE_TEMPLATE/task-issue.md
+++ b/.github/ISSUE_TEMPLATE/task-issue.md
@@ -8,6 +8,7 @@ assignees: ''
 ---
 
 ### Summary
+
 **What we're after:**
 _Briefly describe the goal or user story for this issue. Be sure to add any dependencies down below if there are any._
 


### PR DESCRIPTION
## Summary

- Resolves #2887
_This PR adds a "Task issue" to our list of github issue templates._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  fec-cms repo

## Screenshot
![Screen Shot 2019-05-06 at 1 49 54 PM](https://user-images.githubusercontent.com/12799132/57244318-20910380-7006-11e9-92bb-ba39bbcf083a.png)

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/2820-new-issue-template | [link](https://github.com/fecgov/fec-cms/pull/2874)

## How to test
There's no way to visually test this, so please refer to the screenshot above to see what this template would look like.
____

