### PR TITLE
Apply styles from home

### DIFF
--- a/fec/fec/static/scss/components/_overviews.scss
+++ b/fec/fec/static/scss/components/_overviews.scss
@@ -140,3 +140,25 @@
     @include span-columns(4);
   }
 }
+
+// Rules specifically for the top-raisers chart on the data landing page
+#top-raisers .chart-table .simple-table__row {
+  &:after {
+    content: '';
+    display: block;
+    height: 1rem;
+    border-bottom: 1px solid #d6d7d9;
+    position: relative;
+  }
+  .simple-table__cell {
+    text-align: left;
+  }
+  @include media($med) {
+    &:after {
+      display: none;
+    }
+    .simple-table__cell {
+      text-align: initial;
+    }
+  }
+}

--- a/fec/fec/static/scss/components/_overviews.scss
+++ b/fec/fec/static/scss/components/_overviews.scss
@@ -158,7 +158,10 @@
       display: none;
     }
     .simple-table__cell {
-      text-align: initial;
+      text-align: left;
+      &.t-right-aligned {
+        text-align: right;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Looking at the top raisers bars, apply the styles from the homepage to the raising & spending by the numbers pages

- Resolves #3133 

## Impacted areas of the application
Added style rules that apply to `#top-raisers .chart-table .simple-table__row` so unexpected impact should be low. Would like to confirm we haven't missed anywhere else, or changed anything unexpected.

-  

## Screenshots
Starting point:
![image](https://user-images.githubusercontent.com/26720877/65452832-cf3bb200-ddf6-11e9-885b-965b01146135.png)

Home, small:
![image](https://user-images.githubusercontent.com/26720877/65452756-ae735c80-ddf6-11e9-91ee-40bb39b5838a.png)

Raising, small:
![image](https://user-images.githubusercontent.com/26720877/65452774-b8955b00-ddf6-11e9-87e4-585ba22b3688.png)

Home, wider:
![image](https://user-images.githubusercontent.com/26720877/65452858-dd89ce00-ddf6-11e9-8856-a545d3c23023.png)

Raising, wider:
![image](https://user-images.githubusercontent.com/26720877/65452872-e4b0dc00-ddf6-11e9-8789-5785b56164f1.png)


## Related PRs
None

## How to test
- Pull, build as always
- Verify that the new styles are applied to [Raising](http://127.0.0.1:8000/data/raising-bythenumbers/) & [Spending](http://127.0.0.1:8000/data/spending-bythenumbers/) by the numbers
- Verify that other earning/spending charts are unaffected (anywhere else?)
- Verify that nothing else is affected (where?)

____

