### PR TITLE
Apply reset filter to receipts and individual contributions datatable

### DIFF
--- a/fec/fec/static/js/modules/filters/filter-set.js
+++ b/fec/fec/static/js/modules/filters/filter-set.js
@@ -176,7 +176,10 @@ FilterSet.prototype.activateSwitchedFilters = function(dataType) {
   );
 
   // Set forceRemove: true to clear date filters that are usually nonremovable
-  this.$body.trigger('tag:removeAll', { forceRemove: true });
+  this.$body.trigger('tag:removeAll', {
+    forceRemove: true,
+    fromFilterSet: true
+  });
   // Go through the current panel and set loaded-once on each input
   // So that they don't show loading indicators
   _.each(this.filters, function(filter) {

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -504,6 +504,9 @@ DataTable.prototype.initFilters = function() {
       resultType: 'results',
       showResultCount: true,
       tableTitle: this.opts.title
+      // We're using the table title to decide whether to clear or reset filters.
+      // This is a temporary solution to clear filters and not break pages/tables that still require two-year restrictions
+      // TODO
     });
     this.$widgets.find('.js-filter-tags').prepend(tagList.$body);
     this.filterPanel = new FilterPanel();


### PR DESCRIPTION
## Summary

- Resolves #2987 
_This adds reset filters button and functionality to schedule_a tables: receipts and individual contributions._

## Impacted areas of the application
List general components of the application that this PR will affect:

- http://localhost:8000/data/receipts/
- http://localhost:8000/data/receipts/individual-contributions/

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/2987-fix-clear-all-filters-links | [link](https://github.com/fecgov/fec-cms/pull/2990)

## How to test
1. Check out this branch
2. Go to [receipts](http://localhost:8000/data/receipts/) and click on "Reset filters" button in the top right. 
Make sure that the page resets correctly to: 
two_year_transaction_period=2020
min_date=01/01/2019
max_date=12/31/2020
3. Go to [individual contributions](http://localhost:8000/data/receipts/individual-contributions/) and click on "Reset filters" button in the top right. 
Make sure that the page resets correctly to: 
two_year_transaction_period=2020
min_date=01/01/2019
max_date=12/31/2020
____

