### PR TITLE
Update missing processed data message

### DIFF
--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -443,15 +443,15 @@ function missingDataReason(dataType) {
   // Returns a string explaining why data may not be showing
   // which is then used by the noData.hbs message
   var reasons = {
-    contributions: 'The committee has not received any contributions over $200',
-    disbursements: 'The committee has not made any disbursements',
+    contributions: 'The committee has not received any contributions over $200.',
+    disbursements: 'The committee has not made any disbursements.',
     'independent-expenditures':
-      'No independent expenditures have been made in support or opposition of this candidate',
+      'No independent expenditures have been made in support or opposition of this candidate.',
     'communication-costs':
-      'No communication costs have been made in support or opposition of this candidate',
+      'No communication costs have been made in support or opposition of this candidate.',
     electioneering:
-      'No electioneering communications have been made that mention this candidate',
-    'ie-made': 'The committee has not made any independent expenditures'
+      'No electioneering communications have been made that mention this candidate.',
+    'ie-made': 'The committee has not made any independent expenditures.'
   };
 
   return reasons[dataType] || false;

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -443,7 +443,8 @@ function missingDataReason(dataType) {
   // Returns a string explaining why data may not be showing
   // which is then used by the noData.hbs message
   var reasons = {
-    contributions: 'The committee has not received any contributions over $200.',
+    contributions:
+      'The committee has not received any contributions over $200.',
     disbursements: 'The committee has not made any disbursements.',
     'independent-expenditures':
       'No independent expenditures have been made in support or opposition of this candidate.',

--- a/fec/fec/static/js/object-assign-polyfill.js
+++ b/fec/fec/static/js/object-assign-polyfill.js
@@ -1,9 +1,11 @@
 if (typeof Object.assign != 'function') {
   // Must be writable: true, enumerable: false, configurable: true
-  Object.defineProperty(Object, "assign", {
-    value: function assign(target, varArgs) { // .length of function is 2
+  Object.defineProperty(Object, 'assign', {
+    value: function assign(target, varArgs) {
+      // .length of function is 2
       'use strict';
-      if (target == null) { // TypeError if undefined or null
+      if (target == null) {
+        // TypeError if undefined or null
         throw new TypeError('Cannot convert undefined or null to object');
       }
 
@@ -12,7 +14,8 @@ if (typeof Object.assign != 'function') {
       for (var index = 1; index < arguments.length; index++) {
         var nextSource = arguments[index];
 
-        if (nextSource != null) { // Skip over if undefined or null
+        if (nextSource != null) {
+          // Skip over if undefined or null
           for (var nextKey in nextSource) {
             // Avoid bugs when hasOwnProperty is shadowed
             if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -565,7 +565,7 @@ $(document).ready(function() {
             singleEntityItemizedExport: true,
             paginator: tables.SeekPaginator,
             hideEmptyOpts: {
-              dataType: 'disbursements to committees',
+              dataType: 'disbursements',
               name: context.name,
               reason: helpers.missingDataReason('disbursements'),
               timePeriod: context.timePeriod
@@ -590,7 +590,7 @@ $(document).ready(function() {
             singleEntityItemizedExport: true,
             paginator: tables.SeekPaginator,
             hideEmptyOpts: {
-              dataType: 'disbursements to committees',
+              dataType: 'disbursements',
               name: context.name,
               reason: helpers.missingDataReason('disbursements'),
               timePeriod: context.timePeriod
@@ -615,7 +615,7 @@ $(document).ready(function() {
             callbacks: aggregateCallbacks,
             order: [[1, 'desc']],
             hideEmptyOpts: {
-              dataType: 'disbursements to committees',
+              dataType: 'disbursements',
               name: context.name,
               reason: helpers.missingDataReason('disbursements'),
               timePeriod: context.timePeriod

--- a/fec/fec/static/js/templates/tables/noData.hbs
+++ b/fec/fec/static/js/templates/tables/noData.hbs
@@ -5,13 +5,15 @@
     <ul class="list--bulleted">
       {{#if reason }}
         <li>{{reason}}</li>
+      {{ else }}
+        <li>No one filed this type of activity during the time period.</li>
       {{/if}}
       <li>
         We’re still processing the data. Try looking for
         <a href="https://www.fec.gov/data/filings/?data_type=efiling" target="_blank" rel="noopener noreferrer">raw versions of committee filings</a>.
         Raw files are only available for electronic filers.
       </li>
-      <li>No one filed this type of activity during the time period.</li>
+
       <li>The filing deadline hasn’t passed yet.</li>
     </ul>
 

--- a/fec/fec/static/js/templates/tables/noData.hbs
+++ b/fec/fec/static/js/templates/tables/noData.hbs
@@ -1,13 +1,11 @@
 <div class="message message--info">
   <p>We don't have <strong>{{dataType}}</strong> for <strong>{{timePeriod}}</strong>.</p>
-  {{#if reason }}
-    <p>This is because:</p>
-    <ul class="list--bulleted">
-      <li>{{reason}}</li>
-    </ul>
-  {{else}}
+
     <p>This can be because:</p>
     <ul class="list--bulleted">
+      {{#if reason }}
+        <li>{{reason}}</li>
+      {{/if}}
       <li>
         We’re still processing the data. Try looking for
         <a href="https://www.fec.gov/data/filings/?data_type=efiling" target="_blank" rel="noopener noreferrer">raw versions of committee filings</a>.
@@ -16,7 +14,7 @@
       <li>No one filed this type of activity during the time period.</li>
       <li>The filing deadline hasn’t passed yet.</li>
     </ul>
-  {{/if}}
+
   <div class="message--alert__bottom">
     <p>Think this result is a mistake or have questions?</p>
     <p>


### PR DESCRIPTION
## Summary (required)

Resolves #2895 
- Add default 'no data' messages to specific datatype 'no data' messages. 
1) Either show data-specific messages or "No one filed this type of activity during the time period." 
2) Still processing the data
3) Filing deadline hasn't passed
- Relabel disbursements from `disbursements to committees` to `disbursements` - not all disbursements are to committees

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate/Committee profile pages: Raising/Spending tabs "no data" messages

## Screenshots

### Before
![Screen Shot 2019-05-31 at 3 54 11 PM](https://user-images.githubusercontent.com/31420082/58731320-6ac69400-83bc-11e9-9083-b69d03e867da.png)

### After
![Screen Shot 2019-05-31 at 4 48 25 PM](https://user-images.githubusercontent.com/31420082/58733945-0c051880-83c4-11e9-8ff3-6d8e02dc4959.png)



### Before
![Screen Shot 2019-05-31 at 3 58 36 PM](https://user-images.githubusercontent.com/31420082/58731567-11129980-83bd-11e9-9b61-719ec0442003.png)

### After
![Screen Shot 2019-05-31 at 4 48 55 PM](https://user-images.githubusercontent.com/31420082/58733952-0f989f80-83c4-11e9-8196-c924eb279cfd.png)


## Related PRs
https://github.com/fecgov/fec-cms/pull/1989

## Testing links
- http://localhost:8000/data/committee/C00508184/?tab=raising
- http://localhost:8000/data/committee/C00508184/?tab=spending
- http://localhost:8000/data/committee/C00583567/?tab=raising
