### PR TITLE
Added DFL party to blue bar styles for Democrats

### DIFF
--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -203,7 +203,7 @@ h3 + .simple-table {
     background-color: $gray-dark;
     height: u(2rem);
 
-    &[data-party="DEM"] {
+    &[data-party="DEM"], &[data-party="DFL"] {
       background-color: $blue-data;
     }
 


### PR DESCRIPTION
## Summary

- Resolves #2918 
_This adds `data-party="DFL"` to the styles for blue bars on raising and spending._

## Impacted areas of the application
List general components of the application that this PR will affect:

- http://localhost:8000/data/raising-bythenumbers/
-  http://localhost:8000/data/spending-bythenumbers/

## Screenshots

Right now the change is only apparent in the 2020 house numbers.

<img width="726" alt="Screen Shot 2019-05-30 at 11 47 08 AM" src="https://user-images.githubusercontent.com/12799132/58645562-9c166580-82d1-11e9-8abe-9d55ce425a47.png">

## How to test
- Check out the PR and `npm run build` to compile the new style.
- Go to https://www.fec.gov/data/raising-bythenumbers/?office=H
- Make sure the DFL party is blue instead of gray
____

