### PR TITLE
[HOTFIX - USE GITFLOW] Update commissioner listing on homepage and leadership landing page

### DIFF
--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -104,16 +104,6 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static 'img/headshot--petersen.jpg' %}" alt="Headshot of Matthew S. Petersen">
-            <div class="icon-heading__content">
-              <div class="t-lead"><a href="/about/leadership-and-structure/mathew-s-petersen">Matthew S. Petersen</a></div>
-              <div class="t-note">Vice Chairman</div>
-              <div class="t-sans">Republican</div>
-            </div>
-          </div>
-        </div>
-        <div class="grid__item">
-          <div class="icon-heading">
             <img class="icon-heading__image" src="{% static 'img/headshot--hunter.jpg' %}" alt="Headshot of Caroline C. Hunter">
             <div class="icon-heading__content">
               <div class="t-lead"><a href="/about/leadership-and-structure/caroline-c-hunter">Caroline C. Hunter</a></div>
@@ -127,6 +117,15 @@
             <div class="icon-heading__content">
               <div class="t-lead"><a href="/about/leadership-and-structure/steven-t-walther">Steven T. Walther</a></div>
               <div class="t-sans">Independent</div>
+            </div>
+          </div>
+        </div>
+        <div class="grid__item">
+          <div class="icon-heading">
+            <img class="icon-heading__image" src="{% static 'img/headshot--no-photo.jpg' %}" alt="Vacant Position">
+            <div class="icon-heading__content">
+              <div class="t-lead">Vacant seat</div>
+              <div class="t-sans"></div>
             </div>
           </div>
         </div>

--- a/fec/home/templates/partials/current-commissioners.html
+++ b/fec/home/templates/partials/current-commissioners.html
@@ -7,28 +7,10 @@
 <div class="grid grid--2-wide">
 {% if chair_commissioner %}
   {% include 'partials/commissioner.html' with commissioner=chair_commissioner %}
-{% else %}
-  <div class="grid__item commissioner-height">
-  <div class="icon-heading">
-    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of vacant seat">
-    <div class="icon-heading__content">
-      <div class="t-lead">Vacant Chair seat</div>
-    </div>
-  </div>
-</div>
 {% endif %}
 
 {% if vice_commissioner %}
   {% include 'partials/commissioner.html' with commissioner=vice_commissioner %}
-{% else %}
-  <div class="grid__item commissioner-height">
-  <div class="icon-heading">
-    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of vacant seat">
-    <div class="icon-heading__content">
-      <div class="t-lead">Vacant Vice-Chair seat</div>
-    </div>
-  </div>
-</div>
 {% endif %}
 
 {% for commissioner in commissioners %}

--- a/fec/home/templatetags/commissioners.py
+++ b/fec/home/templatetags/commissioners.py
@@ -16,7 +16,7 @@ def current_commissioners():
         | Q(commissioner_title__startswith='Vice')) \
         .order_by('last_name')
 
-    vacant_seats = range(0, 4 - commissioners.count())
+    vacant_seats = range(0, 6 - commissioners.count() - len(CommissionerPage.objects.filter(commissioner_title__startswith='Chair')) - len(CommissionerPage.objects.filter(commissioner_title__startswith='Vice')))
 
     return {
         'chair_commissioner': chair_commissioner,

--- a/fec/home/templatetags/commissioners.py
+++ b/fec/home/templatetags/commissioners.py
@@ -8,19 +8,29 @@ register = template.Library()
 
 @register.inclusion_tag('partials/current-commissioners.html')
 def current_commissioners():
-    chair_commissioner = CommissionerPage.objects.filter(commissioner_title__startswith='Chair') \
+    current_commissioners = CommissionerPage.objects.filter(term_expiration__isnull=True)
+    chair_commissioner = current_commissioners.filter(commissioner_title__startswith='Chair') \
         .exclude(commissioner_title__contains='Vice').first()
-    vice_commissioner = CommissionerPage.objects.filter(commissioner_title__startswith='Vice').first()
-    commissioners = CommissionerPage.objects.filter(term_expiration__isnull=True) \
+    vice_commissioner = current_commissioners.filter(commissioner_title__startswith='Vice').first()
+    other_commissioners = current_commissioners \
         .exclude(Q(commissioner_title__startswith='Chair') \
         | Q(commissioner_title__startswith='Vice')) \
         .order_by('last_name')
 
-    vacant_seats = range(0, 6 - commissioners.count() - len(CommissionerPage.objects.filter(commissioner_title__startswith='Chair')) - len(CommissionerPage.objects.filter(commissioner_title__startswith='Vice')))
+    # Checks if there are any current commissioners
+    if current_commissioners:
+        try:
+            current_commissioners_count = len(current_commissioners)
+        except:
+            current_commissioners_count = 1
+    else:
+        current_commissioners_count = 0
+
+    vacant_seats = range(0, 6 - current_commissioners_count)
 
     return {
         'chair_commissioner': chair_commissioner,
         'vice_commissioner': vice_commissioner,
-        'commissioners': commissioners,
+        'commissioners': other_commissioners,
         'vacant_seats' : vacant_seats,
     }


### PR DESCRIPTION
## Summary

- Resolves #3129 
_Removes departing commissioner from homepage as reflected in the ticket._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Homepage

## Screenshots

<img width="928" alt="Screen Shot 2019-08-27 at 2 09 05 PM" src="https://user-images.githubusercontent.com/12799132/63800675-42bfd180-c8d4-11e9-87ce-5428384a3790.png">

## How to test
- Checkout branch
- ./manage.py runserver
- Ensure that the HTML on the homepage reflects the commissioner change accurately. http://localhost:8000/
- Go to the leadership and structure page here: http://localhost:8000/about/leadership-and-structure/
- Ensure that if a Chair and Vice Chair are populated that it will put those first. Otherwise show commissioners in alpha by last name
____

