### PR TITLE
Specify 2-year totals explicitly

### DIFF
--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -45,7 +45,7 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Communication costs</h3>
         <a class="heading__right button--alt button--browse"
-            href="/data/communication_costs/?committee_id={{ committee_id }}&min_date={{ cycle_start(cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}">Filter this data
+            href="/data/communication-costs/?committee_id={{ committee_id }}&min_date={{ cycle_start(cycle) | date(fmt='%m-%d-%Y') }}&max_date={{ cycle_end(cycle) | date(fmt='%m-%d-%Y') }}">Filter this data
         </a>
       </div>
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="communication-cost-committee" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -29,6 +29,7 @@ var mapUrl = helpers.buildUrl(
   {
     candidate_id: $map.data('candidate-id'),
     cycle: $map.data('cycle'),
+    election_full: false,
     per_page: 99
   }
 );
@@ -501,6 +502,7 @@ function initContributionsTables() {
     query: {
       candidate_id: opts.candidate_id,
       cycle: opts.cycle,
+      election_full: false,
       sort_hide_null: false,
       per_page: 99
     },
@@ -546,6 +548,7 @@ function initContributionsTables() {
     query: {
       candidate_id: opts.candidate_id,
       cycle: opts.cycle,
+      election_full: false,
       sort: 'size'
     },
     columns: [

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -649,6 +649,9 @@ $(document).ready(function() {
         break;
       case 'electioneering-committee':
         path = ['committee', committeeId, 'electioneering', 'by_candidate'];
+        query = _.extend(query, {
+          election_full: false
+        });
         tables.DataTable.defer($table, {
           path: path,
           query: query,

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -379,7 +379,8 @@ $(document).ready(function() {
     var committeeId = $table.attr('data-committee');
     var cycle = $table.attr('data-cycle');
     var query = {
-      cycle: cycle
+      cycle: cycle,
+      election_full: false
     };
     var path;
     var opts;
@@ -649,9 +650,6 @@ $(document).ready(function() {
         break;
       case 'electioneering-committee':
         path = ['committee', committeeId, 'electioneering', 'by_candidate'];
-        query = _.extend(query, {
-          election_full: false
-        });
         tables.DataTable.defer($table, {
           path: path,
           query: query,


### PR DESCRIPTION
## Summary (required)

Front-end followup for https://github.com/fecgov/openFEC/issues/3686

- Specify 2-year totals for aggregates - election_full now defaults to True
- Fix link for communication costs "filter this data" button

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile page Raising aggregates

## Related PRs

branch | PR
------ | ------
feature/change-default-election-full | https://github.com/fecgov/openFEC/pull/3846


## How to test
- Point to `dev` API
- Check that http://localhost:8000/data/candidate/S4NJ00185/ should match https://www.fec.gov/data/candidate/S4NJ00185/ for State and Size aggregates
- "Filter this data" button should now work for http://localhost:8000/data/committee/C70000716/?tab=spending&cycle=2018
