### PR TITLE
3087 Change Google Analytics Account Numbers from 18F's

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -153,7 +153,7 @@
 
     ga('set', 'anonymizeIp', true);
     ga('set', 'forceSSL', true);
-    ga('create', 'UA-48605964-22', 'auto');
+    ga('create', 'UA-16134356-1', 'auto');
     ga('send', 'pageview');
   </script>
   <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>

--- a/fec/data/templates/layouts/widgets.jinja
+++ b/fec/data/templates/layouts/widgets.jinja
@@ -67,7 +67,7 @@
 
     ga('set', 'anonymizeIp', true);
     ga('set', 'forceSSL', true);
-    ga('create', 'UA-48605964-22', 'auto');
+    ga('create', 'UA-16134356-1', 'auto');
     ga('send', 'pageview');
   </script>
   <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>

--- a/fec/fec/static/js/modules/analytics.js
+++ b/fec/fec/static/js/modules/analytics.js
@@ -39,7 +39,7 @@ function init() {
     );
   }
 
-  ga('create', 'UA-48605964-22', 'auto', 'notDAP');
+  ga('create', 'UA-16134356-1', 'auto', 'notDAP');
   ga('notDAP.set', 'forceSSL', true);
   ga('notDAP.set', 'anonymizeIp', true);
 }

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -164,7 +164,7 @@
 
       ga('set', 'anonymizeIp', true);
       ga('set', 'forceSSL', true);
-      ga('create', 'UA-48605964-22', 'auto');
+      ga('create', 'UA-16134356-1', 'auto');
       ga('send', 'pageview');
     </script>
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -165,7 +165,7 @@
 
       ga('set', 'anonymizeIp', true);
       ga('set', 'forceSSL', true);
-      ga('create', 'UA-48605964-22', 'auto');
+      ga('create', 'UA-16134356-1', 'auto');
       ga('send', 'pageview');
     </script>
 


### PR DESCRIPTION
## Summary

- Resolves #3087 
Change every instance of `UA-48605964-22` to `UA-16134356-1` so we're sending Google Analytics tracking data to our (FEC) account instead of to FEC's account. The GSA account should be unaffected.

## Impacted areas of the application
We're only changing the account numbers. Users should see zero difference in site performance.

## Screenshots
None

## Related PRs
None

## How to test
Testing analytics can be tricky. As-is, we shouldn't be able to test anything until the code is on production and we start seeing numbers come through to GA.

One possible complication for this update is that our Classic tracking is an older version of GA than our current Production version. I'm pretty sure simply updating the account should work but want to double-check.

Because our analytics code is inside conditional checks (`{% if not settings.DEBUG %}`, `{% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}`), we could remove those conditionals so the code actually runs.

Except GA should ignore any tracking requests to our account that aren't specifically from our domain (e.g., dev is technically on cloud.gov). Maybe we should set up another property under our GA account specifically for our non-production environments? This would help when transitioning to Google Tag Manager ( #2840 ), too.


____

