### PR TITLE
"Filter this data" button link to regularly scheduled reports

### DIFF
--- a/fec/data/templates/partials/candidate/other-spending-tab.jinja
+++ b/fec/data/templates/partials/candidate/other-spending-tab.jinja
@@ -15,7 +15,7 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Independent expenditures</h3>
         <a class="heading__right button--alt button--browse"
-          href="/data/independent-expenditures/?min_date={{ cycle_start(min_cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(max_cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}">Filter this data</a>
+          href="/data/independent-expenditures/?min_date={{ cycle_start(min_cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(max_cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}&data_type=processed&is_notice=false">Filter this data</a>
       </div>
       <div class="results-info results-info--simple js-other-spending-totals" data-spending-type="independentExpenditures">
         <div class="usa-width-one-half">

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -45,7 +45,7 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Communication costs</h3>
         <a class="heading__right button--alt button--browse"
-            href="/data/communication_costs/committee_id={{ committee_id }}&min_date={{ cycle_start(cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}>Filter this data
+            href="/data/communication_costs/?committee_id={{ committee_id }}&min_date={{ cycle_start(cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}">Filter this data
         </a>
       </div>
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="communication-cost-committee" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -45,7 +45,7 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Communication costs</h3>
         <a class="heading__right button--alt button--browse"
-            href="/data/communication_costs/?committee_id={{ committee_id }}&min_date={{ cycle_start(cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}">Filter this data
+            href="/data/communication_costs/committee_id={{ committee_id }}&min_date={{ cycle_start(cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}>Filter this data
         </a>
       </div>
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="communication-cost-committee" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">
@@ -71,8 +71,8 @@
       <p>Any disbursement for a broadcast, cable or satellite communication that (1) refers to a clearly identified candidate for federal office; (2) is publicly distributed within certain time periods before an election and (3) is targeted to the relevant electorate.</p>
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="electioneering-committee" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">
         <thead>
-          <th scope="col">Candidate</th> 
-          <th scope="col">Amount</th>   
+          <th scope="col">Candidate</th>
+          <th scope="col">Amount</th>
         </thead>
       </table>
       <div class="datatable__note">
@@ -86,7 +86,7 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Independent expenditures</h3>
         <a class="heading__right button--alt button--browse"
-            href="/data/independent-expenditures/?committee_id={{ committee_id }}&min_date={{ cycle_start(cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}">Filter this data</a>
+            href="/data/independent-expenditures/?committee_id={{ committee_id }}&min_date={{ cycle_start(cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}&data_type=processed&is_notice=false">Filter this data</a>
       </div>
       <p>This tab shows spending that this committee has made in support of or opposition to a candidate. None of the funds are directly given to or spent by the candidate.</p>
       {% if totals %}
@@ -108,7 +108,7 @@
       </div>
     </div>
     {% endif %}
-    
+
     {% if committee_type == 'E' %}
     <div class="entity__figure row" id="disbursement-transactions" >
       <div class="heading--section heading--with-action">

--- a/fec/fec/static/js/modules/filters/filter-set.js
+++ b/fec/fec/static/js/modules/filters/filter-set.js
@@ -133,7 +133,9 @@ FilterSet.prototype.clear = function() {
 };
 
 FilterSet.prototype.handleTagRemoved = function(e, opts) {
-  var $input = this.$body.find('#' + opts.key);
+  //var $input = this.$body.find('#' + opts.key);
+  var $input = $(document.getElementById(opts.key))
+
   if ($input.length > 0) {
     var type = $input.get(0).type;
 

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -160,7 +160,10 @@ FilterTypeahead.prototype.removeCheckbox = function(e, opts) {
 
   // tag removal
   if (opts) {
-    $input = this.$selected.find('#' + opts.key);
+    //$input = this.$selected.find('#' + opts.key);
+    var $input_id = $(document.getElementById(opts.key))
+    input = this.$selected.find($input_id);
+
   }
 
   $input.closest('li').remove();


### PR DESCRIPTION
## Summary (required)
Candidate and Committee profile pages Independent Expenditure datatable "filter this data" button fixed to link to regularly scheduled reports.

- Resolves #2948

## Impacted areas of the application
modified:   data/templates/partials/candidate/other-spending-tab.jinja
modified:   data/templates/partials/committee/spending.jinja


## How to test
- Checkout and run  `feature/2948-filter-this-data-btn-correct-link`
- Test Candidate and Committee profile pages  on the  `other spending tab` and `independent-expenditures` tabs respectively. The "filter this data button" above the   Independent Expenditure datatable should go to regularly scheduled reports.
<img width="234" alt="Screen Shot 2019-06-07 at 10 40 07 PM" src="https://user-images.githubusercontent.com/5572856/59141102-4139d980-8975-11e9-9ee7-96574a4b7697.png">

http://127.0.0.1:8000/data/candidate/P80001571/?tab=other-spending
http://127.0.0.1:8000/data/committee/C00571703/?tab=spending#independent-expenditures

____

