### PR TITLE
Update house candidate datatable to show full election results

### DIFF
--- a/fec/data/templates/macros/filters/election-filter.jinja
+++ b/fec/data/templates/macros/filters/election-filter.jinja
@@ -3,7 +3,7 @@
     {% set duration = 4 %}
     {% set years = range(constants.DEFAULT_PRESIDENTIAL_YEAR, 1976, -4) %}
     {% set default_cycle = constants.DEFAULT_PRESIDENTIAL_YEAR %}
-  {% elif office == 'senate' %}
+  {% elif office in ['house', 'senate'] %}
     {% set duration = 6 %}
     {% set years = range(constants.DEFAULT_ELECTION_YEAR + 4, 1976, -2) %}
     {% set default_cycle = constants.DEFAULT_ELECTION_YEAR %}
@@ -25,21 +25,16 @@
     {% endfor %}
   </select>
   {% if office in ['president', 'senate'] %}
-  <fieldset class="toggles toggles--vertical">
-    <legend class="label">Time period</legend>
-    <div class="js-cycles"></div>
-  </fieldset>
-  <input type="hidden" name="{{ cycle_name }}" />
-  <input type="hidden" name="{{ full_name }}" />
+    <fieldset class="toggles toggles--vertical">
+      <legend class="label">Time period</legend>
+      <div class="js-cycles"></div>
+    </fieldset>
+    <input type="hidden" name="{{ cycle_name }}" />
+    <input type="hidden" name="{{ full_name }}" />
+  {% else %}
+    <!-- House candidates should always be election_full=True -->
+    <input type="hidden" name="{{ full_name }}" value="True" />
   {% endif %}
-</div>
-{% endmacro %}
 
-{% macro single_cycle(name, title) %}	
-  <label class="label" for="{{ name }}">{{ title }}</label>	
-  <select id="{{name}}" name="{{ name }}" class="js-election select--full">	
-    {% for year in range(2020, 1976, -2) %}	
-      <option value="{{ year }}" {% if year == constants.DEFAULT_TIME_PERIOD %}selected{% endif %}>{{ year|fmt_year_range }}</option>	
-    {% endfor %}	
-  </select>	
+</div>
 {% endmacro %}

--- a/fec/data/templates/partials/candidates-office-filter.jinja
+++ b/fec/data/templates/partials/candidates-office-filter.jinja
@@ -1,47 +1,43 @@
-{% extends 'partials/filters.jinja' %}	
+{% extends 'partials/filters.jinja' %}
 
