### PR TITLE
Add new data summary language to various pages

### DIFF
--- a/fec/data/templates/macros/bythenumbers.jinja
+++ b/fec/data/templates/macros/bythenumbers.jinja
@@ -34,7 +34,7 @@
         {% endfor %}
       </select>
   </form>
-  
+
   <span class="t-sans js-dates"></span>
   <div class="chart-table simple-table--responsive js-top-table" id="top-table" aria-live="polite" role="grid">
     <div role="row" class="simple-table__header">
@@ -42,7 +42,7 @@
       <div role="columnheader" class="simple-table__header-cell cell--20 t-right-aligned">Total {{ action }}</div>
       <div role="columnheader" class="simple-table__header-cell cell--40"></div>
     </div>
-  
+
   </div>
   <div class="results-info">
     <button class="js-previous is-disabled button button--standard button--previous"><span class="u-visually-hidden">Previous page</span></button>
@@ -51,11 +51,16 @@
       Showing <span class="js-page-info"></span> entries
     </div>
   </div>
+
 </div>
+
 <div class="content__section row">
   <ul class="list--buttons u-float-right">
     <li><a class="button button--standard button--table" href="/data/{{ value_field }}">Browse {{value_field}}</a></li>
     <li><button class="button button--alt js-ga-event"  data-a11y-dialog-show="{{ action }}-modal" data-ga-event="{{ action }} methodology modal clicked" aria-controls="{{ action }}-modal">Methodology</button></li>
+
+
   </ul>
+<p><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
 </div>
 {% endmacro %}

--- a/fec/data/templates/macros/disclaimer.jinja
+++ b/fec/data/templates/macros/disclaimer.jinja
@@ -4,3 +4,13 @@
     {# <a href="{{ url_for(type, committee_id=id, cycle=cycle) }}">access the list of itemized transactions.</a></p> #}
   </div>
 {% endmacro %}
+{% macro summary() %}
+  <div class="accordion--neutral">
+    <div class="accordion__content">
+      <div class="message message--info message--small">
+        <p class="t-sans">Newly filed summary data may not appear for up to 48 hours.</p>
+       </div>
+     </div>
+   </div>
+{% endmacro %}
+

--- a/fec/data/templates/macros/tables.jinja
+++ b/fec/data/templates/macros/tables.jinja
@@ -62,5 +62,6 @@ not 'type' object, so use 'link' to check for 'independent-expenditures' and 'pa
     </tr>
   {% endfor %}
 </table>
+<p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
 </figure>
 {% endmacro %}

--- a/fec/data/templates/partials/browse-data/raising.jinja
+++ b/fec/data/templates/partials/browse-data/raising.jinja
@@ -57,6 +57,7 @@
       </li>
       <li>
         <div class="content__section--indent-left">
+          <p class="t-note">Newly filed summary data may not appear for up to 48 hours.</p>
           <div class="js-accordion accordion--neutral" data-content-prefix="methodology_raising">
             <button type="button" class="js-accordion-trigger accordion__button">Methodology</button>
             <div class="accordion__content">

--- a/fec/data/templates/partials/browse-data/raising.jinja
+++ b/fec/data/templates/partials/browse-data/raising.jinja
@@ -56,8 +56,10 @@
         </section>
       </li>
       <li>
-        <div class="content__section--indent-left">
-          <p class="t-note">Newly filed summary data may not appear for up to 48 hours.</p>
+        <div class="content__section--ruled">
+
+            <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
+
           <div class="js-accordion accordion--neutral" data-content-prefix="methodology_raising">
             <button type="button" class="js-accordion-trigger accordion__button">Methodology</button>
             <div class="accordion__content">

--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -116,6 +116,7 @@
       </li>
       <li>
         <div class="content__section--indent-left">
+          <p class="t-note">Newly filed summary data may not appear for up to 48 hours.</p>
           <div class="js-accordion accordion--neutral" data-content-prefix="methodology_spending">
             <button type="button" class="js-accordion-trigger accordion__button">Methodology</button>
             <div class="accordion__content">

--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -115,8 +115,8 @@
         </section>
       </li>
       <li>
-        <div class="content__section--indent-left">
-          <p class="t-note">Newly filed summary data may not appear for up to 48 hours.</p>
+        <div class="content__section--ruled">
+          <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
           <div class="js-accordion accordion--neutral" data-content-prefix="methodology_spending">
             <button type="button" class="js-accordion-trigger accordion__button">Methodology</button>
             <div class="accordion__content">

--- a/fec/data/templates/partials/candidate/other-spending-tab.jinja
+++ b/fec/data/templates/partials/candidate/other-spending-tab.jinja
@@ -30,6 +30,9 @@
           <span class="t-block t-sans">Spent by others to <strong>oppose</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
         </div>
       </div>
+
+        <p class="t-note">Newly filed summary data may not appear for up to 48 hours.</p>
+
       <table
           class="data-table data-table--heading-borders"
           data-type="independent-expenditures"

--- a/fec/data/templates/partials/candidate/raising.jinja
+++ b/fec/data/templates/partials/candidate/raising.jinja
@@ -56,8 +56,8 @@
         </div>
       </div>
       <div class="content__section--ruled">
-      <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
-    </div>
+        <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
+      </div>
     </div>
     {% endif %}
 

--- a/fec/data/templates/partials/candidate/raising.jinja
+++ b/fec/data/templates/partials/candidate/raising.jinja
@@ -55,6 +55,9 @@
           </div>
         </div>
       </div>
+      <div class="content__section--ruled">
+      <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
+    </div>
     </div>
     {% endif %}
 

--- a/fec/data/templates/partials/candidate/spending.jinja
+++ b/fec/data/templates/partials/candidate/spending.jinja
@@ -59,6 +59,9 @@
           </div>
         </div>
       </div>
+      <div class="content__section--ruled">
+        <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
+      </div>
     </div>
     {% endif %}
 

--- a/fec/data/templates/partials/candidates-office-filter.jinja
+++ b/fec/data/templates/partials/candidates-office-filter.jinja
@@ -8,6 +8,7 @@
 {% import 'macros/filters/election-filter.jinja' as election_filter %}
 {% import 'macros/filters/range.jinja' as range_filter %}
 {% import 'macros/filters/years.jinja' as years %}
+{% import 'macros/disclaimer.jinja' as disclaimer %}
 
  {% block filters %}
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
@@ -41,5 +42,7 @@
       </div>
     {% endif %}
   </div>
+
 </div>
+{{ disclaimer.summary() }}
 {% endblock %}

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -15,6 +15,7 @@
             </div>
           </div>
           {{ tables.summary(ie_summary) }}
+          <p class="t-note">Newly filed summary data may not appear for up to 48 hours.</p>
         </div>
       <!-- Inaugural Committees -->
       {% elif organization_type == 'I' %}

--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -34,6 +34,9 @@
             </div>
           </div>
         </div>
+        <div class="content__section--ruled">
+        <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
+      </div>
       </div>
     {% endif %}
     <div class="entity__figure" id="individual-contribution-transactions">

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -37,6 +37,9 @@
           </div>
         </div>
       </div>
+      <div class="content__section--ruled">
+        <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
+      </div>
     </div>
     {% endif %}
 

--- a/fec/fec/static/scss/layout/_layout.scss
+++ b/fec/fec/static/scss/layout/_layout.scss
@@ -181,6 +181,10 @@
   margin-right: u(1rem);
 }
 
