### PR TITLE
Fix committee info and raising/spending tabs for future candidates

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -256,8 +256,7 @@ def load_nested_type(parent_type, c_id, nested_type, *path, **filters):
     )
 
 
-def load_with_nested(primary_type, primary_id, secondary_type, cycle=None,
-                     cycle_key='cycle', **query):
+def load_with_nested(primary_type, primary_id, secondary_type, cycle=None, **query):
     """ Handle Candidate or Committee endpoint
         Example: /candidate/P80003338/committees
         primary_type: "candidate"
@@ -277,8 +276,8 @@ def load_with_nested(primary_type, primary_id, secondary_type, cycle=None,
     )
 
     cycle = cycle or max(data['cycles'])
+    path = ('history', str(cycle))
 
-    path = ('history', str(data[cycle_key]))
     """ Get data for secondary_type
         Example: committee data for /candidate/P80003338/committees
     """

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -145,3 +145,42 @@ class TestCandidate(TestCase):
         candidate = get_candidate('H001', 2016, True)
         assert candidate["election_years"] == [2014, 2016, 2018]
         assert candidate["election_year"] == 2016
+
+    def test_future_candidate_max_cycle(
+        self,
+        load_with_nested_mock,
+        load_first_row_data_mock,
+        load_candidate_statement_of_candidacy_mock,
+    ):
+
+        test_candidate = copy.deepcopy(self.STOCK_CANDIDATE)
+        test_candidate["candidate_id"] = ["S001"]
+        test_candidate["fec_cycles_in_election"] = [2016, 2018, 2020]
+        test_candidate["election_years"] = [2018, 2024]
+        test_candidate["rounded_election_years"] = [2018, 2024]
+
+        test_committee_list = copy.deepcopy(self.STOCK_COMMITTEE_LIST)
+        test_committee_list[0] = (
+            {
+                'designation': 'P',
+                'cycles': [2016, 2014, 2012, 2018, 2020],
+                'name': 'My Primary Campaign Committee',
+                'cycle': 2018,
+                'committee_id': 'C001',
+            },
+        )
+        test_committee_list.append(
+            {
+                'designation': 'P',
+                'cycles': [2016, 2014, 2012, 2018, 2020],
+                'name': 'My Primary Campaign Committee',
+                'cycle': 2024,
+                'committee_id': 'C001',
+            }
+        )
+
+        load_with_nested_mock.return_value = (test_candidate, mock.MagicMock(), 2024)
+        candidate = get_candidate('S001', 2024, True)
+        assert candidate["election_years"] == [2018, 2024]
+        assert candidate["election_year"] == 2024
+        assert candidate["max_cycle"] == 2020

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -32,23 +32,29 @@ class TestCandidate(TestCase):
             'name': 'My Primary Campaign Committee',
             'cycle': 2016,
             'committee_id': 'C001',
-        }, {
+        },
+        {
             'designation': 'A',
             'cycles': [2016, 2014, 2012, 2018],
             'name': 'My Authorized Campaign Committee',
             'cycle': 2016,
             'committee_id': 'C002',
-        }, {
+        },
+        {
             'designation': 'J',
             'cycles': [2016, 2014, 2012, 2018],
             'name': 'Joint Fundraising Committee',
             'cycle': 2016,
             'committee_id': 'C003',
-        }
+        },
     ]
 
-    def test_base_case(self, load_with_nested_mock, load_first_row_data_mock,
-                       load_candidate_statement_of_candidacy_mock):
+    def test_base_case(
+        self,
+        load_with_nested_mock,
+        load_first_row_data_mock,
+        load_candidate_statement_of_candidacy_mock,
+    ):
         cycle = 2016
         show_full_election = True
 
@@ -56,14 +62,13 @@ class TestCandidate(TestCase):
         load_with_nested_mock.return_value = (
             test_candidate,
             self.STOCK_COMMITTEE_LIST,
-            cycle
+            cycle,
         )
         candidate = get_candidate('H001', 2018, show_full_election)
 
         assert candidate['candidate_id'] == test_candidate['candidate_id']
         assert candidate['name'] == test_candidate['name']
-        assert candidate['cycles'] == test_candidate[
-            'fec_cycles_in_election']
+        assert candidate['cycles'] == test_candidate['fec_cycles_in_election']
         assert candidate['min_cycle'] == cycle - 2
         assert candidate['max_cycle'] == cycle
         assert candidate['election_year'] == cycle
@@ -73,8 +78,10 @@ class TestCandidate(TestCase):
         assert candidate['state'] == test_candidate['state']
         assert candidate['district'] == test_candidate['district']
         assert candidate['party_full'] == test_candidate['party_full']
-        assert candidate['incumbent_challenge_full'] == test_candidate[
-            'incumbent_challenge_full']
+        assert (
+            candidate['incumbent_challenge_full']
+            == test_candidate['incumbent_challenge_full']
+        )
         assert candidate['cycle'] == cycle
         assert candidate['result_type'] == 'candidates'
         assert candidate['duration'] == 2
@@ -82,32 +89,41 @@ class TestCandidate(TestCase):
         assert candidate['show_full_election'] == show_full_election
 
         assert candidate['committee_groups'] == {
-            'P': [{
-                'designation': 'P',
-                'cycles': [2016, 2014, 2012, 2018],
-                'name': 'My Primary Campaign Committee',
-                'cycle': 2016,
-                'related_cycle': 2016,
-                'committee_id': 'C001'}],
-            'A': [{
-                'designation': 'A',
-                'cycles': [2016, 2014, 2012, 2018],
-                'name': 'My Authorized Campaign Committee',
-                'cycle': 2016,
-                'related_cycle': 2016,
-                'committee_id': 'C002'}],
-            'J': [{
-                'designation': 'J',
-                'cycles': [2016, 2014, 2012, 2018],
-                'name': 'Joint Fundraising Committee',
-                'cycle': 2016,
-                'related_cycle': 2016,
-                'committee_id': 'C003'}],
+            'P': [
+                {
+                    'designation': 'P',
+                    'cycles': [2016, 2014, 2012, 2018],
+                    'name': 'My Primary Campaign Committee',
+                    'cycle': 2016,
+                    'related_cycle': 2016,
+                    'committee_id': 'C001',
+                }
+            ],
+            'A': [
+                {
+                    'designation': 'A',
+                    'cycles': [2016, 2014, 2012, 2018],
+                    'name': 'My Authorized Campaign Committee',
+                    'cycle': 2016,
+                    'related_cycle': 2016,
+                    'committee_id': 'C002',
+                }
+            ],
+            'J': [
+                {
+                    'designation': 'J',
+                    'cycles': [2016, 2014, 2012, 2018],
+                    'name': 'Joint Fundraising Committee',
+                    'cycle': 2016,
+                    'related_cycle': 2016,
+                    'committee_id': 'C003',
+                }
+            ],
         }
 
         assert candidate['committees_authorized'] == (
-            candidate['committee_groups']['P'] +
-            candidate['committee_groups']['A'])
+            candidate['committee_groups']['P'] + candidate['committee_groups']['A']
+        )
         assert candidate['committee_ids'] == [
             committee['committee_id']
             for committee in candidate['committees_authorized']
@@ -120,7 +136,7 @@ class TestCandidate(TestCase):
             'name': test_candidate["name"],
             'cycle': cycle,
             'electionFull': show_full_election,
-            'candidateID': test_candidate["candidate_id"]
+            'candidateID': test_candidate["candidate_id"],
         }
 
         assert len(candidate['raising_summary']) == 0
@@ -128,8 +144,11 @@ class TestCandidate(TestCase):
         assert len(candidate['cash_summary']) == 0
 
     def test_special_odd_year_return_rounded_number(
-            self, load_with_nested_mock, load_first_row_data_mock,
-            load_candidate_statement_of_candidacy_mock):
+        self,
+        load_with_nested_mock,
+        load_first_row_data_mock,
+        load_candidate_statement_of_candidacy_mock,
+    ):
 
         # use new column rounded_election_years which round odd number in MV.
         test_candidate = copy.deepcopy(self.STOCK_CANDIDATE)
@@ -137,11 +156,7 @@ class TestCandidate(TestCase):
         test_candidate["election_years"] = [2013, 2015, 2018]
         test_candidate["rounded_election_years"] = [2014, 2016, 2018]
 
-        load_with_nested_mock.return_value = (
-            test_candidate,
-            mock.MagicMock(),
-            2016
-        )
+        load_with_nested_mock.return_value = (test_candidate, mock.MagicMock(), 2016)
         candidate = get_candidate('H001', 2016, True)
         assert candidate["election_years"] == [2014, 2016, 2018]
         assert candidate["election_year"] == 2016

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -149,7 +149,6 @@ def get_candidate(candidate_id, cycle, election_full):
         candidate_id,
         'committees',
         cycle=cycle,
-        cycle_key='two_year_period',
         election_full=election_full,
     )
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -166,6 +166,12 @@ def get_candidate(candidate_id, cycle, election_full):
         'candidateID': candidate['candidate_id'],
     }
 
+    # Grab the most recent two-year period with data within this cycle
+    # Used for raising/spending tabs
+    max_cycle = max(
+        year for year in candidate['fec_cycles_in_election'] if year <= cycle
+    )
+
     # Annotate committees with most recent available cycle
     aggregate_cycles = (
         list(range(cycle, cycle - duration, -2)) if election_full else [cycle]
@@ -193,11 +199,12 @@ def get_candidate(candidate_id, cycle, election_full):
     aggregate = api_caller.load_first_row_data(path, **filters)
 
     if election_full:
-        # (5)if election_full is ture, need call
+        # (5)if election_full is true, need call
         # candidate/{candidate_id}/totals/{cycle} second time
-        # (set election_full=false) to get totals for the two-year period
         # for showing on raising and spending tabs
+        # Get most recent 2-year period totals
         filters['election_full'] = False
+        filters['cycle'] = max_cycle
         two_year_totals = api_caller.load_first_row_data(path, **filters)
     else:
         two_year_totals = aggregate
@@ -265,7 +272,7 @@ def get_candidate(candidate_id, cycle, election_full):
         'elections': elections,
         'has_raw_filings': has_raw_filings,
         'incumbent_challenge_full': candidate['incumbent_challenge_full'],
-        'max_cycle': cycle,
+        'max_cycle': max_cycle,
         'min_cycle': min_cycle,
         'min_receipt_date': raw_filing_start_date,
         'name': candidate['name'],


### PR DESCRIPTION
## Summary (required)

- Resolves #3262 
- Resolves #3253 

_Fix committee info and raising/spending tabs for future candidates._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile pages
- Committee profile pages (uses `api_caller.load_with_nested` but shouldn't be impacted)

## Screenshots
## Before
![Screen Shot 2019-10-10 at 3 08 43 PM](https://user-images.githubusercontent.com/31420082/66599110-87e05000-eb70-11e9-9fb1-d17dd59c505d.png)

![Screen Shot 2019-10-10 at 3 08 55 PM](https://user-images.githubusercontent.com/31420082/66599106-844cc900-eb70-11e9-9ed5-20697b617470.png)

## After
![Screen Shot 2019-10-10 at 3 08 11 PM](https://user-images.githubusercontent.com/31420082/66599123-8e6ec780-eb70-11e9-9fa9-60a1635b7dd2.png)

![Screen Shot 2019-10-10 at 3 08 23 PM](https://user-images.githubusercontent.com/31420082/66599116-8b73d700-eb70-11e9-8bcf-617de55d6770.png)



## How to test
- Look at future senate candidate profile pages, future and past cycles
- http://localhost:8000/data/candidates/senate/?election_year=2022&cycle=2022&election_full=true&is_active_candidate=true
- http://localhost:8000/data/candidates/senate/?election_year=2024&cycle=2024&election_full=true&is_active_candidate=true
- Look at other candidate profile pages
- Compare results to production (you can get to a rasising/spending tab 2-year period in production by choosing an older election first)