### PR TITLE
Remediate Snyk-reported vulnerability for jQuery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8083,9 +8083,9 @@
       }
     },
     "jquery": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
-      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "jquery.inputmask": {
       "version": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fullcalendar": "3.3.1",
     "glossary-panel": "1.0.0",
     "hoek": "^5.0.4",
-    "jquery": "3.2.1",
+    "jquery": "3.4.1",
     "jquery.inputmask": "3.3.4",
     "leaflet-providers": "1.1.6",
     "lodash": "^4.17.11",


### PR DESCRIPTION
## Summary:
Snyk medium level vulnerability for jQuery javascript library that makes the application vulnerable to prototype pollution which could lead to denial of service (breaking code) or remote code execution.

Snyk report: https://app.snyk.io/vuln/SNYK-JS-JQUERY-174006

**Introduced through: jquery@3.0.0:**
As of  `jQuery3.0.0`,  the `extend function` can be tricked into modifying the prototype of Object when the attacker controls part of the structure passed to this function. This can let an attacker add or modify an existing property that will then exist on all objects, not just the one being referenced via `extend()`.

**Remediation: Upgrade to jquery@3.4.0:**
jQuery 3.4.0 includes a fix for some unintended behavior when using jQuery.extend(true, {}, ...). If an unsanitized source object contained an enumerable __proto__ property, it could extend the native Object.prototype. This fix is included in jQuery 3.4.0 ( patch diffs exist to patch previous jQuery versions)
**Source: see Minor vulnerability fix: Object.prototype pollution here:**: https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/

- Resolves #2823

## Impacted areas of the application
Upgraded jQuery from `3.2.3` to `3.4.1`
modified:   ../package-lock.json
modified:   ../package.json

**Note:** Generally in our JS modules, we use the Underscore library's `._extend()` convenience function which  has been replaced in some places with native ES6 `Object​.assign()`.  However, jQuery's `$.extend` is commonly used in Plugin development and is found in our calendar and dropdown menu code for example.