+.u-negative--top--margin {
+margin-top: u(-1rem);
+}
+
 // horizontal rule
 
 .hr--lighter {


### PR DESCRIPTION
## Summary (required)
This ticket adds this new language ("Newly filed summary data may not appear for up to 48 hours.") to several places across the site.
- Resolves #3040

## Impacted areas of the application
List general components of the application that this PR will affect:
       fec/data/templates/macros/bythenumbers.jinja
fec/data/templates/macros/disclaimer.jinja
fec/data/templates/macros/tables.jinja
fec/data/templates/partials/browse-data/raising.jinja
fec/data/templates/partials/browse-data/spending.jinja
fec/data/templates/partials/candidate/other-spending-tab.jinja
fec/data/templates/partials/candidate/raising.jinja
fec/data/templates/partials/candidate/spending.jinja
fec/data/templates/partials/candidates-office-filter.jinja
fec/data/templates/partials/committee/financial-summary.jinja
fec/data/templates/partials/committee/raising.jinja
fec/data/templates/partials/committee/spending.jinja
fec/fec/static/scss/layout/_layout.scss

## How to test
- checkout `feature/3040-new-data-summary-language`
- npm run-build sass
- Compare  these pages to the mockups on Issue [3040](https://github.com/fecgov/fec-cms/issues/3040) to ensure that the new language is there and presented properly. 
- These are all linked with http://127.0.0.1:8000 as the URL base,  for local testing:

Data tables: 

- [x] [Presidential candidates](http://127.0.0.1:8000/data/candidates/president/)
- [x] [Senate candidates](http://127.0.0.1:8000/data/candidates/senate/?is_active_candidate=true) 
- [x] [House of Representatives candidates](http://127.0.0.1:8000/data/candidates/house/?is_active_candidate=true)

Visualizations:

 - [x] [Cumulative amount raised by committees](http://127.0.0.1:8000/data/browse-data/?tab=raising) _same as next_
 - [x] [Cumulative amount spent by committees](http://127.0.0.1:8000/data/browse-data/?tab=spending) 
 - [x] [Office/party totals raised and Top raising bar chart](http://127.0.0.1:8000/data/raising-bythenumbers/) - _same as next_
 - [x] [Office/party totals spent and Top spending bar chart](http://127.0.0.1:8000/data/spending-bythenumbers/)

Candidate profile pages: 

 - [x] [Financial summary tab](http://127.0.0.1:8000/data/candidate/P80001571/) - _same as committee profile pages_
 - [x] [Raising tab](http://127.0.0.1:8000/data/candidate/P80001571/?tab=raising) - _same as committee profile pages_
 - [x] [Spending tab](http://127.0.0.1:8000/data/candidate/P80001571/?tab=spending) - _same as committee profile pages_
 - [x] [Spending by others to support or oppose](http://127.0.0.1:8000/data/candidate/P80001571/?tab=other-spending)

Committee profile pages: 

 - [x] [Financial summary tab](http://127.0.0.1:8000/data/committee/C00580100/?cycle=2020) - _same as candidate profile pages_
 - [x] [Raising tab](http://127.0.0.1:8000/data/committee/C00580100/?cycle=2020&tab=raising) - _same as candidate profile pages_
 - [x] [Spending tab](http://127.0.0.1:8000/data/committee/C00580100/?cycle=2020&tab=spending) - _same as candidate profile pages_

