### PR TITLE
Update link in the Record search "no results" message

### DIFF
--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -118,7 +118,7 @@
     {% endif %}
     <p>While all press releases, weekly digests and tips for treasurers are searchable, FEC Record articles published before
     2005 exist only in PDF format and are not included in these search results. Please try another search or visit our
-    <a href="https://transition.fec.gov/pages/fecrecord/fecrecord.shtml">archive of Record articles from 1975-2004</a>.</p>
+    <a href="https://www.fec.gov/updates/record-archive-1975-2004/">archive of Record articles from 1975-2004</a>.</p>
     <p>
     <div class="message--alert__bottom">
       <p>For assistance, <a href="https://www.fec.gov/contact/">contact the FEC</a>.</p>


### PR DESCRIPTION
Making sure the Record search "no results" message points to the latest version of the Record archive page.

## Summary (required)

- Resolves #3122 by linking to the current Record archive page at https://www.fec.gov/updates/record-archive-1975-2004/

## Screenshots

See #3122 for image

## How to test
- [ ] For a Record search that yields no results, search the Record for "inaugural" and set the year to 2004.
- [ ] On the message that comes up, and in the code for the template, make sure any and all links to https://transition.fec.gov/pages/fecrecord/fecrecord.shtml have been changed to point to  /updates/record-archive-1975-2004/
