### PR TITLE
2965 Adjust right padding for select elements

### DIFF
--- a/fec/fec/static/scss/elements/_forms.scss
+++ b/fec/fec/static/scss/elements/_forms.scss
@@ -67,7 +67,7 @@ select {
   background-size: 12px;
   color: $base;
   border: 2px solid $gray;
-  padding: u(.6rem 3rem .6rem 1rem);
+  padding: u(.6rem 3em .6rem 1rem);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
Adjusted the right padding of the `<select>` to base it on its own font size rather than the root document font size

- Resolves #2965 

## Impacted areas of the application
The only style change was for the select element, but it will affect _every_ `<select>` (actual pulldown) on the site. (Anywhere we're using `<div>`s as pulldowns will be unaffected)

## Screenshots
![image](https://user-images.githubusercontent.com/26720877/60525100-c3d75f80-9cbb-11e9-960c-0633bf7cae01.png)

## Related PRs
None

## How to test
- Pull the branch
- npm run build
- Check the right-side padding (internal spacing) of any <select> elements e.g., [Raising](http://localhost:8000/data/raising-bythenumbers/) & [Spending](http://localhost:8000/data/spending-bythenumbers/) By the Numbers pages
- Check any other instances of <select> elements

____
