### PR TITLE
Add fec.gov domain to allowed image sources in CSP

### DIFF
--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -14,7 +14,7 @@ class AddSecureHeaders(MiddlewareMixin):
         content_security_policy = {
             "default-src": "'self' *.fec.gov *.app.cloud.gov https://www.google-analytics.com",
             "frame-src": "'self' https://www.google.com/recaptcha/ https://www.youtube.com/",
-            "img-src": "'self' data: https://*.ssl.fastly.net https://www.google-analytics.com https://www.googletagmanager.com *.app.cloud.gov",
+            "img-src": "'self' *.fec.gov *.app.cloud.gov data: https://*.ssl.fastly.net https://www.google-analytics.com https://www.googletagmanager.com",
             "script-src": "'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.google-analytics.com https://www.googletagmanager.com https://polyfill.io https://dap.digitalgov.gov",
             "style-src": "'self' data: 'unsafe-inline'",
             "object-src": "'none'",


### PR DESCRIPTION
## Summary (required)

- Resolves #3191 
_This allows images from the *.fec.gov domain to be on the app.cloud.gov domains._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Image sources from fec.gov domain

## Screenshots

### Before
<img width="1011" alt="Screen Shot 2019-10-16 at 4 15 58 PM" src="https://user-images.githubusercontent.com/12799132/66955412-45b38480-f030-11e9-81ed-4368207fbdbc.png">

### After 
<img width="952" alt="Screen Shot 2019-10-16 at 4 17 27 PM" src="https://user-images.githubusercontent.com/12799132/66955511-801d2180-f030-11e9-8a1c-16107f318fde.png">

## How to test
- [ ] Go to any wagtail page on your local
- [ ] Insert an HTML block and add image source code from fec.gov domain. Like this:
`<img alt="San Diego Regional Conference" height="208" src="https://www.fec.gov/resources/cms-content/images/San_Diego_Web_Header_wag.original.png" width="620">`
- [ ] Preview the page and the image inserted with the HTML block should appear with no CSP errors in the console

