### PR TITLE
Add raw filings section to candidate profile page

### DIFF
--- a/fec/data/templates/candidates-single.jinja
+++ b/fec/data/templates/candidates-single.jinja
@@ -112,6 +112,9 @@
             aria-controls="panel6"
             href="#section-6">Filings</a>
             <ul>
+              {% if has_raw_filings %}
+                <li><a href="#raw-filings">Raw electronic filings</a></li>
+              {% endif %}
               <li><a href="#statements-of-candidacy">Statements of candidacy</a></li>
               <li><a href="#other">Other documents filed</a></li>
             </ul>

--- a/fec/data/templates/macros/entity-pages.jinja
+++ b/fec/data/templates/macros/entity-pages.jinja
@@ -33,8 +33,13 @@
     <div class="entity__figure row" id="raw-filings">
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Raw electronic filings</h3>
+        {% set link = "/data/filings/?data_type=efiling&committee_id="+committee_id+
+        "&min_receipt_date="+min_receipt_date %}
+        {% if cycle %}
+          {% set link = link +"&cycle="+cycle|string %}
+        {% endif %}
         <a class="heading__right button button--alt button--browse"
-           href="/data/filings/?data_type='efiling'&committee_id={{ committee_id }}&cycle={{ cycle }}">
+           href="{{ link }}">
           Filter this data
         </a>
       </div>

--- a/fec/data/templates/macros/entity-pages.jinja
+++ b/fec/data/templates/macros/entity-pages.jinja
@@ -33,10 +33,10 @@
     <div class="entity__figure row" id="raw-filings">
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Raw electronic filings</h3>
-        {% set link = "/data/filings/?data_type=efiling&committee_id="+committee_id+
-        "&min_receipt_date="+min_receipt_date %}
+        {% set link = "/data/filings/?data_type=efiling&committee_id=" + committee_id +
+          "&min_receipt_date=" + min_receipt_date %}
         {% if cycle %}
-          {% set link = link +"&cycle="+cycle|string %}
+          {% set link = link + "&cycle=" + cycle|string %}
         {% endif %}
         <a class="heading__right button button--alt button--browse"
            href="{{ link }}">

--- a/fec/data/templates/macros/entity-pages.jinja
+++ b/fec/data/templates/macros/entity-pages.jinja
@@ -51,7 +51,7 @@
         </thead>
       </table>
       <div class="datatable__note">
-        <p class="t-note">This data has not yet been categorized and coded by the FEC. It's pulled directly from a committee's raw, electronic reports. It doesn't include paper filings.</p>
+        <p class="t-note">This data has not yet been categorized and coded by the FEC. It's pulled directly from a filer's raw, electronic reports. It doesn't include paper filings.</p>
       </div>
     </div>
 {% endmacro %}

--- a/fec/data/templates/macros/entity-pages.jinja
+++ b/fec/data/templates/macros/entity-pages.jinja
@@ -29,7 +29,7 @@
     </div>
 {% endmacro %}
 
-{% macro raw_filings_table(cycle, committee_id, min_receipt_date) %}
+{% macro raw_filings_table(cycle, committee_id, min_receipt_date, is_committee=True) %}
     <div class="entity__figure row" id="raw-filings">
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Raw electronic filings</h3>
@@ -49,8 +49,10 @@
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="raw-filings" data-min-date="{{ min_receipt_date }}" data-cycle="{{ cycle }}" data-committee="{{ committee_id }}">
         <thead>
           <th scope="col">Document</th>
-          <th scope="col">Coverage start date</th>
-          <th scope="col">Coverage end date</th>
+          {% if is_committee %}
+            <th scope="col">Coverage start date</th>
+            <th scope="col">Coverage end date</th>
+          {% endif %}
           <th scope="col">Date filed</th>
           <th scope="col">Image number</th>
         </thead>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -6,6 +6,9 @@
   <h2 id="section-6-heading">Candidate filings</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
