### PR TITLE
Temporarily Remove SSF/Leadership PACS  options from Disbursements datatable

### DIFF
--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -1,4 +1,4 @@
-{% macro field(name='committee_type', include_ssfs = True) %}
+{% macro field(name='committee_type', include_ssfs = True, include_leadership_pac = True, include_lobbyist_pac = True) %}
 
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="hsp-committee_type">
@@ -55,14 +55,20 @@
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
       <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
         <ul class="dropdown__list">
-          <li class="dropdown__item">
-            <input id="designation-checkbox-B" type="checkbox" name="designation" value="B">
-            <label class="dropdown__value" for="designation-checkbox-B">Lobbyist/Registrant PAC</label>
-          </li>
-          <li class="dropdown__item">
-            <input id="designation-checkbox-D" type="checkbox" name="designation" value="D">
-            <label class="dropdown__value" for="designation-checkbox-D">Leadership PAC</label>
-          </li>
+          {# Temporarily adding Lobbyist/Registrant PAC committee type exclusion from receipts and individual contributions until it is fixed in our data #}
+        {% if include_lobbyist_pac %}
+        <li class="dropdown__item">
+          <input id="designation-checkbox-B" type="checkbox" name="designation" value="B">
+          <label class="dropdown__value" for="designation-checkbox-B">Lobbyist/Registrant PAC</label>
+        </li>
+        {% endif %}
+        {# Temporarily adding Leadership PAC committee type exclusion from receipts and individual contributions until it is fixed in our data #}
+        {% if include_leadership_pac %}
+        <li class="dropdown__item">
+          <input id="designation-checkbox-D" type="checkbox" name="designation" value="D">
+          <label class="dropdown__value" for="designation-checkbox-D">Leadership PAC</label>
+        </li>
+        {% endif %}
           <li class="dropdown__item">
             <input id="committee-type-checkbox-N" type="checkbox" name="{{ name }}" value="N">
             <label class="dropdown__value" for="committee-type-checkbox-N">PAC - nonqualified</label>

--- a/fec/data/templates/macros/filters/spender-committee-types.jinja
+++ b/fec/data/templates/macros/filters/spender-committee-types.jinja
@@ -1,4 +1,4 @@
-{% macro field(name='spender_committee_type', include_ssfs = True) %}
+{% macro field(name='spender_committee_type', include_ssfs = True, include_leadership_pac = True) %}
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-name="spender_committee_type" data-filter="checkbox">
     <legend class="label" for="committee_type">Authorized committees</legend>
@@ -58,10 +58,13 @@
           <input id="designation-checkbox-B" type="checkbox" name="designation" value="B">
           <label class="dropdown__value" for="designation-checkbox-B">Lobbyist/Registrant PAC</label>
         </li>
+        {# Temporarily adding Leadership PAC committee type exclusion from disbursements until it is fixed in our data #}
+        {% if include_leadership_pac %}
         <li class="dropdown__item">
           <input id="designation-checkbox-D" type="checkbox" name="designation" value="D">
           <label class="dropdown__value" for="designation-checkbox-D">Leadership PAC</label>
         </li>
+        {% endif %}
         <li class="dropdown__item">
           <input id="committee-type-checkbox-N" type="checkbox" name="spender_committee_type" value="N">
           <label class="dropdown__value" for="committee-type-checkbox-N">PAC - nonqualified</label>
@@ -78,8 +81,8 @@
           <input id="committee-type-checkbox-W" type="checkbox" name="spender_committee_type" value="W">
           <label class="dropdown__value" for="committee-type-checkbox-W">PAC with non-contribution account - qualified</label>
         </li>
-        {# Temporarily adding SSFs committee type exclusion from receipts and individual contributions until it is fixed in our data #}
-          {% if include_ssfs %}
+        {# Temporarily adding SSFs committee type exclusion from disbursements until it is fixed in our data #}
+        {% if include_ssfs %}
         <li class="dropdown__subhead">Separate segregated funds</li>
         <li class="dropdown__item">
           <input id="org-type-checkbox-C" name="organization_type" type="checkbox" value="C">

--- a/fec/data/templates/macros/filters/spender-committee-types.jinja
+++ b/fec/data/templates/macros/filters/spender-committee-types.jinja
@@ -1,4 +1,4 @@
-{% macro field(name='spender_committee_type', include_ssfs = True, include_leadership_pac = True) %}
+{% macro field(name='spender_committee_type', include_ssfs = True, include_leadership_pac = True, include_lobbyist_pac = True) %}
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-name="spender_committee_type" data-filter="checkbox">
     <legend class="label" for="committee_type">Authorized committees</legend>
@@ -54,10 +54,13 @@
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
       <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
       <ul class="dropdown__list">
+        {# Temporarily adding Lobbyist/Registrant PAC committee type exclusion from disbursements until it is fixed in our data #}
+        {% if include_lobbyist_pac %}
         <li class="dropdown__item">
           <input id="designation-checkbox-B" type="checkbox" name="designation" value="B">
           <label class="dropdown__value" for="designation-checkbox-B">Lobbyist/Registrant PAC</label>
         </li>
+        {% endif %}
         {# Temporarily adding Leadership PAC committee type exclusion from disbursements until it is fixed in our data #}
         {% if include_leadership_pac %}
         <li class="dropdown__item">

--- a/fec/data/templates/macros/filters/spender-committee-types.jinja
+++ b/fec/data/templates/macros/filters/spender-committee-types.jinja
@@ -1,3 +1,4 @@
+{% macro field(name='spender_committee_type', include_ssfs = True) %}
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-name="spender_committee_type" data-filter="checkbox">
     <legend class="label" for="committee_type">Authorized committees</legend>
@@ -77,6 +78,8 @@
           <input id="committee-type-checkbox-W" type="checkbox" name="spender_committee_type" value="W">
           <label class="dropdown__value" for="committee-type-checkbox-W">PAC with non-contribution account - qualified</label>
         </li>
+        {# Temporarily adding SSFs committee type exclusion from receipts and individual contributions until it is fixed in our data #}
+          {% if include_ssfs %}
         <li class="dropdown__subhead">Separate segregated funds</li>
         <li class="dropdown__item">
           <input id="org-type-checkbox-C" name="organization_type" type="checkbox" value="C">
@@ -102,6 +105,7 @@
           <input id="org-type-checkbox-W" name="organization_type" type="checkbox" value="W">
           <label class="dropdown__value" for="org-type-checkbox-W">Corporation without capital stock</label>
         </li>
+        {% endif %}
       </ul>
     </div>
   </fieldset>
@@ -149,3 +153,4 @@
     </div>
   </fieldset>
 </div>
+{% endmacro %}

--- a/fec/data/templates/partials/disbursements-filter.jinja
+++ b/fec/data/templates/partials/disbursements-filter.jinja
@@ -58,7 +58,7 @@ Filter disbursements
   <button type="button" class="js-accordion-trigger accordion__button">Spender committee type</button>
   <div class="accordion__content">
     {% import 'macros/filters/spender-committee-types.jinja' as spender_committee_type %}
-    {{ spender_committee_type.field(name='spender_committee_type', include_ssfs = False) }}
+    {{ spender_committee_type.field(name='spender_committee_type', include_ssfs = False, include_leadership_pac = False) }}
   </div>
 </div>
 {% endblock %}

--- a/fec/data/templates/partials/disbursements-filter.jinja
+++ b/fec/data/templates/partials/disbursements-filter.jinja
@@ -57,7 +57,8 @@ Filter disbursements
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Spender committee type</button>
   <div class="accordion__content">
-    {% include 'partials/filters/spender-committee-types.jinja' %}
+    {% import 'macros/filters/spender-committee-types.jinja' as spender_committee_type %}
+    {{ spender_committee_type.field(name='spender_committee_type', include_ssfs = False) }}
   </div>
 </div>
 {% endblock %}

--- a/fec/data/templates/partials/disbursements-filter.jinja
+++ b/fec/data/templates/partials/disbursements-filter.jinja
@@ -58,7 +58,7 @@ Filter disbursements
   <button type="button" class="js-accordion-trigger accordion__button">Spender committee type</button>
   <div class="accordion__content">
     {% import 'macros/filters/spender-committee-types.jinja' as spender_committee_type %}
-    {{ spender_committee_type.field(name='spender_committee_type', include_ssfs = False, include_leadership_pac = False) }}
+    {{ spender_committee_type.field(name='spender_committee_type', include_ssfs = False, include_leadership_pac = False, include_lobbyist_pac = False) }}
   </div>
 </div>
 {% endblock %}

--- a/fec/data/templates/partials/individual-contributions-filter.jinja
+++ b/fec/data/templates/partials/individual-contributions-filter.jinja
@@ -36,7 +36,7 @@ Filter individual contributions
   <button type="button" class="js-accordion-trigger accordion__button">Recipient committee type</button>
   <div class="accordion__content">
     {% import 'macros/filters/committee-types.jinja' as committee_type %}
-    {{ committee_type.field(name='recipient_committee_type', include_ssfs = False) }}
+    {{ committee_type.field(name='recipient_committee_type', include_ssfs = False, include_leadership_pac = False, include_lobbyist_pac = False) }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Contribution details</button>
   <div class="accordion__content">

--- a/fec/data/templates/partials/receipts-filter.jinja
+++ b/fec/data/templates/partials/receipts-filter.jinja
@@ -51,7 +51,7 @@ Filter receipts
   <button type="button" class="js-accordion-trigger accordion__button">Recipient committee type</button>
   <div class="accordion__content">
     {% import 'macros/filters/committee-types.jinja' as committee_type %}
-    {{ committee_type.field(name='recipient_committee_type', include_ssfs = False) }}
+    {{ committee_type.field(name='recipient_committee_type', include_ssfs = False, include_leadership_pac = False, include_lobbyist_pac = False) }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Receipt details</button>
   <div class="accordion__content">


### PR DESCRIPTION
## Summary
Remove `Separate segregated funds (SSF)` and `Leadership PAC` options from Disbursements datatable  > Filters > Spender Committee Type > PACS dropdown

- Resolves #2966 
Related PR: https://github.com/fecgov/fec-cms/pull/2941

Changed spender-committee-types.jinja partial to macro, added ssf conditional option. 

It may have been possible  to reuse the commitee-types.jinja macro here since currently the options are the same for both rasing and spending datatables--  But, this macro should remain separate in case we ever need to have different filter options for Disbursements VS. raising datatables( Receipts , Individual Contributions) .

## Impacted areas of the application
**renamed:**    data/templates/partials/filters/spender-committee-types.jinja -> data/templates/macros/filters/spender-committee-types.jinja
**modified:**   data/templates/partials/disbursements-filter.jinja

## How to test
- checkout and run branch
-  go to http://127.0.0.1:8000/data/disbursements/
- Look at `Filters > Spender Committee Type > PACS dropdown`
- Make sure Leadership PAC option has been removed
- Make sure the Separate segregated funds (SSF) section  has been removed. The last item in the dropdown should be : `PAC with non-contribution account - qualified`




