### PR TITLE
[Merge with openFEC 3919]Fix Candidate profile financial summary page inconsistent data.

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -298,6 +298,13 @@ def load_first_row_data(*path_parts, **filters):
     return response['results'][0] if response['results'] else None
 
 
+def load_endpoint_data(*path_parts, **filters):
+    return _call_api(
+        *path_parts,
+        **filters
+    )
+
+
 def load_cmte_financials(committee_id, **filters):
     filters.update({
         'is_amended': 'false',
@@ -313,18 +320,6 @@ def load_cmte_financials(committee_id, **filters):
         'reports': reports['results'],
         'totals': totals['results'],
     }
-
-
-def load_candidate_totals(candidate_id, cycle, election_full=True):
-    """This function is not used since 08/2019."""
-    response = _call_api(
-        'candidate',
-        candidate_id,
-        'totals',
-        cycle=cycle,
-        election_full=election_full,
-    )
-    return response['results'][0] if response['results'] else None
 
 
 def load_candidate_statement_of_candidacy(candidate_id, cycle):

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -210,7 +210,7 @@ def load_legal_admin_fines(admin_fine_no):
     url = '/legal/docs/admin_fines/'
     admin_fine = _call_api(url, parse.quote(admin_fine_no))
     if not admin_fine:
-       raise Http404
+        raise Http404
     admin_fine = admin_fine['docs'][0]
     admin_fine['disposition_text'] = [d['action'] for d in admin_fine['commission_votes']]
     documents_by_type = OrderedDict()
@@ -293,6 +293,11 @@ def load_with_nested(primary_type, primary_id, secondary_type, cycle=None,
     return data, nested_data['results'], cycle
 
 
+def load_first_row_data(*path_parts, **filters):
+    response = _call_api(*path_parts, **filters)
+    return response['results'][0] if response['results'] else None
+
+
 def load_cmte_financials(committee_id, **filters):
     filters.update({
         'is_amended': 'false',
@@ -311,12 +316,13 @@ def load_cmte_financials(committee_id, **filters):
 
 
 def load_candidate_totals(candidate_id, cycle, election_full=True):
+    """This function is not used since 08/2019."""
     response = _call_api(
         'candidate',
         candidate_id,
         'totals',
         cycle=cycle,
-        full_election=election_full,
+        election_full=election_full,
     )
     return response['results'][0] if response['results'] else None
 
@@ -429,7 +435,6 @@ def call_senate_specials(state):
     )
 
     return special_results.get('results')
-
 
 
 def format_special_results(special_results=[]):

--- a/fec/data/templates/candidates-single.jinja
+++ b/fec/data/templates/candidates-single.jinja
@@ -112,7 +112,10 @@
             aria-controls="panel6"
             href="#section-6">Filings</a>
             <ul>
-             <li><a href="#statements-of-candidacy">Statements of candidacy</a></li>
+            {% if has_raw_filings %}
+              <li><a href="#raw-filings">Raw electronic filings</a></li>
+            {% endif %}
+            <li><a href="#statements-of-candidacy">Statements of candidacy</a></li>
               <li><a href="#other">Other documents filed</a></li>
             </ul>
         </li>

--- a/fec/data/templates/candidates-single.jinja
+++ b/fec/data/templates/candidates-single.jinja
@@ -112,10 +112,7 @@
             aria-controls="panel6"
             href="#section-6">Filings</a>
             <ul>
-              {% if has_raw_filings %}
-                <li><a href="#raw-filings">Raw electronic filings</a></li>
-              {% endif %}
-              <li><a href="#statements-of-candidacy">Statements of candidacy</a></li>
+             <li><a href="#statements-of-candidacy">Statements of candidacy</a></li>
               <li><a href="#other">Other documents filed</a></li>
             </ul>
         </li>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -6,9 +6,6 @@
   <h2 id="section-6-heading">Candidate filings</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
-    {% if has_raw_filings %}
-      {{ entity.raw_filings_table(cycle=None, committee_id=candidate_id, min_receipt_date=min_receipt_date, is_committee=False) }}
-    {% endif %}
       <div id="statements-of-candidacy" class="entity__figure row">
         <div class="content__section">
           <div class="heading--section heading--with-action">

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -6,6 +6,9 @@
   <h2 id="section-6-heading">Candidate filings</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
+    {% if has_raw_filings %}
+      {{ entity.raw_filings_table(cycle=None, committee_id=candidate_id, min_receipt_date=min_receipt_date, is_committee=False) }}
+    {% endif %}
       <div id="statements-of-candidacy" class="entity__figure row">
         <div class="content__section">
           <div class="heading--section heading--with-action">

--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -14,12 +14,12 @@
     <ul class="list--bulleted">
       {% for committee in committee_groups['P'] | reverse %}
       <li>
-        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }} ({{ committee.committee_id}})</a>
       </li>
       {% endfor %}
       {% for committee in committee_groups['A'] | reverse %}
       <li>
-        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }} ({{ committee.committee_id}})</a>
       </li>
       {% endfor %}
     </ul>

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -115,208 +115,6 @@ def browse_data(request):
     return render(request, 'browse-data.jinja', {'title': 'Browse data', 'parent': 'data'})
 
 
