### PR TITLE
Fix radio button selected-state

### DIFF
--- a/fec/fec/static/scss/elements/_forms.scss
+++ b/fec/fec/static/scss/elements/_forms.scss
@@ -171,12 +171,20 @@ input[type="file"] {
   border-radius: u(1.6rem);
 }
 
-[type="checkbox"]:checked + label,
+[type="checkbox"]:checked + label {
+  background-color: transparent;
+
+  &::before {
+    background-color: $gray-dark;
+  }
+}
+
 [type="radio"]:checked + label {
   background-color: transparent;
 
   &::before {
     background-color: $gray-dark;
+    box-shadow: 0 0 0 1.2px $inverse inset;
   }
 }
 


### PR DESCRIPTION
## Summary
Add box shadow to fix radio selected-state

- Resolves #2950

Added ` box-shadow: 0 0 0 1.2px $inverse inset;` to `[type="radio"]:checked + label::before`

## Impacted areas of the application
modified:   fec/static/scss/elements/_forms.scss

## Screenshots
**Before**
<img width="266" alt="Screen Shot 2019-07-03 at 1 58 26 AM" src="https://user-images.githubusercontent.com/5572856/60566840-28cf9b80-9d36-11e9-919a-d713dd8a229b.png">

<hr>

**After**
<img width="282" alt="Screen Shot 2019-07-03 at 1 53 50 AM" src="https://user-images.githubusercontent.com/5572856/60566628-78fa2e00-9d35-11e9-8ccc-8c33511ddd0c.png">

## How to test
- checkout `feature/radio-button-selected-state`
- npm run build-sass
- Go to `http://127.0.0.1:8000/data/legal/search/advisory-opinions`
- See new radio button selected-state under `Citations` filter section
____

