### PR TITLE
Fix "Filter this data" buttons for filings

### DIFF
--- a/fec/data/templates/macros/entity-pages.jinja
+++ b/fec/data/templates/macros/entity-pages.jinja
@@ -1,4 +1,4 @@
-{% macro filings_table(title, dataType, cycle, committee_id, showTrigger=False) %}
+{% macro filings_table(title, dataType, showTrigger=False) %}
 
 <!-- `namespace` is needed to persist `form_types` outside the loop -->
 
@@ -40,13 +40,13 @@
     </div>
 {% endmacro %}
 
-{% macro raw_filings_table(cycle, committee_id, min_receipt_date, is_committee=True) %}
+{% macro raw_filings_table(is_committee=True) %}
     <div class="entity__figure row" id="raw-filings">
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Raw electronic filings</h3>
         {% set link = "/data/filings/?data_type=efiling&committee_id=" + committee_id +
           "&min_receipt_date=" + min_receipt_date %}
-        {% if cycle %}
+        {% if is_committee %}
           {% set link = link + "&cycle=" + cycle|string %}
         {% endif %}
         <a class="heading__right button button--alt button--browse"

--- a/fec/data/templates/macros/entity-pages.jinja
+++ b/fec/data/templates/macros/entity-pages.jinja
@@ -1,9 +1,20 @@
 {% macro filings_table(title, dataType, cycle, committee_id, showTrigger=False) %}
+
+<!-- `namespace` is needed to persist `form_types` outside the loop -->
+
+<!-- Unlike the table logic in committee-single.js, we can't currenly use excludes -->
+<!-- All form types should include all RFAIs until we can exclude request types -->
+{% set ns = namespace(form_types='form_type=RFAI') %}
+
+{% for form_type in filings_lookup[dataType] %}
+    {% set ns.form_types = ns.form_types + '&form_type=' + form_type %}
+{% endfor %}
+
     <div class="entity__figure row" id="{{dataType}}">
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">{{ title }}</h3>
         <a class="heading__right button button--alt button--browse"
-           href="/data/filings/?committee_id={{ committee_id }}&cycle={{ cycle }}">
+           href="/data/filings/?committee_id={{ committee_id }}&cycle={{ cycle }}&{{ns.form_types}}">
           Filter this data
         </a>
       </div>

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -1,4 +1,5 @@
-{% import 'macros/entity-pages.jinja' as entity %}
+{% import 'macros/entity-pages.jinja' as entity with context %}
+<!-- `with context` passes template variables to the macro -->
 {% import 'macros/missing.jinja' as missing %}
 
 <section id="section-6" role="tabpanel" aria-hidden="true" aria-labelledby="section-6-heading">
@@ -7,7 +8,7 @@
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
     {% if has_raw_filings %}
-      {{ entity.raw_filings_table(cycle=None, committee_id=candidate_id, min_receipt_date=min_receipt_date, is_committee=False) }}
+      {{ entity.raw_filings_table(is_committee=False) }}
     {% endif %}
       <div id="statements-of-candidacy" class="entity__figure row">
         <div class="content__section">

--- a/fec/data/templates/partials/candidate/filings-tab.jinja
+++ b/fec/data/templates/partials/candidate/filings-tab.jinja
@@ -49,7 +49,7 @@
     <div class="entity__figure entity__figure row" id="other">
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Other documents filed</h3>
-        <a class="heading__right button--alt button--browse"href="/data/filings/?candidate_id={{ candidate_id }}">Filter this data
+        <a class="heading__right button--alt button--browse"href="/data/filings/?candidate_id={{ candidate_id }}&form_type=F99&form_type=RFAI">Filter this data
         </a>
       </div>
       <table

--- a/fec/data/templates/partials/committee/filings.jinja
+++ b/fec/data/templates/partials/committee/filings.jinja
@@ -1,5 +1,6 @@
 {% import 'macros/cycle-select.jinja' as select %}
-{% import 'macros/entity-pages.jinja' as entity %}
+{% import 'macros/entity-pages.jinja' as entity with context %}
+<!-- `with context` allows the template variables to be passed to the macro -->
 
 <section id="section-5" role="tabpanel" aria-hidden="true" aria-labelledby="section-5-heading">
   <h2 id="section-5-heading">

