### PR TITLE
2951 Remove monospace font from column heads

### DIFF
--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -79,7 +79,7 @@ var receiptDateColumn = {
 var pagesColumn = {
   data: 'beginning_image_number',
   orderable: false,
-  className: 'min-tablet hide-panel column--xs column--number t-mono',
+  className: 'min-tablet hide-panel column--xs column--number',
   render: function(data, type, row) {
     // Image numbers in 2015 and later begin with YYYYMMDD,
     // which makes for a very big number.

--- a/fec/fec/static/scss/components/_type-styles.scss
+++ b/fec/fec/static/scss/components/_type-styles.scss
@@ -193,6 +193,7 @@
   padding-left: u(2rem);
 }
 
-.t-mono {
+// mono space currency font, except don't apply it to <th> or "role=columnheader" elements
+.t-mono:not(th), .t-mono:not([role="columnheader"]) {
   font-family: $currency-monospace !important;
 }


### PR DESCRIPTION
## Summary
Removing the monospace currency font from column heads, and from page number columns

- Resolves #2951 

## Impacted areas of the application
Ideally we'd skip adding the `t-mono` class to the <th> and other column-heading elements. As a quick fix, I changed the css rules to only apply to elements that aren't <th> and that don't have a role of `columneader`

## Screenshots
![image](https://user-images.githubusercontent.com/26720877/59114726-cd1c1900-8915-11e9-980c-d236cf5b79ce.png)

## Related PRs
None

## How to test
- Go to a datatables page like http://127.0.0.1:8000/data/receipts/ and make sure the "Amount" total text _and_ that the numbers in the column are monospace
____

