### PR TITLE
Change to check settings.FEC_CMS_ENVIRONMENT

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -66,10 +66,16 @@
   </script>
 </head>
 <body>
-{# Google Tag Manager (noscript) #}
-{% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' and FEATURES.use_tag_manager %}
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-{% endif %}
+  {# Google Tag Manager (noscript) #}
+  {% if FEATURES.use_tag_manager %}
+    {% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
+      {# Google Tag Manager for Production #}
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {% else %}
+      {# Google Tag Manager for NOT Production #}
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PMSLNL3" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {% endif %}
+  {% endif %}
 
 {% import 'macros/search.jinja' as search %}
 {% include 'partials/warnings.jinja' %}

--- a/fec/data/templates/layouts/widgets.jinja
+++ b/fec/data/templates/layouts/widgets.jinja
@@ -61,10 +61,16 @@
 </head>
 <body>
   {# Google Tag Manager (noscript) #}
-  {% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' and FEATURES.use_tag_manager %}
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  {% if FEATURES.use_tag_manager %}
+    {% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
+      {# Google Tag Manager for Production #}
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {% else %}
+      {# Google Tag Manager for NOT Production #}
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PMSLNL3" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {% endif %}
   {% endif %}
-  
+
   <main id="main" {% if section %} data-section="{{section}}"{% endif %}>
     {% block body %}{% endblock %}
   </main>

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -33,8 +33,14 @@
     <![endif]-->
 
     {# Google Tag Manager (noscript) #}
-    {% if not settings.DEBUG %}
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {% if settings.FEATURES.use_tag_manager %}
+      {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
+        {# Google Tag Manager for Production #}
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      {% else %}
+        {# Google Tag Manager for NOT Production #}
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PMSLNL3" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      {% endif %}
     {% endif %}
     
     {% wagtailuserbar %}
@@ -173,7 +179,7 @@
     {% endblock %}
 
     {# Google Analytics and DAP without Tag Manager and only for production #}
-    {% if not settings.DEBUG and not settings.FEATURES.use_tag_manager %}}
+    {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not settings.FEATURES.use_tag_manager %}}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -9,7 +9,7 @@
 
     {# Google Tag Manager #}
     {% if settings.FEATURES.use_tag_manager %}
-      {% if not settings.DEBUG %}
+      {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
         {# Google Tag Manager for Production #}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
       {% else %}

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -9,7 +9,7 @@
 
     {# Google Tag Manager #}
     {% if settings.FEATURES.use_tag_manager %}
-      {% if not settings.DEBUG %}
+      {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
         {# Google Tag Manager for Production #}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
       {% else %}
@@ -113,6 +113,7 @@
     {% endif %}
 
     <main id="main">
+      <h1>environment: {{ settings.FEC_CMS_ENVIRONMENT }}</h1>
       {% block content %}{% endblock %}
     </main>
 

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -33,8 +33,14 @@
     <![endif]-->
 
     {# Google Tag Manager (noscript) #}
-    {% if not settings.DEBUG %}
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {% if settings.FEATURES.use_tag_manager %}
+      {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
+        {# Google Tag Manager for Production #}
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      {% else %}
+        {# Google Tag Manager for NOT Production #}
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PMSLNL3" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      {% endif %}
     {% endif %}
     
     {% wagtailuserbar %}
@@ -174,7 +180,7 @@
     {% endblock %}
 
     {# Google Analytics and DAP without Tag Manager and only for production #}
-    {% if not settings.DEBUG and not settings.FEATURES.use_tag_manager %}
+    {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not settings.FEATURES.use_tag_manager %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -113,7 +113,6 @@
     {% endif %}
 
     <main id="main">
-      <h1>environment: {{ settings.FEC_CMS_ENVIRONMENT }}</h1>
       {% block content %}{% endblock %}
     </main>
 


### PR DESCRIPTION
## Summary

- Resolves #2840 
Updated the html templates so the GTM implementation is looking at `settings.FEC_CMS_ENVIRONMENT` rather than `settings.DEBUG`. I don't know why the previous GTM/DAP tag conditional but DEBUG is used to show us error messages or only log them.

## Impacted areas of the application
List general components of the application that this PR will affect:
Updated the two html templates—will affect the homepage and other Wagtail pages; won't affect pages based on Jinja templates.


## Screenshots
None

## Related PRs
None

## How to test
- Pull and build like normal
- Make sure the `FEC_FEATURE_USE_TAG_MANAGER` environment var is `true`
- Run the server locally
- Verify that the homepage and another Wagtail page is using the non-Production Tag Manager container
- Push to Dev or Feature
- Make sure `FEC_FEATURE_USE_TAG_MANAGER` is `true` there, too
- Check homepage, a Wagtail page, a Jinja page, and a legal page to make sure the non-Production Tag Manager container ID is being used (as of this writing, it's using the Production container ID)
____

