### PR TITLE
Feature/3232 wccf committee api call

### DIFF
--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -101,7 +101,12 @@ function ContributionsByState() {
   // Where to find individual candidate details
   this.basePath_candidatePath = ['candidate'];
   // Where to find individual candidate details
-  this.basePath_candidateCommitteesPath = ['candidate', '000', 'committees'];
+  this.basePath_candidateCommitteesPath = [
+    'candidate',
+    '000', // candidate ID
+    'committees',
+    'history'
+  ];
   // Where to find the highest-earning candidates:
   this.basePath_highestRaising = ['candidates', 'totals'];
   // Where to find the list of states:

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -106,7 +106,7 @@ function ContributionsByState() {
     '000', // candidate ID
     'committees',
     'history',
-    2020
+    2020 // election year / cycle
   ];
   // Where to find the highest-earning candidates:
   this.basePath_highestRaising = ['candidates', 'totals'];

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -105,7 +105,8 @@ function ContributionsByState() {
     'candidate',
     '000', // candidate ID
     'committees',
-    'history'
+    'history',
+    2020
   ];
   // Where to find the highest-earning candidates:
   this.basePath_highestRaising = ['candidates', 'totals'];
@@ -386,12 +387,13 @@ ContributionsByState.prototype.loadCandidateCommitteeDetails = function() {
 
   // Before we fetch, make sure the query path has the current candidate id
   this.basePath_candidateCommitteesPath[1] = this.candidateDetails.candidate_id;
+  // and the current election year/cycle
+  this.basePath_candidateCommitteesPath[4] = this.baseStatesQuery.cycle;
 
   let committeesQuery = Object.assign(
     {},
     {
       per_page: 100,
-      cycle: this.baseStatesQuery.cycle,
       election_full: true
     }
   );


### PR DESCRIPTION
## Summary

- Resolves #3232 
- Updates the path to the API for retrieving committee IDs

## Impacted areas of the application
- Only that one query/fetch in this one widget

## Screenshots
No visible changes

## Related PRs
There are several other WCCF PRs but none that help or hinder this issue.

## How to test
- Pull, build, and run this branch like always.
- Check that we gets lists of states data (The committee call is after the candidate details but before the list of states).
- Check that the numbers agree with the individual contributions pages of the same data.
- All approved? Merge and delete the branch.

Note: this PR does not include any of the other WCCF work. The states may be odd colors. The legend may have outdated labels. The Indiv Contribs links may or may not be linking correctly.
____

