### PR TITLE
[MERGE WITH GIT FLOW] 2959 column headers font

### DIFF
--- a/fec/fec/static/scss/components/_type-styles.scss
+++ b/fec/fec/static/scss/components/_type-styles.scss
@@ -194,6 +194,10 @@
 }
 
 // mono space currency font, except don't apply it to <th> or "role=columnheader" elements
-.t-mono:not(th), .t-mono:not([role="columnheader"]) {
-  font-family: $currency-monospace !important;
+.t-mono {
+  font-family: $currency-monospace;
+}
+thead .t-mono,
+th .t-mono {
+  font-family: inherit;
 }

--- a/fec/fec/static/scss/components/_type-styles.scss
+++ b/fec/fec/static/scss/components/_type-styles.scss
@@ -193,10 +193,11 @@
   padding-left: u(2rem);
 }
 
-// mono space currency font, except don't apply it to <th> or "role=columnheader" elements
+// mono space currency font
 .t-mono {
   font-family: $currency-monospace;
 }
+// except for where it's inside a <thead> or <th>
 thead .t-mono,
 th .t-mono {
   font-family: inherit;


### PR DESCRIPTION
## Summary
Refined the sass style rule where the t-mono rule is concerned, removed the !important and 

- Resolves #2959 

## Impacted areas of the application
Only the sass file was updated, though it will affect anywhere (site-wide) that the t-mono class is used.

## Screenshots
![image](https://user-images.githubusercontent.com/26720877/59363292-ee5c7b00-8d02-11e9-90f5-ca8650d6cc1b.png)
![image](https://user-images.githubusercontent.com/26720877/59363302-f1f00200-8d02-11e9-9bd7-1db8b83928ed.png)

## Related PRs


## How to test
- Pull the branch
- `npm run build`
- Check any pages with stacks of currency (stacks of currency should be monospace…)
- Check that all table header text is displayed (…and their headers should _not_ be)

____

