### PR TITLE
[On Hold] Add content security policy headers

### DIFF
--- a/fec/data/templates/partials/meta-tags.jinja
+++ b/fec/data/templates/partials/meta-tags.jinja
@@ -7,7 +7,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="description" content="{{ description }}">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: *.fec.gov; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' data: 'unsafe-inline'; img-src 'self' data: *.ssl.fastly.net; frame-src 'self' https://www.google.com">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: *.fec.gov; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov; style-src 'self' data: 'unsafe-inline'; img-src 'self' data: *.ssl.fastly.net; frame-src 'self' https://www.google.com">
 
 <!-- Mobile Specific Metas
 ================================================== -->

--- a/fec/data/templates/partials/meta-tags.jinja
+++ b/fec/data/templates/partials/meta-tags.jinja
@@ -7,46 +7,46 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="description" content="{{ description }}">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: *.fec.gov; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov; style-src 'self' data: 'unsafe-inline'; img-src 'self' data: *.ssl.fastly.net; frame-src 'self' https://www.google.com">
+<meta http-equiv="Content-Security-Policy" content="{{ CONTENT_SECURITY_POLICY|safe }}">
 
-<!-- Mobile Specific Metas
-================================================== -->
+{# Mobile Specific Metas -#}
+{#- ================================================== -#}
 <meta name="HandheldFriendly" content="True">
 <meta name="MobileOptimized" content="320">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
-<!-- Twitter
-================================================== -->
+{# Twitter -#}
+{#- ================================================== -#}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ title | trim }} - FEC.gov">
 <meta name="twitter:description" content="{{ description }}">
 <meta name="twitter:image" content="{{ static('img/social/data.png') }}">
 
-<!-- Facebook
-================================================== -->
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ CANONICAL_BASE }}" />
-<meta property="og:title" content="{{ title | trim }} - FEC.gov" />
-<meta property="og:site_name" content="FEC.gov" />
-<meta property="og:description" content="{{ description }}" />
-<meta property="og:image" content="{{ static('img/social/data.png') }}" />
+{# Facebook -#}
+{#- ================================================== -#}
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ CANONICAL_BASE }}">
+<meta property="og:title" content="{{ title | trim }} - FEC.gov">
+<meta property="og:site_name" content="FEC.gov">
+<meta property="og:description" content="{{ description }}">
+<meta property="og:image" content="{{ static('img/social/data.png') }}">
 
-<!-- Google
-================================================== -->
+{# Google -#}
+{#- ================================================== -#}
 <link rel="canonical" href="{{ CANONICAL_BASE }}">
 
-<!-- Favicons
-================================================== -->
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-57x57.png') }}" />
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-72x72.png') }}" />
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-114x114.png') }}" />
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-120x120.png') }}" />
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-144x144.png') }}" />
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-152x152.png') }}" />
+{# Favicons -#}
+{#- ================================================== -#}
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-57x57.png') }}">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-72x72.png') }}">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-114x114.png') }}">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-120x120.png') }}">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-144x144.png') }}">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ static('img/favicon/data/apple-touch-icon-152x152.png') }}">
 
-<link rel="icon" type="image/png" href="{{ static('img/favicon/favicon-32x32.png') }}" sizes="32x32" />
-<link rel="icon" type="image/png" href="{{ static('img/favicon/favicon-16x16.png') }}" sizes="16x16" />
+<link rel="icon" type="image/png" href="{{ static('img/favicon/favicon-32x32.png') }}" sizes="32x32">
+<link rel="icon" type="image/png" href="{{ static('img/favicon/favicon-16x16.png') }}" sizes="16x16">
 
-<meta name="application-name" content="&nbsp;"/>
-<meta name="msapplication-TileColor" content="#FFFFFF" />
-<meta name="msapplication-TileImage" href="{{ static('img/favicon/data/mstile-144x144.png') }}" />
+<meta name="application-name" content="&nbsp;">
+<meta name="msapplication-TileColor" content="#FFFFFF">
+<meta name="msapplication-TileImage" href="{{ static('img/favicon/data/mstile-144x144.png') }}">

