### PR TITLE
Update 500 error message

### DIFF
--- a/fec/fec/templates/500.html
+++ b/fec/fec/templates/500.html
@@ -7,7 +7,7 @@
   <div class="container">
     <div class="message message--alert message--big">
       <h1 class="message__title">Server error</h1>
-      <p>Sorry, this page failed to load. This happened because of an internal error, and our web team has been notified. Please try again, and thanks for your patience.</p>
+      <p>Sorry, this page failed to load. Check the FEC’s <a href="https://www.fec.gov/status">API status page</a> to see if we are experiencing a temporary outage. If not, please try again, and thanks for your patience.</p>
       <p>If you'd like to contact our team, use the <a href="javascript:$('.js-feedback.feedback__toggle.button--cta-secondary').click();" style="text-decoration:none">feedback box</a> on the bottom of any page or <a href="https://www.fec.gov/contact/">contact the FEC</a>.</p>
     </div>
   </div>


### PR DESCRIPTION
Linking to FEC status page for API

## Summary (required)

- Resolves #3113 by updating the API status error message to link to https://www.fec.gov/status.

## Impacted areas of the application
- Affects 500 error message

## Screenshots

- _Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface or front end change, include both a Before and After screenshot._

## How to test
  - Generate a 500 error (paging @patphongs for help with this)
  - Ensure that link to https://www.fec.gov/status is working and points to http://status.open.fec.gov/.

