### PR TITLE
Fix candidate profile no financial activity issue

### DIFF
--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -14,7 +14,7 @@ class TestCandidate(TestCase):
     STOCK_CANDIDATE = {
         "candidate_id": "H001",
         "name": "Lady Liberty",
-        "cycles": [2014, 2016, 2018],
+        "fec_cycles_in_election": [2014, 2016, 2018],
         "election_years": [2016, 2018],
         "rounded_election_years": [2016, 2018],
         "election_districts": ["01", "02"],
@@ -62,7 +62,8 @@ class TestCandidate(TestCase):
 
         assert candidate['candidate_id'] == test_candidate['candidate_id']
         assert candidate['name'] == test_candidate['name']
-        assert candidate['cycles'] == test_candidate['cycles']
+        assert candidate['cycles'] == test_candidate[
+            'fec_cycles_in_election']
         assert candidate['min_cycle'] == cycle - 2
         assert candidate['max_cycle'] == cycle
         assert candidate['election_year'] == cycle
@@ -101,7 +102,7 @@ class TestCandidate(TestCase):
                 'name': 'Joint Fundraising Committee',
                 'cycle': 2016,
                 'related_cycle': 2016,
-                'committee_id': 'C003'}]
+                'committee_id': 'C003'}],
         }
 
         assert candidate['committees_authorized'] == (
@@ -132,7 +133,7 @@ class TestCandidate(TestCase):
 
         # use new column rounded_election_years which round odd number in MV.
         test_candidate = copy.deepcopy(self.STOCK_CANDIDATE)
-        test_candidate["cycles"] = [2016, 2018]
+        test_candidate["fec_cycles_in_election"] = [2016, 2018]
         test_candidate["election_years"] = [2013, 2015, 2018]
         test_candidate["rounded_election_years"] = [2014, 2016, 2018]
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -160,7 +160,7 @@ def get_candidate(candidate_id, cycle, election_full):
 
     # For JavaScript
     context_vars = {
-        'cycles': candidate['cycles'],
+        'cycles': candidate['fec_cycles_in_election'],
         'name': candidate['name'],
         'cycle': cycle,
         'electionFull': election_full,
@@ -258,7 +258,7 @@ def get_candidate(candidate_id, cycle, election_full):
         'committees_authorized': committees_authorized,
         'context_vars': context_vars,
         'cycle': int(cycle),
-        'cycles': candidate['cycles'],
+        'cycles': candidate['fec_cycles_in_election'],
         'district': candidate['district'],
         'duration': duration,
         'election_year': cycle,


### PR DESCRIPTION
## Summary (required)

- Resolves [#[_3127_]](https://github.com/fecgov/fec-cms/issues/3127)
We replace value of cycles with new column:  **fec_cycles_in_election**
<img width="274" alt="66178008-c2f2f880-e631-11e9-90eb-8d708423ade8" src="https://user-images.githubusercontent.com/24395751/66316159-222c6380-e8e5-11e9-95f9-0cfde0ba17c6.png">


## Impacted areas of the application
Candidate Profile page
 

## How to test:
1. checkout cms feature branch
2. point to dev api
3. run tests
pytest
./manage.py test data.tests
npm run test-single

4. ./manage.py runserver
5. compare candidate on Raising / Spending page with prod.

P00003392
http://127.0.0.1:8000/data/candidate/P00003392/?tab=raising

P80001571
http://127.0.0.1:8000/data/candidate/P80001571/?tab=raising&cycle=2018&election_full=False


<img width="237" alt="66177724-9f7b7e00-e630-11e9-9c13-17041fd65bb6" src="https://user-images.githubusercontent.com/24395751/66316857-653b0680-e8e6-11e9-868e-a0a90858bf1e.png">
