### PR TITLE
Fix mismatched case/vertical spacing on Cand. profile pages

### DIFF
--- a/fec/fec/static/js/templates/electionCycles.hbs
+++ b/fec/fec/static/js/templates/electionCycles.hbs
@@ -1,5 +1,5 @@
 <fieldset class="js-subcycle-select">
-  <legend class="cycle-select__label">Time period</legend>
+  <legend class="label cycle-select__label">Time period</legend>
   <div class="toggles">
     {{#each this}}
     <label>


### PR DESCRIPTION
## Summary:
Fix mismatched case/vertical spacing between `Election dropdown` and `Time Period toggle` on Candidate profile pages.
Example:
https://www.fec.gov/data/candidate/P00009423/?cycle=2020&election_full=true&tab=about-candidate
Also on `Spending by others to support or appose` tab

- Resolves #2967

## Impacted areas of the application
modified:   fec/static/js/templates/electionCycles.hbs

## How to test
- Checkout  branch
- `npm run build`
- `./manage.py runserver`
- Check that Election dropdown and Time Period toggles are vertically aligned and uppercase
Example page:
http://127.0.0.1:8000/data/candidate/P00009423/?cycle=2020&election_full=true&tab=about-candidate
- Also check `Spending by others to support or appose` tab