--- a/fec/data/templates/partials/committee/filings.jinja
+++ b/fec/data/templates/partials/committee/filings.jinja
@@ -9,16 +9,16 @@
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'filings')}}
     {% if has_raw_filings %}
-      {{ entity.raw_filings_table(cycle, committee_id, min_receipt_date) }}
+      {{ entity.raw_filings_table() }}
     {% endif %}
     {% if committee_type == 'E' %}
-      {{ entity.filings_table('24 hour reports', 'notices', cycle, committee_id) }}
-      {{ entity.filings_table('Other documents', 'other', cycle, committee_id) }}
+      {{ entity.filings_table('24 hour reports', 'notices') }}
+      {{ entity.filings_table('Other documents', 'other') }}
     {% else %}
-      {{ entity.filings_table('Regularly filed reports', 'reports', cycle, committee_id, showTrigger=True) }}
-      {{ entity.filings_table('24- and 48-hour reports', 'notices', cycle, committee_id) }}
-      {{ entity.filings_table('Statements of organization', 'statements', cycle, committee_id) }}
-      {{ entity.filings_table('Other documents', 'other', cycle, committee_id) }}
+      {{ entity.filings_table('Regularly filed reports', 'reports', showTrigger=True) }}
+      {{ entity.filings_table('24- and 48-hour reports', 'notices') }}
+      {{ entity.filings_table('Statements of organization', 'statements') }}
+      {{ entity.filings_table('Other documents', 'other') }}
     {% endif %}
   </div>
 </section>

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -446,6 +446,14 @@ def get_committee(committee_id, cycle):
     else:
         template_variables['has_raw_filings'] = False
 
+    # Needed for filings tab
+    template_variables['filings_lookup'] = {
+        'reports': ['F3', 'F3X', 'F3P', 'F3L', 'F4', 'F5', 'F7', 'F13'],
+        'notices': ['F5', 'F24', 'F6', 'F9', 'F10', 'F11'],
+        'statements': ['F1'],
+        'other': ['F1M', 'F8', 'F99', 'F12']
+    }
+
     return template_variables
 
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -253,6 +253,8 @@ def get_candidate(candidate_id, cycle, election_full):
         'cash_summary': cash_summary,
         'committee_groups': committee_groups,
         'committee_ids': committee_ids,
