### PR TITLE
Updates for global site search

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -213,7 +213,8 @@ for category in report_category_groups.keys():
 SEARCH_DESCENDANTS_OF = [
     '/home/legal-resources/',
     '/home/help-candidates-and-committees/',
-    '/home/press/'
+    '/home/press/',
+    '/home/introduction-campaign-finance/'
 ]
 
 # These are the parent pages for which we want *only* direct children

--- a/fec/search/management/commands/index_pages.py
+++ b/fec/search/management/commands/index_pages.py
@@ -8,8 +8,6 @@ from django.core.management import BaseCommand
 
 from home.models import Page
 
-
-DIGITALGOV_DRAWER_KEY_TRANSITION = settings.FEC_DIGITALGOV_DRAWER_KEY_TRANSITION
 drawer = settings.DIGITALGOV_DRAWER_HANDLE
 key = settings.FEC_DIGITALGOV_DRAWER_KEY_MAIN
 

--- a/fec/search/management/commands/index_pages.py
+++ b/fec/search/management/commands/index_pages.py
@@ -23,12 +23,6 @@ class Command(BaseCommand):
             help='Path to JSON file to load'
         )
 
-        parser.add_argument(
-            '-transition',
-            action='store_true',
-            help="Add this flag to add to the transition drawer"
-        )
-
     def handle(self, *args, **options):
         self.stdout.write(self.style.WARNING('Indexing pages'))
 

--- a/fec/search/management/commands/index_pages.py
+++ b/fec/search/management/commands/index_pages.py
@@ -32,11 +32,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.stdout.write(self.style.WARNING('Indexing pages'))
 
-        # If we're putting in the transition drawer, use those creds
-        if options['transition']:
-            drawer = 'transition'
-            key = DIGITALGOV_DRAWER_KEY_TRANSITION
-
         if options['json_file_path']:
             file_name = options['json_file_path']
         else:

--- a/fec/search/management/data/transition_pages.json
+++ b/fec/search/management/data/transition_pages.json
@@ -1,31 +1,10 @@
 [
   {
-    "document_id": "transition-1",
-    "path": "http://transition.fec.gov/pubrec/publicrecordsoffice.shtml#using",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Public Records Office"
-  },
-  {
-    "document_id": "transition-2",
-    "path": "http://transition.fec.gov/info/hearings.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Public Hearings"
-  },
-  {
     "document_id": "transition-3",
     "path": "http://transition.fec.gov/af/af.shtml",
     "created": "04/01/2017",
     "language": "en",
     "title": "FEC Administrative Fine Program"
-  },
-  {
-    "document_id": "transition-4",
-    "path": "http://transition.fec.gov/af/AFPRegulations.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "AFP Regulations"
   },
   {
     "document_id": "transition-5",
@@ -70,13 +49,6 @@
     "title": "Help Complying with the Federal Campaign Finance Law (FECA)"
   },
   {
-    "document_id": "transition-11",
-    "path": "http://transition.fec.gov/elecfil/electron.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Electronic Filing"
-  },
-  {
     "document_id": "transition-12",
     "path": "http://transition.fec.gov/elecfil/electron.shtml",
     "created": "04/01/2017",
@@ -84,81 +56,11 @@
     "title": "Electronic Filing"
   },
   {
-    "document_id": "transition-13",
-    "path": "http://transition.fec.gov/info/forms.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "FEC Reporting Forms"
-  },
-  {
-    "document_id": "transition-14",
-    "path": "http://transition.fec.gov/info/ElectionDate/",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Federal Election Compliance Information"
-  },
-  {
-    "document_id": "transition-15",
-    "path": "http://transition.fec.gov/info/publications.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "FEC Publications"
-  },
-  {
-    "document_id": "transition-16",
-    "path": "http://transition.fec.gov/info/publications.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "FEC Publications"
-  },
-  {
     "document_id": "transition-17",
     "path": "http://transition.fec.gov/pages/brochures/brochures.shtml",
     "created": "04/01/2017",
     "language": "en",
     "title": "FEC Brochures"
-  },
-  {
-    "document_id": "transition-18",
-    "path": "http://transition.fec.gov/pages/bcra/bcra_update.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Bipartisan Campaign Reform Act of 2002"
-  },
-  {
-    "document_id": "transition-19",
-    "path": "http://transition.fec.gov/info/outreach.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "FEC Educational Outreach"
-  },
-  {
-    "document_id": "transition-20",
-    "path": "http://transition.fec.gov/info/elearning.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "FEC Educational Outreach"
-  },
-  {
-    "document_id": "transition-21",
-    "path": "http://transition.fec.gov/info/outreach.shtml#conferences",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "FEC Educational Outreach"
-  },
-  {
-    "document_id": "transition-22",
-    "path": "http://transition.fec.gov/info/outreach.shtml#roundtables",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "FEC Educational Outreach"
-  },
-  {
-    "document_id": "transition-23",
-    "path": "http://transition.fec.gov/info/outreach.shtml#appearances",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "FEC Educational Outreach"
   },
   {
     "document_id": "transition-24",
@@ -222,68 +124,5 @@
     "created": "04/01/2017",
     "language": "en",
     "title": "Federal Election Commission Home Page"
-  },
-  {
-    "document_id": "transition-33",
-    "path": "http://transition.fec.gov/ans/answers.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Quick Answers"
-  },
-  {
-    "document_id": "transition-34",
-    "path": "http://transition.fec.gov/ans/answers_general.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Quick Answers-General Questions"
-  },
-  {
-    "document_id": "transition-35",
-    "path": "http://transition.fec.gov/ans/answers_disclosure.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Quick Answers - Disclosure"
-  },
-  {
-    "document_id": "transition-36",
-    "path": "http://transition.fec.gov/ans/answers_compliance.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Quick Answers - Compliance"
-  },
-  {
-    "document_id": "transition-37",
-    "path": "http://transition.fec.gov/ans/answers_filing.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Quick Answers - Filing"
-  },
-  {
-    "document_id": "transition-38",
-    "path": "http://transition.fec.gov/ans/answers_candidate.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Quick Answers - Candidate"
-  },
-  {
-    "document_id": "transition-39",
-    "path": "http://transition.fec.gov/ans/answers_pac.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Quick Answers - PAC"
-  },
-  {
-    "document_id": "transition-40",
-    "path": "http://transition.fec.gov/ans/answers_party.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Quick Answers - Party"
-  },
-  {
-    "document_id": "transition-41",
-    "path": "http://transition.fec.gov/ans/answers_public_funding.shtml",
-    "created": "04/01/2017",
-    "language": "en",
-    "title": "Quick Answers: Public Funding"
   }
 ]

