### PR TITLE
Add most recent Form 1 to committee profile pages

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -304,21 +304,23 @@ def load_endpoint_results(*path_parts, **filters):
 
 
 def load_candidate_statement_of_candidacy(candidate_id):
+    """Get most recent F2 - default sort is `-receipt_date`"""
     response = _call_api(
         'filings',
         candidate_id=candidate_id,
         form_type='F2',
     )
-    return response.get('results', [])
+    return response['results'][0] if response['results'] else None
 
 
 def load_committee_statement_of_organization(committee_id):
+    """Get most recent F1 - default sort is `-receipt_date`"""
     response = _call_api(
         'filings',
         committee_id=committee_id,
         form_type='F1'
     )
-    return response.get('results', [])
+    return response['results'][0] if response['results'] else None
 
 
 def result_or_404(data):

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -20,207 +20,206 @@ logger = logging.getLogger(__name__)
 
 session = requests.Session()
 http_adapter = requests.adapters.HTTPAdapter(max_retries=2)
-session.mount('https://', http_adapter)
+session.mount("https://", http_adapter)
 
 
 def _call_api(*path_parts, **filters):
     if settings.FEC_API_KEY_PRIVATE:
-        filters['api_key'] = settings.FEC_API_KEY_PRIVATE
+        filters["api_key"] = settings.FEC_API_KEY_PRIVATE
 
-    path = os.path.join(
-        settings.FEC_API_VERSION,
-        *[x.strip('/') for x in path_parts]
-    )
+    path = os.path.join(settings.FEC_API_VERSION, *[x.strip("/") for x in path_parts])
     url = parse.urljoin(settings.FEC_API_URL, path)
     results = session.get(url, params=filters)
 
     # Log the caller function and API endpoint
     current_frame = inspect.currentframe()
     caller_frame = inspect.getouterframes(current_frame, 2)
-    logger.info('{0}: {1}'.format(caller_frame[1][3], results.url))
+    logger.info("{0}: {1}".format(caller_frame[1][3], results.url))
 
     if results.ok:
         return results.json()
     else:
-        logger.error('API ERROR with status {0} for {1} with filters: {2}'.format(
-            results.status_code,
-            url,
-            filters
-        ))
+        logger.error(
+            "API ERROR with status {0} for {1} with filters: {2}".format(
+                results.status_code, url, filters
+            )
+        )
 
-        return {'results': []}
+        return {"results": []}
 
 
 def load_search_results(query, query_type=None):
     filters = {}
 
     if query:
-        filters['q'] = query
-        filters['sort'] = ['-receipts']
-        filters['per_page'] = 5
-        candidates = _call_api('/candidates/search', **filters)
-        committees = _call_api('/committees', **filters)
+        filters["q"] = query
+        filters["sort"] = ["-receipts"]
+        filters["per_page"] = 5
+        candidates = _call_api("/candidates/search", **filters)
+        committees = _call_api("/committees", **filters)
         return {
-            'candidates': candidates if len(candidates) else [],
-            'committees': committees if len(committees) else [],
+            "candidates": candidates if len(candidates) else [],
+            "committees": committees if len(committees) else [],
         }
 
 
-def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwargs):
+def load_legal_search_results(query, query_type="all", offset=0, limit=20, **kwargs):
     filters = dict((key, value) for key, value in kwargs.items() if value)
 
     # Apply specific parameters if only looking for one type
-    if query or query_type != 'all':
-        filters['hits_returned'] = limit
-        filters['type'] = query_type
-        filters['from_hit'] = offset
+    if query or query_type != "all":
+        filters["hits_returned"] = limit
+        filters["type"] = query_type
+        filters["from_hit"] = offset
 
         if query:
-            filters['q'] = query
+            filters["q"] = query
 
-    results = _call_api('legal', 'search', **filters)
-    results['limit'] = limit
-    results['offset'] = offset
+    results = _call_api("legal", "search", **filters)
+    results["limit"] = limit
+    results["offset"] = offset
 
-    if 'statutes' in results:
-        results['statutes_returned'] = len(results['statutes'])
+    if "statutes" in results:
+        results["statutes_returned"] = len(results["statutes"])
 
-    if 'regulations' in results:
-        results['regulations_returned'] = len(results['regulations'])
+    if "regulations" in results:
+        results["regulations_returned"] = len(results["regulations"])
 
-    if 'advisory_opinions' in results:
-        results['advisory_opinions_returned'] = len(results['advisory_opinions'])
+    if "advisory_opinions" in results:
+        results["advisory_opinions_returned"] = len(results["advisory_opinions"])
 
-    if 'murs' in results:
-        results['murs_returned'] = len(results['murs'])
+    if "murs" in results:
+        results["murs_returned"] = len(results["murs"])
 
-    if 'adrs' in results:
-        results['adrs_returned'] = len(results['adrs'])
+    if "adrs" in results:
+        results["adrs_returned"] = len(results["adrs"])
 
-    if 'admin_fines' in results:
-        results['admin_fines_returned'] = len(results['admin_fines'])
+    if "admin_fines" in results:
+        results["admin_fines_returned"] = len(results["admin_fines"])
 
     return results
 
 
 def load_legal_advisory_opinion(ao_no):
-    url = '/legal/docs/advisory_opinions/'
+    url = "/legal/docs/advisory_opinions/"
     results = _call_api(url, parse.quote(ao_no))
 
-    if not (results and 'docs' in results and results['docs']):
+    if not (results and "docs" in results and results["docs"]):
         raise Http404()
 
-    ao = results['docs'][0]
-    ao['sorted_documents'] = _get_sorted_documents(ao)
-    ao['entities'] = sorted(ao['entities'], key=itemgetter('role'), reverse=True)
+    ao = results["docs"][0]
+    ao["sorted_documents"] = _get_sorted_documents(ao)
+    ao["entities"] = sorted(ao["entities"], key=itemgetter("role"), reverse=True)
     return ao
 
 
 def load_legal_mur(mur_no):
 
-    url = '/legal/docs/murs/'
+    url = "/legal/docs/murs/"
     mur = _call_api(url, parse.quote(mur_no))
 
     if not mur:
         raise Http404
 
-    mur = mur['docs'][0]
+    mur = mur["docs"][0]
 
-    if mur['mur_type'] == 'current':
+    if mur["mur_type"] == "current":
         complainants = []
-        for participant in mur['participants']:
+        for participant in mur["participants"]:
             citations = []
-            for stage in participant['citations']:
-                for url in participant['citations'][stage]:
-                    if 'uscode' in url:
-                        section = re.search('section=([0-9]+)', url).group(1)
-                        citations.append({'text': section, 'url': url})
-                    if 'cfr' in url:
-                        title_no = re.search('titlenum=([0-9]+)', url).group(1)
-                        part_no = re.search('partnum=([0-9]+)', url).group(1)
-                        section_no = re.search('sectionnum=([0-9]+)', url).group(1)
-                        text = '%s C.F.R. %s.%s' % (title_no, part_no, section_no)
-                        citations.append({'text': text, 'url': url})
-            participant['citations'] = citations
+            for stage in participant["citations"]:
+                for url in participant["citations"][stage]:
+                    if "uscode" in url:
+                        section = re.search("section=([0-9]+)", url).group(1)
+                        citations.append({"text": section, "url": url})
+                    if "cfr" in url:
+                        title_no = re.search("titlenum=([0-9]+)", url).group(1)
+                        part_no = re.search("partnum=([0-9]+)", url).group(1)
+                        section_no = re.search("sectionnum=([0-9]+)", url).group(1)
+                        text = "%s C.F.R. %s.%s" % (title_no, part_no, section_no)
+                        citations.append({"text": text, "url": url})
+            participant["citations"] = citations
 
-            if 'complainant' in participant['role'].lower():
-                complainants.append(participant['name'])
+            if "complainant" in participant["role"].lower():
+                complainants.append(participant["name"])
 
-        mur['disposition_text'] = [d['action'] for d in mur['commission_votes']]
+        mur["disposition_text"] = [d["action"] for d in mur["commission_votes"]]
 
-        mur['collated_dispositions'] = collate_dispositions(mur['dispositions'])
-        mur['complainants'] = complainants
-        mur['participants_by_type'] = _get_sorted_participants_by_type(mur)
+        mur["collated_dispositions"] = collate_dispositions(mur["dispositions"])
+        mur["complainants"] = complainants
+        mur["participants_by_type"] = _get_sorted_participants_by_type(mur)
 
         documents_by_type = OrderedDict()
-        for doc in mur['documents']:
-            if doc['category'] in documents_by_type:
-                documents_by_type[doc['category']].append(doc)
+        for doc in mur["documents"]:
+            if doc["category"] in documents_by_type:
+                documents_by_type[doc["category"]].append(doc)
             else:
-                documents_by_type[doc['category']] = [doc]
-        mur['documents_by_type'] = documents_by_type
+                documents_by_type[doc["category"]] = [doc]
+        mur["documents_by_type"] = documents_by_type
     return mur
 
 
 def load_legal_adr(adr_no):
 
-    url = '/legal/docs/adrs/'
+    url = "/legal/docs/adrs/"
     adr = _call_api(url, parse.quote(adr_no))
 
     if not adr:
         raise Http404
 
-    adr = adr['docs'][0]
+    adr = adr["docs"][0]
 
     complainants = []
-    for participant in adr['participants']:
+    for participant in adr["participants"]:
         citations = []
-        for stage in participant['citations']:
-            for url in participant['citations'][stage]:
-                if 'uscode' in url:
-                    section = re.search('section=([0-9]+)', url).group(1)
-                    citations.append({'text': section, 'url': url})
-                if 'cfr' in url:
-                    title_no = re.search('titlenum=([0-9]+)', url).group(1)
-                    part_no = re.search('partnum=([0-9]+)', url).group(1)
-                    section_no = re.search('sectionnum=([0-9]+)', url).group(1)
-                    text = '%s C.F.R. %s.%s' % (title_no, part_no, section_no)
-                    citations.append({'text': text, 'url': url})
-        participant['citations'] = citations
+        for stage in participant["citations"]:
+            for url in participant["citations"][stage]:
+                if "uscode" in url:
+                    section = re.search("section=([0-9]+)", url).group(1)
+                    citations.append({"text": section, "url": url})
+                if "cfr" in url:
+                    title_no = re.search("titlenum=([0-9]+)", url).group(1)
+                    part_no = re.search("partnum=([0-9]+)", url).group(1)
+                    section_no = re.search("sectionnum=([0-9]+)", url).group(1)
+                    text = "%s C.F.R. %s.%s" % (title_no, part_no, section_no)
+                    citations.append({"text": text, "url": url})
+        participant["citations"] = citations
 
-        if 'complainant' in participant['role'].lower():
-            complainants.append(participant['name'])
+        if "complainant" in participant["role"].lower():
+            complainants.append(participant["name"])
 
-    adr['disposition_text'] = [d['action'] for d in adr['commission_votes']]
+    adr["disposition_text"] = [d["action"] for d in adr["commission_votes"]]
 
-    adr['collated_dispositions'] = collate_dispositions(adr['dispositions'])
-    adr['complainants'] = complainants
-    adr['participants_by_type'] = _get_sorted_participants_by_type(adr)
+    adr["collated_dispositions"] = collate_dispositions(adr["dispositions"])
+    adr["complainants"] = complainants
+    adr["participants_by_type"] = _get_sorted_participants_by_type(adr)
 
     documents_by_type = OrderedDict()
-    for doc in adr['documents']:
-        if doc['category'] in documents_by_type:
-            documents_by_type[doc['category']].append(doc)
+    for doc in adr["documents"]:
+        if doc["category"] in documents_by_type:
+            documents_by_type[doc["category"]].append(doc)
         else:
-            documents_by_type[doc['category']] = [doc]
-    adr['documents_by_type'] = documents_by_type
+            documents_by_type[doc["category"]] = [doc]
+    adr["documents_by_type"] = documents_by_type
     return adr
 
 
 def load_legal_admin_fines(admin_fine_no):
-    url = '/legal/docs/admin_fines/'
+    url = "/legal/docs/admin_fines/"
     admin_fine = _call_api(url, parse.quote(admin_fine_no))
     if not admin_fine:
         raise Http404
-    admin_fine = admin_fine['docs'][0]
-    admin_fine['disposition_text'] = [d['action'] for d in admin_fine['commission_votes']]
+    admin_fine = admin_fine["docs"][0]
+    admin_fine["disposition_text"] = [
+        d["action"] for d in admin_fine["commission_votes"]
+    ]
     documents_by_type = OrderedDict()
-    for doc in admin_fine['documents']:
-        if doc['category'] in documents_by_type:
-            documents_by_type[doc['category']].append(doc)
+    for doc in admin_fine["documents"]:
+        if doc["category"] in documents_by_type:
+            documents_by_type[doc["category"]].append(doc)
         else:
-            documents_by_type[doc['category']] = [doc]
-    admin_fine['documents_by_type'] = documents_by_type
+            documents_by_type[doc["category"]] = [doc]
+    admin_fine["documents_by_type"] = documents_by_type
     return admin_fine
 
 
@@ -228,13 +227,15 @@ def collate_dispositions(dispositions):
     """ Collate dispositions - group them by disposition, penalty """
     collated_dispositions = OrderedDict()
     for row in dispositions:
-        if row['disposition'] in collated_dispositions:
-            if row['penalty'] in collated_dispositions[row['disposition']]:
-                collated_dispositions[row['disposition']][row['penalty']].append(row)
+        if row["disposition"] in collated_dispositions:
+            if row["penalty"] in collated_dispositions[row["disposition"]]:
+                collated_dispositions[row["disposition"]][row["penalty"]].append(row)
             else:
-                collated_dispositions[row['disposition']][row['penalty']] = [row]
+                collated_dispositions[row["disposition"]][row["penalty"]] = [row]
         else:
-            collated_dispositions[row['disposition']] = OrderedDict({row['penalty']: [row]})
+            collated_dispositions[row["disposition"]] = OrderedDict(
+                {row["penalty"]: [row]}
+            )
     return collated_dispositions
 
 
@@ -247,14 +248,7 @@ def load_single_type(data_type, c_id, *path, **filters):
 
 def load_nested_type(parent_type, c_id, nested_type, *path, **filters):
     # Call API with nested types in load_with_nested
-    return _call_api(
-        parent_type,
-        c_id,
-        nested_type,
-        *path,
-        per_page=100,
-        **filters
-    )
+    return _call_api(parent_type, c_id, nested_type, *path, per_page=100, **filters)
 
 
 def load_with_nested(primary_type, primary_id, secondary_type, cycle=None, **query):
