### PR TITLE
Update the Updates message

### DIFF
--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -9,7 +9,7 @@
     <button type="button" class="js-accordion-trigger accordion__button">About latest updates</button>
     <div class="accordion__content">
       <p>Weekly Digests are published every Friday and summarize the week's publicly disclosed activity. Press releases are published as news happens.</p>
-      <p>FEC Record articles inform candidates and committees about FEC developments and are published as news happens. Tips for Treasurers are published once a week.</p>
+      <p>FEC Record articles inform candidates and committees about FEC developments and are published as news happens. Access Record articles from 1975 through 2004 on the <a href="https://www.fec.gov/updates/record-archive-1975-2004/">Record archive page</a>. Tips for Treasurers are published once a week.</p>
     </div>
   </div>
   <div class="js-accordion accordion--neutral" data-content-prefix="email_signup">


### PR DESCRIPTION
## Summary (required)

- Resolves #3122 
Updating the message on the Updates page to link the Record archive.

## Screenshots

- Refer to #3122 for screenshot


## How to test
- Refer to #3122 for message
- Verify that link goes to https://www.fec.gov/updates/record-archive-1975-2004/.
- Go to /updates/ and click + "About latest updates" to verify that message and link are there.

