### PR TITLE
Remove Line 24, disbursements, edit spending tab language

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -412,7 +412,6 @@ line_numbers = {
             ('F3X-21B', 'Other federal operating expenditures (Line 21b)'),
             ('F3X-22', 'Transfers to affiliated/other party committees (Line 22)'),
             ('F3X-23', 'Contributions to federal candidates/committees and other political committees (Line 23)'),
-            ('F3X-24', 'Independent expenditures (Line 24)'),
             ('F3X-26', 'Loan repayments made (Line 26)'),
             ('F3X-27', 'Loans made (Line 27)'),
             ('F3X-28A', 'Refunds of Contributions Made to Individuals/Persons Other Than Political Committees (Line 28a)'),

--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -10,8 +10,8 @@
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
-          <h4><a href="/data/disbursements">All disbursements</a></h4>
-          <p>Search all disbursements from committees by the recipient, purpose, amount and date.</p>
+          <h4><a href="/data/disbursements">Disbursements</a></h4>
+          <p>Search select disbursements from committees by the recipient, purpose, amount and date. Excludes <a href="/help-candidates-and-committees/candidate-taking-receipts/#outside-spending">outside spending</a> to support or appose candidates.</p>
         </div>
       </li>
       <li>

--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -11,7 +11,7 @@
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/disbursements">Disbursements</a></h4>
-          <p>Search select disbursements from committees by the recipient, purpose, amount and date. Excludes <a href="/help-candidates-and-committees/candidate-taking-receipts/#outside-spending">outside spending</a> to support or appose candidates.</p>
+          <p>Search select disbursements from committees by the recipient, purpose, amount and date. Excludes <a href="/help-candidates-and-committees/candidate-taking-receipts/#outside-spending">outside spending</a> to support or oppose candidates.</p>
         </div>
       </li>
       <li>


### PR DESCRIPTION
## Summary
- Remove line 24 from Add filter on Disbursements filters > Disbursement Details > Disbursement Type > Made by PACs or party committees
- Make changes to language on  data/browse-data/?tab=spending

- Resolves #3019 

## Impacted areas of the application
modified:   data/constants.py
modified:   data/templates/partials/browse-data/spending.jinja

## How to test
- checkout and run feature/3019-remove-line-24-disbursements
- Confirm that Filters > Disbursement Details > Disbursement Type > Made by PACs or party - committees now does not include `Independent expenditures (Line 24)`
- Confirm text on `http://127.0.0.1:8000/data/browse-data/?tab=spending` reflects [Option 2 of the issue](https://github.com/fecgov/fec-cms/issues/3019#issuecomment-510618274)
