### PR TITLE
Add security response headers

### DIFF
--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -3,23 +3,26 @@ from django.conf import settings
 
 
 class SecurityHeaders(MiddlewareMixin):
+    """Add secure headers to each response"""
 
     def process_response(self, request, response):
 
         if settings.FEC_CMS_ENVIRONMENT == settings.ENVIRONMENTS.get('local'):
-            content_security_policy = ''\
-                'default-src \'self\' data: *.fec.gov localhost:* http://127.0.0.1:* http://*.app.cloud.gov https://*.app.cloud.gov; '\
-                'frame-src \'self\' https://www.google.com; '\
-                'img-src \'self\' data: http://*.fastly.net;'\
-                'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://www.google.com https://www.gstatic.com https://polyfill.io; '\
-                'style-src \'self\' data: \'unsafe-inline\'; '
+            content_security_policy = \
+                "default-src 'self' " \
+                "data: *.fec.gov localhost:* http://127.0.0.1:* *.app.cloud.gov; " \
+                "frame-src 'self' https://www.google.com; " \
+                "img-src 'self' data: http://*.fastly.net; " \
+                "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com https://polyfill.io; " \
+                "style-src 'self' data: 'unsafe-inline'; "
         else:
-            content_security_policy = ''\
-                'default-src \'self\' data: *.fec.gov; '\
-                'frame-src \'self\' https://www.google.com;'\
-                'img-src \'self\' data: http://*.fastly.net; '\
-                'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://www.google.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov; '\
-                'style-src \'self\' data: \'unsafe-inline\'; '
-        response['Content-Security-Policy'] = content_security_policy
-        response['cache-control'] = "max-age=600"
+            content_security_policy = \
+                "default-src 'self' " \
+                "data: *.fec.gov *.app.cloud.gov https://www.google-analytics.com; " \
+                "frame-src 'self' https://www.google.com; " \
+                "img-src 'self' data: http://*.fastly.net https://www.google-analytics.com; " \
+                "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.google-analytics.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov; " \
+                "style-src 'self' data: 'unsafe-inline'; "
+        response["Content-Security-Policy"] = content_security_policy
+        response["cache-control"] = "max-age=600"
         return response

--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -8,11 +8,12 @@ class AddSecureHeaders(MiddlewareMixin):
     def process_response(self, request, response):
 
         content_security_policy = {
-            "default-src": "'self' data: *.fec.gov *.app.cloud.gov https://www.google-analytics.com",
+            "default-src": "'self' *.fec.gov *.app.cloud.gov https://www.google-analytics.com",
             "frame-src": "'self' https://www.google.com",
             "img-src": "'self' data: http://*.fastly.net https://www.google-analytics.com",
             "script-src": "'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.google-analytics.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov",
-            "style-src": "'self' data: 'unsafe-inline'"
+            "style-src": "'self' data: 'unsafe-inline'",
+            "object-src": "'none'",
         }
         if settings.FEC_CMS_ENVIRONMENT == settings.ENVIRONMENTS.get('local'):
             content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"

--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -9,9 +9,9 @@ class AddSecureHeaders(MiddlewareMixin):
 
         content_security_policy = {
             "default-src": "'self' *.fec.gov *.app.cloud.gov https://www.google-analytics.com",
-            "frame-src": "'self' https://www.google.com",
+            "frame-src": "'self' https://www.google.com/recaptcha/",
             "img-src": "'self' data: http://*.fastly.net https://www.google-analytics.com",
-            "script-src": "'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.google-analytics.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov",
+            "script-src": "'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.google-analytics.com https://polyfill.io https://dap.digitalgov.gov",
             "style-src": "'self' data: 'unsafe-inline'",
             "object-src": "'none'",
         }

--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -2,27 +2,24 @@ from django.utils.deprecation import MiddlewareMixin
 from django.conf import settings
 
 
-class SecurityHeaders(MiddlewareMixin):
+class AddSecureHeaders(MiddlewareMixin):
     """Add secure headers to each response"""
 
     def process_response(self, request, response):
 
+        content_security_policy = {
+            "default-src": "'self' data: *.fec.gov *.app.cloud.gov https://www.google-analytics.com",
+            "frame-src": "'self' https://www.google.com",
+            "img-src": "'self' data: http://*.fastly.net https://www.google-analytics.com",
+            "script-src": "'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.google-analytics.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov",
+            "style-src": "'self' data: 'unsafe-inline'"
+        }
         if settings.FEC_CMS_ENVIRONMENT == settings.ENVIRONMENTS.get('local'):