+    {% if has_raw_filings %}
+      {{ entity.raw_filings_table(cycle, candidate_id, min_receipt_date) }}
+    {% endif %}
       <div id="statements-of-candidacy" class="entity__figure row">
         <div class="content__section">
           <div class="heading--section heading--with-action">

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -7,7 +7,7 @@
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
     {% if has_raw_filings %}
-      {{ entity.raw_filings_table(cycle, candidate_id, min_receipt_date) }}
+      {{ entity.raw_filings_table(cycle=None, committee_id=candidate_id, min_receipt_date=min_receipt_date) }}
     {% endif %}
       <div id="statements-of-candidacy" class="entity__figure row">
         <div class="content__section">

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -7,7 +7,7 @@
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
     {% if has_raw_filings %}
-      {{ entity.raw_filings_table(cycle=None, committee_id=candidate_id, min_receipt_date=min_receipt_date) }}
+      {{ entity.raw_filings_table(cycle=None, committee_id=candidate_id, min_receipt_date=min_receipt_date, is_committee=False) }}
     {% endif %}
       <div id="statements-of-candidacy" class="entity__figure row">
         <div class="content__section">

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -207,9 +207,9 @@ def get_senate_cycles(senate_class, cycle=None):
 
 
 def three_days_ago():
-    """Find the date three days ago"""
+    """Find the date three days ago, return as mm/dd/yyyy"""
     three_days_ago = datetime.datetime.today() - datetime.timedelta(days=3)
-    return three_days_ago.strftime('%m/%d/%y')
+    return three_days_ago.strftime('%m/%d/%Y')
 
 
 def extend(*dicts):

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -267,10 +267,7 @@ def get_candidate(candidate_id, cycle, election_full):
         committee_id=candidate['candidate_id'],
         min_receipt_date=raw_filing_start_date,
     )
-    if len(raw_filings.get('results')) > 0:
-        has_raw_filings = True
-    else:
-        has_raw_filings = False
+    has_raw_filings = True if raw_filings.get('results') else False
 
     return {
         'name': candidate['name'],
@@ -462,8 +459,9 @@ def get_committee(committee_id, cycle):
             committee_id=committee['committee_id'],
             min_receipt_date=template_variables['min_receipt_date'],
         )
-        if len(raw_filings.get('results')) > 0:
-            template_variables['has_raw_filings'] = True
+        template_variables['has_raw_filings'] = (
+            True if raw_filings.get('results') else False
+        )
     else:
         template_variables['has_raw_filings'] = False
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -50,7 +50,7 @@ def aggregate_totals(request):
 
     max_election_year = utils.current_cycle() + 4
     election_years = utils.get_cycles(max_election_year)
-    
+
     FEATURES = settings.FEATURES
 
     return render(
@@ -259,6 +259,19 @@ def get_candidate(candidate_id, cycle, election_full):
         reverse=True,
     )
 
+    raw_filing_start_date = utils.three_days_ago()
+    raw_filings = api_caller._call_api(
+        'efile',
+        'filings',
+        cycle=cycle,
+        committee_id=candidate['candidate_id'],
+        min_receipt_date=raw_filing_start_date,
+    )
+    if len(raw_filings.get('results')) > 0:
+        has_raw_filings = True
+    else:
+        has_raw_filings = False
+
     return {
         'name': candidate['name'],
         'cycle': int(cycle),
@@ -289,6 +302,8 @@ def get_candidate(candidate_id, cycle, election_full):
         'statement_of_candidacy': statement_of_candidacy,
         'elections': elections,
         'candidate': candidate,
+        'has_raw_filings': has_raw_filings,
+        'min_receipt_date': raw_filing_start_date,
         'context_vars': context_vars,
     }
 

