### PR TITLE
Feature/2988 remove clear all filters

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -502,7 +502,8 @@ DataTable.prototype.initFilters = function() {
   if (this.opts.useFilters) {
     var tagList = new filterTags.TagList({
       resultType: 'results',
-      showResultCount: true
+      showResultCount: true,
+      tableTitle: this.opts.title
     });
     this.$widgets.find('.js-filter-tags').prepend(tagList.$body);
     this.filterPanel = new FilterPanel();

--- a/tasks.py
+++ b/tasks.py
@@ -74,9 +74,10 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    # ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     #('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),
+    ('dev', lambda _, branch: branch == 'feature/2988-remove-clear-all-filters')
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -74,10 +74,9 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    # ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     #('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),
-    ('dev', lambda _, branch: branch == 'feature/2988-remove-clear-all-filters')
 )
 
 


### PR DESCRIPTION
## Summary
Hiding Clear all filters from the Receipts and Individual Contributions tables until we can more fully implement the Reset filters functionality.

- Resolves #2988 


## Impacted areas of the application
- Added a tableTitle var in modules/tables to be sent to a new TagList item.
- Modified filters/filter-tags to read the tableTitle and display the Clear all filters button as needed.

## Screenshots
![image](https://user-images.githubusercontent.com/26720877/60295497-dafc0300-98f1-11e9-921c-b5bce6bb8377.png)

## Related PRs

branch | PR
------ | ------
feature/2987-fix-clear-all-filters-links | #2990 

## How to test
- Pull the branch
- `npm run build`
- Make sure [Receipts](http://localhost:8000/data/receipts/) doesn't have a "Clear all filters" option on the right
- [Individual contributions](http://localhost:8000/data/receipts/individual-contributions/) also shouldn't have the "Clear all filters"
- [Disbursements](http://localhost:8000/data/disbursements/) *should* have the "Clear all filters option" and behave normally
- Same for [IE](http://localhost:8000/data/independent-expenditures/) and the other tables
- The [calendar](http://localhost:8000/calendar/) uses the same "Clear all filters" module; its functionality should be unchanged as well
- All other instances of "Clear all filters" should function as expected
____

