### PR TITLE
Remove CSP reporting from production

### DIFF
--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -7,10 +7,6 @@ class AddSecureHeaders(MiddlewareMixin):
 
     def process_response(self, request, response):
 
-        # Report violations to the API due to CSRF issue with Django route
-        REPORT_URI = "{0}/report-csp-violation/?api_key={1}".format(
-            settings.FEC_API_URL, settings.FEC_API_KEY_PUBLIC
-        )
         content_security_policy = {
             "default-src": "'self' *.fec.gov *.app.cloud.gov https://www.google-analytics.com",
             "frame-src": "'self' https://www.google.com/recaptcha/ https://www.youtube.com/",
@@ -18,10 +14,16 @@ class AddSecureHeaders(MiddlewareMixin):
             "script-src": "'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.google-analytics.com https://www.googletagmanager.com https://polyfill.io https://dap.digitalgov.gov",
             "style-src": "'self' data: 'unsafe-inline'",
             "object-src": "'none'",
-            "report-uri": REPORT_URI,
         }
         if settings.FEC_CMS_ENVIRONMENT == 'LOCAL':
             content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"
+        # Skip CSP reporting in production so we don't clutter up the logs
+        if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION':
+            # Report violations to the API
+            report_uri = "{0}/report-csp-violation/?api_key={1}".format(
+                settings.FEC_API_URL, settings.FEC_API_KEY_PUBLIC
+            )
+            content_security_policy["report-uri"] = report_uri
 
         response["Content-Security-Policy"] = "".join(
             "{0} {1}; ".format(directive, value)


### PR DESCRIPTION
## Summary (required)

Resolves fecgov/fec-cms#3296 
Remove CSP reporting from production - too many reports cluttering the logs

## Impacted areas of the application
List general components of the application that this PR will affect:

-  CSP headers/reporting in production

## How to test
- Check out this branch 
- ` export FEC_CMS_ENVIRONMENT="prod"`
- run your local CMS
- in another tab, `curl -I "localhost:8000"` shouldn't have a `report-uri` in the `Content-Security-Policy` header
