### PR TITLE
[Review with openFEC #4032] Default statutes search to all, capitalize titles

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -69,7 +69,8 @@ def load_search_results(query, query_type=None):
 def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwargs):
     filters = dict((key, value) for key, value in kwargs.items() if value)
 
-    if query or query_type in ['advisory_opinions', 'murs', 'adrs', 'admin_fines', 'statutes']:
+    # Apply specific parameters if only looking for one type
+    if query or query_type != 'all':
         filters['hits_returned'] = limit
         filters['type'] = query_type
         filters['from_hit'] = offset

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -69,7 +69,7 @@ def load_search_results(query, query_type=None):
 def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwargs):
     filters = dict((key, value) for key, value in kwargs.items() if value)
 
-    if query or query_type in ['advisory_opinions', 'murs', 'adrs', 'admin_fines']:
+    if query or query_type in ['advisory_opinions', 'murs', 'adrs', 'admin_fines', 'statutes']:
         filters['hits_returned'] = limit
         filters['type'] = query_type
         filters['from_hit'] = offset

--- a/fec/legal/templates/legal-search-results-regulations.jinja
+++ b/fec/legal/templates/legal-search-results-regulations.jinja
@@ -1,6 +1,6 @@
 {% extends "layouts/legal-doc-search-results.jinja" %}
 {% import 'macros/legal.jinja' as legal %}
-{% set document_type_display_name = 'regulations' %}
+{% set document_type_display_name = 'Regulations' %}
 
 {% block header %}
 <header class="page-header slab slab--primary">

--- a/fec/legal/templates/legal-search-results-statutes.jinja
+++ b/fec/legal/templates/legal-search-results-statutes.jinja
@@ -1,6 +1,6 @@
 {% extends "layouts/legal-doc-search-results.jinja" %}
 {% import 'macros/legal.jinja' as legal %}
-{% set document_type_display_name = 'statutes' %}
+{% set document_type_display_name = 'Statutes' %}
 
 {% block header %}
 <header class="page-header slab slab--primary">

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -200,8 +200,7 @@ def legal_doc_search_regulations(request):
     query = request.GET.get('search', '')
     offset = request.GET.get('offset', 0)
 
-    if query:
-        results = api_caller.load_legal_search_results(query, 'regulations', offset=offset)
+    results = api_caller.load_legal_search_results(query, 'regulations', offset=offset)
 
     return render(request, 'legal-search-results-regulations.jinja', {
         'parent': 'legal',
@@ -216,8 +215,7 @@ def legal_doc_search_statutes(request):
     query = request.GET.get('search', '')
     offset = request.GET.get('offset', 0)
 
-    if query:
-        results = api_caller.load_legal_search_results(query, 'statutes', offset=offset)
+    results = api_caller.load_legal_search_results(query, 'statutes', offset=offset)
 
     return render(request, 'legal-search-results-statutes.jinja', {
         'parent': 'legal',


### PR DESCRIPTION
## Summary (required)

Resolves https://github.com/fecgov/openFEC/issues/4028
- Default statutes  and regulations search to all - don't require a query to return results (matches AOs and MURs)
- Capitalize titles for statutes and regulations searches

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Statutes and Regulation search

## Screenshots

## Before

<img width="954" alt="Screen Shot 2019-10-24 at 9 10 15 PM" src="https://user-images.githubusercontent.com/31420082/67535926-cdd60180-f6a2-11e9-945f-68aa317f74f8.png">
<img width="954" alt="Screen Shot 2019-10-24 at 9 09 58 PM" src="https://user-images.githubusercontent.com/31420082/67535928-cdd60180-f6a2-11e9-918d-01d8364fbced.png">

## After
<img width="954" alt="Screen Shot 2019-10-24 at 9 10 33 PM" src="https://user-images.githubusercontent.com/31420082/67535925-cdd60180-f6a2-11e9-8757-7b3ceb491581.png">
<img width="954" alt="Screen Shot 2019-10-24 at 9 09 53 PM" src="https://user-images.githubusercontent.com/31420082/67535929-cdd60180-f6a2-11e9-8e0e-407eee4f432a.png">


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
openFEC: feature/4028-default-statutes-regs-to-all | https://github.com/fecgov/openFEC/pull/4032

## How to test

- Run this branch, point to `dev` API after https://github.com/fecgov/openFEC/pull/4032 is merged or run the API locally following the directions in that PR
- Go to http://localhost:8000/legal-resources/ and click on "Statutes" or "Regulations"
<img width="492" alt="Screen Shot 2019-10-24 at 9 27 40 PM" src="https://user-images.githubusercontent.com/31420082/67536454-3f16b400-f6a5-11e9-9e96-4f2141a94d1d.png">
- For Statutes, all results load (and "statutes" is capitalized)
- For Regulations, hitting "search" returns all regulations