### PR TITLE
Add checkbox to exclude incumbents that are not seeking re-election

### DIFF
--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -7,7 +7,7 @@
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
-          <h4><a href="/data/candidates/?has_raised_funds=true">All candidates</a></h4>
+          <h4><a href="/data/candidates/?has_raised_funds=true&is_active_candidate=true">All candidates</a></h4>
           <p class ="u-margin--bottom">Search candidates for president, Senate and House for all years by location, party and more.</p>
           <div class="js-accordion accordion--neutral" data-content-prefix="all-candidates">
             <button type="button" class="js-accordion-trigger accordion__button">Download this data as .CSV to use on your own</button>
@@ -42,14 +42,14 @@
       <li>
        <i class="icon i-magnifying-glass icon--absolute--left"></i>
        <div class="content__section--indent-left">
-         <h4><a href="/data/candidates/senate/">Senate candidates</a></h4>
+         <h4><a href="/data/candidates/senate/?is_active_candidate=true">Senate candidates</a></h4>
          <p>Search Senate candidate data including money raised, money spent, cash on hand and debt.</p>
        </div>
       </li>
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
-          <h4><a href="/data/candidates/house/">House of Representatives candidates</a></h4>
+          <h4><a href="/data/candidates/house/?is_active_candidate=true">House of Representatives candidates</a></h4>
           <p>Search House candidate data including money raised, money spent, cash on hand and debt.</p>
          </div>
       </li>

--- a/fec/data/templates/partials/candidates-filter.jinja
+++ b/fec/data/templates/partials/candidates-filter.jinja
@@ -11,13 +11,12 @@
 {% block filters %}
 <div class="filters__inner">
   {{ typeahead.field('q', 'Candidate name or ID', '', dataset='candidates', allow_text=True) }}
-
   {{ years.years('election_year', 'Election year', end_year=constants.END_YEAR + 4) }}
   {{ office.checkbox() }}
   {{ parties.checkbox() }}
   {{ states.field('state') }}
   {{ districts.dropdown() }}
-
+  {% include 'partials/filters/active-candidates.jinja' %}
   {{ date.field('first_file_date', 'Date first filed statement of candidacy', '') }}
   <div class="filter">
     <fieldset class="js-filter" data-filter="checkbox">

--- a/fec/data/templates/partials/candidates-office-filter.jinja
+++ b/fec/data/templates/partials/candidates-office-filter.jinja
@@ -24,6 +24,9 @@
     {% if table_context['office'] == 'house' %}
       {{ districts.dropdown() }}
     {% endif %}
+    {% if table_context['office'] in ['senate', 'house'] %}
+      {% include 'partials/filters/active-candidates.jinja' %}
+    {% endif %}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Candidate financials</button>
   <div class="accordion__content">

--- a/fec/data/templates/partials/filters/active-candidates.jinja
+++ b/fec/data/templates/partials/filters/active-candidates.jinja
@@ -1,0 +1,11 @@
+<div class="filter">
+<fieldset class="js-filter" data-filter="checkbox">
+  <legend class="label">Candidate status</legend>
+  <ul>
+    <li>
+      <input id="cycle-checkbox-is-active-candidate" name="is_active_candidate" type="checkbox" value="true">
+      <label for="cycle-checkbox-is-active-candidate">Exclude incumbents not seeking re-election</label>
+    </li>
+  </ul>
+</fieldset>
+</div>


### PR DESCRIPTION
## Summary (required)

- Resolves #2927
Add checkbox to exclude incumbents that are not seeking re-election

## Impacted areas of the application
List general components of the application that this PR will affect:

- Default views when clicking to the following datatables from http://localhost:8000/data/browse-data/?tab=candidates
- http://localhost:8000/data/candidates/
- http://localhost:8000/data/candidates/senate/
- http://localhost:8000/data/candidates/house/

## Screenshots

### All candidates datatable
![Screen Shot 2019-06-12 at 3 40 37 PM](https://user-images.githubusercontent.com/31420082/59381084-a9e3d600-8d28-11e9-8be4-0892903388a6.png)

### Senate candidates datatable
![Screen Shot 2019-06-12 at 3 41 16 PM](https://user-images.githubusercontent.com/31420082/59381097-ae0ff380-8d28-11e9-8660-f0f97398c0c0.png)

### House candidates datatable
![Screen Shot 2019-06-12 at 3 41 32 PM](https://user-images.githubusercontent.com/31420082/59381101-b10ae400-8d28-11e9-883d-a794baf55bbc.png)