--- a/fec/fec/static/js/modules/filters/filter-set.js
+++ b/fec/fec/static/js/modules/filters/filter-set.js
@@ -133,7 +133,7 @@ FilterSet.prototype.clear = function() {
 };
 
 FilterSet.prototype.handleTagRemoved = function(e, opts) {
-  var $input = $(document.getElementById(opts.key))
+  var $input = $(document.getElementById(opts.key));
   if ($input.length > 0) {
     var type = $input.get(0).type;
 

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -160,7 +160,7 @@ FilterTypeahead.prototype.removeCheckbox = function(e, opts) {
 
   // tag removal
   if (opts) {
-    var $input_id = $(document.getElementById(opts.key))
+    var $input_id = $(document.getElementById(opts.key));
     $input = this.$selected.find($input_id);
   }
 

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -135,6 +135,14 @@ var otherDocumentsColumns = [
   })
 ];
 
+var rawFilingsColumns = columnHelpers.getColumns(columns.filings, [
+  'document_type',
+  'coverage_start_date',
+  'coverage_end_date',
+  'receipt_date',
+  'beginning_image_number'
+]);
+
 var itemizedDisbursementColumns = [
   {
     data: 'committee_id',
@@ -620,6 +628,36 @@ function initStatementsOfCandidacyTable() {
   });
 }
 
+function initRawFilingsTable() {
+  var $table = $('table[data-type="raw-filings"]');
+  var candidateId = $table.attr('data-committee');
+  var min_date = $table.attr('data-min-date');
+  var path = ['efile', 'filings'];
+  tables.DataTable.defer($table, {
+    path: path,
+    query: {
+      committee_id: candidateId,
+      min_receipt_date: min_date,
+      sort: ['-receipt_date']
+    },
+    columns: rawFilingsColumns,
+    order: [[2, 'desc']],
+    dom: tables.simpleDOM,
+    pagingType: 'simple',
+    lengthMenu: [10, 30, 50],
+    hideEmpty: false,
+    useExport: true,
+    callbacks: {
+      afterRender: filings.renderModal
+    },
+    drawCallback: function() {
+      this.dropdowns = $table.find('.dropdown').map(function(idx, elm) {
+        return new dropdown.Dropdown($(elm), { checkboxes: false });
+      });
+    }
+  });
+}
+
 $(document).ready(function() {
   var query = URI.parseQuery(window.location.search);
 
@@ -628,6 +666,7 @@ $(document).ready(function() {
   initDisbursementsTable();
   initContributionsTables();
   initStatementsOfCandidacyTable();
+  initRawFilingsTable();
 
   // If on the other spending tab, init the totals
   // Otherwise add an event listener to build them on showing the tab

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -137,8 +137,6 @@ var otherDocumentsColumns = [
 
 var rawFilingsColumns = columnHelpers.getColumns(columns.filings, [
   'document_type',
-  'coverage_start_date',
-  'coverage_end_date',
   'receipt_date',
   'beginning_image_number'
 ]);


### PR DESCRIPTION
## Summary (required)

Resolves #2866 

- Add raw filings section to candidate profile page
- Change text to say "directly from a ~committee's~ filer's raw, electronic reports" because candidates and non-committee filers can have raw filings
- Fix bug with "filter this data" button going to processed 
- Only filter committee raw efilings by cycle - show all for candidates
- Fix bug with date filter

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile page, filings tab

## Screenshots

### Before
![Screen Shot 2019-06-18 at 12 33 41 PM](https://user-images.githubusercontent.com/31420082/59702421-a7b8c600-91c5-11e9-940a-7b396ee66fcc.png)

### After
![Screen Shot 2019-06-18 at 12 34 04 PM](https://user-images.githubusercontent.com/31420082/59702418-a4bdd580-91c5-11e9-9ecf-35f528d22936.png)

## How to test

- You can point to any space's API for this work
- As of 6/18, test with http://localhost:8000/data/candidate/P00011486/?tab=filings and http://localhost:8000/data/committee/C00000885/?tab=filings and see raw electronic filings
- If it's been more than a few days, look at candidates with recently filed F2's ([query of most recent raw F2s](https://api.open.fec.gov/v1/filings/?per_page=20&page=1&sort_hide_null=false&form_type=F2&api_key=DEMO_KEY&sort=-receipt_date&sort_null_only=false&sort_nulls_last=false))
- Confirm that @rfultz's fix for #2952 also fixes the clickable options for candidate raw filings