### PR TITLE
Remove SSFs from receipts and individual contributions datatable

### DIFF
--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -1,4 +1,4 @@
-{% macro field(name='committee_type') %}
+{% macro field(name='committee_type', include_ssfs = True) %}
 
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="hsp-committee_type">
@@ -79,31 +79,34 @@
           <input id="committee-type-checkbox-W" type="checkbox" name="{{ name }}" value="W">
           <label class="dropdown__value" for="committee-type-checkbox-W">PAC with non-contribution account - qualified</label>
         </li>
-        <li class="dropdown__subhead">Separate segregated funds</li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-C" name="organization_type" type="checkbox" value="C">
-          <label class="dropdown__value" for="org-type-checkbox-C">Corporation</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-L" name="organization_type" type="checkbox" value="L">
-          <label class="dropdown__value" for="org-type-checkbox-L">Labor organization</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-M" name="organization_type" type="checkbox" value="M">
-          <label class="dropdown__value" for="org-type-checkbox-M">Membership organization</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-T" name="organization_type" type="checkbox" value="T">
-          <label class="dropdown__value" for="org-type-checkbox-T">Trade association</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-V" name="organization_type" type="checkbox" value="V">
-          <label class="dropdown__value" for="org-type-checkbox-V">Cooperative</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-W" name="organization_type" type="checkbox" value="W">
-          <label class="dropdown__value" for="org-type-checkbox-W">Corporation without capital stock</label>
-        </li>
+        {# Temporarily adding SSFs committee type exclusion from receipts and individual contributions until it is fixed in our data #}
+        {% if include_ssfs %}
+          <li class="dropdown__subhead">Separate segregated funds</li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-C" name="organization_type" type="checkbox" value="C">
+            <label class="dropdown__value" for="org-type-checkbox-C">Corporation</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-L" name="organization_type" type="checkbox" value="L">
+            <label class="dropdown__value" for="org-type-checkbox-L">Labor organization</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-M" name="organization_type" type="checkbox" value="M">
+            <label class="dropdown__value" for="org-type-checkbox-M">Membership organization</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-T" name="organization_type" type="checkbox" value="T">
+            <label class="dropdown__value" for="org-type-checkbox-T">Trade association</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-V" name="organization_type" type="checkbox" value="V">
+            <label class="dropdown__value" for="org-type-checkbox-V">Cooperative</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-W" name="organization_type" type="checkbox" value="W">
+            <label class="dropdown__value" for="org-type-checkbox-W">Corporation without capital stock</label>
+          </li>
+        {% endif %}
       </ul>
     </div>
   </fieldset>

--- a/fec/data/templates/partials/individual-contributions-filter.jinja
+++ b/fec/data/templates/partials/individual-contributions-filter.jinja
@@ -28,7 +28,7 @@ Filter individual contributions
   <button type="button" class="js-accordion-trigger accordion__button">Recipient committee type</button>
   <div class="accordion__content">
     {% import 'macros/filters/committee-types.jinja' as committee_type %}
-    {{ committee_type.field(name='recipient_committee_type') }}
+    {{ committee_type.field(name='recipient_committee_type', include_ssfs = False) }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Transaction details</button>
   <div class="accordion__content">

--- a/fec/data/templates/partials/receipts-filter.jinja
+++ b/fec/data/templates/partials/receipts-filter.jinja
@@ -43,7 +43,7 @@ Filter receipts
   <button type="button" class="js-accordion-trigger accordion__button">Recipient committee type</button>
   <div class="accordion__content">
     {% import 'macros/filters/committee-types.jinja' as committee_type %}
-    {{ committee_type.field(name='recipient_committee_type') }}
+    {{ committee_type.field(name='recipient_committee_type', include_ssfs = False) }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Receipt details</button>
   <div class="accordion__content">


### PR DESCRIPTION
## Summary

- Resolves #2913 
_Temporarily adding `include_ssfs` parameter into committee-types template in order to exclude SSFs from individual contributions and receipts datatable filters._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Receipts datatable: http://localhost:8000/data/receipts/
- Individual contributions datatable: http://localhost:8000/data/receipts/individual-contributions/

## Screenshots

![Screen Shot 2019-06-05 at 10 43 44 AM](https://user-images.githubusercontent.com/12799132/58965633-e8085500-877e-11e9-9924-8fe7c63d2c20.png)

## How to test
- Go to Receipts and Individual contributions datatables and make sure that the SSF committee types are removed from the PACS list
   - http://localhost:8000/data/receipts/
   - http://localhost:8000/data/receipts/individual-contributions/
- Ensure that other datatables with this `committee-types.jinja` filter is uneffected and still includes the SSFs in the PACS list.
   - http://localhost:8000/data/disbursements/
____

