### PR TITLE
Add tests for datatable rendering

### DIFF
--- a/fec/data/tests/test_datatables.py
+++ b/fec/data/tests/test_datatables.py
@@ -21,7 +21,7 @@ class TestDatatablesRender(TestCase):
 
     def test_disbursements(self):
         response = client.get('/data/disbursements/')
-        assert response.status_code == 200
+        assert response.status_code in (200, 302)
 
     def test_independent_expenditures(self):
         response = client.get('/data/independent-expenditures/')

--- a/fec/data/tests/test_datatables.py
+++ b/fec/data/tests/test_datatables.py
@@ -10,79 +10,79 @@ class TestDatatablesRender(TestCase):
     # Raising
 
     def test_receipts(self):
-        response = client.get('/data/receipts/')
+        response = client.get('/data/receipts/', follow=True)
         assert response.status_code == 200
 
     def test_individual_contributions(self):
-        response = client.get('/data/individual-contributions/')
+        response = client.get('/data/individual-contributions/', follow=True)
         assert response.status_code == 200
 
     # Spending
 
     def test_disbursements(self):
-        response = client.get('/data/disbursements/')
-        assert response.status_code in (200, 302)
+        response = client.get('/data/disbursements/', follow=True)
+        assert response.status_code == 200
 
     def test_independent_expenditures(self):
-        response = client.get('/data/independent-expenditures/')
+        response = client.get('/data/independent-expenditures/', follow=True)
         assert response.status_code == 200
 
     def test_party_coordinated_expenditures(self):
-        response = client.get('/data/party-coordinated-expenditures/')
+        response = client.get('/data/party-coordinated-expenditures/', follow=True)
         assert response.status_code == 200
 
     def test_electioneering_communications(self):
-        response = client.get('/data/electioneering-communications/')
+        response = client.get('/data/electioneering-communications/', follow=True)
         assert response.status_code == 200
 
     def test_communication_costs(self):
-        response = client.get('/data/communication-costs/')
+        response = client.get('/data/communication-costs/', follow=True)
         assert response.status_code == 200
 
     # Loans and Debts
     def test_loans(self):
-        response = client.get('/data/loans/')
+        response = client.get('/data/loans/', follow=True)
         assert response.status_code == 200
 
     # Candidates
 
     def test_all_candidates(self):
-        response = client.get('/data/candidates/')
+        response = client.get('/data/candidates/', follow=True)
         assert response.status_code == 200
 
     def test_presidential_candidates(self):
-        response = client.get('/data/candidates/president/')
+        response = client.get('/data/candidates/president/', follow=True)
         assert response.status_code == 200
 
     def test_senate_candidates(self):
-        response = client.get('/data/candidates/senate/')
+        response = client.get('/data/candidates/senate/', follow=True)
         assert response.status_code == 200
 
     def test_house_candidates(self):
-        response = client.get('/data/candidates/house/')
+        response = client.get('/data/candidates/house/', follow=True)
         assert response.status_code == 200
 
     # Committees
 
     def test_all_committees(self):
-        response = client.get('/data/committees/')
+        response = client.get('/data/committees/', follow=True)
         assert response.status_code == 200
 
     # Filings and reports
 
     def test_all_filings(self):
-        response = client.get('/data/filings/')
+        response = client.get('/data/filings/', follow=True)
         assert response.status_code == 200
 
     def test_presidential_reports(self):
-        response = client.get('/data/reports/presidential/')
+        response = client.get('/data/reports/presidential/', follow=True)
         assert response.status_code == 200
 
     def test_house_senate_reports(self):
-        response = client.get('/data/reports/house-senate/')
+        response = client.get('/data/reports/house-senate/', follow=True)
         assert response.status_code == 200
 
     def test_pac_party_reports(self):
-        response = client.get('/data/reports/pac-party/')
+        response = client.get('/data/reports/pac-party/', follow=True)
         assert response.status_code == 200
 

--- a/fec/data/tests/test_datatables.py
+++ b/fec/data/tests/test_datatables.py
@@ -1,0 +1,88 @@
+from django.test import Client
+from django.test import TestCase
+
+
+client = Client()
+
+
+class TestDatatablesRender(TestCase):
+
+    # Raising
+
+    def test_receipts(self):
+        response = client.get('/data/receipts/')
+        assert response.status_code == 200
+
+    def test_individual_contributions(self):
+        response = client.get('/data/individual-contributions/')
+        assert response.status_code == 200
+
+    # Spending
+
+    def test_disbursements(self):
+        response = client.get('/data/disbursements/')
+        assert response.status_code == 200
+
+    def test_independent_expenditures(self):
+        response = client.get('/data/independent-expenditures/')
+        assert response.status_code == 200
+
+    def test_party_coordinated_expenditures(self):
+        response = client.get('/data/party-coordinated-expenditures/')
+        assert response.status_code == 200
+
+    def test_electioneering_communications(self):
+        response = client.get('/data/electioneering-communications/')
+        assert response.status_code == 200
+
+    def test_communication_costs(self):
+        response = client.get('/data/communication-costs/')
+        assert response.status_code == 200
+
+    # Loans and Debts
+    def test_loans(self):
+        response = client.get('/data/loans/')
+        assert response.status_code == 200
+
+    # Candidates
+
+    def test_all_candidates(self):
+        response = client.get('/data/candidates/')
+        assert response.status_code == 200
+
+    def test_presidential_candidates(self):
+        response = client.get('/data/candidates/president/')
+        assert response.status_code == 200
+
+    def test_senate_candidates(self):
+        response = client.get('/data/candidates/senate/')
+        assert response.status_code == 200
+
+    def test_house_candidates(self):
+        response = client.get('/data/candidates/house/')
+        assert response.status_code == 200
+
+    # Committees
+
+    def test_all_committees(self):
+        response = client.get('/data/committees/')
+        assert response.status_code == 200
+
+    # Filings and reports
+
+    def test_all_filings(self):
+        response = client.get('/data/filings/')
+        assert response.status_code == 200
+
+    def test_presidential_reports(self):
+        response = client.get('/data/reports/presidential/')
+        assert response.status_code == 200
+
+    def test_house_senate_reports(self):
+        response = client.get('/data/reports/house-senate/')
+        assert response.status_code == 200
+
+    def test_pac_party_reports(self):
+        response = client.get('/data/reports/pac-party/')
+        assert response.status_code == 200
+


### PR DESCRIPTION
## Summary (required)

- Resolves issue found in testing where we accidentally broke some data tables with a refactor and tests passed

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Test coverage for data tables

## How to test
 - `git checkout 4230b12b79d593312f5f427f20eec0ebbf764336` (From https://github.com/fecgov/fec-cms/pull/2914)
- Run `pytest` from `fec-cms` home directory
- Tests should fail
