### PR TITLE
Fix disbursement date range and add default date range to redirect

### DIFF
--- a/fec/data/templates/partials/disbursements-filter.jinja
+++ b/fec/data/templates/partials/disbursements-filter.jinja
@@ -28,7 +28,7 @@ Filter disbursements
   {{ typeahead.field('committee_id', 'Spender name or ID') }}
   {{ typeahead.field('recipient_name', 'Recipient name or ID', allow_text=True) }}
   {{ years.cycles('two_year_transaction_period', 'Report time period', show_tooltip=True)  }}
-  {{ date.field('disbursement_date_range', 'Disbursement date range' ) }}
+  {{ date.field('date', 'Disbursement date range' ) }}
 </div>
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <button type="button" class="js-accordion-trigger accordion__button">Recipient details</button>

--- a/fec/data/views_datatables.py
+++ b/fec/data/views_datatables.py
@@ -57,9 +57,14 @@ def communication_costs(request):
     })
 
 
+# Temporarily adding min and max date redirect until we can
+# handle null disbursement dates in a future implementation
 def disbursements(request):
     if len(request.GET) == 0: 
-        return redirect('/data/disbursements/?two_year_transaction_period=' + str(constants.DEFAULT_ELECTION_YEAR))
+        return redirect('/data/disbursements/?two_year_transaction_period=' 
+        + str(constants.DEFAULT_ELECTION_YEAR) 
+        + '&min_date=' + '01/01/' + str(constants.DEFAULT_ELECTION_YEAR - 1) 
+        + '&max_date=' + '12/31/' + str(constants.DEFAULT_ELECTION_YEAR))
 
     return render(request, 'datatable.jinja', {
         'parent': 'data',


### PR DESCRIPTION
## Summary

- Resolves #2928 
_Fix disbursement date range parameter name and add min and max date to disbursement redirects._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Disbursements datatable: http://localhost:8000/data/disbursements/

## Screenshots

<img width="1673" alt="Screen Shot 2019-05-31 at 4 09 51 PM" src="https://user-images.githubusercontent.com/12799132/58732173-b67a3d00-83be-11e9-8fb0-a0640d6b5abe.png">

## How to test
- `./manage.py runserver`
- Go to disbursements datatable: http://localhost:8000/data/disbursements/
- Make sure redirect is tacking on this to the URL string: `two_year_transaction_period=2020&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020`
____

