### PR TITLE
Fix 404 bug for House candidate profile page

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -121,6 +121,12 @@ def get_candidate(candidate_id, cycle, election_full):
     and candidate financial data needed to render the candidate profile page
     """
 
+    """
+    for House, set election_full=False except State=PR to solve cms issue#2937
+    """
+    if candidate_id.startswith('H', 0, 1) and candidate_id[2:4] != 'PR':
+        election_full = False
+
     candidate, committees, cycle = api_caller.load_with_nested(
         'candidate',
         candidate_id,


### PR DESCRIPTION
## Summary (required)
ex: https://www.fec.gov/data/elections/house/GA/06/2018/
on GA/06/2018 page, Click candidate name links in the table. Some of the candidates linked will 404, such as OSSOFF, T. JONATHAN and MOODY, DAN.

- Resolves [#[_2937_]](https://github.com/fecgov/fec-cms/issues/2937)
_Include a summary of proposed changes._
set election_full=False except State=PR in get_candidate function of views.py

## Impacted areas of the application
candidate profile page for House

## How to test locally
1)checkout this cms branch 
2)point to dev api: export FEC_API_URL=https://fec-dev-api.app.cloud.gov
3)test url:
http://127.0.0.1:8000/data/elections/house/GA/06/2018/
click "OSSOFF, T. JONATHAN and MOODY, DAN."

or you can go through chose state = PR to test any candidate profile page.

(Notes: This is short term solution, we will work on long term solution to use candidate/candidate_id/totals endpoint to populate data for this page.)