-# def get_candidate(candidate_id, cycle, election_full):
-#     """
-#     this function is replaced by get_candidate_summary on 08/2019. It can be deleted later. 
-
-#     """
-
-#     """
-#     Given candidate_id, cycle, election_full, call the API and get the candidate
-#     and candidate financial data needed to render the candidate profile page
-#     """
-
-#     """
-#     for House, set election_full=False except State=PR to solve cms issue#2937
-#     """
-#     if candidate_id.startswith('H', 0, 1) and candidate_id[2:4] != 'PR':
-#         election_full = False
-
-#     candidate, committees, cycle = api_caller.load_with_nested(
-#         'candidate',
-#         candidate_id,
-#         'committees',
-#         cycle=cycle,
-#         cycle_key='two_year_period',
-#         election_full=election_full,
-#     )
-#     # cycle corresponds to the two-year period for which the committee has financial activity.
-#     # when selected election cycle is not in list of election years, get the next election cycle
-#     if election_full and cycle and cycle not in candidate['election_years']:
-
-#         next_cycle = next(
-#             (year for year in sorted(candidate['election_years']) if year > cycle),
-#             max(candidate['election_years']),
-#         )
-
-#         # If the next_cycle is odd set it to whatever the cycle value was- falls back to the cycle
-#         # and then set election_full to false
-#         # This solves issue# 1945 with odd year special elections
-#         if next_cycle % 2 > 0:
-#             next_cycle = cycle
-#             election_full = False
-#         # get the next election cycle data for this candidate
-#         candidate, committees, cycle = api_caller.load_with_nested(
-#             'candidate',
-#             candidate_id,
-#             'committees',
-#             cycle=next_cycle,
-#             cycle_key='two_year_period',
-#             election_full=election_full,
-#         )
-
-#     # Addresses issue#1644 - make any odd year special election an even year
-#     #  for displaying elections for pulldown menu in Candidate pages
-#     #  Using Set to ensure no duplicate years in final list
-#     even_election_years = list(
-#         {year + (year % 2) for year in candidate.get('election_years', [])}
-#     )
-
-#     election_year = next(
-#         (year for year in sorted(even_election_years) if year >= cycle), None
-#     )
-
-#     # If the candidate is not running in a future election,
-#     # return the most recent even eleciton year
-#     if not election_year:
-#         election_year = max(even_election_years)
-
-#     result_type = 'candidates'
-#     duration = election_durations.get(candidate['office'], 2)
-#     min_cycle = cycle - duration if election_full else cycle
-#     report_type = report_types.get(candidate['office'])
-
-#     # For JavaScript
-#     context_vars = {
-#         'cycles': candidate['cycles'],
-#         'name': candidate['name'],
-#         'cycle': cycle,
-#         'electionFull': election_full,
-#         'candidateID': candidate['candidate_id'],
-#     }
-
-#     # In the case of when a presidential or senate candidate has filed
-#     # for a future year that's beyond the current cycle,
-#     # set a max_cycle var to the current cycle we're in
-#     # and when calling the API for totals, set election_full to False.
-#     # The max_cycle value is also referenced in the templates for setting
-#     # the cycle for itemized tables. Because these are only in 2-year chunks,
-#     # the cycle should never be beyond the one we're in.
-#     cycles = [cycle for cycle in candidate['cycles'] if cycle <= utils.current_cycle()]
-#     # New transactions will appear after the Q1 of a new election year - this delays the rollover to a new cycle by 104 days
-#     max_cycle = (
-#         cycle
-#         if cycle <= utils.current_cycle(delayed_start=True)
-#         else utils.current_cycle(delayed_start=True)
-#     )
-#     show_full_election = election_full if cycle <= utils.current_cycle() else False
-
-#     # Annotate committees with most recent available cycle
-#     aggregate_cycles = (
-#         list(range(cycle, cycle - duration, -2)) if election_full else [cycle]
-#     )
-#     for committee in committees:
-#         committee['related_cycle'] = (
-#             max(cycle for cycle in aggregate_cycles if cycle in committee['cycles'])
-#             if election_full
-#             else candidate['two_year_period']
-#         )
-
-#     # Group the committees by designation
-#     committee_groups = groupby(committees, lambda each: each['designation'])
-#     committees_authorized = committee_groups.get('P', []) + committee_groups.get(
-#         'A', []
-#     )
-
-#     committee_ids = [committee['committee_id'] for committee in committees_authorized]
-
-#     # Get aggregate totals for the financial summary
-#     # And pass through the data processing utils
-#     aggregate = api_caller.load_candidate_totals(
-#         candidate['candidate_id'], cycle=cycle, election_full=election_full
-#     )
-#     if aggregate:
-#         raising_summary = utils.process_raising_data(aggregate)
-#         spending_summary = utils.process_spending_data(aggregate)
-#         cash_summary = utils.process_cash_data(aggregate)
-#     else:
-#         raising_summary = None
-#         spending_summary = None
-#         cash_summary = None
-
-#     # Get totals for the last two-year period of a cycle for showing on
-#     # raising and spending tabs
-#     two_year_totals = api_caller.load_candidate_totals(
-#         candidate['candidate_id'], cycle=max_cycle, election_full=False
-#     )
-
-#     # Get the statements of candidacy
-#     statement_of_candidacy = api_caller.load_candidate_statement_of_candidacy(
-#         candidate['candidate_id'], cycle=cycle
-#     )
-
-#     if statement_of_candidacy:
-#         for statement in statement_of_candidacy:
-#             # convert string to python datetime and parse for readable output
-#             statement['receipt_date'] = datetime.datetime.strptime(
-#                 statement['receipt_date'], '%Y-%m-%dT%H:%M:%S'
-#             )
-#             statement['receipt_date'] = statement['receipt_date'].strftime('%m/%d/%Y')
-
-#     # Get all the elections
-#     elections = sorted(
-#         zip(candidate['election_years'], candidate['election_districts']),
-#         key=lambda pair: pair[0],
-#         reverse=True,
-#     )
-
-#     raw_filing_start_date = utils.three_days_ago()
-#     raw_filings = api_caller._call_api(
-#         'efile',
-#         'filings',
-#         cycle=cycle,
-#         committee_id=candidate['candidate_id'],
-#         min_receipt_date=raw_filing_start_date,
-#     )
-#     has_raw_filings = True if raw_filings.get('results') else False
-
-#     return {
-#         'name': candidate['name'],
-#         'cycle': int(cycle),
-#         'office': candidate['office'],
-#         'office_full': candidate['office_full'],
-#         'state': candidate['state'],
-#         'district': candidate['district'],
-#         'candidate_id': candidate_id,
-#         'party_full': candidate['party_full'],
-#         'incumbent_challenge_full': candidate['incumbent_challenge_full'],
-#         'election_year': election_year,
-#         'election_years': even_election_years,
-#         'result_type': result_type,
-#         'duration': duration,
-#         'min_cycle': min_cycle,
-#         'report_type': report_type,
-#         'cycles': cycles,
-#         'max_cycle': max_cycle,
-#         'show_full_election': show_full_election,
-#         'committee_groups': committee_groups,
-#         'committees_authorized': committees_authorized,
-#         'committee_ids': committee_ids,
-#         'raising_summary': raising_summary,
-#         'spending_summary': spending_summary,
-#         'cash_summary': cash_summary,
-#         'aggregate': aggregate,
-#         'two_year_totals': two_year_totals,
-#         'statement_of_candidacy': statement_of_candidacy,
-#         'elections': elections,
-#         'candidate': candidate,
-#         'has_raw_filings': has_raw_filings,
-#         'min_receipt_date': raw_filing_start_date,
-#         'context_vars': context_vars,
-#         'aggregate_cycles': aggregate_cycles,
-#     }
-
-
 def get_candidate(candidate_id, cycle, election_full):
     """
     1) By passing parameter "candidate_id" to get candidate data.
@@ -437,6 +235,16 @@ def get_candidate(candidate_id, cycle, election_full):
         reverse=True,
     )
 
+    # (7)call efile/filings/ under tag:efiling
+    # Check if there are raw_filings for this candidate
+    raw_filing_start_date = utils.three_days_ago()
+    filters['min_receipt_date'] = raw_filing_start_date
+    filters['committee_id'] = candidate['candidate_id']
+    filters['cycle'] = cycle
+    filters['per_page'] = 100
+    path = '/efile/' + '/filings/'
+    raw_filings = api_caller.load_endpoint_data(path, **filters)
+    has_raw_filings = True if raw_filings.get('results') else False
     return {
         'aggregate': aggregate,
         'aggregate_cycles': aggregate_cycles,
@@ -454,14 +262,15 @@ def get_candidate(candidate_id, cycle, election_full):
         'election_year': cycle,
         'election_years': candidate.get('rounded_election_years'),
         'elections': elections,
+        'has_raw_filings': has_raw_filings,
         'incumbent_challenge_full': candidate['incumbent_challenge_full'],
         'max_cycle': cycle,
         'min_cycle': min_cycle,
+        'min_receipt_date': raw_filing_start_date,
         'name': candidate['name'],
         'office': candidate['office'],
         'office_full': candidate['office_full'],
         'party_full': candidate['party_full'],
-        'two_year_totals': two_year_totals,
         'raising_summary': raising_summary,
         'report_type': report_type,
         'result_type': result_type,
@@ -469,6 +278,7 @@ def get_candidate(candidate_id, cycle, election_full):
         'spending_summary': spending_summary,
         'state': candidate['state'],
         'statement_of_candidacy': statement_of_candidacy,
+        'two_year_totals': two_year_totals,
     }
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #[3076](https://github.com/fecgov/fec-cms/issues/3076)]
Reference openFEC PR: [https://github.com/fecgov/openFEC/pull/3919](https://github.com/fecgov/openFEC/pull/3919)

_Include a summary of proposed changes._
We modified three endpoint files:
CandidateTotalsView
CandidateHistoryView
CommitteeHistoryView

This PR will modified get_candidate function to use above updated endpoints.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile financial summary page.


## How to test
1) setup both openFEC and fec-cms on local.
2) openFEC: checkout branch: feature/refactor_ofec_totals_candidate_committees_mv
set SQLA_CONN  = dev
3) setup fec-cms point to your local api:
export DATABASE_URL=postgresql://:@/cfdm_cms_test
export FEC_API_URL=http://localhost:5000
FEC_WEB_API_KEY_PRIVATE=xxxxxxxxx
FEC_WEB_API_KEY_PUBLIC=xxxxxxxxx
export FEC_CMS_ENVIRONMENT=LOCAL
export FEC_FEATURE_HOME_MAP=1&&export FEC_FEATURE_HOME_BARCHARTS=1&& export FEC_FEATURE_AGGR_TOTS=1

4) run several test commands
a) npm run test-single 
b) pytest 
c) ./manage.py test
d) or ./manage.py test home.tests
./manage.py test data.tests

5)./manage.py runserver

6) test candidate profile page


(1) from globe search, pick up any candidate to go to candidate profile page.
will display the latest election year data (election=full) for that candidate.
<img width="486" alt="21_cms_globe_search" src="https://user-images.githubusercontent.com/24395751/63294665-e425a280-c298-11e9-9bc6-a0132403b03c.png">


(2) from all candidates page , search any candidate or click candidate name.
ex: P00003392
you can click different time period. for P00003392, 
Total receipts(election_full=true) => 2014 receipts + 2016 receipts
<img width="599" alt="22_P00003392_summary" src="https://user-images.githubusercontent.com/24395751/63294717-04556180-c299-11e9-9b8d-cb41900e50a8.png">


3) from election page to find any candidate to test.
ex: (special candidate, election year =2017) 
2018, Georgia, district 6
—>click show all under Results
click: OSSOFF, T. JONATHAN (H8GA06195)
you will see financial summary page. the election drop down list show even number.
<img width="1002" alt="23_special_cand" src="https://user-images.githubusercontent.com/24395751/63294744-146d4100-c299-11e9-84a0-141aca1dc723.png">

more examples:
P80001571
P00003392  (C00575795,C00431569)
S0NY00188
H8GA06195  (special )   C00630426
H8IN07259
H6PR00082(Puerto Rico)


Notes: 1)The old function **get_candidate** in views.py is commented out for compare  conveniently. after merging this PR, we can create a ticket to remove it.

2)we also found a couple of existing bugs related with this. will have follow up tickets.



