### PR TITLE
Updates guides.html to add new Other Filers sections

### DIFF
--- a/fec/home/templates/home/candidate-and-committee-services/guides.html
+++ b/fec/home/templates/home/candidate-and-committee-services/guides.html
@@ -173,6 +173,7 @@
       <section id="cand-comm-guides-other-filers" role="tabpanel" aria-hidden="true" aria-labelledby="other-filers">
         <h2>Other filers</h2>
         <p>Every person, group of persons or organization, other than a political committee, that makes certain communications may be required to file certain disclosure forms with the FEC, as well as comply with disclaimer requirements for specific types of communications.</p>
+        <p>Host committees, convention committees and inaugural committees must register and file specific disclosure forms with the FEC regarding their activities.</p>
         <div class="grid grid--2-wide">
           <div class="grid__item">
             <ul class="t-sans list--spacious">

--- a/fec/home/templates/home/candidate-and-committee-services/guides.html
+++ b/fec/home/templates/home/candidate-and-committee-services/guides.html
@@ -189,4 +189,4 @@
     </div>
   </div>
 </div>
-
+{% endblock %}

--- a/fec/home/templates/home/candidate-and-committee-services/guides.html
+++ b/fec/home/templates/home/candidate-and-committee-services/guides.html
@@ -179,6 +179,8 @@
               <li><a href="/help-candidates-and-committees/other-filers/#independent-expenditures-by-persons-other-than-political-committees">Independent expenditures by persons other than political committees</a> &#187;</li>
               <li><a href="/help-candidates-and-committees/other-filers/#express-advocacy-communications-to-restricted-class-by-corporations-labor-organizations-and-membership-organizations">Express advocacy communications to restricted class by corporations, labor organizations and membership organizations</a> &#187;</li>
               <li><a href="/help-candidates-and-committees/other-filers/#electioneering-communications">Electioneering communications</a> &#187;</li>
+              <li><a href="/help-candidates-and-committees/other-filers/#host-and-convention-committees">Host and convention committees</a> &#187;</li>
+              <li><a href="/help-candidates-and-committees/other-filers/#inaugural-committees">Inaugural committees</a> &#187;</li>
             </ul>
           </div>
         </div>
@@ -187,4 +189,3 @@
   </div>
 </div>
 
-{% endblock %}


### PR DESCRIPTION
## Summary (required)

- Resolves #3230 by adding new sections for host/convention committees and inaugural committees to "other filers"


## Impacted areas of the application
CMS

## Screenshots

<img width="754" alt="otherfilers" src="https://user-images.githubusercontent.com/24437369/67393744-f827a200-f570-11e9-8847-7c3e0b0d36ac.png">

## How to test

Note:  I decided to use the section titles rather than the titles in the screenshot for the links. Made more sense to do it that way.

Intro sentence: 
Host committees, convention committees and inaugural committees must register and file specific disclosure forms with the FEC regarding their activities.
Link for host committees: /help-candidates-and-committees/other-filers/#host-and-convention-committees. 
Link title now: Host and convention committees
Link for inaugural committees: /help-candidates-and-committees/other-filers/#inaugural-committees 
Link title now: Inaugural committees

- [x] For @kathycarothers verify that the links point to the correct sections and no typos. Also verify the intro sentence looks good.

- [ ] For @patphongs please check coding for the new sentence and the two links.
