### PR TITLE
WCCF: Update candidate cycle in link and make election years even

### DIFF
--- a/fec/fec/static/js/polyfills.js
+++ b/fec/fec/static/js/polyfills.js
@@ -42,3 +42,7 @@ import 'whatwg-fetch';
  * TODO used for
  */
 import 'promise-polyfill/src/polyfill';
+
+// For ES6 Set data structure
+// eslint-disable-next-line no-unused-vars
+var Set = require('es6-set');

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -419,7 +419,7 @@ ContributionsByState.prototype.displayUpdatedData_candidate = function() {
   // Grab election_years from the candidate details
   let candidateElectionYears = this.candidateDetails.election_years;
   let evenElectionYears = candidateElectionYears.map(electionYear => {
-    if (electionYear % 2 == 0) {
+    if (electionYear % 2 === 0) {
       return electionYear;
     } else {
       electionYear = electionYear + 1;

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -427,6 +427,7 @@ ContributionsByState.prototype.displayUpdatedData_candidate = function() {
     }
   });
   // Take the new even election years set and make it distinct
+  // eslint-disable-next-line no-undef
   let validElectionYears = [...new Set(evenElectionYears)];
   // Sort them so the most recent is first so it'll be on top of the <select>
   validElectionYears.sort((a, b) => b - a);
@@ -649,7 +650,12 @@ ContributionsByState.prototype.handleTypeaheadFocus = function() {
 };
 
 // Set the candidate's name and link change
-ContributionsByState.prototype.setCandidateName = function(id, candidateName, party, cycle) {
+ContributionsByState.prototype.setCandidateName = function(
+  id,
+  candidateName,
+  party,
+  cycle
+) {
   let candidateNameElement = this.candidateDetailsHolder.querySelector('h1');
   candidateNameElement.innerHTML = `<a href="/data/candidate/${id}/?cycle=${cycle}&election_full=true">${candidateName}</a> [${party}]`;
 };

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -417,7 +417,17 @@ ContributionsByState.prototype.displayUpdatedData_candidate = function() {
   // TODO - handle if there are no years
   // TODO - handle if there is only one year
   // Grab election_years from the candidate details
-  let validElectionYears = this.candidateDetails.election_years;
+  let candidateElectionYears = this.candidateDetails.election_years;
+  let evenElectionYears = candidateElectionYears.map(electionYear => {
+    if (electionYear % 2 == 0) {
+      return electionYear;
+    } else {
+      electionYear = electionYear + 1;
+      return electionYear;
+    }
+  });
+  // Take the new even election years set and make it distinct
+  let validElectionYears = [...new Set(evenElectionYears)];
   // Sort them so the most recent is first so it'll be on top of the <select>
   validElectionYears.sort((a, b) => b - a);
   // Remember what year's election we're currently showing (will help if we were switching between candidates of the same year)

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -402,14 +402,6 @@ ContributionsByState.prototype.displayUpdatedData_candidate = function() {
   let theTypeahead = document.querySelector('#contribs-by-state-cand');
   if (!theTypeahead.value) theTypeahead.value = this.candidateDetails.name;
 
-  // Handle the candidate's name…
-  let candidateNameElement = this.candidateDetailsHolder.querySelector('h1');
-  candidateNameElement.innerHTML = `<a href="/data/candidate/${
-    this.candidateDetails.candidate_id
-  }/?cycle=${this.baseStatesQuery.cycle}&election_full=true">${
-    this.candidateDetails.name
-  }</a> [${this.candidateDetails.party}]`;
-
   // …their desired office during this election…
   let candidateOfficeHolder = this.candidateDetailsHolder.querySelector('h2');
   let theOfficeName = this.candidateDetails.office_full;
@@ -463,6 +455,14 @@ ContributionsByState.prototype.displayUpdatedData_candidate = function() {
 
     // this.loadStatesData();
   }
+  // Update candidate name and link
+  this.setCandidateName(
+    this.candidateDetails.candidate_id,
+    this.candidateDetails.name,
+    this.candidateDetails.party,
+    this.baseStatesQuery.cycle
+  );
+
   // Load the new states data
   this.loadStatesData();
 };
@@ -638,6 +638,12 @@ ContributionsByState.prototype.handleTypeaheadFocus = function() {
   this.typeahead_revertValue = theTypeahead.value;
 };
 
+// Set the candidate's name and link change
+ContributionsByState.prototype.setCandidateName = function(id, candidateName, party, cycle) {
+  let candidateNameElement = this.candidateDetailsHolder.querySelector('h1');
+  candidateNameElement.innerHTML = `<a href="/data/candidate/${id}/?cycle=${cycle}&election_full=true">${candidateName}</a> [${party}]`;
+};
+
 /**
  * Called on the election year control's change event
  * Starts loading the new data
@@ -646,6 +652,14 @@ ContributionsByState.prototype.handleTypeaheadFocus = function() {
 ContributionsByState.prototype.handleElectionYearChange = function(e) {
   e.preventDefault();
   this.baseStatesQuery.cycle = this.yearControl.value;
+  // Update candidate name and link
+  this.setCandidateName(
+    this.candidateDetails.candidate_id,
+    this.candidateDetails.name,
+    this.candidateDetails.party,
+    this.baseStatesQuery.cycle
+  );
+
   // We don't need to load the candidate details for a year change, so we'll just jump right to loading the states data.
   this.loadStatesData();
 };

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "clean-webpack-plugin": "^0.1.16",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.9.1",
+    "es6-set": "^0.1.5",
     "eslint": "^6.2.1",
     "eslint-config-prettier": "^4.0.0",
     "eslint-loader": "^2.2.1",


### PR DESCRIPTION
## Summary

Where contributions come from updates:
- Update candidate link with the correct selected election year
- Handle odd year special elections by converting list to even years 

## Screenshots

Odd numbered election years converted to even. Example, candidate ID H8GA06195
<img width="739" alt="Screen Shot 2019-09-30 at 10 51 52 PM" src="https://user-images.githubusercontent.com/12799132/65930765-ecfbaf00-e3d4-11e9-9e5c-0b5402398a9f.png">

## How to test
- [ ] Search in type ahead and select any candidate. Check the link in the candidate name details to make sure the election year matches what is in the selected election year dropdown
- [ ] Update the election year from the election year dropdown. Check the link in the candidate name details to make sure the election year matches what is in the selected election year dropdown
- [ ] Check a candidate with an odd election year. Such as this candidate ID H8GA06195. Make sure that the odd election year displayed is now even.
____

