### PR TITLE
Remove extra space causing bad link

### DIFF
--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -40,7 +40,7 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Individual contributions</h3>
         <a class="heading__right button--alt button--browse"
-            href="/data/individual-contributions/?committee_id={{ committee_id }}& two_year_transaction_period={{ cycle }}">Filter this data</a>
+            href="/data/individual-contributions/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}">Filter this data</a>
       </div>
       <fieldset class="row toggles js-toggles">
         <legend class="label">Group by:</legend>


### PR DESCRIPTION
## Summary (required)

Resolves https://github.com/fecgov/openFEC/issues/3802

Remove extra space causing bad link

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee profile pages "Filter this data" button on Raising tab

## How to test

- http://localhost:8000/data/committee/C00695510/?cycle=2020&tab=raising "Filter this data" button takes you to Individual Contributions for `2019-2020`, not `All Report Years`
