### PR TITLE
Update aggregate totals links with full election cycles

### DIFF
--- a/fec/data/templates/elections.jinja
+++ b/fec/data/templates/elections.jinja
@@ -53,6 +53,7 @@ var context = {
   election: {
     cycle: '{{ cycle }}',
     election_full: true,
+    duration: '{{ election_duration }}',
     office: '{{ office }}',
     state: '{{ state or '' }}',
     stateFull: '{{ state_full or '' }}',

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -514,6 +514,11 @@ def elections(request, office, cycle, state=None, district=None):
     if (state is not None) and (state and state.upper() not in constants.states):
         raise Http404()
 
+    election_duration = election_durations.get(office[0].upper(), 2)
+    # Puerto Rico house/resident commissioners have 4-year cycles
+    if state and state.upper() == 'PR':
+        election_duration = 4
+
     # map/redirect legacy tab names to correct anchor
     tab = request.GET.get('tab', '').replace('/', '')
     legacy_tabs = {
@@ -546,6 +551,7 @@ def elections(request, office, cycle, state=None, district=None):
             'office_code': office[0],
             'parent': 'data',
             'cycle': cycle,
+            'election_duration': election_duration,
             'cycles': cycles,
             'state': state,
             'state_full': constants.states[state.upper()] if state else None,

--- a/fec/fec/static/js/modules/column-helpers.js
+++ b/fec/fec/static/js/modules/column-helpers.js
@@ -103,11 +103,27 @@ function buildEntityLink(data, url, category, opts) {
   return anchor.outerHTML;
 }
 
-function buildAggregateUrl(cycle, includeTransactionPeriod) {
-  var dates = helpers.cycleDates(cycle);
+function  buildAggregateUrl(cycle, includeTransactionPeriod, duration) {
+  var dates = helpers.cycleDates(cycle, duration);
+  console.log(includeTransactionPeriod);
   if (includeTransactionPeriod) {
-    return {
-      two_year_transaction_period: cycle
+    if (duration == 4) {
+      return {
+        two_year_transaction_period: cycle,
+        two_year_transaction_period: cycle - 2
+      }
+    }
+    else if (duration == 6) {
+      return {
+        two_year_transaction_period: cycle,
+        two_year_transaction_period: cycle - 2,
+        two_year_transaction_period: cycle - 4
+      }
+    }
+    else {
+      return {
+        two_year_transaction_period: cycle
+      }
     };
   } else {
     return {
@@ -132,13 +148,16 @@ function buildTotalLink(path, getParams) {
       if (path.indexOf('receipts') > -1 || path.indexOf('disbursements') > -1) {
         includeTransactionPeriod = true;
       }
+      console.log("buildTotalLink params.duration");
+      console.log(params.duration);
       var uri = helpers.buildAppUrl(
         path,
         _.extend(
           { committee_id: row.committee_id },
           buildAggregateUrl(
             _.extend({}, row, params).cycle,
-            includeTransactionPeriod
+            includeTransactionPeriod,
+            params.duration
           ),
           params
         )
@@ -170,11 +189,15 @@ function makeCommitteeColumn(opts, context, factory) {
       ) {
         row.cycle = context.election.cycle;
         var column = meta.settings.aoColumns[meta.col].data;
+        row.duration = context.election.duration;
+        console.log("makeCommitteeColumn duration");
+        console.log(row.duration);
         return _.extend(
           {
             committee_id: (context.candidates[row.candidate_id] || {})
               .committee_ids,
-            two_year_transaction_period: row.cycle
+            two_year_transaction_period: row.cycle//,
+            //duration: row.duration
           },
           factory(data, type, row, meta, column)
         );

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -257,13 +257,26 @@ function formatCycleRange(year, duration) {
 }
 
 function cycleDates(year, duration) {
-  console.log("cycleDates duration");
-  console.log(duration);
-  console.log(year - duration + 1)
   return {
     min: '01-01-' + (year - duration + 1),
     max: '12-31-' + year
   };
+}
+
+function multiCycles(cycle, duration, label = 'two_year_transaction_period') {
+  if (duration == 6) {
+    return {
+      [label]: [cycle, cycle - 2, cycle - 4]
+    };
+  } else if (duration == 4) {
+    return {
+      [label]: [cycle, cycle - 2]
+    };
+  } else {
+    return {
+      [label]: cycle
+    };
+  }
 }
 
 function ensureArray(value) {
@@ -532,6 +545,7 @@ module.exports = {
   buildTableQuery: buildTableQuery,
   currency: currency,
   cycleDates: cycleDates,
+  multiCycles: multiCycles,
   datetime: datetime,
   dollar: dollar,
   ensureArray: ensureArray,

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -256,9 +256,12 @@ function formatCycleRange(year, duration) {
   return firstYear + '–' + year;
 }
 
-function cycleDates(year) {
+function cycleDates(year, duration) {
+  console.log("cycleDates duration");
+  console.log(duration);
+  console.log(year - duration + 1)
   return {
-    min: '01-01-' + (year - 1),
+    min: '01-01-' + (year - duration + 1),
     max: '12-31-' + year
   };
 }

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -322,6 +322,11 @@ function buildTableQuery(context) {
     .object()
     .value();
 
+  // remove duration from API query - only needed for JS calculations
+  if (query.duration) {
+    delete query.duration;
+  }
+
   return _.extend(query, {
     per_page: pageLength,
     sort_hide_null: true

--- a/fec/fec/tests/js/column-helpers.js
+++ b/fec/fec/tests/js/column-helpers.js
@@ -52,6 +52,14 @@ describe('column helpers', function() {
       expect(results).to.have.all.keys('two_year_transaction_period');
       expect(results.two_year_transaction_period).to.equal(2018);
     });
+
+    it('should return multiple two year transaction periods when duration > 2', function() {
+      var results = columnHelpers.buildAggregateUrl(2018, true, 4);
+      expect(results).to.be.an('object');
+      expect(results).to.have.all.keys('two_year_transaction_period');
+      expect(results.two_year_transaction_period).to.eql([2018, 2016]); //deep equal
+    });
+
   });
 
   describe('buildEntityLink', function() {


### PR DESCRIPTION
## Summary (required)

- Resolves #2790: Update aggregate totals links with full election cycles

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Election profile pages "Individual contributions to candidates" State/Size chart and Other spending (IE, EC, CC) sections: https://www.fec.gov/data/elections/president/2020/#individual-contributions
- Candidate/committee profile pages Raising and Spending tabs, https://www.fec.gov/data/candidate/P60007168/?cycle=2020&election_full=true&tab=raising and 
https://www.fec.gov/data/committee/C00696948/?cycle=2020&tab=raising

## Screenshots

![Screen Shot 2019-07-19 at 4 17 31 PM](https://user-images.githubusercontent.com/31420082/61563166-24e38f00-aa41-11e9-8d21-c3962863572e.png)
![Screen Shot 2019-07-19 at 4 17 03 PM](https://user-images.githubusercontent.com/31420082/61563167-24e38f00-aa41-11e9-8e60-3b1d4d67dc84.png)

## How to test

- Point to `dev` or `stage` API (stage will be faster)
- Election profile pages should have expanded date ranges or multiple `two_year_transaction_period`s to correspond with full election cycle. 


- Senate: 6 years http://localhost:8000/data/elections/senate/ME/2020/
- Presidential and PR: 4 years http://localhost:8000/data/elections/president/2020/ and http://localhost:8000/data/elections/house/PR/00/2016/
- House: 2 years http://localhost:8000/data/elections/house/CA/12/2020/