### PR TITLE
feature/2943 Update styles for dropdowns' perfect-scrollbar components

### DIFF
--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -151,7 +151,7 @@
     border-bottom: 1px solid $gray-dark;
     font-size: u(1.4rem);
     font-weight: bold;
-    padding-left: u(.5rem);
+    padding-left: u(.75rem);
 
     &:hover {
       background-color: $inverse;

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -102,7 +102,7 @@
     color: $base;
     display: block;
     margin: 0;
-    padding: u(.5rem 1rem);
+    padding: u(.5rem 1rem .5rem 1.5rem);
     max-width: 100%;
     white-space: nowrap;
 
@@ -121,7 +121,7 @@
       border: 1px solid $gray;
       display: block;
       font-size: u(1.4rem);
-      padding: u(.5rem 1rem);
+      padding: u(.5rem 1rem .5rem 1.5rem);
       text-align: left;
       width: 100%;
 
@@ -147,8 +147,11 @@
 
   // For labeling a group of options
   .dropdown__subhead {
+    border: 1px solid $gray;
+    border-bottom: 1px solid $gray-dark;
     font-size: u(1.4rem);
     font-weight: bold;
+    padding-left: u(.5rem);
 
     &:hover {
       background-color: $inverse;
@@ -214,14 +217,18 @@
 }
 
 .ps-scrollbar-y-rail {
-  position: absolute;
   background: $gray-medium;
-  width: 4px;
   border-left: 1px solid $gray-dark;
+  position: absolute;
+  left: 0;
+  right: auto;
+  width: 4px;
 }
 
 .ps-scrollbar-y {
-  position: absolute;
-  width: 4px;
   background: $gray-dark;
+  left: 0;
+  position: absolute;
+  right: auto;
+  width: 4px;
 }


### PR DESCRIPTION
## Summary

- Resolves #2943 
- Read the code and experimented with the perfect-scrollbars package
- Changed css for the various components involved with the drop-down-type divs
  - Increased the left padding for all elements (inside the drop-downs) so subheads aren't under the scrollers
  - Assigned `left` values to the scroll components rather than rely on a calculated `right`
  - Gave the subheads the same border styles as its sibling elements

## Impacted areas of the application
All changes were inside the css file for the "drop-downs" but that would affect every "drop-down" on the site. (The quotes are because these aren't native `<select>`, `<option>`, and scrollbar elements that just work with every browser, but custom divs being used for custom functionality. Any native elements across the site should be unaffected by these changes.)

## Screenshots
Before & after, general drop-down: (more left padding for the 'after')
![image](https://user-images.githubusercontent.com/26720877/66504202-a96d0900-ea96-11e9-8392-0defe5572de5.png)

Before & after, a drop-down with a subhead: (better alignment on left edge, subhead's right edge is neat, subhead's borders match those of its siblings)
![image](https://user-images.githubusercontent.com/26720877/66504509-3912b780-ea97-11e9-9f9a-d35081b363c2.png)

## Related PRs
None

## How to test
- Pull the branch and run it as usual
- `npm i`
- `npm run build`
- Check a few of the site's drop-downs ([receipts](http://127.0.0.1:8000/data/receipts/?data_type=processed&two_year_transaction_period=2020&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020) has several). Be sure to include
  - without a subhead
  - with a subhead
  - any where the scrollbar should be on the right edge?
- Check appearance and functionality across a few widths, including the smallest and largest
- Approve
- [merge, close]
____

