### PR TITLE
Feature/2948-2956/filter-this-data-button

### DIFF
--- a/fec/data/templates/partials/candidate/other-spending-tab.jinja
+++ b/fec/data/templates/partials/candidate/other-spending-tab.jinja
@@ -15,7 +15,8 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Independent expenditures</h3>
         <a class="heading__right button--alt button--browse"
-          href="/data/independent-expenditures/?min_date={{ cycle_start(min_cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(max_cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}">Filter this data</a>
+          href="/data/independent-expenditures/?min_date={{ cycle_start(min_cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(max_cycle) | date(fmt='%m-%d-%Y') }}&candidate_id={{ candidate_id }}&data_type=processed&is_notice=false">Filter this data</a>
+
       </div>
       <div class="results-info results-info--simple js-other-spending-totals" data-spending-type="independentExpenditures">
         <div class="usa-width-one-half">

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -71,8 +71,8 @@
       <p>Any disbursement for a broadcast, cable or satellite communication that (1) refers to a clearly identified candidate for federal office; (2) is publicly distributed within certain time periods before an election and (3) is targeted to the relevant electorate.</p>
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="electioneering-committee" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">
         <thead>
-          <th scope="col">Candidate</th> 
-          <th scope="col">Amount</th>   
+          <th scope="col">Candidate</th>
+          <th scope="col">Amount</th>
         </thead>
       </table>
       <div class="datatable__note">
@@ -86,7 +86,8 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Independent expenditures</h3>
         <a class="heading__right button--alt button--browse"
-            href="/data/independent-expenditures/?committee_id={{ committee_id }}&min_date={{ cycle_start(cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}">Filter this data</a>
+          href="/data/independent-expenditures/?committee_id={{ committee_id }}&min_date={{ cycle_start(cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}&data_type=processed&is_notice=false">Filter this data</a>
+
       </div>
       <p>This tab shows spending that this committee has made in support of or opposition to a candidate. None of the funds are directly given to or spent by the candidate.</p>
       {% if totals %}
@@ -108,7 +109,7 @@
       </div>
     </div>
     {% endif %}
-    
+
     {% if committee_type == 'E' %}
     <div class="entity__figure row" id="disbursement-transactions" >
       <div class="heading--section heading--with-action">

--- a/fec/fec/static/js/modules/filters/filter-set.js
+++ b/fec/fec/static/js/modules/filters/filter-set.js
@@ -133,7 +133,7 @@ FilterSet.prototype.clear = function() {
 };
 
 FilterSet.prototype.handleTagRemoved = function(e, opts) {
-  var $input = this.$body.find('#' + opts.key);
+  var $input = $(document.getElementById(opts.key))
   if ($input.length > 0) {
     var type = $input.get(0).type;
 

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -160,7 +160,6 @@ FilterTypeahead.prototype.removeCheckbox = function(e, opts) {
 
   // tag removal
   if (opts) {
-    //$input = this.$selected.find('#' + opts.key);
     var $input_id = $(document.getElementById(opts.key))
     $input = this.$selected.find($input_id);
   }

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -162,7 +162,7 @@ FilterTypeahead.prototype.removeCheckbox = function(e, opts) {
   if (opts) {
     //$input = this.$selected.find('#' + opts.key);
     var $input_id = $(document.getElementById(opts.key))
-    input = this.$selected.find($input_id);
+    $input = this.$selected.find($input_id);
 
   }
 


### PR DESCRIPTION
## Summary
"Filter this data" button for IEs on Cand/Comm Profile pages:
Are showing `24-Hour-Reports` instead of  `Regularly Scheduled Reports` (#2948),
Are not respecting Cand/Comm IDs passed as query parameters to the IE datatable (#2956)

- Resolves #2948 
- Resolves #2956 

## Impacted areas of the application
modified: data/templates/partials/candidate/other-spending-tab.jinja
modified: data/templates/partials/committee/spending.jinja

modified:   fec/static/js/modules/filters/filter-set.js
modified:   fec/static/js/modules/filters/filter-typeahead.js
The Sizzle selector engine fails on parsing the long id that gets appended to `input id ="min_date...."` and `input id ="max_date...."`. 
Switching this from a `jQuery CSS selector` to vanilla `getElementByID()` seems to work.
Interestingly, `getElementById()` must be wrapped in jQuery like this:  `$(getElementById())` to return an object with access to jQuery object methods.

Related PR: #2955
## How to test
I## How to test
- Checkout and run  `feature/2948-filter-this-data-btn-correct-link`
- Test Candidate and Committee profile pages  on the  `other spending tab` and `independent-expenditures` tabs respectively. The "filter this data button" above the   Independent Expenditure datatable should go to regularly scheduled reports.
<img width="234" alt="Screen Shot 2019-06-07 at 10 40 07 PM" src="https://user-images.githubusercontent.com/5572856/59141102-4139d980-8975-11e9-9ee7-96574a4b7697.png">

- Should also apply candidate or committee and time period filters to the IE datatable results displayed

- Example pages:
http://127.0.0.1:8000/data/candidate/P80001571/?tab=other-spending
http://127.0.0.1:8000/data/committee/C00571703/?tab=spending#independent-expenditures
____

