### PR TITLE
Feature/3216 wccf map colors

### DIFF
--- a/fec/data/templates/macros/widgets.jinja
+++ b/fec/data/templates/macros/widgets.jinja
@@ -1,6 +1,6 @@
 {% macro select__election_year(election_years, election_year, elementID, electionType = 'H') %}
 <label for="election-year" class="breakdown__title label t-inline-block">Running in:</label>
-<select id="{{ elementID }}" name="cycle" class="js-election-year form-element--inline" aria-controls="">
+<select id="{{ elementID }}" name="cycle" class="js-widget-election-year form-element--inline" aria-controls="">
 {% for eachYear in election_years | sort(reverse=True) %}
   {% if electionType != 'P' or eachYear % 4 == 0 %}
   <option

--- a/fec/fec/static/js/modules/data-map.js
+++ b/fec/fec/static/js/modules/data-map.js
@@ -317,7 +317,7 @@ function drawStateLegend(svg, scale, quantize, quantiles) {
       } else {
         // Otherwise, for the last element, use the penultimate value plus a plus
         toReturn += compactNumber(ticks[i - 1], compactRule).toString();
-        toReturn += '+';  
+        toReturn += '+';
       }
 
       return toReturn;

--- a/fec/fec/static/js/modules/data-map.js
+++ b/fec/fec/static/js/modules/data-map.js
@@ -310,20 +310,15 @@ function drawStateLegend(svg, scale, quantize, quantiles) {
       // d is the data; i is the increment position of the loop
       let toReturn = '';
 
-      if (i === 0) {
-        // To represent values less than this legend element's value
+      if (i < ticks.length - 1) {
+        // If we're looking at any block other than the last,
         toReturn += '<';
+        toReturn += compactNumber(d, compactRule).toString();
       } else {
-        // Otherwise, we need to start with the previous block's value (only the number)
-        let prevLabel = compactNumber(ticks[i - 1], compactRule).toString();
-        toReturn += prevLabel.substring(0, prevLabel.length - 1);
-        toReturn += '-';
+        // Otherwise, for the last element, use the penultimate value plus a plus
+        toReturn += compactNumber(ticks[i - 1], compactRule).toString();
+        toReturn += '+';  
       }
-
-      toReturn += compactNumber(d, compactRule).toString();
-
-      // Add a plus sign to cover the higher-than values
-      if (i == ticks.length - 1) toReturn += '+';
 
       return toReturn;
     });

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -202,8 +202,7 @@ ContributionsByState.prototype.init = function() {
 
   // Fire up the map
   this.map = new DataMap(this.map, {
-    colorScale: ['#f0f9e8', '#a6deb4', '#7bccc4', '#2a9291', '#216a7a'],
-    colorZero: '#ffffff',
+    color: '#36BDBB',
     data: '',
     addLegend: true,
     addTooltips: true


### PR DESCRIPTION
## Summary

- Resolves #3216 
- Resolves #3231 
- Updates the color scale to match the current Individual Contributions map.
- Limits the states' colors to those in the legend.
- Changes the legend text to be ranges rather than single values.

## Impacted areas of the application
All of the changes are contained inside WCCF.

## Screenshots
![image](https://user-images.githubusercontent.com/26720877/66214875-83a7c480-e690-11e9-9d7e-aa2fc490f552.png)



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/3204-wccf-indiv-contribs-btn | #3204 (related, not dependent)

## How to test
- Pull, build, and run like normal (FEC_FEATURE_CONTRIBUTIONS_BY_STATE must be true)
- Change candidates and test values.
  - Warren, Elizabeth (Senate) will default to 2024 and offer all $0s. 2018 has data.
  - San Nicolas, Michael (House) has only a few values.
  - Perot (President) has a few $0s.
  - Mondale (President) has low numbers
  - Obama (President, 2008) has the highest numbers to date

Note: The color scale is based on the value of the state with the lowest value + 50% of the range between the lowest and highest states. The goal was to skew the scale so the 2-4 highest-raising (and highest population) states—more like showing the mode average more than the median average.
____

