### PR TITLE
Fix H/S/P candidate datatable breadcrumb capitalization

### DIFF
--- a/fec/data/views_datatables.py
+++ b/fec/data/views_datatables.py
@@ -23,15 +23,18 @@ def candidates(request):
 
 
 def candidates_office(request, office):
-    if office.lower() not in ['president', 'senate', 'house']:
+    office = office.lower()
+    if office not in ['president', 'senate', 'house']:
         raise Http404()
+    # only House/Senate are proper-cased
+    office_breadcrumb = office.title() if office in ['senate', 'house'] else office
     return render(request, 'datatable.jinja', {
         'parent': 'data',
         'result_type': 'candidates',
-        'title': 'candidates for ' + office,
+        'title': 'Candidates for ' + office_breadcrumb,
         'slug': 'candidates-office',
         'table_context': OrderedDict([('office', office)]),
-        'columns': constants.table_columns['candidates-office-' + office.lower()]
+        'columns': constants.table_columns['candidates-office-' + office]
     })
 
 

--- a/fec/data/views_datatables.py
+++ b/fec/data/views_datatables.py
@@ -63,10 +63,10 @@ def communication_costs(request):
 # Temporarily adding min and max date redirect until we can
 # handle null disbursement dates in a future implementation
 def disbursements(request):
-    if len(request.GET) == 0: 
-        return redirect('/data/disbursements/?two_year_transaction_period=' 
-        + str(constants.DEFAULT_ELECTION_YEAR) 
-        + '&min_date=' + '01/01/' + str(constants.DEFAULT_ELECTION_YEAR - 1) 
+    if len(request.GET) == 0:
+        return redirect('/data/disbursements/?two_year_transaction_period='
+        + str(constants.DEFAULT_ELECTION_YEAR)
+        + '&min_date=' + '01/01/' + str(constants.DEFAULT_ELECTION_YEAR - 1)
         + '&max_date=' + '12/31/' + str(constants.DEFAULT_ELECTION_YEAR))
 
     return render(request, 'datatable.jinja', {

--- a/fec/fec/static/js/pages/datatable-candidates-office.js
+++ b/fec/fec/static/js/pages/datatable-candidates-office.js
@@ -43,7 +43,7 @@ var defaultSort = {
 };
 
 var officeTitleMap = {
-  president: 'President',
+  president: 'president',
   senate: 'Senate',
   house: 'House of Representatives'
 };


### PR DESCRIPTION
## Summary (required)

- Resolves #2932 

## Impacted areas of the application
List general components of the application that this PR will affect:

-  House/Senate/Presidential candidate datatables

## Screenshots

### Before
![Screen Shot 2019-05-31 at 12 03 12 PM](https://user-images.githubusercontent.com/31420082/58817625-2d4f4a00-85fa-11e9-9022-bf09bf9053d0.png)
![Screen Shot 2019-05-31 at 4 36 03 PM](https://user-images.githubusercontent.com/31420082/58733377-600efd80-83c2-11e9-990c-acaeb5c8a1ae.png)
![Screen Shot 2019-06-03 at 12 18 23 PM](https://user-images.githubusercontent.com/31420082/58817493-d8133880-85f9-11e9-8f62-5d94d09ecc6d.png)

### After
![Screen Shot 2019-05-31 at 4 37 02 PM](https://user-images.githubusercontent.com/31420082/58817655-3dffc000-85fa-11e9-90f2-d7c8ab2503e8.png)
![Screen Shot 2019-05-31 at 4 37 08 PM](https://user-images.githubusercontent.com/31420082/58733386-63a28480-83c2-11e9-97af-01f3d9cab20a.png)
![Screen Shot 2019-06-03 at 12 18 06 PM](https://user-images.githubusercontent.com/31420082/58817470-ccc00d00-85f9-11e9-9074-26c3f04a103d.png)



## How to test
http://localhost:8000/data/candidates/house/
http://localhost:8000/data/candidates/senate/?election_year=2020&cycle=2020&election_full=true
http://localhost:8000/data/candidates/president/?election_year=2020&cycle=2020&election_full=true