--- a/fec/data/templates/partials/meta-tags.jinja
+++ b/fec/data/templates/partials/meta-tags.jinja
@@ -7,6 +7,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="description" content="{{ description }}">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: *.fec.gov; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' data: 'unsafe-inline'; img-src 'self' data: *.ssl.fastly.net; frame-src 'self' https://www.google.com">
 
 <!-- Mobile Specific Metas
 ================================================== -->

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -63,6 +63,22 @@ FEC_CMS_ENVIRONMENT = ENVIRONMENTS.get(env.get_credential('FEC_CMS_ENVIRONMENT')
 CONTACT_EMAIL = 'webmanager@fec.gov'
 WEBMANAGER_EMAIL = "webmanager@fec.gov"
 
+# Used for the content-security-policy meta tag
+CONTENT_SECURITY_POLICY = ''\
+    'default-src \'self\' data: *.fec.gov; '\
+    'frame-src \'self\' https://www.google.com;'\
+    'img-src \'self\' data: http://*.fastly.net; '\
+    'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://www.google.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov; '\
+    'style-src \'self\' data: \'unsafe-inline\'; '
+
+if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:
+    CONTENT_SECURITY_POLICY = ''\
+        'default-src \'self\' data: *.fec.gov localhost:* http://127.0.0.1:* http://*.app.cloud.gov https://*.app.cloud.gov; '\
+        'frame-src \'self\' https://www.google.com; '\
+        'img-src \'self\' data: http://*.fastly.net;'\
+        'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://www.google.com https://www.gstatic.com https://polyfill.io; '\
+        'style-src \'self\' data: \'unsafe-inline\'; '
+
 # Application definition
 INSTALLED_APPS = (
     'django.contrib.admin',
@@ -147,6 +163,7 @@ TEMPLATES = [
                 'CLASSIC_URL': FEC_CLASSIC_URL,
                 'FEC_CMS_ENVIRONMENT': FEC_CMS_ENVIRONMENT,
                 'FEATURES': FEATURES,
+                'CONTENT_SECURITY_POLICY': CONTENT_SECURITY_POLICY,
             },
         }
     },

--- a/fec/fec/templates/partials/meta-tags.html
+++ b/fec/fec/templates/partials/meta-tags.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="description" content="{% if self.search_description %}{{ self.search_description }}{% else %}{{ self.content_section | get_meta_description }}{% endif %}">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: *.fec.gov; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' data: 'unsafe-inline'; img-src 'self' data: *.ssl.fastly.net; frame-src 'self' https://www.google.com">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: *.fec.gov; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov; style-src 'self' data: 'unsafe-inline'; img-src 'self' data: *.ssl.fastly.net; frame-src 'self' https://www.google.com">
 
 <!-- Mobile Specific Metas
 ================================================== -->

--- a/fec/fec/templates/partials/meta-tags.html
+++ b/fec/fec/templates/partials/meta-tags.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="description" content="{% if self.search_description %}{{ self.search_description }}{% else %}{{ self.content_section | get_meta_description }}{% endif %}">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: *.fec.gov; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' data: 'unsafe-inline'; img-src 'self' data: *.ssl.fastly.net; frame-src 'self' https://www.google.com">
 
 <!-- Mobile Specific Metas
 ================================================== -->

--- a/fec/fec/templates/partials/meta-tags.html
+++ b/fec/fec/templates/partials/meta-tags.html
@@ -4,49 +4,49 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="description" content="{% if self.search_description %}{{ self.search_description }}{% else %}{{ self.content_section | get_meta_description }}{% endif %}">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: *.fec.gov; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov; style-src 'self' data: 'unsafe-inline'; img-src 'self' data: *.ssl.fastly.net; frame-src 'self' https://www.google.com">
+<meta http-equiv="Content-Security-Policy" content="{{ settings.CONTENT_SECURITY_POLICY|safe }}">
 
