### PR TITLE
Switch to better-supported typeahead package

### DIFF
--- a/fec/fec/static/js/modules/typeahead.js
+++ b/fec/fec/static/js/modules/typeahead.js
@@ -13,8 +13,8 @@ var helpers = require('./helpers');
 // Hack: Append jQuery to `window` for use by typeahead.js
 window.$ = window.jQuery = $;
 
-require('typeahead.js/dist/typeahead.jquery');
-var Bloodhound = require('typeahead.js/dist/bloodhound');
+require('corejs-typeahead/dist/typeahead.jquery');
+var Bloodhound = require('corejs-typeahead/dist/bloodhound');
 
 var events = require('./events');
 
@@ -241,7 +241,7 @@ var datasets = {
 };
 
 var typeaheadOpts = {
-  minLength: 3,
+  minLength: 3, // minimum characters before a search will happen
   highlight: true,
   hint: false
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3322,6 +3322,14 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "corejs-typeahead": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/corejs-typeahead/-/corejs-typeahead-1.2.1.tgz",
+      "integrity": "sha1-NFqK/mZMxJQHW1m2R3eAfws/Eys=",
+      "requires": {
+        "jquery": ">=1.11"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -7598,12 +7606,6 @@
       "requires": {
         "source-map": "~0.5.3"
       }
-    },
-    "inputmask": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-4.0.8.tgz",
-      "integrity": "sha512-y7TbHasd4tGgOxk1PBF6zZLBzfKt3a5qySF3KuKVNaeuptDpp52jhYOmw1tBJwRxrpJ4s+BOFmWKYsQqjp+r/w==",
-      "dev": true
     },
     "inquirer": {
       "version": "6.5.2",
@@ -13702,14 +13704,6 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
-      }
-    },
-    "typeahead.js": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.11.1.tgz",
-      "integrity": "sha1-TmTmcbIjEKhgb0rsgFkkuoSwFbg=",
-      "requires": {
-        "jquery": ">=1.7"
       }
     },
     "typedarray": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "colorbrewer": "0.0.2",
     "component-sticky": "1.0.0",
     "concat-stream": "^1.6.2",
+    "corejs-typeahead": "^1.2.1",
     "css.escape": "^1.5.1",
     "d3": "3.5.5",
     "datatables.net": "1.10.10",
@@ -59,13 +60,12 @@
     "topojson": "^3.0.2",
     "tough-cookie": "^2.5.0",
     "tunnel-agent": "^0.6.0",
-    "typeahead.js": "0.11.1",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
-    "array-from-polyfill": "^1.0.1",
     "abortcontroller-polyfill": "^1.3.0",
+    "array-from-polyfill": "^1.0.1",
     "babel-eslint": "^7.1.1",
     "babel-jest": "^24.1.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
## Summary

- Resolves #3267 

Using the typeaheads across the site, when there are five results returned (which is the limit for how many results to display), the typeahead displays _no_ results.


## Impacted areas of the application
We changed the typeahead package to one that's had at least one commit during the last four years. ([Twitter typeahead](https://github.com/twitter/typeahead.js) hasn't been updated since 27 April 2015; [corejavascript typeahead](https://github.com/corejavascript/typeahead.js) was updated 25 Sept 2017 ("corejavascript" is the just a developer, not actually _core_ JavaScript.))

We changed the code that powers every typeahead across the site–main site search, WCCF typeahead, all text filters that offer suggestions as users type.


## Screenshots

![image](https://user-images.githubusercontent.com/26720877/67594948-7d5ab480-f733-11e9-92eb-64ca113219eb.png)


## Related PRs
None

## How to test
- Pull, `npm i`, `npm run build`, `./manage.py runserver` like usual
- Use the various typeaheads across the site, using tests that return different numbers of results, especially the limit of results to display (i.e., if the pull-down shows five results, we need to test when more than five, less than five, _and exactly five_ results are returned)
- If you're the last approval, remove "Please review" label, merge and delete the branch

Some known searches:

| Search Term | Results Returned | Previous Results Displayed (limited to 5) |
| --- | --- | --- |
| `hillar` | 7 | 5 |
| `hillary` | 5 | 0 |
| `hillary r` | 2 | 2 |
| `oba` | 7 | 5 |
| `obam` to `obama, barack `| 5 | 0 |
| `obama, barack h` | 1 | 1 |
| `obama, barack / ` | 5 | 0 |
| `obama, barack / j` | 1 | 1 |
| `dol` | 20 | 5 |
| `dole` | 5 | 0 |
| `william je` | 15 | 5 |
| `william jef` | 5 | 0 |
| `william jeff` | 5 | 0 |
| `william jeffe` | 3 | 2 for some reason |
| `kerry, ` ( 👈 space) | 20 | 5 |
| `kerry, j` | 5 | 0 |
| `kerry, jo` | 1 | 1 |

____

