### PR TITLE
[MERGE WITH GIT FLOW] Fix missing/duplicate authorizing candidates

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -307,7 +307,11 @@ def get_committee(committee_id, cycle):
 
     redirect_to_previous = False if cycle else True
     committee, all_candidates, cycle = api_caller.load_with_nested(
-        'committee', committee_id, 'candidates', cycle
+        'committee',
+        committee_id,
+        'candidates',
+        cycle,
+        election_full=False,
     )
 
     # When there are multiple candidate records of various offices (H, S, P)


### PR DESCRIPTION
## Summary (required)

- Resolves #3168
_Fix missing/duplicate authorizing candidates ._

## Impacted areas of the application
List general components of the application that this PR will affect:

- Committee profile pages with authorizing candidates  

## Screenshots

### Before - duplicate and missing
![Screen Shot 2019-09-16 at 1 56 22 PM](https://user-images.githubusercontent.com/31420082/64981854-f2acad00-d88a-11e9-89d8-b682f1a59626.png)
![Screen Shot 2019-09-16 at 1 56 08 PM](https://user-images.githubusercontent.com/31420082/64981853-f2acad00-d88a-11e9-9869-eba4283329ee.png)

### After
![Screen Shot 2019-09-17 at 1 36 24 PM](https://user-images.githubusercontent.com/31420082/65065335-387f7900-d950-11e9-863a-9f4781704421.png)
![Screen Shot 2019-09-17 at 1 36 37 PM](https://user-images.githubusercontent.com/31420082/65065336-387f7900-d950-11e9-8c5c-86647e10d235.png)


## How to test
### dev links (up there as of 1:30pm on 9/17)

- https://dev.fec.gov/data/committee/C00580100/?cycle=2020 
- https://dev.fec.gov/data/committee/C00580100/?cycle=2018 
- https://dev.fec.gov/data/committee/C00575795/?cycle=2016
- https://dev.fec.gov/data/committee/C00696948/?cycle=2020
- https://dev.fec.gov/data/committee/C00659938/?cycle=2020

### local links
- http://localhost:8000/data/committee/C00580100/?cycle=2020 
- http://localhost:8000/data/committee/C00580100/?cycle=2018 
- http://localhost:8000/data/committee/C00575795/?cycle=2016
- http://localhost:8000/data/committee/C00696948/?cycle=2020
- http://localhost:8000/data/committee/C00659938/?cycle=2020

## Related PR
Before this change https://github.com/fecgov/openFEC/pull/3919/files the logic worked a little differently - now we want to grab just the candidate info for the given two-year period (`election_full=False`)