@@ -264,74 +258,60 @@ def load_with_nested(primary_type, primary_id, secondary_type, cycle=None, **que
         primary_id: "P80003338"
         secondary_type: "committees"
     """
-    path = ('history', str(cycle)) if cycle else ('history', )
+    path = ("history", str(cycle)) if cycle else ("history",)
     """ Get data for just primary_type
         Example: candidate data for /candidate/* or committee data for /committee/*
     """
-    data = load_single_type(
-        primary_type,
-        primary_id,
-        *path,
-        per_page=1,
-        **query
-    )
+    data = load_single_type(primary_type, primary_id, *path, per_page=1, **query)
 
-    cycle = cycle or max(data['cycles'])
-    path = ('history', str(cycle))
+    cycle = cycle or max(data["cycles"])
+    path = ("history", str(cycle))
 
     """ Get data for secondary_type
         Example: committee data for /candidate/P80003338/committees
     """
     nested_data = load_nested_type(
-        primary_type,
-        primary_id,
-        secondary_type,
-        *path,
-        **query
+        primary_type, primary_id, secondary_type, *path, **query
     )
 
-    return data, nested_data['results'], cycle
+    return data, nested_data["results"], cycle
 
 
 def load_first_row_data(*path_parts, **filters):
     response = _call_api(*path_parts, **filters)
-    return response['results'][0] if response['results'] else None
+    return response["results"][0] if response["results"] else None
 
 
 def load_endpoint_results(*path_parts, **filters):
     response = _call_api(*path_parts, **filters)
-    return response.get('results', [])
+    return response.get("results", [])
 
 
 def load_candidate_statement_of_candidacy(candidate_id):
     """Get most recent F2 - default sort is `-receipt_date`"""
-    response = _call_api(
-        'filings',
-        candidate_id=candidate_id,
-        form_type='F2',
-    )
-    return response['results'][0] if response['results'] else None
+    response = _call_api("filings", candidate_id=candidate_id, form_type="F2")
+    return response["results"][0] if response["results"] else None
 
 
 def load_committee_statement_of_organization(committee_id):
     """Get most recent F1 - default sort is `-receipt_date`"""
-    response = _call_api(
-        'filings',
-        committee_id=committee_id,
-        form_type='F1'
-    )
-    return response['results'][0] if response['results'] else None
+    response = _call_api("filings", committee_id=committee_id, form_type="F1")
+
+    return response["results"][0] if response["results"] else None
 
 
 def result_or_404(data):
-    if not data.get('results'):
+    if not data.get("results"):
         raise Http404()
-    return data['results'][0]
+    return data["results"][0]
 
 
-def load_top_candidates(sort, office=None, election_year=constants.DEFAULT_ELECTION_YEAR, per_page=5):
+def load_top_candidates(
+    sort, office=None, election_year=constants.DEFAULT_ELECTION_YEAR, per_page=5
+):
     response = _call_api(
-        'candidates', 'totals',
+        "candidates",
+        "totals",
         sort_hide_null=True,
         election_year=election_year,
         election_full=True,
@@ -340,7 +320,7 @@ def load_top_candidates(sort, office=None, election_year=constants.DEFAULT_ELECT
         sort=sort,
         per_page=per_page,
     )
-    return response if 'results' in response else None
+    return response if "results" in response else None
 
 
 def _get_sorted_participants_by_type(mur):
@@ -366,8 +346,8 @@ def _get_sorted_participants_by_type(mur):
     for role in SORTED_PARTICIPANT_ROLES:
         participants_by_type[role] = []
 
-    for participant in mur['participants']:
-        participants_by_type[participant['role']].append(participant['name'])
+    for participant in mur["participants"]:
+        participants_by_type[participant["role"]].append(participant["name"])
 
     # Remove roles without participants
     for role in [key for key, value in participants_by_type.items() if not value]:
@@ -386,15 +366,9 @@ def _get_sorted_documents(ao):
        function performs a _stable_ sort.
     """
     sorted_documents = sorted(
-        ao['documents'],
-        key=itemgetter('description', 'document_id'),
-        reverse=False,
+        ao["documents"], key=itemgetter("description", "document_id"), reverse=False
     )
-    sorted_documents = sorted(
-        sorted_documents,
-        key=itemgetter('date'),
-        reverse=True,
-    )
+    sorted_documents = sorted(sorted_documents, key=itemgetter("date"), reverse=True)
     return sorted_documents
 
 
@@ -404,13 +378,10 @@ def call_senate_specials(state):
         Example: [{details for election1}][{details for election2}]
     """
     special_results = _call_api(
-        'election-dates',
-        election_type_id='SG',
-        office_sought='S',
-        election_state=state,
+        "election-dates", election_type_id="SG", office_sought="S", election_state=state
     )
 
-    return special_results.get('results')
+    return special_results.get("results")
 
 
 def format_special_results(special_results=[]):
@@ -422,8 +393,10 @@ def format_special_results(special_results=[]):
 
     for result in special_results:
         # Round odd years up to even years
-        result['election_year'] = result['election_year'] + (result['election_year'] % 2)
-        senate_specials.append(result.get('election_year', None))
+        result["election_year"] = result["election_year"] + (
+            result["election_year"] % 2
+        )
+        senate_specials.append(result.get("election_year", None))
 
     return senate_specials
 
@@ -433,7 +406,7 @@ def get_regular_senate_cycles(state):
     """
     senate_cycles = []
 
-    for senate_class in ['1', '2', '3']:
+    for senate_class in ["1", "2", "3"]:
         if state.upper() in constants.SENATE_CLASSES[senate_class]:
             senate_cycles += utils.get_senate_cycles(senate_class)
 

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -322,6 +322,15 @@ def load_candidate_statement_of_candidacy(candidate_id, cycle):
     else:
         return []
 
+def load_committee_statement_of_organization(committee_id, cycle):
+    response = _call_api(
+        'filings',
+        committee_id=committee_id,
+        form_type='F1',
+        cycle=cycle
+    )
+    return response.get('results', [])
+
 
 def result_or_404(data):
     if not data.get('results'):

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -303,24 +303,13 @@ def load_endpoint_results(*path_parts, **filters):
     return response.get('results', [])
 
 
-def load_candidate_statement_of_candidacy(candidate_id, cycle):
+def load_candidate_statement_of_candidacy(candidate_id):
     response = _call_api(
         'filings',
         candidate_id=candidate_id,
         form_type='F2',
     )
-
-    # Cycle is always the even year; so to include odd year statements,
-    # check for greater than or equal to the odd year
-    year = cycle - 1
-
-    if 'results' in response:
-        return [
-            statement for statement in response['results']
-            if statement['election_year'] >= year
-        ]
-    else:
-        return []
+    return response.get('results', [])
 
 
 def load_committee_statement_of_organization(committee_id):

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -322,12 +322,12 @@ def load_candidate_statement_of_candidacy(candidate_id, cycle):
     else:
         return []
 
-def load_committee_statement_of_organization(committee_id, cycle):
+
+def load_committee_statement_of_organization(committee_id):
     response = _call_api(
         'filings',
         committee_id=committee_id,
-        form_type='F1',
-        cycle=cycle
+        form_type='F1'
     )
     return response.get('results', [])
 

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -32,20 +32,16 @@
           <td class="figure__label">Statement of candidacy:</td>
           <td class="figure__value">
             <ul>
-            {% for statement in statement_of_candidacy %}
               <li>
-                {% if loop.index == 1 %}
                 <div class="t-block">
                   <i class="icon-circle--check-outline--inline--left"></i>
-                  <a href="{{ statement.pdf_url }}">Current version (PDF)</a>
+                  <a href="{{ statement_of_candidacy.pdf_url }}">Current version (PDF)</a>
                 </div>
-                {% if statement.fec_file_id %}
-                  <div class="t-small u-small-icon-padding--left"> {{ statement.fec_file_id }}</div>
+                {% if statement_of_candidacy.fec_file_id %}
+                  <div class="t-small u-small-icon-padding--left"> {{ statement_of_candidacy.fec_file_id }}</div>
                 {% endif %}
-                <div class="u-small-icon-padding--left"> Filed {{ statement.receipt_date }}</div>
+                <div class="u-small-icon-padding--left"> Filed {{ statement_of_candidacy.receipt_date }}</div>
               </li>
-              {% endif %}
-            {% endfor %}
             </ul>
           </td>
         </tr>

--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -81,6 +81,29 @@
             </td>
           </tr>
         {% endif %}
+        {% if statement_of_organization %}
+        <tr>
+          <td class="figure__label">Statement of organization:</td>
+          <td class="figure__value">
+            <ul>
+            {% for statement in statement_of_organization %}
+              <li>
+                {% if loop.index == 1 %}
+                <div class="t-block">
+                  <i class="icon-circle--check-outline--inline--left"></i>
+                  <a href="{{ statement.pdf_url }}">Current version (PDF)</a>
+                </div>
+                {% if statement.fec_file_id %}
+                  <div class="t-small u-small-icon-padding--left"> {{ statement.fec_file_id }}</div>
+                {% endif %}
+                <div class="u-small-icon-padding--left"> Filed {{ statement.receipt_date }}</div>
+              </li>
+              {% endif %}
+            {% endfor %}
+            </ul>
+          </td>
+        </tr>
+        {% endif %}
         {% if candidates %}
           <tr>
             <td class="figure__label">Authorizing candidate:</td>

--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -86,20 +86,16 @@
           <td class="figure__label">Statement of organization:</td>
           <td class="figure__value">
             <ul>
-            {% for statement in statement_of_organization %}
               <li>
-                {% if loop.index == 1 %}
                 <div class="t-block">
                   <i class="icon-circle--check-outline--inline--left"></i>
-                  <a href="{{ statement.pdf_url }}">Current version (PDF)</a>
+                  <a href="{{ statement_of_organization.pdf_url }}">Current version (PDF)</a>
                 </div>
-                {% if statement.fec_file_id %}
-                  <div class="t-small u-small-icon-padding--left"> {{ statement.fec_file_id }}</div>
+                {% if statement_of_organization.fec_file_id %}
+                  <div class="t-small u-small-icon-padding--left"> {{ statement_of_organization.fec_file_id }}</div>
                 {% endif %}
-                <div class="u-small-icon-padding--left"> Filed {{ statement.receipt_date }}</div>
+                <div class="u-small-icon-padding--left"> Filed {{ statement_of_organization.receipt_date }}</div>
               </li>
-              {% endif %}
-            {% endfor %}
             </ul>
           </td>
         </tr>

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -64,7 +64,14 @@ class TestCandidate(TestCase):
             self.STOCK_COMMITTEE_LIST,
             cycle,
         )
-        candidate = get_candidate('H001', 2018, show_full_election)
+        load_first_row_data_mock.return_value = mock.MagicMock()
+        load_candidate_statement_of_candidacy_mock.return_value = [
+            {"receipt_date": "2019-11-30T00:00:00"},
+            {"receipt_date": "2017-11-30T00:00:00"},
+            {"receipt_date": "2016-11-30T00:00:00"},
+        ]
+
+        candidate = get_candidate("H001", 2018, show_full_election)
 
         assert candidate['candidate_id'] == test_candidate['candidate_id']
         assert candidate['name'] == test_candidate['name']
@@ -143,6 +150,8 @@ class TestCandidate(TestCase):
         assert len(candidate['spending_summary']) == 0
         assert len(candidate['cash_summary']) == 0
 
+        assert candidate["statement_of_candidacy"] == [{'receipt_date': '11/30/2019'}, {'receipt_date': '11/30/2017'}, {'receipt_date': '11/30/2016'}]
+
     def test_special_odd_year_return_rounded_number(
         self,
         load_with_nested_mock,
@@ -157,9 +166,14 @@ class TestCandidate(TestCase):
         test_candidate["rounded_election_years"] = [2014, 2016, 2018]
 
         load_with_nested_mock.return_value = (test_candidate, mock.MagicMock(), 2016)
-        candidate = get_candidate('H001', 2016, True)
+        load_first_row_data_mock.return_value = mock.MagicMock()
+        load_candidate_statement_of_candidacy_mock.return_value = []
+
+        candidate = get_candidate("H001", 2016, True)
         assert candidate["election_years"] == [2014, 2016, 2018]
         assert candidate["election_year"] == 2016
+
+        assert candidate["statement_of_candidacy"] == []
 
     def test_future_candidate_max_cycle(
         self,

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -6,9 +6,11 @@ from data import api_caller
 from data.views import get_candidate
 
 
-@mock.patch.object(api_caller, 'load_candidate_statement_of_candidacy', return_value=None)
-@mock.patch.object(api_caller, 'load_first_row_data')
-@mock.patch.object(api_caller, 'load_with_nested')
+@mock.patch.object(
+    api_caller, "load_candidate_statement_of_candidacy", return_value=None
+)
+@mock.patch.object(api_caller, "load_first_row_data")
+@mock.patch.object(api_caller, "load_with_nested")
 class TestCandidate(TestCase):
 
     STOCK_CANDIDATE = {
@@ -27,25 +29,25 @@ class TestCandidate(TestCase):
     }
     STOCK_COMMITTEE_LIST = [
         {
-            'designation': 'P',
-            'cycles': [2016, 2014, 2012, 2018],
-            'name': 'My Primary Campaign Committee',
-            'cycle': 2016,
-            'committee_id': 'C001',
+            "designation": "P",
+            "cycles": [2016, 2014, 2012, 2018],
+            "name": "My Primary Campaign Committee",
+            "cycle": 2016,
+            "committee_id": "C001",
         },
         {
-            'designation': 'A',
-            'cycles': [2016, 2014, 2012, 2018],
-            'name': 'My Authorized Campaign Committee',
-            'cycle': 2016,
-            'committee_id': 'C002',
+            "designation": "A",
+            "cycles": [2016, 2014, 2012, 2018],
+            "name": "My Authorized Campaign Committee",
+            "cycle": 2016,
+            "committee_id": "C002",
         },
         {
-            'designation': 'J',
-            'cycles': [2016, 2014, 2012, 2018],
-            'name': 'Joint Fundraising Committee',
-            'cycle': 2016,
-            'committee_id': 'C003',
+            "designation": "J",
+            "cycles": [2016, 2014, 2012, 2018],
+            "name": "Joint Fundraising Committee",
+            "cycle": 2016,
+            "committee_id": "C003",
         },
     ]
 
@@ -65,88 +67,90 @@ class TestCandidate(TestCase):
             cycle,
         )
         load_first_row_data_mock.return_value = mock.MagicMock()
-        load_candidate_statement_of_candidacy_mock.return_value = {"receipt_date": "2019-11-30T00:00:00"}
+        load_candidate_statement_of_candidacy_mock.return_value = {
+            "receipt_date": "2019-11-30T00:00:00"
+        }
 
         candidate = get_candidate("H001", 2018, show_full_election)
 
-        assert candidate['candidate_id'] == test_candidate['candidate_id']
-        assert candidate['name'] == test_candidate['name']
-        assert candidate['cycles'] == test_candidate['fec_cycles_in_election']
-        assert candidate['min_cycle'] == cycle - 2
-        assert candidate['max_cycle'] == cycle
-        assert candidate['election_year'] == cycle
-        assert candidate['election_years'] == test_candidate['election_years']
-        assert candidate['office'] == test_candidate['office']
-        assert candidate['office_full'] == test_candidate['office_full']
-        assert candidate['state'] == test_candidate['state']
-        assert candidate['district'] == test_candidate['district']
-        assert candidate['party_full'] == test_candidate['party_full']
+        assert candidate["candidate_id"] == test_candidate["candidate_id"]
+        assert candidate["name"] == test_candidate["name"]
+        assert candidate["cycles"] == test_candidate["fec_cycles_in_election"]
+        assert candidate["min_cycle"] == cycle - 2
+        assert candidate["max_cycle"] == cycle
+        assert candidate["election_year"] == cycle
+        assert candidate["election_years"] == test_candidate["election_years"]
+        assert candidate["office"] == test_candidate["office"]
+        assert candidate["office_full"] == test_candidate["office_full"]
+        assert candidate["state"] == test_candidate["state"]
+        assert candidate["district"] == test_candidate["district"]
+        assert candidate["party_full"] == test_candidate["party_full"]
         assert (
-            candidate['incumbent_challenge_full']
-            == test_candidate['incumbent_challenge_full']
+            candidate["incumbent_challenge_full"]
+            == test_candidate["incumbent_challenge_full"]
         )
-        assert candidate['cycle'] == cycle
-        assert candidate['result_type'] == 'candidates'
-        assert candidate['duration'] == 2
-        assert candidate['report_type'] == 'house-senate'
-        assert candidate['show_full_election'] == show_full_election
+        assert candidate["cycle"] == cycle
+        assert candidate["result_type"] == "candidates"
+        assert candidate["duration"] == 2
+        assert candidate["report_type"] == "house-senate"
+        assert candidate["show_full_election"] == show_full_election
 
-        assert candidate['committee_groups'] == {
-            'P': [
+        assert candidate["committee_groups"] == {
+            "P": [
                 {
-                    'designation': 'P',
-                    'cycles': [2016, 2014, 2012, 2018],
-                    'name': 'My Primary Campaign Committee',
-                    'cycle': 2016,
-                    'related_cycle': 2016,
-                    'committee_id': 'C001',
+                    "designation": "P",
+                    "cycles": [2016, 2014, 2012, 2018],
+                    "name": "My Primary Campaign Committee",
+                    "cycle": 2016,
+                    "related_cycle": 2016,
+                    "committee_id": "C001",
                 }
             ],
-            'A': [
+            "A": [
                 {
-                    'designation': 'A',
-                    'cycles': [2016, 2014, 2012, 2018],
-                    'name': 'My Authorized Campaign Committee',
-                    'cycle': 2016,
-                    'related_cycle': 2016,
-                    'committee_id': 'C002',
+                    "designation": "A",
+                    "cycles": [2016, 2014, 2012, 2018],
+                    "name": "My Authorized Campaign Committee",
+                    "cycle": 2016,
+                    "related_cycle": 2016,
+                    "committee_id": "C002",
                 }
             ],
-            'J': [
+            "J": [
                 {
-                    'designation': 'J',
-                    'cycles': [2016, 2014, 2012, 2018],
-                    'name': 'Joint Fundraising Committee',
-                    'cycle': 2016,
-                    'related_cycle': 2016,
-                    'committee_id': 'C003',
+                    "designation": "J",
+                    "cycles": [2016, 2014, 2012, 2018],
+                    "name": "Joint Fundraising Committee",
+                    "cycle": 2016,
+                    "related_cycle": 2016,
+                    "committee_id": "C003",
                 }
             ],
         }
 
-        assert candidate['committees_authorized'] == (
-            candidate['committee_groups']['P'] + candidate['committee_groups']['A']
+        assert candidate["committees_authorized"] == (
+            candidate["committee_groups"]["P"] + candidate["committee_groups"]["A"]
         )
-        assert candidate['committee_ids'] == [
-            committee['committee_id']
-            for committee in candidate['committees_authorized']
+        assert candidate["committee_ids"] == [
+            committee["committee_id"]
+            for committee in candidate["committees_authorized"]
         ]
 
-        assert candidate['elections'] == [(2018, '02'), (2016, '01')]
-        assert candidate['candidate'] == test_candidate
-        assert candidate['context_vars'] == {
-            'cycles': [2014, 2016, 2018],
-            'name': test_candidate["name"],
-            'cycle': cycle,
-            'electionFull': show_full_election,
-            'candidateID': test_candidate["candidate_id"],
+        assert candidate["elections"] == [(2018, "02"), (2016, "01")]
+        assert candidate["candidate"] == test_candidate
+        assert candidate["context_vars"] == {
+            "cycles": [2014, 2016, 2018],
+            "name": test_candidate["name"],
+            "cycle": cycle,
+            "electionFull": show_full_election,
+            "candidateID": test_candidate["candidate_id"],
         }
 
-        assert len(candidate['raising_summary']) == 0
-        assert len(candidate['spending_summary']) == 0
-        assert len(candidate['cash_summary']) == 0
+        assert len(candidate["raising_summary"]) == 0
+        assert len(candidate["spending_summary"]) == 0
+        assert len(candidate["cash_summary"]) == 0
 
-        assert candidate["statement_of_candidacy"] == {'receipt_date': '11/30/2019'}
+        assert candidate["statement_of_candidacy"] == {"receipt_date": "11/30/2019"}
 
     def test_special_odd_year_return_rounded_number(
         self,
@@ -186,25 +190,25 @@ class TestCandidate(TestCase):
         test_committee_list = copy.deepcopy(self.STOCK_COMMITTEE_LIST)
         test_committee_list[0] = (
             {
-                'designation': 'P',
-                'cycles': [2016, 2014, 2012, 2018, 2020],
-                'name': 'My Primary Campaign Committee',
-                'cycle': 2018,
-                'committee_id': 'C001',
+                "designation": "P",
+                "cycles": [2016, 2014, 2012, 2018, 2020],
+                "name": "My Primary Campaign Committee",
+                "cycle": 2018,
+                "committee_id": "C001",
             },
         )
         test_committee_list.append(
             {
-                'designation': 'P',
-                'cycles': [2016, 2014, 2012, 2018, 2020],
-                'name': 'My Primary Campaign Committee',
-                'cycle': 2024,
-                'committee_id': 'C001',
+                "designation": "P",
+                "cycles": [2016, 2014, 2012, 2018, 2020],
+                "name": "My Primary Campaign Committee",
+                "cycle": 2024,
+                "committee_id": "C001",
             }
         )
 
         load_with_nested_mock.return_value = (test_candidate, mock.MagicMock(), 2024)
-        candidate = get_candidate('S001', 2024, True)
+        candidate = get_candidate("S001", 2024, True)
         assert candidate["election_years"] == [2018, 2024]
         assert candidate["election_year"] == 2024
         assert candidate["max_cycle"] == 2020
@@ -226,25 +230,25 @@ class TestCandidate(TestCase):
         test_committee_list = copy.deepcopy(self.STOCK_COMMITTEE_LIST)
         test_committee_list[0] = (
             {
-                'designation': 'P',
-                'cycles': [2016, 2014, 2012, 2018, 2020],
-                'name': 'My Primary Campaign Committee',
-                'cycle': 2018,
-                'committee_id': 'C001',
+                "designation": "P",
+                "cycles": [2016, 2014, 2012, 2018, 2020],
+                "name": "My Primary Campaign Committee",
+                "cycle": 2018,
+                "committee_id": "C001",
             },
         )
         test_committee_list.append(
             {
-                'designation': 'P',
-                'cycles': [2016, 2014, 2012, 2018, 2020],
-                'name': 'My Primary Campaign Committee',
-                'cycle': 1988,
-                'committee_id': 'C001',
+                "designation": "P",
+                "cycles": [2016, 2014, 2012, 2018, 2020],
+                "name": "My Primary Campaign Committee",
+                "cycle": 1988,
+                "committee_id": "C001",
             }
         )
 
         load_with_nested_mock.return_value = (test_candidate, mock.MagicMock(), 1988)
-        candidate = get_candidate('P001', 1988, True)
+        candidate = get_candidate("P001", 1988, True)
         assert candidate["election_years"] == [1988, 2016, 2020]
         assert candidate["election_year"] == 1988
         assert candidate["max_cycle"] == 1988
@@ -266,25 +270,25 @@ class TestCandidate(TestCase):
         test_committee_list = copy.deepcopy(self.STOCK_COMMITTEE_LIST)
         test_committee_list[0] = (
             {
-                'designation': 'P',
-                'cycles': [2016, 2014, 2012, 2018, 2020],
-                'name': 'My Primary Campaign Committee',
-                'cycle': 2018,
-                'committee_id': 'C001',
+                "designation": "P",
+                "cycles": [2016, 2014, 2012, 2018, 2020],
+                "name": "My Primary Campaign Committee",
+                "cycle": 2018,
+                "committee_id": "C001",
             },
         )
         test_committee_list.append(
             {
-                'designation': 'P',
-                'cycles': [2016, 2014, 2012, 2018, 2020],
-                'name': 'My Primary Campaign Committee',
-                'cycle': 2020,
-                'committee_id': 'C001',
+                "designation": "P",
+                "cycles": [2016, 2014, 2012, 2018, 2020],
+                "name": "My Primary Campaign Committee",
+                "cycle": 2020,
+                "committee_id": "C001",
             }
         )
 
         load_with_nested_mock.return_value = (test_candidate, mock.MagicMock(), 2020)
-        candidate = get_candidate('P002', 2020, True)
+        candidate = get_candidate("P002", 2020, True)
         assert candidate["election_years"] == [2020]
         assert candidate["election_year"] == 2020
         assert candidate["max_cycle"] == 2020

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -6,7 +6,7 @@ from data import api_caller
 from data.views import get_candidate
 
 
-@mock.patch.object(api_caller, 'load_candidate_statement_of_candidacy')
+@mock.patch.object(api_caller, 'load_candidate_statement_of_candidacy', return_value=None)
 @mock.patch.object(api_caller, 'load_first_row_data')
 @mock.patch.object(api_caller, 'load_with_nested')
 class TestCandidate(TestCase):
@@ -65,11 +65,7 @@ class TestCandidate(TestCase):
             cycle,
         )
         load_first_row_data_mock.return_value = mock.MagicMock()
-        load_candidate_statement_of_candidacy_mock.return_value = [
-            {"receipt_date": "2019-11-30T00:00:00"},
-            {"receipt_date": "2017-11-30T00:00:00"},
-            {"receipt_date": "2016-11-30T00:00:00"},
-        ]
+        load_candidate_statement_of_candidacy_mock.return_value = {"receipt_date": "2019-11-30T00:00:00"}
 
         candidate = get_candidate("H001", 2018, show_full_election)
 
@@ -150,7 +146,7 @@ class TestCandidate(TestCase):
         assert len(candidate['spending_summary']) == 0
         assert len(candidate['cash_summary']) == 0
 
-        assert candidate["statement_of_candidacy"] == [{'receipt_date': '11/30/2019'}, {'receipt_date': '11/30/2017'}, {'receipt_date': '11/30/2016'}]
+        assert candidate["statement_of_candidacy"] == {'receipt_date': '11/30/2019'}
 
     def test_special_odd_year_return_rounded_number(
         self,
@@ -167,13 +163,12 @@ class TestCandidate(TestCase):
 
         load_with_nested_mock.return_value = (test_candidate, mock.MagicMock(), 2016)
         load_first_row_data_mock.return_value = mock.MagicMock()
-        load_candidate_statement_of_candidacy_mock.return_value = []
 
         candidate = get_candidate("H001", 2016, True)
         assert candidate["election_years"] == [2014, 2016, 2018]
         assert candidate["election_year"] == 2016
 
-        assert candidate["statement_of_candidacy"] == []
+        assert candidate["statement_of_candidacy"] is None
 
     def test_future_candidate_max_cycle(
         self,

--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -5,7 +5,7 @@ import copy
 from data import views, api_caller
 
 
-@mock.patch.object(api_caller, 'load_committee_statement_of_organization')
+@mock.patch.object(api_caller, 'load_committee_statement_of_organization', return_value=None)
 @mock.patch.object(api_caller, 'load_endpoint_results')
 @mock.patch.object(views, 'load_reports_and_totals')
 @mock.patch.object(views, 'load_cycle_data')
@@ -187,11 +187,7 @@ class TestCommittee(TestCase):
             self.STOCK_TOTALS,
         )
         load_endpoint_results_mock.return_value = mock.MagicMock()
-        load_committee_statement_of_organization_mock.return_value = [
-            {'receipt_date': '2019-11-30T00:00:00'},
-            {'receipt_date': '2017-11-30T00:00:00'},
-            {'receipt_date': '2016-11-30T00:00:00'},
-        ]
+        load_committee_statement_of_organization_mock.return_value = {'receipt_date': '2019-11-30T00:00:00'}
         template_variables = views.get_committee('C001', 2018)
 
         committee = template_variables.get("committee")
@@ -224,11 +220,8 @@ class TestCommittee(TestCase):
         assert template_variables['result_type'] == 'committees'
         assert template_variables['report_type'] == 'pac-party'
         assert template_variables['reports'] == self.STOCK_REPORTS
-        assert template_variables['statement_of_organization'] == [
-            {'receipt_date': '11/30/2019'},
-            {'receipt_date': '11/30/2017'},
-            {'receipt_date': '11/30/2016'},
-        ]
+        assert template_variables['statement_of_organization'] == {'receipt_date': '11/30/2019'}
+
 
     def test_ie_summary(
         self,

--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -5,6 +5,7 @@ import copy
 from data import views, api_caller
 
 
+@mock.patch.object(api_caller, 'load_committee_statement_of_organization')
 @mock.patch.object(api_caller, 'load_endpoint_results')
 @mock.patch.object(views, 'load_reports_and_totals')
 @mock.patch.object(views, 'load_cycle_data')
@@ -173,6 +174,7 @@ class TestCommittee(TestCase):
         load_cycle_data_mock,
         load_reports_and_totals_mock,
         load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
     ):
         cycle = 2018
 
@@ -184,6 +186,12 @@ class TestCommittee(TestCase):
             self.STOCK_REPORTS,
             self.STOCK_TOTALS,
         )
+        load_endpoint_results_mock.return_value = mock.MagicMock()
+        load_committee_statement_of_organization_mock.return_value = [
+            {'receipt_date': '2019-11-30T00:00:00'},
+            {'receipt_date': '2017-11-30T00:00:00'},
+            {'receipt_date': '2016-11-30T00:00:00'},
+        ]
         template_variables = views.get_committee('C001', 2018)
 
         committee = template_variables.get("committee")
@@ -216,6 +224,11 @@ class TestCommittee(TestCase):
         assert template_variables['result_type'] == 'committees'
         assert template_variables['report_type'] == 'pac-party'
         assert template_variables['reports'] == self.STOCK_REPORTS
+        assert template_variables['statement_of_organization'] == [
+            {'receipt_date': '11/30/2019'},
+            {'receipt_date': '11/30/2017'},
+            {'receipt_date': '11/30/2016'},
+        ]
 
     def test_ie_summary(
         self,
@@ -223,6 +236,7 @@ class TestCommittee(TestCase):
         load_cycle_data_mock,
         load_reports_and_totals_mock,
         load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
     ):
         cycle = 2018
 
@@ -252,6 +266,7 @@ class TestCommittee(TestCase):
         load_cycle_data_mock,
         load_reports_and_totals_mock,
         load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
     ):
         cycle = 2018
 
@@ -277,6 +292,7 @@ class TestCommittee(TestCase):
         load_cycle_data_mock,
         load_reports_and_totals_mock,
         load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
     ):
 
         cycle = 2018
@@ -440,6 +456,7 @@ class TestCommittee(TestCase):
         load_cycle_data_mock,
         load_reports_and_totals_mock,
         load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
     ):
         cycle = 2018
 

--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -5,164 +5,166 @@ import copy
 from data import views, api_caller
 
 
-@mock.patch.object(api_caller, 'load_committee_statement_of_organization', return_value=None)
-@mock.patch.object(api_caller, 'load_endpoint_results')
-@mock.patch.object(views, 'load_reports_and_totals')
-@mock.patch.object(views, 'load_cycle_data')
-@mock.patch.object(views, 'load_committee_history')
+@mock.patch.object(
+    api_caller, "load_committee_statement_of_organization", return_value=None
+)
+@mock.patch.object(api_caller, "load_endpoint_results")
+@mock.patch.object(views, "load_reports_and_totals")
+@mock.patch.object(views, "load_cycle_data")
+@mock.patch.object(views, "load_committee_history")
 class TestCommittee(TestCase):
 
     STOCK_COMMITTEE = {
-        'organization_type_full': None,
-        'affiliated_committee_name': 'SOME CONNECTED COMMITTEE',
-        'zip': '37024',
-        'committee_type': 'N',
-        'committee_type_full': 'PAC - Nonqualified',
-        'committee_id': 'C001',
-        'designation_full': 'Joint fundraising committee',
-        'party_full': None,
-        'street_2': None,
-        'designation': 'J',
-        'state_full': 'Tennessee',
-        'party': None,
-        'street_1': 'PO BOX 123',
-        'state': 'TN',
-        'treasurer_name': 'SMITH, SUSAN',
-        'candidate_ids': [],
-        'organization_type': None,
-        'cycles': [2018],
-        'filing_frequency': 'Q',
-        'cycle': 2018,
-        'city': 'BRENTWOOD',
-        'name': 'MY JOINT FUNDRAISING COMMITTEE',
-        'cycles_has_financial': [2018],
-        'last_cycle_has_financial': 2018,
-        'cycles_has_activity': [2018],
-        'last_cycle_has_activity': 2018,
+        "organization_type_full": None,
+        "affiliated_committee_name": "SOME CONNECTED COMMITTEE",
+        "zip": "37024",
+        "committee_type": "N",
+        "committee_type_full": "PAC - Nonqualified",
+        "committee_id": "C001",
+        "designation_full": "Joint fundraising committee",
+        "party_full": None,
+        "street_2": None,
+        "designation": "J",
+        "state_full": "Tennessee",
+        "party": None,
+        "street_1": "PO BOX 123",
+        "state": "TN",
+        "treasurer_name": "SMITH, SUSAN",
+        "candidate_ids": [],
+        "organization_type": None,
+        "cycles": [2018],
+        "filing_frequency": "Q",
+        "cycle": 2018,
+        "city": "BRENTWOOD",
+        "name": "MY JOINT FUNDRAISING COMMITTEE",
+        "cycles_has_financial": [2018],
+        "last_cycle_has_financial": 2018,
+        "cycles_has_activity": [2018],
+        "last_cycle_has_activity": 2018,
     }
 
     STOCK_REPORTS = [
         {
-            'non_allocated_fed_election_activity_period': None,
-            'allocated_federal_election_levin_share_period': None,
-            'total_disbursements_period': 7400.0,
-            'coverage_end_date': '2018-09-30T00:00:00+00:00',
-            'document_description': 'OCTOBER QUARTERLY 2018',
-            'refunded_political_party_committee_contributions_ytd': None,
-            'loans_made_period': None,
-            'net_operating_expenditures_period': None,
-            'committee_type': 'N',
-            'committee_name': 'GREEN VICTORY FUND',
-            'amendment_indicator_full': 'NEW',
-            'net_contributions_period': None,
-            'total_disbursements_ytd': None,
-            'fec_url': 'http://docquery.fec.gov/dcdev/posted/1273093.fec',
-            'other_fed_receipts_period': None,
-            'shared_fed_activity_ytd': None,
-            'cash_on_hand_beginning_period': 0.0,
-            'total_operating_expenditures_ytd': None,
-            'non_allocated_fed_election_activity_ytd': None,
-            'debts_owed_to_committee': 0.0,
-            'pdf_url': ' http://docquery.fec.gopdf042/201810159125475042/20181015912  5475042.pdf',
-            'political_party_committee_contributions_period': None,
-            'other_political_committee_contributions_period': None,
-            'fec_file_id': 'FEC-1273093',
-            'beginning_image_number': '201810159125475042',
-            'cash_on_hand_beginning_calendar_ytd': None,
-            'coordinated_expenditures_by_party_committee_period': None,
-            'total_nonfed_transfers_period': None,
-            'loan_repayments_made_period': None,
-            'fed_candidate_contribution_refunds_period': None,
-            'individual_unitemized_contributions_period': None,
-            'fed_candidate_committee_contribution_refunds_ytd': None,
-            'total_fed_receipts_period': None,
-            'transfers_from_affiliated_party_period': None,
-            'total_contributions_ytd': None,
-            'refunded_political_party_committee_contributions_period': None,
-            'transfers_to_affiliated_committee_period': None,
-            'subtotal_summary_ytd': None,
-            'refunded_individual_contributions_period': None,
-            'transfers_from_nonfed_levin_ytd': None,
-            'other_political_committee_contributions_ytd': None,
-            'report_form': 'Form 3',
-            'total_fed_operating_expenditures_period': None,
-            'total_individual_contributions_period': None,
-            'csv_url': 'http://docquery.fec.gov/csv/093/1273093.csv',
-            'total_contribution_refunds_period': None,
-            'loans_made_ytd': None,
-            'loan_repayments_made_ytd': None,
-            'amendment_indicator': 'N',
-            'total_fed_election_activity_period': None,
-            'transfers_from_nonfed_levin_period': None,
-            'total_contributions_period': None,
-            'offsets_to_operating_expenditures_period': None,
-            'total_fed_election_activity_ytd': None,
-            'report_year': 2018,
-            'offsets_to_operating_expenditures_ytd': None,
-            'other_fed_operating_expenditures_ytd': None,
-            'total_fed_disbursements_ytd': None,
-            'cash_on_hand_close_ytd': None,
-            'most_recent_file_number': 1273093.0,
-            'shared_fed_operating_expenditures_ytd': None,
-            'total_contribution_refunds_ytd': None,
-            'total_nonfed_transfers_ytd': None,
-            'all_loans_received_period': None,
-            'debts_owed_by_committee': 0.0,
-            'shared_fed_activity_period': None,
-            'net_contributions_ytd': None,
-            'transfers_from_affiliated_party_ytd': None,
-            'coverage_start_date': '2018-07-01T00:00:00+00:00',
-            'refunded_individual_contributions_ytd': None,
-            'loan_repayments_received_ytd': None,
-            'individual_unitemized_contributions_ytd': None,
-            'end_image_number': '201810159125475048',
-            'previous_file_number': 1273093.0,
-            'independent_expenditures_ytd': None,
-            'fed_candidate_committee_contributions_ytd': None,
-            'total_fed_receipts_ytd': None,
-            'means_filed': 'e-file',
-            'committee_id': 'C00687574',
-            'amendment_chain': [1273093.0],
-            'total_fed_disbursements_period': None,
-            'cycle': 2018,
-            'transfers_from_nonfed_account_ytd': None,
-            'shared_fed_operating_expenditures_period': None,
-            'shared_nonfed_operating_expenditures_period': None,
-            'receipt_date': '2018-10-15T00:00:00',
-            'refunded_other_political_committee_contributions_period': None,
-            'most_recent': True,
-            'html_url': 'http://docquery.fec.gov/cgi-bin/forms/C00687574/127309',
-            'shared_fed_activity_nonfed_ytd': None,
-            'cash_on_hand_end_period': 0.0,
-            'report_type': 'Q3',
-            'shared_nonfed_operating_expenditures_ytd': None,
-            'subtotal_summary_page_period': None,
-            'loan_repayments_received_period': None,
-            'political_party_committee_contributions_ytd': None,
-            'file_number': 1273093,
-            'total_receipts_period': 7400.0,
-            'other_fed_receipts_ytd': None,
-            'other_disbursements_ytd': None,
-            'calendar_ytd': None,
-            'independent_expenditures_period': None,
-            'individual_itemized_contributions_ytd': None,
-            'refunded_other_political_committee_contributions_ytd': None,
-            'individual_itemized_contributions_period': None,
-            'total_receipts_ytd': None,
-            'other_fed_operating_expenditures_period': None,
-            'transfers_to_affilitated_committees_ytd': None,
-            'report_type_full': 'OCTOBER QUARTERLY',
-            'coordinated_expenditures_by_party_committee_ytd': None,
-            'total_individual_contributions_ytd': None,
-            'fed_candidate_committee_contributions_period': None,
-            'net_operating_expenditures_ytd': None,
-            'transfers_from_nonfed_account_period': None,
-            'total_fed_operating_expenditures_ytd': None,
-            'all_loans_received_ytd': None,
-            'total_operating_expenditures_period': None,
-            'other_disbursements_period': None,
-            'nonfed_share_allocated_disbursements_period': None,
-            'is_amended': False,
+            "non_allocated_fed_election_activity_period": None,
+            "allocated_federal_election_levin_share_period": None,
+            "total_disbursements_period": 7400.0,
+            "coverage_end_date": "2018-09-30T00:00:00+00:00",
+            "document_description": "OCTOBER QUARTERLY 2018",
+            "refunded_political_party_committee_contributions_ytd": None,
+            "loans_made_period": None,
+            "net_operating_expenditures_period": None,
+            "committee_type": "N",
+            "committee_name": "GREEN VICTORY FUND",
+            "amendment_indicator_full": "NEW",
+            "net_contributions_period": None,
+            "total_disbursements_ytd": None,
+            "fec_url": "http://docquery.fec.gov/dcdev/posted/1273093.fec",
+            "other_fed_receipts_period": None,
+            "shared_fed_activity_ytd": None,
+            "cash_on_hand_beginning_period": 0.0,
+            "total_operating_expenditures_ytd": None,
+            "non_allocated_fed_election_activity_ytd": None,
+            "debts_owed_to_committee": 0.0,
+            "pdf_url": " http://docquery.fec.gopdf042/201810159125475042/20181015912  5475042.pdf",
+            "political_party_committee_contributions_period": None,
+            "other_political_committee_contributions_period": None,
+            "fec_file_id": "FEC-1273093",
+            "beginning_image_number": "201810159125475042",
+            "cash_on_hand_beginning_calendar_ytd": None,
+            "coordinated_expenditures_by_party_committee_period": None,
+            "total_nonfed_transfers_period": None,
+            "loan_repayments_made_period": None,
+            "fed_candidate_contribution_refunds_period": None,
+            "individual_unitemized_contributions_period": None,
+            "fed_candidate_committee_contribution_refunds_ytd": None,
+            "total_fed_receipts_period": None,
+            "transfers_from_affiliated_party_period": None,
+            "total_contributions_ytd": None,
+            "refunded_political_party_committee_contributions_period": None,
+            "transfers_to_affiliated_committee_period": None,
+            "subtotal_summary_ytd": None,
+            "refunded_individual_contributions_period": None,
+            "transfers_from_nonfed_levin_ytd": None,
+            "other_political_committee_contributions_ytd": None,
+            "report_form": "Form 3",
+            "total_fed_operating_expenditures_period": None,
+            "total_individual_contributions_period": None,
+            "csv_url": "http://docquery.fec.gov/csv/093/1273093.csv",
+            "total_contribution_refunds_period": None,
+            "loans_made_ytd": None,
+            "loan_repayments_made_ytd": None,
+            "amendment_indicator": "N",
+            "total_fed_election_activity_period": None,
+            "transfers_from_nonfed_levin_period": None,
+            "total_contributions_period": None,
+            "offsets_to_operating_expenditures_period": None,
+            "total_fed_election_activity_ytd": None,
+            "report_year": 2018,
+            "offsets_to_operating_expenditures_ytd": None,
+            "other_fed_operating_expenditures_ytd": None,
+            "total_fed_disbursements_ytd": None,
+            "cash_on_hand_close_ytd": None,
+            "most_recent_file_number": 1273093.0,
+            "shared_fed_operating_expenditures_ytd": None,
+            "total_contribution_refunds_ytd": None,
+            "total_nonfed_transfers_ytd": None,
+            "all_loans_received_period": None,
+            "debts_owed_by_committee": 0.0,
+            "shared_fed_activity_period": None,
+            "net_contributions_ytd": None,
+            "transfers_from_affiliated_party_ytd": None,
+            "coverage_start_date": "2018-07-01T00:00:00+00:00",
+            "refunded_individual_contributions_ytd": None,
+            "loan_repayments_received_ytd": None,
+            "individual_unitemized_contributions_ytd": None,
+            "end_image_number": "201810159125475048",
+            "previous_file_number": 1273093.0,
+            "independent_expenditures_ytd": None,
+            "fed_candidate_committee_contributions_ytd": None,
+            "total_fed_receipts_ytd": None,
+            "means_filed": "e-file",
+            "committee_id": "C00687574",
+            "amendment_chain": [1273093.0],
+            "total_fed_disbursements_period": None,
+            "cycle": 2018,
+            "transfers_from_nonfed_account_ytd": None,
+            "shared_fed_operating_expenditures_period": None,
+            "shared_nonfed_operating_expenditures_period": None,
+            "receipt_date": "2018-10-15T00:00:00",
+            "refunded_other_political_committee_contributions_period": None,
+            "most_recent": True,
+            "html_url": "http://docquery.fec.gov/cgi-bin/forms/C00687574/127309",
+            "shared_fed_activity_nonfed_ytd": None,
+            "cash_on_hand_end_period": 0.0,
+            "report_type": "Q3",
+            "shared_nonfed_operating_expenditures_ytd": None,
+            "subtotal_summary_page_period": None,
+            "loan_repayments_received_period": None,
+            "political_party_committee_contributions_ytd": None,
+            "file_number": 1273093,
+            "total_receipts_period": 7400.0,
+            "other_fed_receipts_ytd": None,
+            "other_disbursements_ytd": None,
+            "calendar_ytd": None,
+            "independent_expenditures_period": None,
+            "individual_itemized_contributions_ytd": None,
+            "refunded_other_political_committee_contributions_ytd": None,
+            "individual_itemized_contributions_period": None,
+            "total_receipts_ytd": None,
+            "other_fed_operating_expenditures_period": None,
+            "transfers_to_affilitated_committees_ytd": None,
+            "report_type_full": "OCTOBER QUARTERLY",
+            "coordinated_expenditures_by_party_committee_ytd": None,
+            "total_individual_contributions_ytd": None,
+            "fed_candidate_committee_contributions_period": None,
+            "net_operating_expenditures_ytd": None,
+            "transfers_from_nonfed_account_period": None,
+            "total_fed_operating_expenditures_ytd": None,
+            "all_loans_received_ytd": None,
+            "total_operating_expenditures_period": None,
+            "other_disbursements_period": None,
+            "nonfed_share_allocated_disbursements_period": None,
+            "is_amended": False,
         }
     ]
 
@@ -187,41 +189,44 @@ class TestCommittee(TestCase):
             self.STOCK_TOTALS,
         )
         load_endpoint_results_mock.return_value = mock.MagicMock()
-        load_committee_statement_of_organization_mock.return_value = {'receipt_date': '2019-11-30T00:00:00'}
-        template_variables = views.get_committee('C001', 2018)
+        load_committee_statement_of_organization_mock.return_value = {
+            "receipt_date": "2019-11-30T00:00:00"
+        }
+        template_variables = views.get_committee("C001", 2018)
 
         committee = template_variables.get("committee")
-        assert committee['name'] == test_committee['name']
-        assert committee['committee_id'] == test_committee['committee_id']
-        assert committee['committee_type_full'] == test_committee['committee_type_full']
-        assert committee['committee_type'] == test_committee['committee_type']
-        assert committee['designation_full'] == test_committee['designation_full']
-        assert committee['street_1'] == test_committee['street_1']
-        assert committee['street_2'] == test_committee['street_2']
-        assert committee['city'] == test_committee['city']
-        assert committee['state'] == test_committee['state']
-        assert committee['zip'] == test_committee['zip']
-        assert committee['treasurer_name'] == test_committee['treasurer_name']
-        assert committee['party_full'] == test_committee['party_full']
+        assert committee["name"] == test_committee["name"]
+        assert committee["committee_id"] == test_committee["committee_id"]
+        assert committee["committee_type_full"] == test_committee["committee_type_full"]
+        assert committee["committee_type"] == test_committee["committee_type"]
+        assert committee["designation_full"] == test_committee["designation_full"]
+        assert committee["street_1"] == test_committee["street_1"]
+        assert committee["street_2"] == test_committee["street_2"]
+        assert committee["city"] == test_committee["city"]
+        assert committee["state"] == test_committee["state"]
+        assert committee["zip"] == test_committee["zip"]
+        assert committee["treasurer_name"] == test_committee["treasurer_name"]
+        assert committee["party_full"] == test_committee["party_full"]
 
-        assert template_variables['context_vars'] == {
-            'cycle': 2018,
-            'timePeriod': '2017–2018',
-            'name': 'MY JOINT FUNDRAISING COMMITTEE',
-            'cycleOutOfRange': False,
-            'lastCycleHasFinancial': 2018,
+        assert template_variables["context_vars"] == {
+            "cycle": 2018,
+            "timePeriod": "2017–2018",
+            "name": "MY JOINT FUNDRAISING COMMITTEE",
+            "cycleOutOfRange": False,
+            "lastCycleHasFinancial": 2018,
         }
-        assert template_variables['parent'] == 'data'
-        assert template_variables['totals'] == []
-        assert template_variables['candidates'] == []
-        assert template_variables['cycle'] == cycle
-        assert template_variables['cycles'] == test_committee['cycles_has_activity']
-        assert template_variables['year'] == test_committee['cycle']
-        assert template_variables['result_type'] == 'committees'
-        assert template_variables['report_type'] == 'pac-party'
-        assert template_variables['reports'] == self.STOCK_REPORTS
-        assert template_variables['statement_of_organization'] == {'receipt_date': '11/30/2019'}
-
+        assert template_variables["parent"] == "data"
+        assert template_variables["totals"] == []
+        assert template_variables["candidates"] == []
+        assert template_variables["cycle"] == cycle
+        assert template_variables["cycles"] == test_committee["cycles_has_activity"]
+        assert template_variables["year"] == test_committee["cycle"]
+        assert template_variables["result_type"] == "committees"
+        assert template_variables["report_type"] == "pac-party"
+        assert template_variables["reports"] == self.STOCK_REPORTS
+        assert template_variables["statement_of_organization"] == {
+            "receipt_date": "11/30/2019"
+        }
 
     def test_ie_summary(
         self,
@@ -234,23 +239,23 @@ class TestCommittee(TestCase):
         cycle = 2018
 
         test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
-        test_committee['committee_type'] = 'I'
+        test_committee["committee_type"] = "I"
 
         load_committee_history_mock.return_value = (test_committee, [], cycle)
         # cycle_out_of_range, last_cycle_has_financial, cycles
         load_cycle_data_mock.return_value = (False, 2018, [2018])
         load_reports_and_totals_mock.return_value = (
-            {'report_type_full': 'YEAR-END', 'report_type': 'YE'},
+            {"report_type_full": "YEAR-END", "report_type": "YE"},
             {
-                'total_independent_contributions': 11000.0,
-                'total_independent_expenditures': 4262.0,
+                "total_independent_contributions": 11000.0,
+                "total_independent_expenditures": 4262.0,
             },
         )
-        template_variables = views.get_committee('C001', 2018)
+        template_variables = views.get_committee("C001", 2018)
 
-        assert template_variables['ie_summary'] == [
-            (11000.0, {'label': 'Contributions received', 'level': '1'}),
-            (4262.0, {'label': 'Independent expenditures', 'level': '1'}),
+        assert template_variables["ie_summary"] == [
+            (11000.0, {"label": "Contributions received", "level": "1"}),
+            (4262.0, {"label": "Independent expenditures", "level": "1"}),
         ]
 
     def test_inaugural_summary(
@@ -264,19 +269,19 @@ class TestCommittee(TestCase):
         cycle = 2018
 
         test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
-        test_committee['organization_type'] = 'I'
+        test_committee["organization_type"] = "I"
         load_committee_history_mock.return_value = (test_committee, [], cycle)
         load_cycle_data_mock.return_value = (False, 2018, [2018])
         load_reports_and_totals_mock.return_value = (
-            {'report_type_full': 'POST INAUGURAL SUPPLEMENT', 'report_type': '90S'},
-            {'receipts': 85530042.0, 'contribution_refunds': 966240.0},
+            {"report_type_full": "POST INAUGURAL SUPPLEMENT", "report_type": "90S"},
+            {"receipts": 85530042.0, "contribution_refunds": 966240.0},
         )
 
-        committee = views.get_committee('C001', 2018)
+        committee = views.get_committee("C001", 2018)
 
-        assert committee['inaugural_summary'] == [
-            (85530042.0, {'label': 'Total Donations Accepted', 'level': '1'}),
-            (966240.0, {'label': 'Total Donations Refunded', 'level': '1'}),
+        assert committee["inaugural_summary"] == [
+            (85530042.0, {"label": "Total Donations Accepted", "level": "1"}),
+            (966240.0, {"label": "Total Donations Refunded", "level": "1"}),
         ]
 
     def test_host_f4_summary(
@@ -291,156 +296,156 @@ class TestCommittee(TestCase):
         cycle = 2018
 
         test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
-        test_committee['organization_type'] = 'H'
+        test_committee["organization_type"] = "H"
         load_committee_history_mock.return_value = (test_committee, [], cycle)
         load_cycle_data_mock.return_value = (False, 2018, [2018])
         load_reports_and_totals_mock.return_value = (
             {
-                'report_type_full': 'POST INAUGURAL SUPPLEMENT',
-                'report_type': '90S',
-                'form_type': 'F4',
+                "report_type_full": "POST INAUGURAL SUPPLEMENT",
+                "report_type": "90S",
+                "form_type": "F4",
             },
             {
-                'cash_on_hand_beginning_period': 503347.81,
-                'committee_name': 'COMMITTEE FOR CHARLOTTE_CHARLOTTE DNC HOST COMMITTEE',
-                'other_disbursements': 0.0,
-                'last_beginning_image_number': '201610109032226424',
-                'itemized_refunds_relating_convention_exp': 0.0,
-                'committee_designation_full': 'Unauthorized',
-                'refunds_relating_convention_exp': 0.0,
-                'cycle': 2016,
-                'committee_type_full': 'Party - Nonqualified',
-                'individual_contributions': 0.0,
-                'unitemized_other_disb': 0.0,
-                'loans_and_loan_repayments_received': 0.0,
-                'last_report_year': 2016,
-                'itemized_other_disb': 0.0,
-                'coverage_start_date': '2016-07-01T00:00:00+00:00',
-                'itemized_other_income': 0.0,
-                'itemized_convention_exp': 4500.0,
-                'exp_subject_limits': 4500.0,
-                'other_refunds': 0.0,
-                'last_cash_on_hand_end_period': 498847.81,
-                'exp_prior_years_subject_limits': 0.0,
-                'all_loans_received': 0.0,
-                'last_report_type_full': 'OCTOBER QUARTERLY',
-                'loans_made': 0.0,
-                'unitemized_other_income': 0.0,
-                'loans_and_loan_repayments_made': 0.0,
-                'receipts': 12345.0,
-                'committee_id': 'C00493254',
-                'fed_disbursements': 0.0,
-                'committee_designation': 'U',
-                'loan_repayments_received': 0.0,
-                'itemized_other_refunds': 0.0,
-                'unitemized_other_refunds': 0.0,
-                'unitemized_refunds_relating_convention_exp': 0.0,
-                'contributions': 0.0,
-                'transfers_from_affiliated_party': 0.0,
-                'coverage_end_date': '2016-09-30T00:00:00+00:00',
-                'convention_exp': 4500.0,
-                'individual_unitemized_contributions': 0.0,
-                'federal_funds': 12345.0,
-                'transfers_to_affiliated_committee': 0.0,
-                'other_fed_receipts': 0.0,
-                'party_full': 'DEMOCRATIC PARTY',
-                'last_debts_owed_by_committee': 5000,
-                'loan_repayments_made': 0.0,
-                'unitemized_convention_exp': 0.0,
-                'committee_type': 'X',
-                'disbursements': 4500.0,
-                'last_debts_owed_to_committee': 1000,
-                'total_exp_subject_limits': None,
+                "cash_on_hand_beginning_period": 503347.81,
+                "committee_name": "COMMITTEE FOR CHARLOTTE_CHARLOTTE DNC HOST COMMITTEE",
+                "other_disbursements": 0.0,
+                "last_beginning_image_number": "201610109032226424",
+                "itemized_refunds_relating_convention_exp": 0.0,
+                "committee_designation_full": "Unauthorized",
+                "refunds_relating_convention_exp": 0.0,
+                "cycle": 2016,
+                "committee_type_full": "Party - Nonqualified",
+                "individual_contributions": 0.0,
+                "unitemized_other_disb": 0.0,
+                "loans_and_loan_repayments_received": 0.0,
+                "last_report_year": 2016,
+                "itemized_other_disb": 0.0,
+                "coverage_start_date": "2016-07-01T00:00:00+00:00",
+                "itemized_other_income": 0.0,
+                "itemized_convention_exp": 4500.0,
+                "exp_subject_limits": 4500.0,
+                "other_refunds": 0.0,
+                "last_cash_on_hand_end_period": 498847.81,
+                "exp_prior_years_subject_limits": 0.0,
+                "all_loans_received": 0.0,
+                "last_report_type_full": "OCTOBER QUARTERLY",
+                "loans_made": 0.0,
+                "unitemized_other_income": 0.0,
+                "loans_and_loan_repayments_made": 0.0,
+                "receipts": 12345.0,
+                "committee_id": "C00493254",
+                "fed_disbursements": 0.0,
+                "committee_designation": "U",
+                "loan_repayments_received": 0.0,
+                "itemized_other_refunds": 0.0,
+                "unitemized_other_refunds": 0.0,
+                "unitemized_refunds_relating_convention_exp": 0.0,
+                "contributions": 0.0,
+                "transfers_from_affiliated_party": 0.0,
+                "coverage_end_date": "2016-09-30T00:00:00+00:00",
+                "convention_exp": 4500.0,
+                "individual_unitemized_contributions": 0.0,
+                "federal_funds": 12345.0,
+                "transfers_to_affiliated_committee": 0.0,
+                "other_fed_receipts": 0.0,
+                "party_full": "DEMOCRATIC PARTY",
+                "last_debts_owed_by_committee": 5000,
+                "loan_repayments_made": 0.0,
+                "unitemized_convention_exp": 0.0,
+                "committee_type": "X",
+                "disbursements": 4500.0,
+                "last_debts_owed_to_committee": 1000,
+                "total_exp_subject_limits": None,
             },
         )
 
-        template_variables = views.get_committee('C001', 2018)
-        assert template_variables['raising_summary'] == [
+        template_variables = views.get_committee("C001", 2018)
+        assert template_variables["raising_summary"] == [
             (
                 12345.0,
-                {'label': 'Total receipts', 'level': '1', 'term': 'total receipts'},
+                {"label": "Total receipts", "level": "1", "term": "total receipts"},
             ),
-            (12345.0, {'label': 'Federal funds', 'level': '2'}),
+            (12345.0, {"label": "Federal funds", "level": "2"}),
             (
                 0.0,
                 {
-                    'label': 'Total Contributions to Defray Convention Expenses',
-                    'level': '2',
+                    "label": "Total Contributions to Defray Convention Expenses",
+                    "level": "2",
                 },
             ),
             (
                 0.0,
                 {
-                    'label': 'Itemized Contributions to Defray Convention Expenses',
-                    'level': '3',
+                    "label": "Itemized Contributions to Defray Convention Expenses",
+                    "level": "3",
                 },
             ),
             (
                 0.0,
                 {
-                    'label': 'Unitemized Contributions to Defray Convention Expenses',
-                    'level': '3',
+                    "label": "Unitemized Contributions to Defray Convention Expenses",
+                    "level": "3",
                 },
             ),
-            (0.0, {'label': 'Transfers from affiliated committees', 'level': '2'}),
-            (0.0, {'label': 'Loans Received', 'level': '3'}),
-            (0.0, {'label': 'Loan Repayments Received', 'level': '3'}),
+            (0.0, {"label": "Transfers from affiliated committees", "level": "2"}),
+            (0.0, {"label": "Loans Received", "level": "3"}),
+            (0.0, {"label": "Loan Repayments Received", "level": "3"}),
             (
                 0.0,
-                {'label': 'Other Refunds, Rebates, Returns of Deposits', 'level': '2'},
-            ),
-            (
-                0.0,
-                {
-                    'label': ' Itemized Other Refunds, Rebates, Returns of Deposits',
-                    'level': '3',
-                },
+                {"label": "Other Refunds, Rebates, Returns of Deposits", "level": "2"},
             ),
             (
                 0.0,
                 {
-                    'label': 'Unitemized Other Refunds, Rebates, Returns of Deposits',
-                    'level': '3',
+                    "label": " Itemized Other Refunds, Rebates, Returns of Deposits",
+                    "level": "3",
                 },
             ),
-            (0.0, {'label': ' Other Income', 'level': '2'}),
-            (0.0, {'label': 'Itemized Other Income', 'level': '3'}),
-            (0.0, {'label': 'Unitemized Other Income', 'level': '3'}),
+            (
+                0.0,
+                {
+                    "label": "Unitemized Other Refunds, Rebates, Returns of Deposits",
+                    "level": "3",
+                },
+            ),
+            (0.0, {"label": " Other Income", "level": "2"}),
+            (0.0, {"label": "Itemized Other Income", "level": "3"}),
+            (0.0, {"label": "Unitemized Other Income", "level": "3"}),
         ]
 
-        assert template_variables['spending_summary'] == [
+        assert template_variables["spending_summary"] == [
             (
                 4500.0,
                 {
-                    'label': 'Total disbursements',
-                    'level': '1',
-                    'term': 'total disbursements',
+                    "label": "Total disbursements",
+                    "level": "1",
+                    "term": "total disbursements",
                 },
             ),
-            (4500.0, {'label': 'Convention Expenditures', 'level': '2'}),
-            (4500.0, {'label': 'Itemized Convention Expenditures', 'level': '3'}),
-            (0.0, {'label': 'Unitemized Convention Expenditures', 'level': '3'}),
-            (0.0, {'label': 'Transfers to Affiliated Committees', 'level': '2'}),
-            (0.0, {'label': 'Loans and Loan Repayments Made', 'level': '2'}),
-            (0.0, {'label': 'Loans Made', 'level': '3'}),
-            (0.0, {'label': 'Loan Repayments Made', 'level': '3'}),
-            (0.0, {'label': 'Other Disbursements', 'level': '2'}),
-            (0.0, {'label': 'Itemized Other Disbursements', 'level': '3'}),
-            (0.0, {'label': 'Unitemized Other Disbursements', 'level': '3'}),
+            (4500.0, {"label": "Convention Expenditures", "level": "2"}),
+            (4500.0, {"label": "Itemized Convention Expenditures", "level": "3"}),
+            (0.0, {"label": "Unitemized Convention Expenditures", "level": "3"}),
+            (0.0, {"label": "Transfers to Affiliated Committees", "level": "2"}),
+            (0.0, {"label": "Loans and Loan Repayments Made", "level": "2"}),
+            (0.0, {"label": "Loans Made", "level": "3"}),
+            (0.0, {"label": "Loan Repayments Made", "level": "3"}),
+            (0.0, {"label": "Other Disbursements", "level": "2"}),
+            (0.0, {"label": "Itemized Other Disbursements", "level": "3"}),
+            (0.0, {"label": "Unitemized Other Disbursements", "level": "3"}),
         ]
 
-        assert template_variables['cash_summary'] == [
-            (503347.81, {'label': 'Beginning cash on hand', 'level': '2'}),
+        assert template_variables["cash_summary"] == [
+            (503347.81, {"label": "Beginning cash on hand", "level": "2"}),
             (
                 498847.81,
                 {
-                    'label': 'Ending cash on hand',
-                    'term': 'ending cash on hand',
-                    'level': '2',
+                    "label": "Ending cash on hand",
+                    "term": "ending cash on hand",
+                    "level": "2",
                 },
             ),
-            (1000, {'label': 'Debts/loans owed to committee', 'level': '2'}),
-            (5000, {'label': 'Debts/loans owed by committee', 'level': '2'}),
+            (1000, {"label": "Debts/loans owed to committee", "level": "2"}),
+            (5000, {"label": "Debts/loans owed by committee", "level": "2"}),
         ]
 
     def test_host_f3x_summary_returns_standard_values(
@@ -454,7 +459,7 @@ class TestCommittee(TestCase):
         cycle = 2018
 
         test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
-        test_committee['organization_type'] = 'H'
+        test_committee["organization_type"] = "H"
         load_committee_history_mock.return_value = (test_committee, [], cycle)
         load_cycle_data_mock.return_value = (False, 2018, [2018])
         load_reports_and_totals_mock.return_value = (
@@ -462,75 +467,75 @@ class TestCommittee(TestCase):
             self.STOCK_TOTALS,
         )
 
-        template_variables = views.get_committee('C001', 2018)
+        template_variables = views.get_committee("C001", 2018)
         committee = template_variables.get("committee")
 
-        assert committee['name'] == test_committee['name']
-        assert committee['committee_id'] == test_committee['committee_id']
-        assert committee['committee_type_full'] == test_committee['committee_type_full']
-        assert committee['committee_type'] == test_committee['committee_type']
-        assert committee['designation_full'] == test_committee['designation_full']
-        assert committee['street_1'] == test_committee['street_1']
-        assert committee['street_2'] == test_committee['street_2']
-        assert committee['city'] == test_committee['city']
-        assert committee['state'] == test_committee['state']
-        assert committee['zip'] == test_committee['zip']
-        assert committee['treasurer_name'] == test_committee['treasurer_name']
-        assert committee['cycle'] == test_committee['cycle']
-        assert committee['cycles'] == test_committee['cycles']
-        assert committee['party_full'] == test_committee['party_full']
+        assert committee["name"] == test_committee["name"]
+        assert committee["committee_id"] == test_committee["committee_id"]
+        assert committee["committee_type_full"] == test_committee["committee_type_full"]
+        assert committee["committee_type"] == test_committee["committee_type"]
+        assert committee["designation_full"] == test_committee["designation_full"]
+        assert committee["street_1"] == test_committee["street_1"]
+        assert committee["street_2"] == test_committee["street_2"]
+        assert committee["city"] == test_committee["city"]
+        assert committee["state"] == test_committee["state"]
+        assert committee["zip"] == test_committee["zip"]
+        assert committee["treasurer_name"] == test_committee["treasurer_name"]
+        assert committee["cycle"] == test_committee["cycle"]
+        assert committee["cycles"] == test_committee["cycles"]
+        assert committee["party_full"] == test_committee["party_full"]
 
-        assert template_variables['year'] == test_committee['cycle']
-        assert template_variables['parent'] == 'data'
-        assert template_variables['context_vars'] == {
-            'cycle': 2018,
-            'timePeriod': '2017–2018',
-            'name': 'MY JOINT FUNDRAISING COMMITTEE',
-            'cycleOutOfRange': False,
-            'lastCycleHasFinancial': 2018,
+        assert template_variables["year"] == test_committee["cycle"]
+        assert template_variables["parent"] == "data"
+        assert template_variables["context_vars"] == {
+            "cycle": 2018,
+            "timePeriod": "2017–2018",
+            "name": "MY JOINT FUNDRAISING COMMITTEE",
+            "cycleOutOfRange": False,
+            "lastCycleHasFinancial": 2018,
         }
-        assert template_variables['totals'] == []
-        assert template_variables['candidates'] == []
-        assert template_variables['result_type'] == 'committees'
-        assert template_variables['report_type'] == 'pac-party'
-        assert template_variables['reports'] == self.STOCK_REPORTS
+        assert template_variables["totals"] == []
+        assert template_variables["candidates"] == []
+        assert template_variables["result_type"] == "committees"
+        assert template_variables["report_type"] == "pac-party"
+        assert template_variables["reports"] == self.STOCK_REPORTS
 
 
-@mock.patch.object(api_caller, 'load_endpoint_results')
-@mock.patch.object(api_caller, 'load_first_row_data')
+@mock.patch.object(api_caller, "load_endpoint_results")
+@mock.patch.object(api_caller, "load_first_row_data")
 class TestCommitteeApiCalls(TestCase):
     def test_load_committee_history_uses_last_cycle_has_financial(
         self, load_first_row_data_mock, load_endpoint_results_mock
     ):
-        committee_id = 'C007'
+        committee_id = "C007"
         cycle = None
         load_first_row_data_mock.return_value = {
-            'city': 'ELK GROVE',
-            'organization_type_full': None,
-            'committee_id': 'C007',
-            'zip': '95624',
-            'last_cycle_has_financial': 2020,
-            'cycle': 2020,
-            'candidate_ids': ['P60017852'],
-            'state_full': 'California',
-            'cycles_has_financial': [2020],
-            'name': 'CLIFTON ROBERTS FOR PRESIDENT',
-            'last_cycle_has_activity': 2020,
-            'organization_type': None,
-            'committee_type_full': 'Presidential',
-            'party_full': 'OTHER',
-            'designation_full': 'Principal campaign committee',
-            'cycles': [2020],
-            'cycles_has_activity': [2020],
-            'committee_type': 'P',
-            'party': 'OTH',
-            'designation': 'P',
-            'affiliated_committee_name': 'NONE',
-            'street_1': '9382 WILLOW POND CIRCLE',
-            'state': 'CA',
-            'street_2': None,
-            'treasurer_name': 'OWENS, STACY',
-            'filing_frequency': 'Q',
+            "city": "ELK GROVE",
+            "organization_type_full": None,
+            "committee_id": "C007",
+            "zip": "95624",
+            "last_cycle_has_financial": 2020,
+            "cycle": 2020,
+            "candidate_ids": ["P60017852"],
+            "state_full": "California",
+            "cycles_has_financial": [2020],
+            "name": "CLIFTON ROBERTS FOR PRESIDENT",
+            "last_cycle_has_activity": 2020,
+            "organization_type": None,
+            "committee_type_full": "Presidential",
+            "party_full": "OTHER",
+            "designation_full": "Principal campaign committee",
+            "cycles": [2020],
+            "cycles_has_activity": [2020],
+            "committee_type": "P",
+            "party": "OTH",
+            "designation": "P",
+            "affiliated_committee_name": "NONE",
+            "street_1": "9382 WILLOW POND CIRCLE",
+            "state": "CA",
+            "street_2": None,
+            "treasurer_name": "OWENS, STACY",
+            "filing_frequency": "Q",
         }
         load_endpoint_results_mock.return_value = mock.MagicMock()
         committee, all_candidates, cycle = views.load_committee_history(
@@ -542,36 +547,36 @@ class TestCommitteeApiCalls(TestCase):
     def test_load_committee_history_uses_last_cycle_has_activity(
         self, load_first_row_data_mock, load_endpoint_results_mock
     ):
-        committee_id = 'C007'
+        committee_id = "C007"
         cycle = None
         first_row_data = {
-            'city': 'ELK GROVE',
-            'organization_type_full': None,
-            'committee_id': 'C007',
-            'zip': '95624',
-            'last_cycle_has_financial': None,
-            'cycle': None,
-            'candidate_ids': ['P60017852'],
-            'state_full': 'California',
-            'cycles_has_financial': [],
-            'name': 'CLIFTON ROBERTS FOR PRESIDENT',
-            'last_cycle_has_activity': 2018,
-            'organization_type': None,
-            'committee_type_full': 'Presidential',
-            'party_full': 'OTHER',
-            'designation_full': 'Principal campaign committee',
-            'cycles': [],
+            "city": "ELK GROVE",
+            "organization_type_full": None,
+            "committee_id": "C007",
+            "zip": "95624",
+            "last_cycle_has_financial": None,
+            "cycle": None,
+            "candidate_ids": ["P60017852"],
+            "state_full": "California",
+            "cycles_has_financial": [],
+            "name": "CLIFTON ROBERTS FOR PRESIDENT",
+            "last_cycle_has_activity": 2018,
+            "organization_type": None,
+            "committee_type_full": "Presidential",
+            "party_full": "OTHER",
+            "designation_full": "Principal campaign committee",
+            "cycles": [],
             # make sure we clean 'None' value in cycles_has_activity correctly
-            'cycles_has_activity': [2018, None],
-            'committee_type': 'P',
-            'party': 'OTH',
-            'designation': 'P',
-            'affiliated_committee_name': 'NONE',
-            'street_1': '9382 WILLOW POND CIRCLE',
-            'state': 'CA',
-            'street_2': None,
-            'treasurer_name': 'OWENS, STACY',
-            'filing_frequency': 'Q',
+            "cycles_has_activity": [2018, None],
+            "committee_type": "P",
+            "party": "OTH",
+            "designation": "P",
+            "affiliated_committee_name": "NONE",
+            "street_1": "9382 WILLOW POND CIRCLE",
+            "state": "CA",
+            "street_2": None,
+            "treasurer_name": "OWENS, STACY",
+            "filing_frequency": "Q",
         }
         load_first_row_data_mock.return_value = first_row_data
         load_endpoint_results_mock.return_value = []
@@ -586,7 +591,7 @@ class TestCommitteeApiCalls(TestCase):
         # in function load_committee_history() in views.py (line 524)
         # we remove 'None' value in cycles_has_activity
         # so make sure cycles_has_activity not include 'None' value anymore,
-        assert None not in committee['cycles_has_activity']
+        assert None not in committee["cycles_has_activity"]
         cycle_out_of_range, fallback_cycle, cycles = views.load_cycle_data(
             committee, cycle
         )
@@ -598,35 +603,35 @@ class TestCommitteeApiCalls(TestCase):
     def test_cycle_out_of_range(
         self, load_first_row_data_mock, load_endpoint_results_mock
     ):
-        committee_id = 'C007'
+        committee_id = "C007"
         cycle = 2020
         first_row_data = {
-            'city': 'ELK GROVE',
-            'organization_type_full': None,
-            'committee_id': 'C007',
-            'zip': '95624',
-            'last_cycle_has_financial': None,
-            'cycle': 2018,
-            'candidate_ids': ['P60017852'],
-            'state_full': 'California',
-            'cycles_has_financial': [2018],
-            'name': 'CLIFTON ROBERTS FOR PRESIDENT',
-            'last_cycle_has_activity': 2018,
-            'organization_type': None,
-            'committee_type_full': 'Presidential',
-            'party_full': 'OTHER',
-            'designation_full': 'Principal campaign committee',
-            'cycles': [],
-            'cycles_has_activity': [2018],
-            'committee_type': 'P',
-            'party': 'OTH',
-            'designation': 'P',
-            'affiliated_committee_name': 'NONE',
-            'street_1': '9382 WILLOW POND CIRCLE',
-            'state': 'CA',
-            'street_2': None,
-            'treasurer_name': 'OWENS, STACY',
-            'filing_frequency': 'Q',
+            "city": "ELK GROVE",
+            "organization_type_full": None,
+            "committee_id": "C007",
+            "zip": "95624",
+            "last_cycle_has_financial": None,
+            "cycle": 2018,
+            "candidate_ids": ["P60017852"],
+            "state_full": "California",
+            "cycles_has_financial": [2018],
+            "name": "CLIFTON ROBERTS FOR PRESIDENT",
+            "last_cycle_has_activity": 2018,
+            "organization_type": None,
+            "committee_type_full": "Presidential",
+            "party_full": "OTHER",
+            "designation_full": "Principal campaign committee",
+            "cycles": [],
+            "cycles_has_activity": [2018],
+            "committee_type": "P",
+            "party": "OTH",
+            "designation": "P",
+            "affiliated_committee_name": "NONE",
+            "street_1": "9382 WILLOW POND CIRCLE",
+            "state": "CA",
+            "street_2": None,
+            "treasurer_name": "OWENS, STACY",
+            "filing_frequency": "Q",
         }
         load_first_row_data_mock.return_value = first_row_data
         load_endpoint_results_mock.return_value = []

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -249,8 +249,7 @@ def get_candidate(candidate_id, cycle, election_full):
     )
 
     if statement_of_candidacy:
-        for statement in statement_of_candidacy:
-            statement["receipt_date"] = format_receipt_date(statement["receipt_date"])
+        statement_of_candidacy["receipt_date"] = format_receipt_date(statement_of_candidacy["receipt_date"])
 
     # Get all the elections
     elections = sorted(
@@ -469,8 +468,7 @@ def get_committee(committee_id, cycle):
     )
 
     if statement_of_organization:
-        for statement in statement_of_organization:
-            statement["receipt_date"] = format_receipt_date(statement["receipt_date"])
+        statement_of_organization["receipt_date"] = format_receipt_date(statement_of_organization["receipt_date"])
 
     template_variables["statement_of_organization"] = statement_of_organization
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from distutils.util import strtobool
 
 import requests
-import datetime
+from datetime import date, datetime
 import github3
 import json
 import re
@@ -39,10 +39,11 @@ validListUrlParamValues = ['P', 'S', 'H']
 # THE list URL PARAM
 
 
+
 def to_date(committee, cycle):
     if committee['committee_type'] in ['H', 'S', 'P']:
         return None
-    return min(datetime.datetime.now().year, int(cycle))
+    return min(datetime.now().year, int(cycle))
 
 
 def aggregate_totals(request):
@@ -82,10 +83,10 @@ def landing(request):
             'top_candidates_raising': top_candidates_raising['results']
             if top_candidates_raising
             else None,
-            'first_of_year': datetime.date(datetime.date.today().year, 1, 1).strftime(
+            'first_of_year': date(date.today().year, 1, 1).strftime(
                 '%m/%d/%Y'
             ),
-            'last_of_year': datetime.date(datetime.date.today().year, 12, 31).strftime(
+            'last_of_year': date(date.today().year, 12, 31).strftime(
                 '%m/%d/%Y'
             ),
             'social_image_identifier': 'data',
@@ -126,6 +127,15 @@ def browse_data(request):
             'social_image_identifier': 'data',
         }
     )
+
+
+def format_receipt_date(receipt_date):
+    # convert string to python datetime
+    receipt_date = datetime.strptime(
+        receipt_date, '%Y-%m-%dT%H:%M:%S'
+    )
+    # parse for readable output
+    return receipt_date.strftime('%m/%d/%Y')
 
 
 def get_candidate(candidate_id, cycle, election_full):
@@ -240,13 +250,7 @@ def get_candidate(candidate_id, cycle, election_full):
 
     if statement_of_candidacy:
         for statement in statement_of_candidacy:
-            # convert string to python datetime and parse for readable output
-            statement['receipt_date'] = datetime.datetime.strptime(
-                statement['receipt_date'], '%Y-%m-%dT%H:%M:%S'
-            )
-            statement['receipt_date'] = statement['receipt_date'].strftime(
-                '%m/%d/%Y'
-            )
+            statement["receipt_date"] = format_receipt_date(statement["receipt_date"])
 
     # Get all the elections
     elections = sorted(

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -245,7 +245,7 @@ def get_candidate(candidate_id, cycle, election_full):
     # (6)Call /filings?candidate_id=P00003392&form_type=F2
     # Get the statements of candidacy
     statement_of_candidacy = api_caller.load_candidate_statement_of_candidacy(
-        candidate['candidate_id'], cycle=cycle
+        candidate['candidate_id']
     )
 
     if statement_of_candidacy:

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -462,6 +462,18 @@ def get_committee(committee_id, cycle):
         'other': ['F1M', 'F8', 'F99', 'F12'],
     }
 
+    # Call /filings?committee_id=C00693234&form_type=F1&cycle=2020
+    # Get the statements of organization
+    statement_of_organization = api_caller.load_committee_statement_of_organization(
+        committee_id, cycle
+    )
+
+    if statement_of_organization:
+        for statement in statement_of_organization:
+            statement["receipt_date"] = format_receipt_date(statement["receipt_date"])
+
+    template_variables["statement_of_organization"] = statement_of_organization
+
     return template_variables
 
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -462,10 +462,10 @@ def get_committee(committee_id, cycle):
         'other': ['F1M', 'F8', 'F99', 'F12'],
     }
 
-    # Call /filings?committee_id=C00693234&form_type=F1&cycle=2020
+    # Call /filings?committee_id=C00693234&form_type=F1
     # Get the statements of organization
     statement_of_organization = api_caller.load_committee_statement_of_organization(
-        committee_id, cycle
+        committee_id
     )
 
     if statement_of_organization:

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -25,31 +25,32 @@ def groupby(values, keygetter):
     return ret
 
 
-election_durations = {'P': 4, 'S': 6, 'H': 2}
+election_durations = {"P": 4, "S": 6, "H": 2}
 
 report_types = {
-    'P': 'presidential',
-    'S': 'house-senate',
-    'H': 'house-senate',
-    'I': 'ie-only',
+    "P": "presidential",
+    "S": "house-senate",
+    "H": "house-senate",
+    "I": "ie-only",
 }
 
-validListUrlParamValues = ['P', 'S', 'H']
+validListUrlParamValues = ["P", "S", "H"]
 # INITIALLY USED BY raising() AND spending() FOR VALIDATING URL PARAMETERS,
 # THE list URL PARAM
 
 
-
 def to_date(committee, cycle):
-    if committee['committee_type'] in ['H', 'S', 'P']:
+    if committee["committee_type"] in ["H", "S", "P"]:
         return None
     return min(datetime.now().year, int(cycle))
 
 
 def aggregate_totals(request):
-    office = request.GET.get('office', 'P')
+    office = request.GET.get("office", "P")
 
-    election_year = int(request.GET.get('election_year', constants.DEFAULT_ELECTION_YEAR))
+    election_year = int(
+        request.GET.get("election_year", constants.DEFAULT_ELECTION_YEAR)
+    )
 
     max_election_year = utils.current_cycle() + 4
     election_years = utils.get_cycles(max_election_year)
@@ -58,38 +59,34 @@ def aggregate_totals(request):
 
     return render(
         request,
-        'widgets/aggregate-totals.jinja',
+        "widgets/aggregate-totals.jinja",
         {
-            'title': 'Aggregate Totals',
-            'election_years': election_years,
-            'election_year': election_year,
-            'office': office,
-            'FEATURES': FEATURES,
-            'social_image_identifier': 'data',
-        }
+            "title": "Aggregate Totals",
+            "election_years": election_years,
+            "election_year": election_year,
+            "office": office,
+            "FEATURES": FEATURES,
+            "social_image_identifier": "data",
+        },
     )
 
 
 def landing(request):
-    top_candidates_raising = api_caller.load_top_candidates('-receipts', per_page=3)
+    top_candidates_raising = api_caller.load_top_candidates("-receipts", per_page=3)
 
     return render(
         request,
-        'landing.jinja',
+        "landing.jinja",
         {
-            'parent': 'data',
-            'title': 'Campaign finance data',
-            'dates': utils.date_ranges(),
-            'top_candidates_raising': top_candidates_raising['results']
+            "parent": "data",
+            "title": "Campaign finance data",
+            "dates": utils.date_ranges(),
+            "top_candidates_raising": top_candidates_raising["results"]
             if top_candidates_raising
             else None,
-            'first_of_year': date(date.today().year, 1, 1).strftime(
-                '%m/%d/%Y'
-            ),
-            'last_of_year': date(date.today().year, 12, 31).strftime(
-                '%m/%d/%Y'
-            ),
-            'social_image_identifier': 'data',
+            "first_of_year": date(date.today().year, 1, 1).strftime("%m/%d/%Y"),
+            "last_of_year": date(date.today().year, 12, 31).strftime("%m/%d/%Y"),
+            "social_image_identifier": "data",
         },
     )
 
@@ -103,39 +100,33 @@ def search(request):
     If there's no query, then we'll load the main landing page with all the
     necessary data.
     """
-    query = request.GET.get('search', '')
+    query = request.GET.get("search", "")
 
-    if re.match('\d{16}', query) or re.match('\d{11}', query):
-        url = 'http://docquery.fec.gov/cgi-bin/fecimg/?' + query
+    if re.match("\d{16}", query) or re.match("\d{11}", query):
+        url = "http://docquery.fec.gov/cgi-bin/fecimg/?" + query
         return redirect(url)
     else:
         results = api_caller.load_search_results(query)
         return render(
             request,
-            'search-results.jinja',
-            {'query': query, 'title': 'Search results', 'results': results},
+            "search-results.jinja",
+            {"query": query, "title": "Search results", "results": results},
         )
 
 
 def browse_data(request):
     return render(
         request,
-        'browse-data.jinja',
-        {
-            'title': 'Browse data',
-            'parent': 'data',
-            'social_image_identifier': 'data',
-        }
+        "browse-data.jinja",
+        {"title": "Browse data", "parent": "data", "social_image_identifier": "data"},
     )
 
 
 def format_receipt_date(receipt_date):
     # convert string to python datetime
-    receipt_date = datetime.strptime(
-        receipt_date, '%Y-%m-%dT%H:%M:%S'
-    )
+    receipt_date = datetime.strptime(receipt_date, "%Y-%m-%dT%H:%M:%S")
     # parse for readable output
-    return receipt_date.strftime('%m/%d/%Y')
+    return receipt_date.strftime("%m/%d/%Y")
 
 
 def get_candidate(candidate_id, cycle, election_full):
@@ -149,9 +140,9 @@ def get_candidate(candidate_id, cycle, election_full):
 
     # (1)call candidate/{candidate_id}/history/ under tag:candidate
     # get rounded_election_years(candidate_election_year).
-    path = '/candidate/' + candidate_id + '/history/'
+    path = "/candidate/" + candidate_id + "/history/"
     filters = {}
-    filters['per_page'] = 1
+    filters["per_page"] = 1
     candidate = api_caller.load_first_row_data(path, **filters)
 
     # a)Build List: even_election_years for candidate election dropdown list
@@ -162,37 +153,37 @@ def get_candidate(candidate_id, cycle, election_full):
 
     # if cycle = null, set cycle = the last of rounded_election_years.
     if not cycle:
-        cycle = max(candidate.get('rounded_election_years'))
+        cycle = max(candidate.get("rounded_election_years"))
 
     # (2)call candidate/{candidate_id}/history/{cycle} under tag:candidate
     # (3)call candidate/{candidate_id}/committees/history/{cycle}
     # under tag:committee.
     candidate, committees, cycle = api_caller.load_with_nested(
-        'candidate',
+        "candidate",
         candidate_id,
-        'committees',
+        "committees",
         cycle=cycle,
         election_full=election_full,
     )
 
-    result_type = 'candidates'
-    duration = election_durations.get(candidate['office'], 2)
+    result_type = "candidates"
+    duration = election_durations.get(candidate["office"], 2)
     min_cycle = cycle - duration if election_full else cycle
-    report_type = report_types.get(candidate['office'])
+    report_type = report_types.get(candidate["office"])
 
     # For JavaScript
     context_vars = {
-        'cycles': candidate['fec_cycles_in_election'],
-        'name': candidate['name'],
-        'cycle': cycle,
-        'electionFull': election_full,
-        'candidateID': candidate['candidate_id'],
+        "cycles": candidate["fec_cycles_in_election"],
+        "name": candidate["name"],
+        "cycle": cycle,
+        "electionFull": election_full,
+        "candidateID": candidate["candidate_id"],
     }
 
     max_cycle = int(cycle)
     # Check if cycle > latest_fec_cycles_in_election, such as:future candidate.
-    if candidate['fec_cycles_in_election']:
-        latest_fec_cycles_in_election = max(candidate['fec_cycles_in_election'])
+    if candidate["fec_cycles_in_election"]:
+        latest_fec_cycles_in_election = max(candidate["fec_cycles_in_election"])
         if int(cycle) > latest_fec_cycles_in_election:
             max_cycle = latest_fec_cycles_in_election
 
@@ -201,25 +192,21 @@ def get_candidate(candidate_id, cycle, election_full):
         list(range(cycle, cycle - duration, -2)) if election_full else [cycle]
     )
     for committee in committees:
-        committee['related_cycle'] = committee['cycle']
+        committee["related_cycle"] = committee["cycle"]
 
     # Group the committees by designation
-    committee_groups = groupby(committees, lambda each: each['designation'])
-    committees_authorized = committee_groups.get(
-        'P', []
-    ) + committee_groups.get(
-        'A', []
+    committee_groups = groupby(committees, lambda each: each["designation"])
+    committees_authorized = committee_groups.get("P", []) + committee_groups.get(
+        "A", []
     )
 
-    committee_ids = [
-        committee['committee_id']for committee in committees_authorized
-    ]
+    committee_ids = [committee["committee_id"] for committee in committees_authorized]
 
     # (4)call candidate/{candidate_id}/totals/{cycle} under tag:candidate
     # Get aggregate totals for the financial summary
-    filters['election_full'] = election_full
-    filters['cycle'] = cycle
-    path = '/candidate/' + candidate_id + '/totals/'
+    filters["election_full"] = election_full
+    filters["cycle"] = cycle
+    path = "/candidate/" + candidate_id + "/totals/"
     aggregate = api_caller.load_first_row_data(path, **filters)
 
     if election_full:
@@ -227,8 +214,8 @@ def get_candidate(candidate_id, cycle, election_full):
         # candidate/{candidate_id}/totals/{cycle} second time
         # for showing on raising and spending tabs
         # Get most recent 2-year period totals
-        filters['election_full'] = False
-        filters['cycle'] = max_cycle
+        filters["election_full"] = False
+        filters["cycle"] = max_cycle
         two_year_totals = api_caller.load_first_row_data(path, **filters)
     else:
         two_year_totals = aggregate
@@ -245,15 +232,17 @@ def get_candidate(candidate_id, cycle, election_full):
     # (6)Call /filings?candidate_id=P00003392&form_type=F2
     # Get the statements of candidacy
     statement_of_candidacy = api_caller.load_candidate_statement_of_candidacy(
-        candidate['candidate_id']
+        candidate["candidate_id"]
     )
 
     if statement_of_candidacy:
-        statement_of_candidacy["receipt_date"] = format_receipt_date(statement_of_candidacy["receipt_date"])
+        statement_of_candidacy["receipt_date"] = format_receipt_date(
+            statement_of_candidacy["receipt_date"]
+        )
 
     # Get all the elections
     elections = sorted(
-        zip(candidate['election_years'], candidate['election_districts']),
+        zip(candidate["election_years"], candidate["election_districts"]),
         key=lambda pair: pair[0],
         reverse=True,
     )
@@ -261,50 +250,50 @@ def get_candidate(candidate_id, cycle, election_full):
     # (7)call efile/filings/ under tag:efiling
     # Check if there are raw_filings for this candidate
     raw_filing_start_date = utils.three_days_ago()
-    filters['min_receipt_date'] = raw_filing_start_date
-    filters['committee_id'] = candidate['candidate_id']
-    filters['cycle'] = cycle
-    filters['per_page'] = 100
-    path = '/efile/' + '/filings/'
+    filters["min_receipt_date"] = raw_filing_start_date
+    filters["committee_id"] = candidate["candidate_id"]
+    filters["cycle"] = cycle
+    filters["per_page"] = 100
+    path = "/efile/" + "/filings/"
     raw_filings = api_caller.load_endpoint_results(path, **filters)
     has_raw_filings = True if raw_filings else False
     return {
-        'aggregate': aggregate,
-        'aggregate_cycles': aggregate_cycles,
-        'candidate': candidate,
-        'candidate_id': candidate_id,
-        'cash_summary': cash_summary,
-        'committee_groups': committee_groups,
-        'committee_ids': committee_ids,
+        "aggregate": aggregate,
+        "aggregate_cycles": aggregate_cycles,
+        "candidate": candidate,
+        "candidate_id": candidate_id,
+        "cash_summary": cash_summary,
+        "committee_groups": committee_groups,
+        "committee_ids": committee_ids,
         # filings endpoint takes candidate ID value as committee ID arg
-        'committee_id': candidate['candidate_id'],
-        'committees_authorized': committees_authorized,
-        'context_vars': context_vars,
-        'cycle': int(cycle),
-        'cycles': candidate['fec_cycles_in_election'],
-        'district': candidate['district'],
-        'duration': duration,
-        'election_year': cycle,
-        'election_years': candidate.get('rounded_election_years'),
-        'elections': elections,
-        'has_raw_filings': has_raw_filings,
-        'incumbent_challenge_full': candidate['incumbent_challenge_full'],
-        'max_cycle': max_cycle,
-        'min_cycle': min_cycle,
-        'min_receipt_date': raw_filing_start_date,
-        'name': candidate['name'],
-        'office': candidate['office'],
-        'office_full': candidate['office_full'],
-        'party_full': candidate['party_full'],
-        'raising_summary': raising_summary,
-        'report_type': report_type,
-        'result_type': result_type,
-        'show_full_election': election_full,
-        'spending_summary': spending_summary,
-        'state': candidate['state'],
-        'statement_of_candidacy': statement_of_candidacy,
-        'two_year_totals': two_year_totals,
-        'social_image_identifier': 'data',
+        "committee_id": candidate["candidate_id"],
+        "committees_authorized": committees_authorized,
+        "context_vars": context_vars,
+        "cycle": int(cycle),
+        "cycles": candidate["fec_cycles_in_election"],
+        "district": candidate["district"],
+        "duration": duration,
+        "election_year": cycle,
+        "election_years": candidate.get("rounded_election_years"),
+        "elections": elections,
+        "has_raw_filings": has_raw_filings,
+        "incumbent_challenge_full": candidate["incumbent_challenge_full"],
+        "max_cycle": max_cycle,
+        "min_cycle": min_cycle,
+        "min_receipt_date": raw_filing_start_date,
+        "name": candidate["name"],
+        "office": candidate["office"],
+        "office_full": candidate["office_full"],
+        "party_full": candidate["party_full"],
+        "raising_summary": raising_summary,
+        "report_type": report_type,
+        "result_type": result_type,
+        "show_full_election": election_full,
+        "spending_summary": spending_summary,
+        "state": candidate["state"],
+        "statement_of_candidacy": statement_of_candidacy,
+        "two_year_totals": two_year_totals,
+        "social_image_identifier": "data",
     }
 
 
@@ -314,15 +303,15 @@ def candidate(request, candidate_id):
     to get the required information from the API,
     and render the candidate profile page template
     """
-    cycle = request.GET.get('cycle', None)
+    cycle = request.GET.get("cycle", None)
     if cycle is not None:
         cycle = int(cycle)
 
-    election_full = request.GET.get('election_full', True)
+    election_full = request.GET.get("election_full", True)
     election_full = bool(strtobool(str(election_full)))
 
     candidate = get_candidate(candidate_id, cycle, election_full)
-    return render(request, 'candidates-single.jinja', candidate)
+    return render(request, "candidates-single.jinja", candidate)
 
 
 def get_committee(committee_id, cycle):
@@ -338,11 +327,11 @@ def get_committee(committee_id, cycle):
     candidates = [
         candidate
         for candidate in all_candidates
-        if committee['committee_type'] == candidate['office']
+        if committee["committee_type"] == candidate["office"]
     ]
 
-    parent = 'data'
-    result_type = 'committees'
+    parent = "data"
+    result_type = "committees"
     cycle = int(cycle)
     year = to_date(committee, cycle)
 
@@ -351,17 +340,17 @@ def get_committee(committee_id, cycle):
     # See https://github.com/fecgov/openFEC/issues/1536
     for candidate in candidates:
         election_years = []
-        for election_year in candidate['election_years']:
+        for election_year in candidate["election_years"]:
             start_of_election_period = (
-                election_year - election_durations[candidate['office']]
+                election_year - election_durations[candidate["office"]]
             )
             if start_of_election_period < cycle and cycle <= election_year:
                 election_years.append(election_year)
         # For each candidate, set related_cycle to the candidate's time period
         # relative to the selected cycle.
-        candidate['related_cycle'] = cycle if election_years else None
+        candidate["related_cycle"] = cycle if election_years else None
 
-    report_type = report_types.get(committee['committee_type'], 'pac-party')
+    report_type = report_types.get(committee["committee_type"], "pac-party")
 
     cycle_out_of_range, fallback_cycle, cycles = load_cycle_data(committee, cycle)
 
@@ -370,95 +359,95 @@ def get_committee(committee_id, cycle):
     )
 
     # Check organization types to determine SSF status
-    is_ssf = committee.get('organization_type') in ['W', 'C', 'L', 'V', 'M', 'T']
+    is_ssf = committee.get("organization_type") in ["W", "C", "L", "V", "M", "T"]
 
     # if cycles_has_activity's options are more than cycles_has_financial's,
     # when clicking back to financial summary/raising/spending,
     # reset cycle=fallback_cycle and timePeriod and.
     # to make sure missing message page show correct timePeriod.
-    time_period_js = str(int(cycle) - 1) + '–' + str(cycle)
+    time_period_js = str(int(cycle) - 1) + "–" + str(cycle)
     cycle_js = cycle
     if cycle_out_of_range:
         cycle_js = fallback_cycle
-        time_period_js = str(int(cycle_js) - 1) + '–' + str(cycle_js)
+        time_period_js = str(int(cycle_js) - 1) + "–" + str(cycle_js)
 
     context_vars = {
-        'cycle': cycle_js,
-        'timePeriod': time_period_js,
-        'name': committee['name'],
-        'cycleOutOfRange': cycle_out_of_range,
-        'lastCycleHasFinancial': fallback_cycle,
+        "cycle": cycle_js,
+        "timePeriod": time_period_js,
+        "name": committee["name"],
+        "cycleOutOfRange": cycle_out_of_range,
+        "lastCycleHasFinancial": fallback_cycle,
     }
 
     template_variables = {
-        'candidates': candidates,
-        'committee': committee,
-        'committee_id': committee_id,
-        'committee_type': committee['committee_type'],
-        'context_vars': context_vars,
-        'cycle': cycle,
-        'cycles': cycles,
-        'is_SSF': is_ssf,
-        'min_receipt_date': utils.three_days_ago(),
-        'cycle_out_of_range': cycle_out_of_range,
-        'parent': parent,
-        'result_type': result_type,
-        'report_type': report_type,
-        'reports': reports,
-        'totals': totals,
-        'min_receipt_date': utils.three_days_ago(),
-        'context_vars': context_vars,
-        'party_full': committee['party_full'],
-        'candidates': candidates,
-        'social_image_identifier': 'data',
-        'year': year,
-        'timePeriod': time_period_js,
+        "candidates": candidates,
+        "committee": committee,
+        "committee_id": committee_id,
+        "committee_type": committee["committee_type"],
+        "context_vars": context_vars,
+        "cycle": cycle,
+        "cycles": cycles,
+        "is_SSF": is_ssf,
+        "min_receipt_date": utils.three_days_ago(),
+        "cycle_out_of_range": cycle_out_of_range,
+        "parent": parent,
+        "result_type": result_type,
+        "report_type": report_type,
+        "reports": reports,
+        "totals": totals,
+        "min_receipt_date": utils.three_days_ago(),
+        "context_vars": context_vars,
+        "party_full": committee["party_full"],
+        "candidates": candidates,
+        "social_image_identifier": "data",
+        "year": year,
+        "timePeriod": time_period_js,
     }
     # Format the current two-year-period's totals
     if reports and totals:
         # IE-only committees
-        if committee['committee_type'] == 'I':
-            template_variables['ie_summary'] = utils.process_ie_data(totals)
+        if committee["committee_type"] == "I":
+            template_variables["ie_summary"] = utils.process_ie_data(totals)
         # Inaugural Committees
-        elif committee['organization_type'] == 'I':
-            template_variables['inaugural_summary'] = utils.process_inaugural_data(
+        elif committee["organization_type"] == "I":
+            template_variables["inaugural_summary"] = utils.process_inaugural_data(
                 totals
             )
         # Host Committees that file on Form 4
-        elif committee['organization_type'] == 'H' and reports['form_type'] == 'F4':
-            template_variables['raising_summary'] = utils.process_host_raising_data(
+        elif committee["organization_type"] == "H" and reports["form_type"] == "F4":
+            template_variables["raising_summary"] = utils.process_host_raising_data(
                 totals
             )
-            template_variables['spending_summary'] = utils.process_host_spending_data(
+            template_variables["spending_summary"] = utils.process_host_spending_data(
                 totals
             )
-            template_variables['cash_summary'] = utils.process_cash_data(totals)
+            template_variables["cash_summary"] = utils.process_cash_data(totals)
         else:
             # All other committees have three tables
-            template_variables['raising_summary'] = utils.process_raising_data(totals)
-            template_variables['spending_summary'] = utils.process_spending_data(totals)
-            template_variables['cash_summary'] = utils.process_cash_data(totals)
+            template_variables["raising_summary"] = utils.process_raising_data(totals)
+            template_variables["spending_summary"] = utils.process_spending_data(totals)
+            template_variables["cash_summary"] = utils.process_cash_data(totals)
 
     # If in the current cycle, check for raw filings in the last three days
     if cycle == utils.current_cycle():
         # (4)call efile/filings under tag: efiling
-        path = '/efile/filings/'
+        path = "/efile/filings/"
         filters = {}
-        filters['cycle'] = cycle
-        filters['committee_id'] = committee['committee_id']
-        filters['min_receipt_date'] = template_variables['min_receipt_date']
+        filters["cycle"] = cycle
+        filters["committee_id"] = committee["committee_id"]
+        filters["min_receipt_date"] = template_variables["min_receipt_date"]
         raw_filings = api_caller.load_endpoint_results(path, **filters)
 
-        template_variables['has_raw_filings'] = True if raw_filings else False
+        template_variables["has_raw_filings"] = True if raw_filings else False
     else:
-        template_variables['has_raw_filings'] = False
+        template_variables["has_raw_filings"] = False
 
     # Needed for filings tab
-    template_variables['filings_lookup'] = {
-        'reports': ['F3', 'F3X', 'F3P', 'F3L', 'F4', 'F5', 'F7', 'F13'],
-        'notices': ['F5', 'F24', 'F6', 'F9', 'F10', 'F11'],
-        'statements': ['F1'],
-        'other': ['F1M', 'F8', 'F99', 'F12'],
+    template_variables["filings_lookup"] = {
+        "reports": ["F3", "F3X", "F3P", "F3L", "F4", "F5", "F7", "F13"],
+        "notices": ["F5", "F24", "F6", "F9", "F10", "F11"],
+        "statements": ["F1"],
+        "other": ["F1M", "F8", "F99", "F12"],
     }
 
     # Call /filings?committee_id=C00693234&form_type=F1
@@ -468,7 +457,9 @@ def get_committee(committee_id, cycle):
     )
 
     if statement_of_organization:
-        statement_of_organization["receipt_date"] = format_receipt_date(statement_of_organization["receipt_date"])
+        statement_of_organization["receipt_date"] = format_receipt_date(
+            statement_of_organization["receipt_date"]
+        )
 
     template_variables["statement_of_organization"] = statement_of_organization
 
@@ -481,63 +472,63 @@ def committee(request, committee_id):
     from the API, and render the committee profile page template
     """
 
-    cycle = request.GET.get('cycle', None)
+    cycle = request.GET.get("cycle", None)
     committee = get_committee(committee_id, cycle)
-    return render(request, 'committees-single.jinja', committee)
+    return render(request, "committees-single.jinja", committee)
 
 
 def load_reports_and_totals(committee_id, cycle, cycle_out_of_range, fallback_cycle):
 
     filters = {
-        'committee_id': committee_id,
-        'cycle': fallback_cycle if cycle_out_of_range else cycle,
-        'per_page': 1,
-        'sort_hide_null': True,
+        "committee_id": committee_id,
+        "cycle": fallback_cycle if cycle_out_of_range else cycle,
+        "per_page": 1,
+        "sort_hide_null": True,
     }
 
     # (3) call /filings? under tag:filings
     # get reports from filings endpoint filter by form_category=REPORT
-    path = '/filings/'
+    path = "/filings/"
     reports = api_caller.load_first_row_data(
-        path, form_category='REPORT', most_recent=True, **filters
+        path, form_category="REPORT", most_recent=True, **filters
     )
 
     # (4)call committee/{committee_id}/totals? under tag:financial
     # get financial totals
-    path = '/committee/' + committee_id + '/totals/'
+    path = "/committee/" + committee_id + "/totals/"
     totals = api_caller.load_first_row_data(path, **filters)
 
     return reports, totals
 
 
 def load_committee_history(committee_id, cycle=None):
-    filters = {'per_page': 1}
+    filters = {"per_page": 1}
     if not cycle:
         # if no cycle parameter given,
         # (1.1)call committee/{committee_id}/history/ under tag:committee
         # set cycle = fallback_cycle
-        path = '/committee/' + committee_id + '/history/'
+        path = "/committee/" + committee_id + "/history/"
         committee = api_caller.load_first_row_data(path, **filters)
-        cycle = committee.get('last_cycle_has_financial')
+        cycle = committee.get("last_cycle_has_financial")
         if not cycle:
             # when committees only file F1.fallback_cycle = null
             # set cycle = last_cycle_has_activity
-            cycle = committee.get('last_cycle_has_activity')
+            cycle = committee.get("last_cycle_has_activity")
     else:
         # (1.2)call committee/{committee_id}/history/{cycle}/
         # under tag:committee
-        path = '/committee/' + committee_id + '/history/' + str(cycle)
+        path = "/committee/" + committee_id + "/history/" + str(cycle)
         committee = api_caller.load_first_row_data(path, **filters)
 
     # (2)call committee/{committee_id}/candidates/history/{cycle}
     # under: candidate, get all candidates associated with that commitee
-    path = '/committee/' + committee_id + '/candidates/history/' + str(cycle)
-    all_candidates = api_caller.load_endpoint_results(
-        path, election_full=False)
+    path = "/committee/" + committee_id + "/candidates/history/" + str(cycle)
+    all_candidates = api_caller.load_endpoint_results(path, election_full=False)
 
     # clean cycles_has_activity, remove 'None' value in cycles_has_activity
-    committee['cycles_has_activity'] = list(
-        filter(None, committee.get('cycles_has_activity')))
+    committee["cycles_has_activity"] = list(
+        filter(None, committee.get("cycles_has_activity"))
+    )
 
     return committee, all_candidates, cycle
 
@@ -547,13 +538,13 @@ def load_cycle_data(committee, cycle):
     # set cycle = fallback_cycle to call endpoint
     # to get reports and totals
 
-    fallback_cycle = committee.get('last_cycle_has_financial')
+    fallback_cycle = committee.get("last_cycle_has_financial")
     if not fallback_cycle:
         # when committees only file F1, fallback_cycle = null
         # set fallback_cycle = last_cycle_has_activity
-        fallback_cycle = committee.get('last_cycle_has_activity')
+        fallback_cycle = committee.get("last_cycle_has_activity")
 
-    cycles = committee.get('cycles_has_activity')
+    cycles = committee.get("cycles_has_activity")
 
     cycle_out_of_range = cycle not in cycles
 
@@ -567,8 +558,13 @@ def elections_lookup(request):
 
     return render(
         request,
-        'election-lookup.jinja',
-        {'parent': 'data', 'cycles': cycles, 'cycle': cycle, 'social_image_identifier': 'data',},
+        "election-lookup.jinja",
+        {
+            "parent": "data",
+            "cycles": cycles,
+            "cycle": cycle,
+            "social_image_identifier": "data",
+        },
     )
 
 
@@ -578,110 +574,114 @@ def elections(request, office, cycle, state=None, district=None):
     max_cycle = utils.current_cycle() + 4
     cycles = utils.get_cycles(max_cycle)
 
-    if office.lower() == 'president':
+    if office.lower() == "president":
         cycles = [each for each in cycles if each % 4 == 0]
-    elif office.lower() == 'senate':
+    elif office.lower() == "senate":
         cycles = api_caller.get_all_senate_cycles(state)
 
-    if office.lower() not in ['president', 'senate', 'house']:
+    if office.lower() not in ["president", "senate", "house"]:
         raise Http404()
     if (state is not None) and (state and state.upper() not in constants.states):
         raise Http404()
 
     election_duration = election_durations.get(office[0].upper(), 2)
     # Puerto Rico house/resident commissioners have 4-year cycles
-    if state and state.upper() == 'PR':
+    if state and state.upper() == "PR":
         election_duration = 4
 
     # map/redirect legacy tab names to correct anchor
-    tab = request.GET.get('tab', '').replace('/', '')
+    tab = request.GET.get("tab", "").replace("/", "")
     legacy_tabs = {
-        'contributions': '#individual-contributions',
-        'totals': '#candidate-financial-totals',
-        'spending-by-others': '#independent-expenditures',
+        "contributions": "#individual-contributions",
+        "totals": "#candidate-financial-totals",
+        "spending-by-others": "#independent-expenditures",
     }
 
     if tab in legacy_tabs:
-        if office == 'house':
+        if office == "house":
             return redirect(
-                reverse('elections-house', args=(office, state, district, cycle))
+                reverse("elections-house", args=(office, state, district, cycle))
                 + legacy_tabs[tab]
             )
-        elif office == 'senate':
+        elif office == "senate":
             return redirect(
-                reverse('elections-senate', args=(office, state, cycle))
+                reverse("elections-senate", args=(office, state, cycle))
                 + legacy_tabs[tab]
             )
-        elif office == 'president':
+        elif office == "president":
             return redirect(
-                reverse('elections-president', args=(office, cycle)) + legacy_tabs[tab]
+                reverse("elections-president", args=(office, cycle)) + legacy_tabs[tab]
             )
 
     return render(
         request,
-        'elections.jinja',
+        "elections.jinja",
         {
-            'office': office,
-            'office_code': office[0],
-            'parent': 'data',
-            'cycle': cycle,
-            'election_duration': election_duration,
-            'cycles': cycles,
-            'state': state,
-            'state_full': constants.states[state.upper()] if state else None,
-            'district': district,
-            'title': utils.election_title(cycle, office, state, district),
-            'social_image_identifier': 'data',
+            "office": office,
+            "office_code": office[0],
+            "parent": "data",
+            "cycle": cycle,
+            "election_duration": election_duration,
+            "cycles": cycles,
+            "state": state,
+            "state_full": constants.states[state.upper()] if state else None,
+            "district": district,
+            "title": utils.election_title(cycle, office, state, district),
+            "social_image_identifier": "data",
         },
     )
 
 
 def raising(request):
-    office = request.GET.get('office', 'P')
+    office = request.GET.get("office", "P")
 
-    election_year = int(request.GET.get('election_year', constants.DEFAULT_ELECTION_YEAR))
+    election_year = int(
+        request.GET.get("election_year", constants.DEFAULT_ELECTION_YEAR)
+    )
 
     max_election_year = utils.current_cycle() + 4
     election_years = utils.get_cycles(max_election_year)
 
     return render(
         request,
-        'raising-bythenumbers.jinja',
+        "raising-bythenumbers.jinja",
         {
-            'parent': 'data',
-            'title': 'Raising: by the numbers',
-            'election_years': election_years,
-            'election_year': election_year,
-            'office': office,
-            'social_image_identifier': 'data',
+            "parent": "data",
+            "title": "Raising: by the numbers",
+            "election_years": election_years,
+            "election_year": election_year,
+            "office": office,
+            "social_image_identifier": "data",
         },
     )
 
 
 def spending(request):
-    office = request.GET.get('office', 'P')
+    office = request.GET.get("office", "P")
 
-    election_year = int(request.GET.get('election_year', constants.DEFAULT_ELECTION_YEAR))
+    election_year = int(
+        request.GET.get("election_year", constants.DEFAULT_ELECTION_YEAR)
+    )
 
     max_election_year = utils.current_cycle() + 4
     election_years = utils.get_cycles(max_election_year)
 
     return render(
         request,
-        'spending-bythenumbers.jinja',
+        "spending-bythenumbers.jinja",
         {
-            'parent': 'data',
-            'title': 'Spending: by the numbers',
-            'election_years': election_years,
-            'election_year': election_year,
-            'office': office,
-            'social_image_identifier': 'data',
+            "parent": "data",
+            "title": "Spending: by the numbers",
+            "election_years": election_years,
+            "election_year": election_year,
+            "office": office,
+            "social_image_identifier": "data",
         },
     )
 
 
 def feedback(request):
-    if request.method == 'POST':
+    if request.method == "POST":
 
         # json.loads() is expecting a string in JSON format:
         # '{"param":"value"}'. Needs to be decoded in Python 3
@@ -689,43 +689,46 @@ def feedback(request):
 
         if not any(
             [
-                data['action'],
-                data['feedback'],
-                data['about'],
-                data['g-recaptcha-response'],
+                data["action"],
+                data["feedback"],
+                data["about"],
+                data["g-recaptcha-response"],
             ]
         ):
-            return JsonResponse({'status': False}, status=500)
+            return JsonResponse({"status": False}, status=500)
         else:
             # verify recaptcha
             verifyRecaptcha = requests.post(
                 "https://www.google.com/recaptcha/api/siteverify",
                 data={
-                    'secret': settings.FEC_RECAPTCHA_SECRET_KEY,
-                    'response': data['g-recaptcha-response'],
+                    "secret": settings.FEC_RECAPTCHA_SECRET_KEY,
+                    "response": data["g-recaptcha-response"],
                 },
             )
             recaptchaResponse = verifyRecaptcha.json()
-            if not recaptchaResponse['success']:
+            if not recaptchaResponse["success"]:
                 # if captcha failed, return failure
-                return JsonResponse({'status': False}, status=500)
+                return JsonResponse({"status": False}, status=500)
             else:
                 # captcha passed, we're ready to submit the issue.
-                title = 'User feedback on ' + request.META.get('HTTP_REFERER')
-                body = ("## What were you trying to do and how can we improve it?\n %s \n\n"
-                        "## General feedback?\n %s \n\n"
-                        "## Tell us about yourself\n %s \n\n"
-                        "## Details\n"
-                        "* URL: %s \n"
-                        "* User Agent: %s") % (
-                            data['action'],
-                            data['feedback'],
-                            data['about'],
-                            request.META.get('HTTP_REFERER'),
-                            request.META['HTTP_USER_AGENT'])
+                title = "User feedback on " + request.META.get("HTTP_REFERER")
+                body = (
+                    "## What were you trying to do and how can we improve it?\n %s \n\n"
+                    "## General feedback?\n %s \n\n"
+                    "## Tell us about yourself\n %s \n\n"
+                    "## Details\n"
+                    "* URL: %s \n"
+                    "* User Agent: %s"
+                ) % (
+                    data["action"],
+                    data["feedback"],
+                    data["about"],
+                    request.META.get("HTTP_REFERER"),
+                    request.META["HTTP_USER_AGENT"],
+                )
 
                 client = github3.login(token=settings.FEC_GITHUB_TOKEN)
-                issue = client.repository('fecgov', 'fec').create_issue(
+                issue = client.repository("fecgov", "fec").create_issue(
                     title, body=body
                 )
 
@@ -735,7 +738,7 @@ def feedback(request):
 
 
 def reactionFeedback(request):
-    if request.method == 'POST':
+    if request.method == "POST":
 
         # json.loads() is expecting a string in JSON format:
         # '{"param":"value"}'. Needs to be decoded in Python 3
@@ -743,26 +746,31 @@ def reactionFeedback(request):
 
         if not all(
             [
-                data['name'],
-                data['location'],
-                data['reaction'],
-                data['g-recaptcha-response'],
-                data['userAgent'],
+                data["name"],
+                data["location"],
+                data["reaction"],
+                data["g-recaptcha-response"],
+                data["userAgent"],
             ]
         ):
             # the required fields were not provided, return error.
-            return JsonResponse({'status': False}, status=500)
+            return JsonResponse({"status": False}, status=500)
         else:
             # verify recaptcha
             verifyRecaptcha = requests.post(
-                "https://www.google.com/recaptcha/api/siteverify", data={'secret': settings.FEC_RECAPTCHA_SECRET_KEY, 'response': data['g-recaptcha-response']})
+                "https://www.google.com/recaptcha/api/siteverify",
+                data={
+                    "secret": settings.FEC_RECAPTCHA_SECRET_KEY,
+                    "response": data["g-recaptcha-response"],
+                },
+            )
             recaptchaResponse = verifyRecaptcha.json()
-            if not recaptchaResponse['success']:
+            if not recaptchaResponse["success"]:
                 # if captcha failed, return failure
-                return JsonResponse({'status': False}, status=500)
+                return JsonResponse({"status": False}, status=500)
             else:
                 # captcha passed, we're ready to submit the issue.
-                title = 'User feedback on ' + request.META.get('HTTP_REFERER')
+                title = "User feedback on " + request.META.get("HTTP_REFERER")
                 body = (
                     "## What were you trying to do and how can we improve it?\n %s \n\n"
                     "## General feedback?\n %s \n\n"
@@ -771,15 +779,20 @@ def reactionFeedback(request):
                     "* URL: %s \n"
                     "* User Agent: %s"
                 ) % (
-                    "\nChart Name: " + data['name'] + "\nChart Location: " + data['location'],
-                    data['feedback'],
-                    "\nThe reaction to the chart is: " + data['reaction'],
-                    request.META.get('HTTP_REFERER'),
-                    data['userAgent'],
+                    "\nChart Name: "
+                    + data["name"]
+                    + "\nChart Location: "
+                    + data["location"],
+                    data["feedback"],
+                    "\nThe reaction to the chart is: " + data["reaction"],
+                    request.META.get("HTTP_REFERER"),
+                    data["userAgent"],
                 )
 
                 client = github3.login(token=settings.FEC_GITHUB_TOKEN)
-                issue = client.repository('fecgov', 'fec').create_issue(title, body=body)
+                issue = client.repository("fecgov", "fec").create_issue(
+                    title, body=body
+                )
 
                 return JsonResponse(issue.to_json(), status=201)
     else:


### PR DESCRIPTION
## Summary (required)

- Resolves #2964

Add most recent Form 1 to committee profile page "About this Committee" tab, add test coverage, move "most recent" logic out of template

Note: Candidate profile page shows most recent regardless of cycle, so for now that's what we're doing with committee profile pages. 

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee profile page "About this Committee" tab, Candidate profile "About this candidate" tab

## Screenshots

## Before
![Screen Shot 2019-10-17 at 9.57.00 AM.png](https://images.zenhubusercontent.com/59a579f28f62dc7798c47359/a5077d95-c6f1-4f11-a314-784d8fe69b7e)

## After
![Screen Shot 2019-10-25 at 10.59.26 AM.png](https://images.zenhubusercontent.com/59a579f28f62dc7798c47359/eb947db1-e856-4e95-bea2-3a40b96e254f)

## How to test
-  run this branch, check out http://localhost:8000/data/committee/C00693234/?tab=about-committee&cycle=2020
- this **won't show up** for non-committee filers, example: http://localhost:8000/data/committee/C90010661/?tab=about-committee
- Candidate page: http://localhost:8000/data/candidate/H8CA05035/?tab=about-candidate&cycle=2018
