### PR TITLE
Fix click-through links from candidate profiles to receipts/disbursements

### DIFF
--- a/fec/data/templates/macros/tables.jinja
+++ b/fec/data/templates/macros/tables.jinja
@@ -1,4 +1,4 @@
-{% macro summary(data, committee_id, cycle, office_or_committee) %}
+{% macro summary(data, committee_id, cycle, office_or_committee, election_full, aggregate_cycles) %}
 
 {% if office_or_committee not in ['P', 'H', 'S'] %}
   {#
@@ -20,7 +20,7 @@
         {% endif %}
       </td>
       <td class="simple-table__cell t-mono">
-{# 
+{#
 case 1: this page comes from data/candidate/<candidate_id>/ :
 The committee_id is a tuple list(the count < 9). see example below:
   a)one candidate has only one committee, committee_id=['C00580100'], count=1
@@ -35,9 +35,17 @@ not 'type' object, so use 'link' to check for 'independent-expenditures' and 'pa
 #}
 
         {% if item[1]['type'] and committee_id|count < 9 %}
-          <a href="/data/{{ item[1]['type']['link'] }}/?{% for id in committee_id -%}committee_id={{ id }}&{%- endfor %}two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
+          <a href="/data/{{ item[1]['type']['link'] }}/?
+          {%- for id in committee_id -%}
+          committee_id={{ id }}&
+          {%- endfor -%}
+          {%- for year in aggregate_cycles -%}
+          two_year_transaction_period={{year}}&
+          {%- endfor -%}
+          election_full={{election_full}}&line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
           </a>
+
         {% elif item[1]['type'] and committee_id|count == 9 %}
           <a href="/data/{{ item[1]['type']['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}

--- a/fec/data/templates/macros/tables.jinja
+++ b/fec/data/templates/macros/tables.jinja
@@ -1,4 +1,4 @@
-{% macro summary(data, committee_id, cycle, office_or_committee, election_full, aggregate_cycles) %}
+{% macro summary(data, committee_id, cycle, office_or_committee, aggregate_cycles) %}
 
 {% if office_or_committee not in ['P', 'H', 'S'] %}
   {#
@@ -42,7 +42,7 @@ not 'type' object, so use 'link' to check for 'independent-expenditures' and 'pa
           {%- for year in aggregate_cycles -%}
           two_year_transaction_period={{year}}&
           {%- endfor -%}
-          election_full={{election_full}}&line_number={{ item[1]['type'][office_or_committee] }}">
+          line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
           </a>
 

--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -36,7 +36,7 @@
         <div class="tag__category u-no-margin">
           <div class="tag__item">Coverage dates: {{ aggregate.coverage_start_date|date }} to {{ aggregate.coverage_end_date|date }}</div>
         </div>
-        {{ tables.summary(raising_summary, committee_ids, cycle, office) }}
+        {{ tables.summary(raising_summary, committee_ids, cycle, office, election_full, aggregate_cycles) }}
       </div>
       <div class="entity__figure entity__figure--narrow" id="total-spent">
         <div class="heading--section heading--with-action">
@@ -48,7 +48,7 @@
         <div class="tag__category u-no-margin">
           <div class="tag__item">Coverage dates: {{ aggregate.coverage_start_date|date }} to {{ aggregate.coverage_end_date|date }}</div>
         </div>
-        {{ tables.summary(spending_summary, committee_ids, cycle, office) }}
+        {{ tables.summary(spending_summary, committee_ids, cycle, office, election_full, aggregate_cycles) }}
       </div>
       <div class="entity__figure entity__figure--narrow" id="cash-summary">
         <div class="heading--section heading--with-action">

--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -36,7 +36,7 @@
         <div class="tag__category u-no-margin">
           <div class="tag__item">Coverage dates: {{ aggregate.coverage_start_date|date }} to {{ aggregate.coverage_end_date|date }}</div>
         </div>
-        {{ tables.summary(raising_summary, committee_ids, cycle, office, election_full, aggregate_cycles) }}
+        {{ tables.summary(raising_summary, committee_ids, cycle, office, aggregate_cycles) }}
       </div>
       <div class="entity__figure entity__figure--narrow" id="total-spent">
         <div class="heading--section heading--with-action">
@@ -48,7 +48,7 @@
         <div class="tag__category u-no-margin">
           <div class="tag__item">Coverage dates: {{ aggregate.coverage_start_date|date }} to {{ aggregate.coverage_end_date|date }}</div>
         </div>
-        {{ tables.summary(spending_summary, committee_ids, cycle, office, election_full, aggregate_cycles) }}
+        {{ tables.summary(spending_summary, committee_ids, cycle, office, aggregate_cycles) }}
       </div>
       <div class="entity__figure entity__figure--narrow" id="cash-summary">
         <div class="heading--section heading--with-action">

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -309,7 +309,6 @@ def get_candidate(candidate_id, cycle, election_full):
         'min_receipt_date': raw_filing_start_date,
         'context_vars': context_vars,
         'aggregate_cycles': aggregate_cycles,
-        'election_full': election_full,
     }
 
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -308,6 +308,8 @@ def get_candidate(candidate_id, cycle, election_full):
         'has_raw_filings': has_raw_filings,
         'min_receipt_date': raw_filing_start_date,
         'context_vars': context_vars,
+        'aggregate_cycles': aggregate_cycles,
+        'election_full': election_full,
     }
 
 


### PR DESCRIPTION
## Summary (required)
Fix click-through from totals links on candidate profile pages  to receipts/disbursements, ensuring that chosen time period is reflected in datatable.

- Resolves #2815
_Include a summary of proposed changes._
Return `aggregate_cycles` , from `get_candidate view` and use it to build the totals  links to receipts and disbursements from  candidate profile pages -- ensuring that the resulting datatable page is filtered by either the chosen two year period or all years in chosen election cycle.

## Impacted areas of the application
modified:   data/templates/macros/tables.jinja
modified:   data/templates/partials/candidate/financial-summary.jinja
modified:   data/views.py

## Screenshots
![all-years-clickthroughA](https://user-images.githubusercontent.com/5572856/60763866-d39fcc80-a04a-11e9-976c-7f7c3905c6c2.gif)



## How to test
- checkout and run branch
- Go to a candidate profile page for Senate and President and confirm that when all years are chosen in the `time period toggle`, totals links to receipts and disbursements show those years when clicking through to the datatable. 
- Confirm that when a particular two year period is chosen, only that is shown on the clicked-through datatable.


____

