### PR TITLE
Disable pre-1980 election profile page links

### DIFF
--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -125,6 +125,22 @@ Handlebars.registerHelper({
   eq: function(v1, v2) {
     return v1 === v2;
   },
+  // less than
+  lt: function(v1, v2) {
+    return v1 < v2;
+  },
+  // greater than
+  gt: function(v1, v2) {
+    return v1 > v2;
+  },
+  // less than or equal to
+  lte: function(v1, v2) {
+    return v1 <= v2;
+  },
+  // greater than or equal to
+  gte: function(v1, v2) {
+    return v1 >= v2;
+  },
   toUpperCase: function(value) {
     return value.substr(0, 1).toUpperCase() + value.substr(1);
   }

--- a/fec/fec/static/js/templates/candidates.hbs
+++ b/fec/fec/static/js/templates/candidates.hbs
@@ -13,7 +13,11 @@
       <td class="panel__term">Election years</td>
       <td class="panel__data">
         {{#each election_years}}
-          <a href="{{electionUrl this parentContext=../this index=@index}}">{{this}}</a>{{#unless @last}}, {{/unless}}
+          {{#if (gte this 1980)}}
+            <a href="{{electionUrl this parentContext=../this index=@index}}">{{this}}</a>{{#unless @last}}, {{/unless}}
+          {{else}}
+            {{this}}{{#unless @last}}, {{/unless}}
+          {{/if}}
         {{/each}}
         </ul>
       </td>

--- a/fec/fec/static/js/templates/candidates.hbs
+++ b/fec/fec/static/js/templates/candidates.hbs
@@ -13,8 +13,10 @@
       <td class="panel__term">Election years</td>
       <td class="panel__data">
         {{#each election_years}}
+          {{! we only have election profile pages starting in 1980}}
           {{#if (gte this 1980)}}
-            <a href="{{electionUrl this parentContext=../this index=@index}}">{{this}}</a>{{#unless @last}}, {{/unless}}
+            <a href="{{electionUrl this parentContext=../this index=@index}}">
+              {{this}}</a>{{#unless @last}}, {{/unless}}
           {{else}}
             {{this}}{{#unless @last}}, {{/unless}}
           {{/if}}


### PR DESCRIPTION
## Summary (required)

- Resolves #3086
Disable pre-1980 election profile page links, add operator handlebars helpers

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate flyout tabs

## Screenshots

## Before

<img width="1108" alt="Screen Shot 2019-09-26 at 4 10 56 PM" src="https://user-images.githubusercontent.com/31420082/65721705-86932b80-e078-11e9-80d3-848b98fddff3.png">

## After
<img width="1140" alt="Screen Shot 2019-09-26 at 4 10 35 PM" src="https://user-images.githubusercontent.com/31420082/65721701-84c96800-e078-11e9-9f1e-2135ad444dea.png">

## How to test
- Connect to any FEC API
- Rebuild JS with `npm run build` or `npm run watch`
 - Go to http://localhost:8000/data/candidates/?q=mcgovern&q=trump&office=P&is_active_candidate=true&has_raised_funds=true
- Click on flyout for McGovern. The election years before 1980 should be disabled and 1980 and later should be enabled. Test that the links work properly when enabled.