-<!-- Mobile Specific Metas
-================================================== -->
+{# Mobile Specific Metas -#}
+{#- ================================================== -#}
 <meta name="HandheldFriendly" content="True">
 <meta name="MobileOptimized" content="320">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
-<!-- Twitter
-================================================== -->
+{# Twitter -#}
+{#- ================================================== -#}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ self.title }} - FEC.gov">
 <meta name="twitter:description" content="{% if self.search_description %}{{ self.search_description }}{% else %}{{ self.content_section | get_meta_description }}{% endif %}">
 <meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ self.content_section | get_social_image }}">
 
-<!-- Facebook
-================================================== -->
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ settings.CANONICAL_BASE }}{{ request.path }}" />
-<meta property="og:title" content="{{ self.title }} - FEC.gov" />
-<meta property="og:site_name" content="FEC.gov" />
-<meta property="og:description" content="{% if self.search_description %}{{ self.search_description }}{% else %}{{ self.content_section | get_meta_description }}{% endif %}" />
-<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ self.content_section | get_social_image }}" />
+{# Facebook -#}
+{#- ================================================== -#}
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ settings.CANONICAL_BASE }}{{ request.path }}">
+<meta property="og:title" content="{{ self.title }} - FEC.gov">
+<meta property="og:site_name" content="FEC.gov">
+<meta property="og:description" content="{% if self.search_description %}{{ self.search_description }}{% else %}{{ self.content_section | get_meta_description }}{% endif %}">
+<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ self.content_section | get_social_image }}">
 
-<!-- Google
-================================================== -->
+{# Google -#}
+{#- ================================================== -#}
 <link rel="canonical" href="{{ settings.CANONICAL_BASE }}{{ request.path }}">
 
-<!-- Search console verifications
-================================================== -->
-<meta name="google-site-verification" content="rEjjZg6JSzXZCFwXo_8bNKK68jrZdqV-yhDqJluWb8k" />
-<meta name="msvalidate.01" content="A6E2BFF1CD488F37FC4A42640E760D02" />
+{# Search console verifications -#}
+{#- ================================================== -#}
+<meta name="google-site-verification" content="rEjjZg6JSzXZCFwXo_8bNKK68jrZdqV-yhDqJluWb8k">
+<meta name="msvalidate.01" content="A6E2BFF1CD488F37FC4A42640E760D02">
 
-<!-- Favicons
-================================================== -->
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'57x57' }}" />
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'72x72' }}" />
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'114x114' }}" />
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'120x120' }}" />
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'144x144' }}" />
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'152x152' }}" />
-<link rel="icon" type="image/png" href="{% static "img/favicon/favicon-32x32.png" %}" sizes="32x32" />
-<link rel="icon" type="image/png" href="{% static "img/favicon/favicon-16x16.png" %}" sizes="16x16" />
-<meta name="application-name" content="&nbsp;"/>
-<meta name="msapplication-TileColor" content="#FFFFFF" />
-<meta name="msapplication-TileImage" content="{% static "img/favicon/general/mstile-144x144.png" %}" />
+{# Favicons -#}
+{#- ================================================== -#}
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'57x57' }}">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'72x72' }}">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'114x114' }}">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'120x120' }}">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'144x144' }}">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'152x152' }}">
+<link rel="icon" type="image/png" href="{% static "img/favicon/favicon-32x32.png" %}" sizes="32x32">
+<link rel="icon" type="image/png" href="{% static "img/favicon/favicon-16x16.png" %}" sizes="16x16">
+<meta name="application-name" content="&nbsp;">
+<meta name="msapplication-TileColor" content="#FFFFFF">
+<meta name="msapplication-TileImage" content="{% static "img/favicon/general/mstile-144x144.png" %}" >


### PR DESCRIPTION
## Summary

- Resolves #3069 
_This adds content security policy headers to every page on our website._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  This will impact everything on our website. Need to make sure that there are no loading errors for anything we pull into our site like api calls, scripts, images, fonts, etc. 

## Screenshots

None, this is pure code

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
openFEC/feature/3876-add-response-headers | [link](https://github.com/fecgov/openFEC/pull/3891)

## How to test
Check each template type to make sure that the content security policy is not interfering with anything we're pulling into the site.
- [ ] Homepage
- [ ] Data landing
- [ ] Election search page
- [ ] All datatable pages
- [ ] Candidate profile pages
- [ ] Committee profile pages
- [ ] Election profile pages
- [ ] Wagtail admin (creating new pages, updating pages, saving pages, adding new block components)
- [x] Wagtail generated pages
- [x] Legal resource pages

For developers, open up your inspector console and look for errors like this: 

"Refused to load the script 'https://example.gov' because it violates the following Content Security Policy directive:..."