### PR TITLE
#2840 Implement Tag Manager

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -23,6 +23,17 @@
     </script>
   {% endblock %}
 
+  {# Google Tag Manager #}
+  {% if FEATURES.use_tag_manager %}
+    {% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
+      {# Google Tag Manager for Production #}
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+    {% else %}
+      {# Google Tag Manager for not-Production: #}
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PMSLNL3');</script>
+    {% endif %}
+  {% endif %}
+
   <script>
     BASE_PATH = '/data';
     API_LOCATION = '{{ FEC_API_URL }}';
@@ -55,6 +66,11 @@
   </script>
 </head>
 <body>
+{# Google Tag Manager (noscript) #}
+{% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' and FEATURES.use_tag_manager %}
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+{% endif %}
+
 {% import 'macros/search.jinja' as search %}
 {% include 'partials/warnings.jinja' %}
 
@@ -144,7 +160,8 @@
   <script defer type="text/javascript" src='https://www.google.com/recaptcha/api.js'></script>
 {% block scripts %}{% endblock %}
 
-{% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
+{# Google Analytics and DAP without Tag Manager and only for production #}
+{% if (FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not FEATURES.use_tag_manager) %}
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/fec/data/templates/layouts/widgets.jinja
+++ b/fec/data/templates/layouts/widgets.jinja
@@ -21,6 +21,17 @@
     </script>
   {% endblock %}
 
+  {# Google Tag Manager #}
+  {% if FEATURES.use_tag_manager %}
+    {% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
+      {# Google Tag Manager for Production #}
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+    {% else %}
+      {# Google Tag Manager for not-Production: #}
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PMSLNL3');</script>
+    {% endif %}
+  {% endif %}
+  
   <script>
     BASE_PATH = '/data';
     API_LOCATION = '{{ FEC_API_URL }}';
@@ -49,6 +60,11 @@
   </script>
 </head>
 <body>
+  {# Google Tag Manager (noscript) #}
+  {% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' and FEATURES.use_tag_manager %}
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  {% endif %}
+  
   <main id="main" {% if section %} data-section="{{section}}"{% endif %}>
     {% block body %}{% endblock %}
   </main>
@@ -58,7 +74,8 @@
 {# {% block modals %}{% endblock %} #}
 {% block scripts %}{% endblock %}
 
-{% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
+{# Google Analytics and DAP without Tag Manager and only for production #}
+{% if (FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not FEATURES.use_tag_manager) %}
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -50,6 +50,7 @@ FEATURES = {
     'aggregatetotals': bool(env.get_credential('FEC_FEATURE_AGGR_TOTS', '')),
     'map': bool(env.get_credential('FEC_FEATURE_HOME_MAP', '')),
     'barcharts': bool(env.get_credential('FEC_FEATURE_HOME_BARCHARTS', '')),
+    'use_tag_manager': bool(env.get_credential('FEC_FEATURE_USE_TAG_MANAGER', '')),
 }
 
 ENVIRONMENTS = {

--- a/fec/fec/static/js/modules/analytics.js
+++ b/fec/fec/static/js/modules/analytics.js
@@ -2,6 +2,8 @@
 
 /* global ga */
 
+// TODO - should this all be moved into Tag Manager?
+
 var _ = require('underscore');
 var URI = require('urijs');
 

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -7,7 +7,7 @@ var URI = require('urijs');
 var _ = require('underscore');
 var moment = require('moment');
 
-var analytics = require('./analytics');
+var analytics = require('./analytics'); // TODO - move this to Tag Manager?
 
 var ElectionForm = require('./election-form').ElectionForm;
 var ElectionMap = require('./election-map').ElectionMap;

--- a/fec/fec/static/js/modules/keyword-modal.js
+++ b/fec/fec/static/js/modules/keyword-modal.js
@@ -5,7 +5,7 @@
 var $ = require('jquery');
 var URI = require('urijs');
 var A11yDialog = require('a11y-dialog');
-var analytics = require('./analytics');
+var analytics = require('./analytics'); // TODO - move this to Tag Manager?
 
 /**
  * KeywordModal

--- a/fec/fec/static/js/modules/reaction-box.js
+++ b/fec/fec/static/js/modules/reaction-box.js
@@ -10,7 +10,7 @@
 
 var $ = require('jquery');
 var helpers = require('./helpers');
-var analytics = require('./analytics');
+var analytics = require('./analytics'); // TODO - move this to Tag Manager?
 
 function ReactionBox(selector) {
   this.$element = $(selector);

--- a/fec/fec/static/js/modules/urls.js
+++ b/fec/fec/static/js/modules/urls.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var URI = require('urijs');
 
-var analytics = require('./analytics');
+var analytics = require('./analytics'); // TODO - move this to Tag Manager?
 var helpers = require('./helpers');
 
 function updateQuery(params, fields) {

--- a/fec/fec/static/js/pages/bythenumbers.js
+++ b/fec/fec/static/js/pages/bythenumbers.js
@@ -3,7 +3,7 @@
 /* global context, ga */
 
 var $ = require('jquery');
-var analytics = require('../modules/analytics');
+var analytics = require('../modules/analytics'); // TODO - move this to Tag Manager?
 var TopEntities = require('../modules/top-entities').TopEntities;
 
 new TopEntities('.js-top-entities', context.type);

--- a/fec/fec/static/js/pages/data-landing.js
+++ b/fec/fec/static/js/pages/data-landing.js
@@ -4,7 +4,7 @@
 
 var $ = require('jquery');
 var lookup = require('../modules/election-lookup');
-var analytics = require('../modules/analytics');
+var analytics = require('../modules/analytics'); // TODO - move this to Tag Manager?
 
 $(document).ready(function() {
   new lookup.ElectionLookup('#election-lookup', false);

--- a/fec/fec/static/js/vendor/tablist.js
+++ b/fec/fec/static/js/vendor/tablist.js
@@ -9,7 +9,7 @@ var _ = require('underscore');
 
 var events = require('../modules/events');
 
-var analytics = require('../modules//analytics');
+var analytics = require('../modules/analytics'); // TODO - move this to Tag Manager?
 
 // The class for the container div
 

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -7,6 +7,17 @@
 
     <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }} | FEC {% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
 
+    {# Google Tag Manager #}
+    {% if settings.FEATURES.use_tag_manager %}
+      {% if not settings.DEBUG %}
+        {# Google Tag Manager for Production #}
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+      {% else %}
+        {# Google Tag Manager for NOT Production #}
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PMSLNL3');</script>
+      {% endif %}
+    {% endif %}
+    
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
     {% endblock %}
@@ -20,6 +31,12 @@
       <p style="color: #ffffff; font-size: 16px;">You&apos;re using an older version of Internet Explorer. Please update or switch to another browser like Chrome, Firefox, or Edge for a better experience. <a style="color: #ffffff; text-decoration: underline" target="_blank" href="http://browsehappy.com/">Learn how to update your browser</a>.</p>
     </div>
     <![endif]-->
+
+    {# Google Tag Manager (noscript) #}
+    {% if not settings.DEBUG %}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {% endif %}
+    
     {% wagtailuserbar %}
     <a href="#main" class="skip-nav">skip navigation</a>
 
@@ -155,7 +172,8 @@
     {# Override this in templates to add extra javascript #}
     {% endblock %}
 
-    {% if not settings.DEBUG %}
+    {# Google Analytics and DAP without Tag Manager and only for production #}
+    {% if not settings.DEBUG and not settings.FEATURES.use_tag_manager %}}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -7,6 +7,17 @@
 
     <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }} | FEC {% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
 
+    {# Google Tag Manager #}
+    {% if settings.FEATURES.use_tag_manager %}
+      {% if not settings.DEBUG %}
+        {# Google Tag Manager for Production #}
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+      {% else %}
+        {# Google Tag Manager for NOT Production #}
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PMSLNL3');</script>
+      {% endif %}
+    {% endif %}
+    
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'elections.css' %}" />
@@ -20,6 +31,12 @@
       <p style="color: #ffffff; font-size: 16px;">You&apos;re using an older version of Internet Explorer. Please update or switch to another browser like Chrome, Firefox, or Edge for a better experience. <a style="color: #ffffff; text-decoration: underline" target="_blank" href="http://browsehappy.com/">Learn how to update your browser</a>.</p>
     </div>
     <![endif]-->
+
+    {# Google Tag Manager (noscript) #}
+    {% if not settings.DEBUG %}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {% endif %}
+    
     {% wagtailuserbar %}
     <a href="#main" class="skip-nav">skip navigation</a>
     {% if self.title == "Homepage" or self.title == "Home" %}
@@ -156,7 +173,8 @@
     {# Override this in templates to add extra javascript #}
     {% endblock %}
 
-    {% if not settings.DEBUG %}
+    {# Google Analytics and DAP without Tag Manager and only for production #}
+    {% if not settings.DEBUG and not settings.FEATURES.use_tag_manager %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/fec/fec/tests/js/analytics.js
+++ b/fec/fec/tests/js/analytics.js
@@ -3,7 +3,7 @@
 var chai = require('chai');
 var expect = chai.expect;
 
-var analytics = require('../../static/js/modules/analytics');
+var analytics = require('../../static/js/modules/analytics'); // TODO - Move this to Tag Manager?
 
 describe('analytics', function() {
   it('sorts query parameters', function() {

--- a/fec/fec/tests/js/urls.js
+++ b/fec/fec/tests/js/urls.js
@@ -7,7 +7,7 @@ var expect = chai.expect;
 chai.use(sinonChai);
 
 var urls = require('../../static/js/modules/urls');
-var analytics = require('../../static/js/modules/analytics');
+var analytics = require('../../static/js/modules/analytics'); // TODO - Move this to Tag Manager?
 
 // var params = {office: ['P']};
 // var fields = ['office', 'cycle'];


### PR DESCRIPTION
## Summary

- Resolves #2840 

Progress:

- [x] Add feature flag
- [x] Wrap current analytics inside the feature flag
- [x] Create Tag Manager (GTM) container for non-Production
- [x] Add Production GTM container to pages behind feature flag
- [x] Add non-Production container to pages as an alternate to the Production container
- [x] Add `<noscript>` GTM elements to templates
- [x] Add code to non-Production container to confirm it's loading
- [ ] **Confirm proper GA/DAP/GTM elements are loading**
- [ ] Comb site to migrate any necessary GA events to GTM data layer
- [ ] Confirm successful migration of GA events to GTM
- [ ] Confirm GSA DAP is unaffected (all GSA DAP events are still coming through)
- [ ] Remove current/then-retired GA and DAP implementation
- [ ] Remove feature flag?
- [ ] Add new events?

## Impacted areas of the application

Every page of the site should be affected.

Created the env var.

The major changes were to the templates:
- fec/data/templates/layouts/[main, widgets].jinja
- fec/fec/templates/[base, home_base].html

## Screenshots

None

## Related PRs

None

## How to test
- Pull and build the site like usual
- Check the homepage for the GSA DAP tag
  1. Update DEBUG settings to false
  1. Run server
  1. check the page source (in the browser)
  1. cmd-f for `_fed_an_ua_tag` (the GSA DAP element)
  1. confirm that the tag is in the page
  1. cmd-f for 'googletagmanager`
  1. confirm that it does **not** exist
- Visit a data page and confirm that the tag is in the page source
- Go to the calendar to confirm that the GSA DAP element (`_fed_an_ua_tag`) is in the page.
- Interrupt the server
- Set the feature flag `export set FEC_FEATURE_USE_TAG_MANAGER=true`
- Restart the server
- Check the homepage source again. Confirm that:
  1. `_fed_an_ua_tag` is gone
  1. `googletagmanager` **does** appear
  1. GTM is using the `GTM-PMSLNL3` container (search the page source, or check near the end of the GTM `<script>`)
  1. GTM is **not** using the production container of `GTM-T5HPRLH`
  1. the Console in inspector is showing a message like "loaded the Tag Manager dev container"
- Check those same things for a data page
- Check those same things for a calendar page
- Celebrate 🎉

## Next steps

See the Progress list in the Summary at the top
____

