### PR TITLE
Add analytics

### DIFF
--- a/fec/fec/static/js/widgets/aggregate-totals-box.js
+++ b/fec/fec/static/js/widgets/aggregate-totals-box.js
@@ -446,6 +446,8 @@ AggregateTotalsBox.prototype.refreshYearsSelect = function() {
   } else {
     this.yearControl.fireEvent('onchange');
   }
+
+  logUsage(this.baseQuery.office, this.baseQuery.election_year);
 };
 
 /**
@@ -705,6 +707,22 @@ function buildElement(callingInstance, scriptElement) {
   else scriptElement.parentElement.insertBefore(toReturn, scriptElement);
 
   return toReturn;
+}
+
+/**
+ * Handles the usage analytics for this module
+ * @todo - Decide how to gather usage insights while embedded
+ * @param {String} officeAbbrev - The user-selected election office
+ * @param {*} electionYear - String or Number, the user-selected election year
+ */
+function logUsage(officeAbbrev, electionYear) {
+  if (window.ga) {
+    window.ga('send', 'event', {
+      eventCategory: 'Widget-AggregateTotals',
+      eventAction: 'interaction',
+      eventLabel: officeAbbrev + ',' + electionYear
+    });
+  }
 }
 
 new AggregateTotalsBox();


### PR DESCRIPTION
## Summary
Adding analytics for the aggregate totals widget

- Resolves #2802 


## Impacted areas of the application

The new code is solely inside aggregate-totals-box.js. It's hidden behind an `if (window.ga)` so it shouldn't do anything if the `ga` element hasn't been created.

## Screenshots
None

## Related PRs
None

## How to test
- Pull the branch
- `npm run buiild-js`
- `npm run test-single`
- Make sure the build and tests succeed

Because it's analytics, we may not be able to test it until it's on production
____