-{% import 'macros/filters/text.jinja' as text %}	
-{% import 'macros/filters/parties.jinja' as parties %}	
-{% import 'macros/filters/states.jinja' as states %}	
-{% import 'macros/filters/districts.jinja' as districts %}	
-{% import 'macros/filters/typeahead-filter.jinja' as typeahead %}	
-{% import 'macros/filters/election-filter.jinja' as election_filter %}	
-{% import 'macros/filters/range.jinja' as range_filter %}	
-{% import 'macros/filters/years.jinja' as years %}	
+{% import 'macros/filters/text.jinja' as text %}
+{% import 'macros/filters/parties.jinja' as parties %}
+{% import 'macros/filters/states.jinja' as states %}
+{% import 'macros/filters/districts.jinja' as districts %}
+{% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
+{% import 'macros/filters/election-filter.jinja' as election_filter %}
+{% import 'macros/filters/range.jinja' as range_filter %}
+{% import 'macros/filters/years.jinja' as years %}
 
- {% block filters %}	
-<div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">	
-  <div class="filters__inner">	
-    {{ typeahead.field('q', 'Candidate name or ID', '', dataset='candidates', allow_text=True) }}	
-    {% if table_context['office'] == 'house' %}	
-      {{ election_filter.single_cycle('cycle', 'Two-year period') }}	
-    {% else %}	
-      {{ election_filter.full_cycle('election_year', 'Election year', 'cycle', 'election_full', table_context['office']) }}	
-      <input id="election_full" name="election_full" type="checkbox" value="true">	
-    {% endif %}	
-  </div>	
-  <button type="button" class="js-accordion-trigger accordion__button">Candidate information</button>	
-  <div class="accordion__content">	
-    {{ parties.checkbox() }}	
-    {% if table_context['office'] in ['senate', 'house'] %}	
-      {{ states.field('state') }}	
-    {% endif %}	
-    {% if table_context['office'] == 'house' %}	
-      {{ districts.dropdown() }}	
-    {% endif %}	
-  </div>	
-  <button type="button" class="js-accordion-trigger accordion__button">Candidate financials</button>	
-  <div class="accordion__content">	
-    {{ range_filter.amount('receipts', 'Total receipts') }}	
-    {{ range_filter.amount('disbursements', 'Total disbursements') }}	
-    {{ range_filter.amount('cash_on_hand_end_period', 'Cash on hand') }}	
-    {{ range_filter.amount('debts_owed_by_committee', 'Debts owed by committee') }}	
-    {% if table_context['office'] == 'president' %}	
-      <div class="js-filter" data-filter="checkbox">	
-        <input id="federal-funds-flag" name="federal_funds_flag" type="checkbox" value="true">	
-        <label class="dropdown__value" for="federal-funds-flag">Has accepted presidential public funds</label>	
-      </div>	
-    {% endif %}	
-  </div>	
-</div>	
+ {% block filters %}
+<div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
+  <div class="filters__inner">
+    {{ typeahead.field('q', 'Candidate name or ID', '', dataset='candidates', allow_text=True) }}
+    {{ election_filter.full_cycle('election_year', 'Election year', 'cycle', 'election_full', table_context['office']) }}
+    <input id="election_full" name="election_full" type="checkbox" value="true">
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Candidate information</button>
+  <div class="accordion__content">
+    {{ parties.checkbox() }}
+    {% if table_context['office'] in ['senate', 'house'] %}
+      {{ states.field('state') }}
+    {% endif %}
+    {% if table_context['office'] == 'house' %}
+      {{ districts.dropdown() }}
+    {% endif %}
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Candidate financials</button>
+  <div class="accordion__content">
+    {{ range_filter.amount('receipts', 'Total receipts') }}
+    {{ range_filter.amount('disbursements', 'Total disbursements') }}
+    {{ range_filter.amount('cash_on_hand_end_period', 'Cash on hand') }}
+    {{ range_filter.amount('debts_owed_by_committee', 'Debts owed by committee') }}
+    {% if table_context['office'] == 'president' %}
+      <div class="js-filter" data-filter="checkbox">
+        <input id="federal-funds-flag" name="federal_funds_flag" type="checkbox" value="true">
+        <label class="dropdown__value" for="federal-funds-flag">Has accepted presidential public funds</label>
+      </div>
+    {% endif %}
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary (required)

Part one of https://github.com/fecgov/openFEC/issues/3673 
- Update the front end house candidates total to pass `election_full=True` and `election_year=2020` because results are correct
- Relabel time frame from two-year-period to election year to match other data tables


## Impacted areas of the application
List general components of the application that this PR will affect:

-  House candidate datables

## Screenshots

### Before
![Screen Shot 2019-05-29 at 10 53 50 AM](https://user-images.githubusercontent.com/31420082/58567504-73726b00-8200-11e9-9a9f-d7fb1cf7ab19.png)

### After
![Screen Shot 2019-05-29 at 10 55 03 AM](https://user-images.githubusercontent.com/31420082/58567509-753c2e80-8200-11e9-9d65-008505849f13.png)



## How to test
- house datatable for MI 3 http://localhost:8000/data/candidates/house/?election_year=2020&election_full=True&state=MI&district=03 should show six results, which matches candidate datatable in production: 
https://www.fec.gov/data/candidates/?election_year=2020&state=MI&district=03