-            content_security_policy = \
-                "default-src 'self' " \
-                "data: *.fec.gov localhost:* http://127.0.0.1:* *.app.cloud.gov; " \
-                "frame-src 'self' https://www.google.com; " \
-                "img-src 'self' data: http://*.fastly.net; " \
-                "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com https://polyfill.io; " \
-                "style-src 'self' data: 'unsafe-inline'; "
-        else:
-            content_security_policy = \
-                "default-src 'self' " \
-                "data: *.fec.gov *.app.cloud.gov https://www.google-analytics.com; " \
-                "frame-src 'self' https://www.google.com; " \
-                "img-src 'self' data: http://*.fastly.net https://www.google-analytics.com; " \
-                "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.google-analytics.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov; " \
-                "style-src 'self' data: 'unsafe-inline'; "
-        response["Content-Security-Policy"] = content_security_policy
+            content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"
+
+        response["Content-Security-Policy"] = "".join(
+            "{0} {1}; ".format(directive, value)
+            for directive, value in content_security_policy.items()
+        )
         response["cache-control"] = "max-age=600"
         return response

--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -14,6 +14,8 @@ class AddSecureHeaders(MiddlewareMixin):
             "script-src": "'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.google-analytics.com https://polyfill.io https://dap.digitalgov.gov",
             "style-src": "'self' data: 'unsafe-inline'",
             "object-src": "'none'",
+            # Report to the API until we can figure out CSRF issue
+            "report-uri": "{0}report-csp-violations/?api_key={1}".format(settings.FEC_API_URL, settings.FEC_API_KEY_PUBLIC),
         }
         if settings.FEC_CMS_ENVIRONMENT == settings.ENVIRONMENTS.get('local'):
             content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"

--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -1,0 +1,25 @@
+from django.utils.deprecation import MiddlewareMixin
+from django.conf import settings
+
+
+class SecurityHeaders(MiddlewareMixin):
+
+    def process_response(self, request, response):
+
+        if settings.FEC_CMS_ENVIRONMENT == settings.ENVIRONMENTS.get('local'):
+            content_security_policy = ''\
+                'default-src \'self\' data: *.fec.gov localhost:* http://127.0.0.1:* http://*.app.cloud.gov https://*.app.cloud.gov; '\
+                'frame-src \'self\' https://www.google.com; '\
+                'img-src \'self\' data: http://*.fastly.net;'\
+                'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://www.google.com https://www.gstatic.com https://polyfill.io; '\
+                'style-src \'self\' data: \'unsafe-inline\'; '
+        else:
+            content_security_policy = ''\
+                'default-src \'self\' data: *.fec.gov; '\
+                'frame-src \'self\' https://www.google.com;'\
+                'img-src \'self\' data: http://*.fastly.net; '\
+                'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://www.google.com https://www.gstatic.com https://polyfill.io https://dap.digitalgov.gov; '\
+                'style-src \'self\' data: \'unsafe-inline\'; '
+        response['Content-Security-Policy'] = content_security_policy
+        response['cache-control'] = "max-age=600"
+        return response

--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -7,6 +7,10 @@ class AddSecureHeaders(MiddlewareMixin):
 
     def process_response(self, request, response):
 
+        # Report violations to the API due to CSRF issue with Django route
+        REPORT_URI = "{0}/report-csp-violation/?api_key={1}".format(
+            settings.FEC_API_URL, settings.FEC_API_KEY_PUBLIC
+        )
         content_security_policy = {
             "default-src": "'self' *.fec.gov *.app.cloud.gov https://www.google-analytics.com",
             "frame-src": "'self' https://www.google.com/recaptcha/",
@@ -14,8 +18,7 @@ class AddSecureHeaders(MiddlewareMixin):
             "script-src": "'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.google-analytics.com https://polyfill.io https://dap.digitalgov.gov",
             "style-src": "'self' data: 'unsafe-inline'",
             "object-src": "'none'",
-            # Report to the API until we can figure out CSRF issue
-            "report-uri": "{0}report-csp-violations/?api_key={1}".format(settings.FEC_API_URL, settings.FEC_API_KEY_PUBLIC),
+            "report-uri": REPORT_URI,
         }
         if settings.FEC_CMS_ENVIRONMENT == settings.ENVIRONMENTS.get('local'):
             content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"

