### PR TITLE
Fix mailto link in ao, legal and legal search templates

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -60,7 +60,6 @@ ENVIRONMENTS = {
     'feature': 'FEATURE',
 }
 FEC_CMS_ENVIRONMENT = ENVIRONMENTS.get(env.get_credential('FEC_CMS_ENVIRONMENT'), 'LOCAL')
-CONTACT_EMAIL = 'webmanager@fec.gov'
 WEBMANAGER_EMAIL = "webmanager@fec.gov"
 
 # Application definition

--- a/fec/legal/templates/layouts/legal-doc-search-results.jinja
+++ b/fec/legal/templates/layouts/legal-doc-search-results.jinja
@@ -58,7 +58,7 @@
             {% if query %}
             <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources=Administrative_Fine%2CAdvisory_Opinion%2CAlternative_Dispute_Resolution%2CAudit_Reports%2CMatters_Under_Review%2CMatters_Under_Review_Archived%2CRulemaster%2CCandidate_Summary%2CCommittee_Summary%2Cfec.gov&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
             {% endif %}
-            <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
+            <li><a class="button button--standard" href="mailto:{{ WEBMANAGER_EMAIL }}">Email our team</a></li>
             <li><a class="button button--standard" href="https://github.com/fecgov/fec/issues">File an issue</a></li>
           </ul>
         </div>

--- a/fec/legal/templates/legal-search-results-advisory_opinions.jinja
+++ b/fec/legal/templates/legal-search-results-advisory_opinions.jinja
@@ -10,7 +10,7 @@
 
 {% block search %}
 <input id="query" type="hidden" value="{{ query }}" />
-<input id="contact-email" type="hidden" value="{{ contact_email }}" />
+<input id="contact-email" type="hidden" value="{{ WEBMANAGER_EMAIL }}" />
 <input id="advisory_opinion_page" type="hidden" value="/data/legal/advisory-opinions/ao_no" />
 <div id="root"></div>
 <script src="{{ asset_for_js('legalApp.js') }}"></script>

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -107,7 +107,7 @@
       {% if query %}
       <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources={{ '%2C'.join(fec_resources or []) }}&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
       {% endif %}
-      <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
+      <li><a class="button button--standard" href="mailto:{{ WEBMANAGER_EMAIL }}">Email our team</a></li>
       <li><a class="button button--standard" href="https://github.com/fecgov/fec/issues">File an issue</a></li>
     </ul>
   </div>


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/fec-cms/issues/3080

_Include a summary of proposed changes._

Update below templates to use `webmanager_email` variable. Remove the unused variable `contact_emai`l from base.py

1.  fec/settings/base.py
2.  legal/templates/layouts/legal-doc-search-results.jinja
3.  legal/templates/legal-search-results-advisory_opinions.jinja
4.  legal/templates/macros/legal.jinja

## Impacted areas of the application
List general components of the application that this PR will affect:

-  AO search
- Statues search
- All Legal search


## Screenshots

- _Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface or front end change, include both a Before and After screenshot._

** Before:**

<img width="1440" alt="Screen Shot 2019-08-02 at 3 42 24 PM" src="https://user-images.githubusercontent.com/11650355/62395267-ba047e80-b53d-11e9-8a15-10261a4a58a9.png">

<img width="1393" alt="Screen Shot 2019-08-02 at 3 41 20 PM" src="https://user-images.githubusercontent.com/11650355/62395266-ba047e80-b53d-11e9-887b-53bc440d623e.png">

<img width="1436" alt="Screen Shot 2019-08-02 at 3 43 07 PM" src="https://user-images.githubusercontent.com/11650355/62395269-ba047e80-b53d-11e9-99e7-18e6f9ba86ef.png">
<img width="1439" alt="Screen Shot 2019-08-02 at 3 43 19 PM" src="https://user-images.githubusercontent.com/11650355/62395270-ba047e80-b53d-11e9-9dcd-d41df000a34a.png">
<img width="1428" alt="Screen Shot 2019-08-02 at 3 43 43 PM" src="https://user-images.githubusercontent.com/11650355/62395271-ba047e80-b53d-11e9-8a35-00b1992c2569.png">
<img width="1440" alt="Screen Shot 2019-08-02 at 3 43 56 PM" src="https://user-images.githubusercontent.com/11650355/62395272-ba047e80-b53d-11e9-8e6c-c67321a68335.png">

**After :**
http://127.0.0.1:8000/data/legal/search/advisory-opinions/?type=advisory_opinions&search=adsfasdfdsf&q=adsfasdfdsf&ao_category=F

<img width="1436" alt="Screen Shot 2019-08-02 at 3 01 04 PM" src="https://user-images.githubusercontent.com/11650355/62393033-06988b80-b537-11e9-975f-674beeafe676.png">

http://127.0.0.1:8000/data/legal/search/statutes/?search=asdfsdf

<img width="1436" alt="Screen Shot 2019-08-02 at 3 01 39 PM" src="https://user-images.githubusercontent.com/11650355/62393802-347ecf80-b539-11e9-810f-adf421217bb2.png">

http://127.0.0.1:8000/data/legal/search/?search_type=all&search=asdfasdfasdfsdf
<img width="1435" alt="Screen Shot 2019-08-02 at 3 25 12 PM" src="https://user-images.githubusercontent.com/11650355/62394194-7b20f980-b53a-11e9-80f0-44ed09e02412.png">
<img width="1438" alt="Screen Shot 2019-08-02 at 3 25 39 PM" src="https://user-images.githubusercontent.com/11650355/62394196-7bb99000-b53a-11e9-9f76-39012b900e8d.png">
<img width="1435" alt="Screen Shot 2019-08-02 at 3 25 56 PM" src="https://user-images.githubusercontent.com/11650355/62394199-7bb99000-b53a-11e9-9a37-e6d7ccbf9b2f.png">
<img width="1437" alt="Screen Shot 2019-08-02 at 3 26 06 PM" src="https://user-images.githubusercontent.com/11650355/62394200-7bb99000-b53a-11e9-8c30-02525ea92472.png">
<img width="1440" alt="Screen Shot 2019-08-02 at 3 23 19 PM" src="https://user-images.githubusercontent.com/11650355/62394201-7bb99000-b53a-11e9-9197-44450658537d.png">

## How to test
- checkout the branch `feature/3080-fix-mailto-link`
- point to dev, stage or prod api
- start the server` ./manage.py runserver`
- open each one of the links below and click on the `Email our Team` button. That should open outlook/mac app email with a To address  field prefilled with `webmanager.fec.gov`

http://127.0.0.1:8000/data/legal/search/advisory-opinions/?type=advisory_opinions&search=adsfasdfdsf&q=adsfasdfdsf&ao_category=F

http://127.0.0.1:8000/data/legal/search/statutes/?search=asdfsdf

http://127.0.0.1:8000/data/legal/search/?search_type=all&search=asdfasdfasdfsdf



