### PR TITLE
Raise the dropdown z-index

### DIFF
--- a/fec/fec/static/js/draftail/components/Modal.js
+++ b/fec/fec/static/js/draftail/components/Modal.js
@@ -57,7 +57,7 @@ const Modal = ({ children, handleClose, title }) => (
       pointerEvents: 'auto',
       position: 'fixed',
       top: 'calc(50% - 100px)',
-      zIndex: '100'
+      zIndex: 1100 //(see _variables.scss $z11)
     }}
   >
     <Cancel handleClose={handleClose} />

--- a/fec/fec/static/js/legal/filters/CitationFilter.js
+++ b/fec/fec/static/js/legal/filters/CitationFilter.js
@@ -175,7 +175,7 @@ class CitationFilter extends React.Component {
               position: 'absolute',
               top: '100%',
               left: '0px',
-              zIndex: 100,
+              zIndex: 1100, //(see _variables.scss $z11)
               display: this.dropdownDisplay()
             }}
           >

--- a/fec/fec/static/scss/_variables.scss
+++ b/fec/fec/static/scss/_variables.scss
@@ -62,11 +62,14 @@ $neutral-focus: $primary;
 $z1: 100;
 $z2: 200;
 $z3: 300;
-$z4: 400;
+$z4: 400; // leaflet map panels are here, too
 $z5: 500;
 $z6: 600;
 $z7: 700;
 $z8: 800;
+$z9: 900; 
+$z10: 1000; // leaflet map controls (zoom in/out)
+$z11: 1100;
 $z-max: 90000000;
 
 $z-overlay: $z2;
@@ -76,4 +79,5 @@ $z-navigation: $z7;
 $z-header: $z6;
 $z-sticky: $z7;
 $z-glossary: $z8;
+$z-dropdowns: $z11;
 $z-feedback: $z-max;

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -93,7 +93,7 @@
   overflow: hidden;
   text-align: left;
   top: u(3.4rem);
-  z-index: $z2;
+  z-index: $z-dropdowns;
 
   .dropdown__value,
   label.dropdown__value {

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -93,7 +93,7 @@
   overflow: hidden;
   text-align: left;
   top: u(3.4rem);
-  z-index: $z1;
+  z-index: $z2;
 
   .dropdown__value,
   label.dropdown__value {

--- a/fec/fec/static/scss/components/_search-bar.scss
+++ b/fec/fec/static/scss/components/_search-bar.scss
@@ -211,6 +211,8 @@ $search-button-width: u(5.6rem);
   text-align: left;
   top: u(3.5rem) !important;
   width: 100%;
+  // z-index is being set on the element through a node_modules JS so adding an !important to fight that:
+  z-index: $z-dropdowns !important;
 }
 
 .tt-suggestion {

--- a/fec/fec/static/scss/widgets/contributions-by-state.scss
+++ b/fec/fec/static/scss/widgets/contributions-by-state.scss
@@ -425,7 +425,7 @@ aside.contribs-by-state {
     display: none;
     position: absolute;
     width: 100%;
-    z-index: 99; // The typeahead menu is at 100 and we want it to be visible above this
+    z-index: $z1;
 
     &.is-loading {
       display: block;
@@ -577,7 +577,7 @@ aside.contribs-by-state {
   padding: 1.5rem;
   position: absolute;
   text-align: center;
-  z-index: 400;
+  z-index: $z4;
   
   .tooltip__title {
     border-bottom: 1px solid #112e51;


### PR DESCRIPTION
## Summary

- Resolves #3166 
- Resolves #3245 
- Resolves #1254 
- Created new variables to use for z-index values
- Applied `$z-dropdowns` to `.dropdown_panel`
- Mimicked z-dropdowns in local JavaScript files and commented to why I chose that value
- Moved dropdowns to 1100 so they're above everything except modals

## Impacted areas of the application
The changes only affected the depth of a handful of elements, but they could now conflict with other existing components—unlikely, but still a possibility.


## Screenshots
A fixed #3166 
![image](https://user-images.githubusercontent.com/26720877/66406471-a9e3a200-e9b9-11e9-89c2-c0cfaa9aa205.png)

A fixed #3245 
![image](https://user-images.githubusercontent.com/26720877/66425199-10c68280-e9dd-11e9-86f8-d6a06818bb2f.png)


## Related PRs
None

## How to test
- `npm i`, `npm run build`, `./manage.py runserver`
- Check /data/elections/president/2020/
  - Under "Individual contributions to candidates"
  - Open the "More" pull-down,
  - Make sure it's in front of the other content
- Check /data/
  - In the "Look up candidate and committee profiles" block
  - Enter something like "America" that has a lot of results
  - Make sure it's in front of the other content (especially the map and its controls at the non-phone widths)
- Test them both across multiple browser widths, from as small to as large as you can.
- Test several other places on the site where there are pull-downs and modals check the various stacking orders.
- **UPDATE**: This PR will also address #1254 so we should check the site search typeahead suggestions, too. (@JonellaCulmer , @patphongs , I know you've already approved the rest)
- Approve
- [Merge and delete the branch]
____