+        # filings endpoint takes candidate ID value as committee ID arg
+        'committee_id': candidate['candidate_id'],
         'committees_authorized': committees_authorized,
         'context_vars': context_vars,
         'cycle': int(cycle),

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -324,11 +324,14 @@ function initOtherDocumentsTable() {
     query: {
       candidate_id: candidateId,
       form_type: ['F99', 'RFAI'],
-      /* Performing an include would only show RFAI form types. For this reason, excludes need to be
-         used for request_type
+      /* Performing an include would only show RFAI form types.
+      For this reason, excludes need to be used for request_type
 
       Exclude all request types except for:
-      // RQ-5: RFAI referencing Statement of Candidacy */
+        - RQ-5: RFAI referencing Statement of Candidacy
+
+      If this logic changes, update "Filter this data" button in filings-tab.jinja
+      */
       request_type: ['-1', '-2', '-3', '-4', '-5', '-6', '-7', '-8', '-9'],
       sort_hide_null: ['false']
     },

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -728,15 +728,19 @@ $(document).ready(function() {
                   'RFAI'
                 ],
                 report_type: ['-24', '-48'],
-                /* Performing an include would only show RFAI form types. For this reason, excludes need to be
-               used for request_type
+                /* Performing an include would only show RFAI form types.
+                For this reason, excludes need to be used for request_type
 
-            Exclude all request types except for:
-               - RQ-2: RFAI referencing Report of Receipts and Expenditures
-               - RQ-3: RFAI referencing second notice reports
-               - RQ-4: RFAI referencing Independent Expenditure filer
-               - RQ-7: RFAI referencing failure to file
-               - RQ-8: RFAI referencing public disclosure */
+                Exclude all request types except for:
+                  - RQ-2: RFAI referencing Report of Receipts and Expenditures
+                  - RQ-3: RFAI referencing second notice reports
+                  - RQ-4: RFAI referencing Independent Expenditure filer
+                  - RQ-7: RFAI referencing failure to file
+                  - RQ-8: RFAI referencing public disclosure
+
+                If this logic changes, update "Filter this data" button
+                in entity-pages.jinja
+                */
                 request_type: ['-1', '-5', '-6', '-9'],
                 sort: [
                   '-coverage_end_date',
@@ -765,15 +769,18 @@ $(document).ready(function() {
               {
                 form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11', 'RFAI'],
                 report_type: ['-Q1', '-Q2', '-Q3', '-YE'],
-                /* Performing an include would only show RFAI form types. For this reason, excludes need to be
-               used for request_type
+                /* Performing an include would only show RFAI form types.
+                For this reason, excludes need to be used for request_type
 
-            Exclude all request types except for:
-               - RQ-2: RFAI referencing Report of Receipts and Expenditures
-               - RQ-4: RFAI referencing Independent Expenditure filer
+                Exclude all request types except for:
+                  - RQ-2: RFAI referencing Report of Receipts and Expenditures
+                  - RQ-4: RFAI referencing Independent Expenditure filer
 
-            Exclude quarterly report_types so F5 quarterlies don't appear
-            */
+                Exclude quarterly report_types so F5 quarterlies don't appear
+
+                If this logic changes, update "Filter this data" button
+                in entity-pages.jinja
+                */
                 request_type: ['-1', '-3', '-5', '-6', '-7', '-8', '-9'],
                 sort_hide_null: ['false']
               },
@@ -793,12 +800,16 @@ $(document).ready(function() {
             query: _.extend(
               {
                 form_type: ['F1', 'RFAI'],
-                /* Performing an include would only show RFAI form types. For this reason, excludes need to be
-               used for request_type
+                /* Performing an include would only show RFAI form types.
+                For this reason, excludes need to be used for request_type
 
-            Exclude all request types except for:
-               - RQ-1: RFAI referencing Statement of organization
-               - RQ-6: RFAI referencing 2nd notice State of organization */
+                Exclude all request types except for:
+                  - RQ-1: RFAI referencing Statement of organization
+                  - RQ-6: RFAI referencing 2nd notice State of organization
+
+                If this logic changes, update "Filter this data" button
+                in entity-pages.jinja
+                */
                 request_type: ['-2', '-3', '-4', '-5', '-7', '-8', '-9'],
                 sort_hide_null: ['false']
               },
@@ -818,11 +829,15 @@ $(document).ready(function() {
             query: _.extend(
               {
                 form_type: ['F1M', 'F8', 'F99', 'F12', 'RFAI'],
-                /* Performing an include would only show RFAI form types. For this reason, excludes need to be
-               used for request_type
+                /* Performing an include would only show RFAI form types.
+                For this reason, excludes need to be used for request_type
 
-            Exclude all request types except for:
-               - RQ-9: RFAI referencing Multicandidate status */
+                Exclude all request types except for:
+                  - RQ-9: RFAI referencing Multicandidate status
+
+                If this logic changes, update "Filter this data" button
+                in entity-pages.jinja
+                */
                 request_type: ['-1', '-2', '-3', '-4', '-5', '-6', '-7', '-8'],
                 sort_hide_null: ['false']
               },


### PR DESCRIPTION
## Summary (required)

Resolves #3119
- Fix "Filter this data" buttons for filings
- Refactor filings macros to inherit template variables

## Impacted areas of the application
List general components of the application that this PR will affect:

- Candidate profile pages, filings tab
- Committee profile pages, filings tab

## How to test'
- Connect to any FEC API
 - Candidate profile page, filings tab -  "other documents" "filter this data" button should go to just the displayed filings and all RFAIs (unable to exclude by request type) http://localhost:8000/data/committee/C00560847/?cycle=2018&tab=filings#other
- Committee profile page, filings tab -  all data section "filter this data" buttons should go the the form types listed and all RFAIs http://localhost:8000/data/committee/C00035691/?cycle=2020&tab=filings
- Look for raw candidate/commitee filings and make sure raw filings appear properly (can look at filings raw data table). Note that there's an existing bug for brand new candidates so look for a F2 for an existing candidate

