### PR TITLE
Feature/3181 fixes updates search

### DIFF
--- a/fec/fec/static/js/modules/form-nav.js
+++ b/fec/fec/static/js/modules/form-nav.js
@@ -6,10 +6,16 @@
 
 function FormNav(form) {
   this.form = form;
-  this.form.addEventListener('change', this.handleChange.bind(this));
+  this.form.addEventListener('change', this.clearNamesIfNull.bind(this));
+  this.form.addEventListener('submit', this.clearNamesIfNull.bind(this));
 }
 
-FormNav.prototype.handleChange = function() {
+/**
+ * We don't want empty elements to send empty vars into the form submit.
+ * So, if it has no value, remove its name, too.
+ * @param {Event} e MouseEvent, TouchEvent
+ */
+FormNav.prototype.clearNamesIfNull = function(e) {
   var allSelects = this.form.querySelectorAll('select,input');
   // Remove names from all selects with no values
   for (var i = 0; i < allSelects.length; i++) {
@@ -19,7 +25,7 @@ FormNav.prototype.handleChange = function() {
     }
   }
 
-  this.form.submit();
+  if (e.type == 'change') this.form.submit();
 };
 
 module.exports = { FormNav: FormNav };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7599,12 +7599,6 @@
         "source-map": "~0.5.3"
       }
     },
-    "inputmask": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-4.0.8.tgz",
-      "integrity": "sha512-y7TbHasd4tGgOxk1PBF6zZLBzfKt3a5qySF3KuKVNaeuptDpp52jhYOmw1tBJwRxrpJ4s+BOFmWKYsQqjp+r/w==",
-      "dev": true
-    },
     "inquirer": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",


### PR DESCRIPTION
## Summary

- Resolves #3181 

Solves the issue of [Updates](https://www.fec.gov/updates/) returning no results after clicking magnifying glass after receiving the exact same results.


## Impacted areas of the application
The issue was because clicking the magnifying glass does a native form submit to the same page as itself, but those elements (e.g., year) exist so are passed through as empty query parameters, and then sent through the query.

There's a change event, too, that removes the names of any form elements without values, effectively exempting them from the form submission.

I renamed that function; added it as a submit handler, too; and limited the form.submit command to only fire for the change event since the submit event is going to do that anyway.

Also: I've been getting a changed package-lock for a while so I committed it, too.

## Screenshots

None that could show the problem as clearly fixed

## Related PRs

None

## How to test
- Pull the branch, `npm i`, `npm run build`, `./manage.py runserver` like normal
- Go to [Updates](http://127.0.0.1:8000/updates/)
- In the middle of the page, enter 'test' as a search term
- Tab away or otherwise blur that element
- Page should reload and show results
- Change the search term to 'tests' and tab out
- Page should reload and show results
- Click the magnifying glass (without changing the search term)
- Page should reload and show results
- **It's 👆 that Prod fails, doesn't show results, and has added a `year=` to the URL**
- Verify that other pages that use this module (@patphongs ?) are still working—the search term _and_ the other elements
- Approve
- If you're the last approval, merge and delete
____

