### PR TITLE
Adjust z-index of .data-table

### DIFF
--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -255,7 +255,7 @@
 
   .dropdown__panel {
     right: 0;
-    top: u(3rem);
+    top: calc(50% + 1.5rem - 1px);
     min-width: 70px;
   }
 

--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -60,16 +60,17 @@
 .data-table {
   @include transform(translateX(0%));
   @include transition-property(transform);
-  @include transition-duration(.5s);
+  @include transition-duration(0.5s);
   height: 100%;
   font-family: $sans-serif;
   position: relative;
   table-layout: auto;
+  z-index: $z1;
 
   th {
     line-height: u(1.4rem);
-    letter-spacing: -.3px;
-    padding: u(.5rem 1rem);
+    letter-spacing: -0.3px;
+    padding: u(0.5rem 1rem);
     border-bottom: 1px solid $primary;
 
     &.sorting,
@@ -116,7 +117,7 @@
 
     &.row-color-contrast,
     &:nth-child(even) {
-      background-color: rgba($gray-lightest, .5);
+      background-color: rgba($gray-lightest, 0.5);
     }
 
     &.row-color-normal {
@@ -124,12 +125,12 @@
     }
 
     &.row-active {
-      border-left: .5rem solid $primary;
+      border-left: 0.5rem solid $primary;
     }
   }
 
   td {
-    @include transition(padding-left, .2s);
+    @include transition(padding-left, 0.2s);
     padding: u(1rem);
     border-left: 1px solid $neutral;
 
@@ -163,8 +164,9 @@
         font-size: u(1.4rem);
         line-height: u(1.4rem);
 
-        ol, li {
-          margin-left :u(.9rem);
+        ol,
+        li {
+          margin-left: u(0.9rem);
           line-height: u(1.4rem);
         }
       }
@@ -176,8 +178,8 @@
   }
 
   .value-bar {
-    margin-top: u(.5rem);
-    height: u(.5rem);
+    margin-top: u(0.5rem);
+    height: u(0.5rem);
   }
 
   @include media($lg) {
@@ -210,7 +212,7 @@
   border-top: 2px solid $primary;
 
   td {
-    padding: u(.5rem);
+    padding: u(0.5rem);
     vertical-align: middle;
   }
 
@@ -221,14 +223,13 @@
 
 // Special styles for rows that trigger panels
 .row--has-panel {
-    @include transition(border-left-width, .2s);
-    cursor: pointer;
+  @include transition(border-left-width, 0.2s);
+  cursor: pointer;
 }
 
 .row-active {
-
   td {
-    background-color: rgba($gray-lightest, .3);
+    background-color: rgba($gray-lightest, 0.3);
     border-top: 1px solid $gray-lightest;
     border-bottom: 1px solid $gray-lightest;
   }
@@ -259,7 +260,7 @@
   }
 
   .dropdown__value {
-    padding: u(.5rem .75rem);
+    padding: u(0.5rem 0.75rem);
   }
 }
 
@@ -278,7 +279,7 @@
     display: block;
     height: u(1rem);
     left: u(-1.5rem);
-    margin-top: u(-.5rem);
+    margin-top: u(-0.5rem);
     position: absolute;
     top: 50%;
     width: u(1rem);
@@ -287,7 +288,7 @@
 
 .data-table {
   .is-incumbent::before {
-    top: u(.8rem);
+    top: u(0.8rem);
   }
 }
 
@@ -297,7 +298,6 @@
 }
 
 .dataTables_scrollBody {
-
   .data-table {
     position: static;
   }


### PR DESCRIPTION
## Summary

Assigning a (new) z-index to parent objects of download options lists.

Pull-downs inside tables were visible but couldn't receive click/tap actions when the row was such that its pull-down could appear behind the table's footer—the footer's transparent background was receiving the click/tap action.

Because elements load and stack in front of preceding elements by default, we're giving a z-index to tables so the pull-down elements inside them will appear in front of the tables' footer elements.

- Resolves #2952 

## Impacted areas of the application

The only change was to apply a z-index to .data-table at line 68, which will only affect those tables. As a side effect, though, there could be a situation where something that was (and should have been) in front of the table will now be behind the a data-table element.

Adjusted the `top` value for `.dropdown__panel` from 3rem (which doesn't adjust for rows that are more than one line tall) to a calculation of [middle - 1.5rem (half of 3, the height of the `<button>` that toggles the `<ul>`) - 1 px].

The other changes in the file are from the linter and are "nothing"—zeroes and whitespace adjustments.

## Screenshots

The overall look should be unaffected, but the .fec and .pdf options should now receive hover/rollover and click/tap events and react accordingly:
![image](https://user-images.githubusercontent.com/26720877/59709705-60d2cc80-91d5-11e9-8904-14352c9fc7e9.png)

## Related PRs
None

## How to test
- Pull the branch
- `npm run build`
- Check tables with download options that collide with the table footers to make sure other options than the first receive mouse events.
  - At http://localhost:8000/data/committee/C00000885/?tab=filings, the last entries' download pull-downs' .fec and .pdf options should be fully functional. The other pulldowns on the page should still be unaffected and fully functional.
  - Same with http://localhost:8000/data/candidate/P00011486/?tab=filings, the last row in the table, its download pull-down should be fully functional while the table's footer elements—and every other element on the page—should function as expected.
- Other places across the site where the data-table class is used should be unaffected—basically every data table.
____

