### PR TITLE
add condition for amendment_chain != null

### DIFF
--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -444,7 +444,7 @@ function amendmentVersionDescription(row) {
   // This checks for terminatino reports and if the amendment number is greater
   // than 0 or the amendment chain is longer than 1, it is an amendment
   else if (row.amendment_indicator === API.amendment_indicator_terminated) {
-    if (row.amendment_chain.length > 1) {
+    if (row.amendment_chain != null && row.amendment_chain.length > 1) {
       amendment_num = row.amendment_chain.length - 1;
       description = ' Amendment ' + amendment_num;
     } else {


### PR DESCRIPTION
## Summary (required)

- Resolves #3060 
- add condition to `helpers.js` to ensure `amendment_chain.length` is not called before checking to see that `amendment_chain` is not null.

## Impacted areas of the application
- `helpers.js`

## How to test
- check out this branch
- `pytest`
- run local cms and check [example case](http://localhost:8000/data/reports/house-senate/?data_type=processed&committee_id=C00498683) where `amendment_chain` is null behaves as expected