### PR TITLE
[MERGE WITH GIT FLOW] Hotfix: Increase application memory on prod

### DIFF
--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -4,6 +4,7 @@ buildpack: python_buildpack
 routes:
   - route: fec-prod-cms.app.cloud.gov
 instances: 4
+memory: 1G
 services:
   - cms-creds-prod
   - fec-creds-prod


### PR DESCRIPTION
## Summary (required)

- Resolves #3197 
Increase application memory on prod from default `512MB` ([see cloud.gov docs](https://cloud.gov/docs/apps/limits/#application-limit-options-sizing)) to `1GB`

We tested this in `dev` with branch `feature/test-application-memory`. Circle output: https://circleci.com/gh/fecgov/fec-cms/2661

