### PR TITLE
#2822 - Update requirements.txt to Jinja2==2.10.1 from 2.9.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ whitenoise==2.0.3
 wagtail==2.2.1
 # TODO: pin version
 django-audit-log
-Jinja2==2.9.6
+Jinja2==2.10.1
 django_jinja==2.4.1
 CacheControl==0.11.5
 cachetools==1.0.2


### PR DESCRIPTION
## Summary

Upgrading Jinja from 2.9.6 to 2.10.1 

- Resolves #2822 

## Impacted areas of the application
Only requirements.txt was changed and the site shouldn't see any other impact, but here are the [release notes for 2.10.1](http://jinja.pocoo.org/docs/2.10/changelog/).

## Screenshots
No visual changes

## Related PRs
None

## How to test
- Pull the branch
- If `manage.py` is running, close it
- Go to the root directory beside `requirements.txt`
- Run `pip install -r requirements.txt`
- Let it do its thing
- Go back into `./fec` to run `manage.py` (`./manage.py runserver`)
- Check the site for any hiccups
____

