### PR TITLE
Fix  URL path in links for candidate raw filings links

### DIFF
--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -347,6 +347,13 @@ var filings = {
           helpers.buildAppUrl(['candidate', row.candidate_id], cycle),
           'candidate'
         );
+        // If committee ID is actually a candidate ID, use 'candidate' in URI
+      } else if (row.committee_id.match(/^[H, S, P]+\w+$/)) {
+        return columnHelpers.buildEntityLink(
+          row.committee_name,
+          helpers.buildAppUrl(['candidate', row.committee_id], cycle),
+          'committee'
+        );
       } else if (row.committee_name) {
         return columnHelpers.buildEntityLink(
           row.committee_name,


### PR DESCRIPTION
## Summary
Currently, The URL in links to candidate profile pages on `Raw filings`  has  `committee` instead of `candidate` in the path. This happens because the API data  that builds the `Raw filings table` has candidate IDs in the committee ID parameter. This PR changes the path to `candidate` if the ID begins with `H, S or P`. 

- Resolves #2865
**Issue 2865: Candidate links on raw filings datatable 404**
Note: Many of the candidate (and committee) links on the first one or two pages of Raw filings datatable will still return a 404 because this is Raw, unprocessed data and often a profile page has not yet been created for these recent filings. For example, while testing this over several days, on one day, only one of the six candidate links on the first two pages worked.

Delving into this issue exposed  the  broader UX/Usability issue where we are regularly and knowingly presenting broken links to the user which could effecting bounce-rates and user-confidence. The following issue offers an attempt to mitigate this: https://github.com/fecgov/fec-cms/issues/2993

## Impacted areas of the application
fec/static/js/modules/columns.js


## How to test
- checkout branch and run `npm run build before running the branch
- `go to http://127.0.0.1:8000/data/filings/?data_type=efiling
- Find a candidate name and confirm that the URL in the link has `candidate` in the path (pointing to a candidate profile page)
Please note that many of these links may return a 404 because a candidate profile page does not yet exist.