--- a/fec/search/management/data/web_app_pages.json
+++ b/fec/search/management/data/web_app_pages.json
@@ -2,7 +2,7 @@
   {
     "document_id": "app-1",
     "title": "Campaign finance data home",
-    "path": "https://beta.fec.gov/data/",
+    "path": "https://www.fec.gov/data/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -12,7 +12,7 @@
   {
     "document_id": "app-2",
     "title": "Advanced data",
-    "path": "https://beta.fec.gov/data/advanced/",
+    "path": "https://www.fec.gov/data/advanced/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -22,7 +22,7 @@
   {
     "document_id": "app-3",
     "title": "Browse receipts",
-    "path": "https://beta.fec.gov/data/receipts/",
+    "path": "https://www.fec.gov/data/receipts/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -32,7 +32,7 @@
   {
     "document_id": "app-4",
     "title": "Browse individual contributions",
-    "path": "https://beta.fec.gov/data/receipts/individual-contributions",
+    "path": "https://www.fec.gov/data/receipts/individual-contributions",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -42,7 +42,7 @@
   {
     "document_id": "app-5",
     "title": "Browse disbursements",
-    "path": "https://beta.fec.gov/data/disbursements",
+    "path": "https://www.fec.gov/data/disbursements",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -52,7 +52,7 @@
   {
     "document_id": "app-6",
     "title": "Browse independent expenditures",
-    "path": "https://beta.fec.gov/data/independent-expenditures/",
+    "path": "https://www.fec.gov/data/independent-expenditures/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -62,7 +62,7 @@
   {
     "document_id": "app-7",
     "title": "Browse party coordinated expenditures",
-    "path": "https://beta.fec.gov/data/party-coordinated-expenditures/",
+    "path": "https://www.fec.gov/data/party-coordinated-expenditures/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -72,7 +72,7 @@
   {
     "document_id": "app-8",
     "title": "Browse electioneering communications",
-    "path": "https://beta.fec.gov/data/electioneering-communications/",
+    "path": "https://www.fec.gov/data/electioneering-communications/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -82,7 +82,7 @@
   {
     "document_id": "app-9",
     "title": "Browse communication costs",
-    "path": "https://beta.fec.gov/data/communication-costs/",
+    "path": "https://www.fec.gov/data/communication-costs/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -92,7 +92,7 @@
   {
     "document_id": "app-10",
     "title": "Browse loans",
-    "path": "https://beta.fec.gov/data/loans/",
+    "path": "https://www.fec.gov/data/loans/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -102,7 +102,7 @@
   {
     "document_id": "app-12",
     "title": "Browse all candidates",
-    "path": "https://beta.fec.gov/data/candidates/",
+    "path": "https://www.fec.gov/data/candidates/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -112,7 +112,7 @@
   {
     "document_id": "app-13",
     "title": "Browse candidates for president",
-    "path": "https://beta.fec.gov/data/candidates/president/",
+    "path": "https://www.fec.gov/data/candidates/president/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -122,7 +122,7 @@
   {
     "document_id": "app-14",
     "title": "Browse candidates for Senate",
-    "path": "https://beta.fec.gov/data/candidates/senate/",
+    "path": "https://www.fec.gov/data/candidates/senate/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -132,7 +132,7 @@
   {
     "document_id": "app-15",
     "title": "Browse candidates for House of Representatives",
-    "path": "https://beta.fec.gov/data/candidates/house/",
+    "path": "https://www.fec.gov/data/candidates/house/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -142,7 +142,7 @@
   {
     "document_id": "app-16",
     "title": "Browse all committees",
-    "path": "https://beta.fec.gov/data/committees/",
+    "path": "https://www.fec.gov/data/committees/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -152,7 +152,7 @@
   {
     "document_id": "app-17",
     "title": "Browse all filings",
-    "path": "https://beta.fec.gov/data/filings/",
+    "path": "https://www.fec.gov/data/filings/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -162,7 +162,7 @@
   {
     "document_id": "app-18",
     "title": "Browse presidential committee reports",
-    "path": "https://beta.fec.gov/data/reports/presidential/",
+    "path": "https://www.fec.gov/data/reports/presidential/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -172,7 +172,7 @@
   {
     "document_id": "app-19",
     "title": "Browse House and Senate committee reports",
-    "path": "https://beta.fec.gov/data/reports/house-senate/",
+    "path": "https://www.fec.gov/data/reports/house-senate/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -182,7 +182,7 @@
   {
     "document_id": "app-20",
     "title": "Browse PAC and Party committee reports",
-    "path": "https://beta.fec.gov/data/reports/pac-party/",
+    "path": "https://www.fec.gov/data/reports/pac-party/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -192,7 +192,7 @@
   {
     "document_id": "app-21",
     "title": "Raising breakdown",
-    "path": "https://beta.fec.gov/data/raising/",
+    "path": "https://www.fec.gov/data/raising/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -202,7 +202,7 @@
   {
     "document_id": "app-22",
     "title": "Spending breakdown",
-    "path": "https://beta.fec.gov/data/spending/",
+    "path": "https://www.fec.gov/data/spending/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,
@@ -212,7 +212,7 @@
   {
     "document_id": "app-23",
     "title": "Find candidates and elections by location",
-    "path": "https://beta.fec.gov/data/elections/",
+    "path": "https://www.fec.gov/data/elections/",
     "created": "2017-04-01",
     "language": "en",
     "promote": true,


### PR DESCRIPTION
## Summary

- Resolves #2991 

Reindexing has already been completed on the website using search.gov and our custom indexing scripts. Followed documentation based on what was written here: https://github.com/fecgov/fec-cms/blob/develop/fec/search/management/instructions.md

The transition drawer did not exist in our search.gov interface, therefore, I removed it from the site index commands. 

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Global search on site's header

## How to test
- [ ] Re-activate your account on the rebranded search.gov. If you have not logged into search.gov for more than 90 days, your account has been deactivated. You'll need to email search@support.digitalgov.gov
- [ ] Login to search.gov and look around
- [ ] Get a fresh dump of the wagtail CMS database and update your CMS DB on your local machine.
- [ ] Follow documentation under this branch: https://github.com/fecgov/fec-cms/blob/feature/2991-global-site-search/fec/search/management/instructions.md to understand how scraping and indexing works
- [ ] Attempt to run scrape and index commands using this branch
- [ ] Take a look at the main drawer referenced in the documentation. If an index has been done, it will push it to the search.gov main drawer and it should say that it has been updated recently.
____