--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -14,13 +14,13 @@ class AddSecureHeaders(MiddlewareMixin):
         content_security_policy = {
             "default-src": "'self' *.fec.gov *.app.cloud.gov https://www.google-analytics.com",
             "frame-src": "'self' https://www.google.com/recaptcha/",
-            "img-src": "'self' data: http://*.fastly.net https://www.google-analytics.com",
+            "img-src": "'self' data: https://*.ssl.fastly.net https://www.google-analytics.com *.app.cloud.gov",
             "script-src": "'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.google-analytics.com https://polyfill.io https://dap.digitalgov.gov",
             "style-src": "'self' data: 'unsafe-inline'",
             "object-src": "'none'",
             "report-uri": REPORT_URI,
         }
-        if settings.FEC_CMS_ENVIRONMENT == settings.ENVIRONMENTS.get('local'):
+        if settings.FEC_CMS_ENVIRONMENT == 'LOCAL':
             content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"
 
         response["Content-Security-Policy"] = "".join(

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -123,6 +123,10 @@ MIDDLEWARE_CLASSES = (
     'audit_log.middleware.UserLoggingMiddleware',
 )
 
+CSRF_TRUSTED_ORIGINS = ["*.fec.gov", "*.app.cloud.gov"]
+if FEC_CMS_ENVIRONMENT == 'LOCAL':
+    CSRF_TRUSTED_ORIGINS.extend(["127.0.0.1:5000"])
+
 ROOT_URLCONF = 'fec.urls'
 
 from data import constants

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -110,7 +110,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'fec.middleware.SecurityHeaders',  # custom response headers
+    'fec.middleware.AddSecureHeaders',  # custom response headers
     'uaa_client.middleware.UaaRefreshMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -110,6 +110,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'fec.middleware.SecurityHeaders',  # custom response headers
     'uaa_client.middleware.UaaRefreshMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -123,7 +123,7 @@ MIDDLEWARE_CLASSES = (
     'audit_log.middleware.UserLoggingMiddleware',
 )
 
-CSRF_TRUSTED_ORIGINS = ["*.fec.gov", "*.app.cloud.gov"]
+CSRF_TRUSTED_ORIGINS = ["fec.gov", "app.cloud.gov"]
 if FEC_CMS_ENVIRONMENT == 'LOCAL':
     CSRF_TRUSTED_ORIGINS.extend(["127.0.0.1:5000"])
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8713,9 +8713,9 @@
       "dev": true
     },
     "leaflet-providers": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/leaflet-providers/-/leaflet-providers-1.1.6.tgz",
-      "integrity": "sha1-ui2G4zkTs01cwQrycQmsN502YSc="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/leaflet-providers/-/leaflet-providers-1.8.0.tgz",
+      "integrity": "sha512-y0qr1PxrcCq3Vah+COptp29xDmuAEu4Wg/a8YDL+hztfqdsO+OQJzE4aZ+ZVoHFucX5HP5ELw0nrD+xa5T8m0g=="
     },
     "levn": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "glossary-panel": "1.0.0",
     "jquery": "^3.4.1",
     "jquery.inputmask": "3.3.4",
-    "leaflet-providers": "1.1.6",
+    "leaflet-providers": "1.8.0 ",
     "lodash": "^4.17.14",
     "minimatch": "^3.0.4",
     "moment": "2.20.1",


### PR DESCRIPTION
## Summary

Resolves #3069 
- Adds content security policy response headers to every page. See original issue for background information.
- Add `report-uri` that sends violation reports to API for now (ran into csrf issues with a Django route)
- Add `CSRF_TRUSTED_ORIGINS` setting to address csrf errors

## Impacted areas of the application
List general components of the application that this PR will affect:

-  This will impact everything on our website. Need to make sure that there are no loading errors for anything we pull into our site like api calls, scripts, images, fonts, etc. 

## Screenshots

None, this is pure code

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
openFEC/feature/3876-add-response-headers | [link](https://github.com/fecgov/openFEC/pull/3891)

## How to test
Check each section of the site to make sure that the content security policy is not interfering with anything we're pulling into the site.
- [x] Homepage
- [x] Data landing
- [x] Election search page
- [x] All datatable pages
- [x] Candidate profile pages
- [x] Committee profile pages
- [x] Election profile pages
- [x] Wagtail admin (creating new pages, updating pages, saving pages, adding new block components)
- [x] Wagtail generated pages
- [x] Legal resource pages

## How to test the changes on stage

- I pushed a deploy to `stage` with Circle (as of 8/28) (stage.fec.gov)
- Test API for console errors
- Curl API to check headers
- Run scan like https://securityheaders.com/ and https://csp-evaluator.withgoogle.com/ results
- Make sure CMS can still access what it needs