### PR TITLE
feature/3204 WCCF Individual Contributions links

### DIFF
--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -45,11 +45,11 @@ function formatAsCurrency(passedValue, roundToWhole = true) {
 }
 
 /**
- * Builds the link
- * @param {Number} cycle
+ * Builds the link/url to a filtered Individual Contributions page/list
+ * @param {Number} cycle The candidate's election year
  * @param {String} office 'H', 'P', or 'S'
- * @param {Array} committeeIDs
- * @param {String} stateID Optional. A null value will build the URL for the country
+ * @param {Array} committeeIDs An array of strings of the candidate's committees
+ * @param {String} stateID Optional. A null value will not filter for any state but show entries for the entire country
  * @returns {String} URL or empty string depending on
  */
 function buildIndividualContributionsUrl(cycle, office, committeeIDs, stateID) {

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -769,8 +769,9 @@ ContributionsByState.prototype.handleElectionYearChange = function(e) {
     this.baseStatesQuery.cycle
   );
 
-  // We don't need to load the candidate details for a year change, so we'll just jump right to loading the states data.
-  this.loadStatesData();
+  // We don't need to load the candidate details for a year change,
+  // so we'll just jump right to loading the committees data for the newly-chosen year.
+  this.loadCandidateCommitteeDetails();
 };
 
 /**

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -265,7 +265,7 @@ ContributionsByState.prototype.init = function() {
   );
   this.buttonIndivContribs.addEventListener(
     'click',
-    this.handleBrowseIndivContribsClick.bind(this)
+    this.updateBrowseIndivContribsButton.bind(this)
   );
 
   // Initialize the remote table header
@@ -614,6 +614,9 @@ ContributionsByState.prototype.displayUpdatedData_states = function() {
   // Update the time stamp above the states list
   this.updateCycleTimeStamp();
 
+  // Update the Individual Contributions button/link at the bottom
+  this.updateBrowseIndivContribsButton();
+
   // Let the map know that the data has been updated
   this.map.handleDataRefresh(theData);
 
@@ -795,10 +798,9 @@ ContributionsByState.prototype.handleErrorState = function(errorCode) {
 };
 
 /**
- * Assigns the Invididual Contributions button href right before the click action happens
- * @param {MouseEvent} e
+ * Updates the href of the Individual Contributions link/button at the bottom of the widget
  */
-ContributionsByState.prototype.handleBrowseIndivContribsClick = function(e) {
+ContributionsByState.prototype.updateBrowseIndivContribsButton = function() {
   // We need to go through the committee results and build an array of the committee IDs
   // to send to {@see buildIndividualContributionsUrl() }
   let theCommittees = this.data_candidateCommittees.results;
@@ -807,7 +809,10 @@ ContributionsByState.prototype.handleBrowseIndivContribsClick = function(e) {
     theCommitteeIDs.push(theCommittees[i].committee_id);
   }
 
-  e.target.setAttribute(
+  let theButton = this.element.querySelector(
+    '.js-browse-indiv-contribs-by-state'
+  );
+  theButton.setAttribute(
     'href',
     buildIndividualContributionsUrl(
       this.baseStatesQuery.cycle,
@@ -815,8 +820,6 @@ ContributionsByState.prototype.handleBrowseIndivContribsClick = function(e) {
       theCommitteeIDs
     )
   );
-
-  // Let the normal click action happen—no reason to e.preventDefault()
 };
 
 /**


### PR DESCRIPTION
## Summary

- Resolves #3204

Fixes the Individual Contributions link at the bottom of the widget to apply committee filters. Updates the table of dollar values so they link to their filtered datatable pages, too.
Generally cleaned up comments, documentation, linting.

## Impacted areas of the application

Changes are all inside the WCCF widget, though there is a new API call to get the candidates committee IDs, and we've added links to the individual contributions page (with filters applied)

## Screenshots

![image](https://user-images.githubusercontent.com/26720877/66070177-d7929c00-e51e-11e9-8bf0-730e4b2ad301.png)


## Related PRs

None

## How to test
- Pull and build the branch like normal
- Make sure env var FEC_FEATURE_CONTRIBUTIONS_BY_STATE is true
- Visit /data/raising-bythenumbers/
- For several candidates, check that the Individual Contributions button and dollar-figure links (circled in red on the attached screenshot) go to the correct datatable pages.

____

