### PR TITLE
Remove extra line in candiate datatables

### DIFF
--- a/fec/data/templates/partials/candidates-office-filter.jinja
+++ b/fec/data/templates/partials/candidates-office-filter.jinja
@@ -14,7 +14,6 @@
   <div class="filters__inner">
     {{ typeahead.field('q', 'Candidate name or ID', '', dataset='candidates', allow_text=True) }}
     {{ election_filter.full_cycle('election_year', 'Election year', 'cycle', 'election_full', table_context['office']) }}
-    <input id="election_full" name="election_full" type="checkbox" value="true">
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Candidate information</button>
   <div class="accordion__content">


### PR DESCRIPTION
## Summary (required)

- Resolves issue found in testing 
Remove extra line in candidate datatables

## Impacted areas of the application
List general components of the application that this PR will affect:

-  House/Senate/Presidential datatables

## Screenshots

### Before
![Screen Shot 2019-06-03 at 10 08 26 AM](https://user-images.githubusercontent.com/31420082/58808422-038d2780-85e8-11e9-915d-9e982b7115c2.png)
![Screen Shot 2019-06-03 at 10 08 36 AM](https://user-images.githubusercontent.com/31420082/58808425-07b94500-85e8-11e9-9968-c09c2c7d97a8.png)
![Screen Shot 2019-06-03 at 10 08 41 AM](https://user-images.githubusercontent.com/31420082/58808431-0a1b9f00-85e8-11e9-8fbb-4f76a263f2cd.png)

### After


![Screen Shot 2019-06-03 at 10 08 46 AM](https://user-images.githubusercontent.com/31420082/58808451-0f78e980-85e8-11e9-8397-999c56a08911.png)
![Screen Shot 2019-06-03 at 10 08 51 AM](https://user-images.githubusercontent.com/31420082/58808456-1142ad00-85e8-11e9-8fbd-41844162e97f.png)
![Screen Shot 2019-06-03 at 10 08 55 AM](https://user-images.githubusercontent.com/31420082/58808462-130c7080-85e8-11e9-8826-fd19e28a4225.png)

## How to test
- http://localhost:8000/data/candidates/house/?election_year=2020&election_full=True
- http://localhost:8000/data/candidates/senate/?election_year=2020&cycle=2020&election_full=true
- http://localhost:8000/data/candidates/president/?election_year=2020&cycle=2020&election_full=true
