### PR TITLE
Reaction box for WCCF, simplify reaction box implementation

### DIFF
--- a/fec/data/templates/partials/browse-data/raising.jinja
+++ b/fec/data/templates/partials/browse-data/raising.jinja
@@ -1,5 +1,4 @@
 {% import 'macros/chart-committee-overviews.jinja' as chart %}
-{% import 'macros/reaction-box.jinja' as reaction %}
 
 <section class="row" id="raising" aria-hidden="false" role="tabpanel">
   <h2>Raising</h2>

--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -1,5 +1,4 @@
 {% import 'macros/chart-committee-overviews.jinja' as chart %}
-{% import 'macros/reaction-box.jinja' as reaction %}
 
 <section class="row" id="spending" aria-hidden="true" role="tabpanel" >
   <h2>Spending</h2>

--- a/fec/data/templates/raising-bythenumbers.jinja
+++ b/fec/data/templates/raising-bythenumbers.jinja
@@ -1,5 +1,6 @@
 {% extends "layouts/sidebar-page.jinja" %}
 {% import "macros/bythenumbers.jinja" as breakdowns %}
+{% import 'macros/reaction-box.jinja' as reaction %}
 
 {% block css %}
 <link rel="stylesheet" type="text/css" href="{{ asset_for_css('data-landing.css') }}" />
@@ -50,6 +51,9 @@
 {# <script defer id="gov_fec_contribs_by_state_script" src="{{ asset_for_js('widgets/contributions-by-state.js') }}"></script> #}
 {# <iframe src="/widgets/contributions-by-state" id="fec-gov-contribs-by-state"></iframe> #}
 {% include 'partials/widgets/contributions-by-state.jinja' %}
+{% if FEATURES.wccf_reaction %}
+{{ reaction.reaction_box('contributions_by_state', 'raising-by-the-numbers') }}
+{% endif %}
 </section>
 {% endif %}
 {% endblock %}
@@ -82,4 +86,5 @@
   }
   </script>
   <script src="{{ asset_for_js('bythenumbers.js') }}"></script>
+  <script src="{{ asset_for_js('reaction-box.js') }}"></script>
 {% endblock %}

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -52,6 +52,7 @@ FEATURES = {
     'barcharts': bool(env.get_credential('FEC_FEATURE_HOME_BARCHARTS', '')),
     'use_tag_manager': bool(env.get_credential('FEC_FEATURE_USE_TAG_MANAGER', '')),
     'contributionsbystate': bool(env.get_credential('FEC_FEATURE_CONTRIBUTIONS_BY_STATE', '')),
+    'wccf_reaction': bool(env.get_credential('FEC_FEATURE_WCCF_REACTION', '')),
 }
 
 ENVIRONMENTS = {

--- a/fec/fec/static/js/pages/data-browse-data.js
+++ b/fec/fec/static/js/pages/data-browse-data.js
@@ -4,7 +4,6 @@ var $ = require('jquery');
 
 var LineChartCommittees = require('../modules/line-chart-committees')
   .LineChartCommittees;
-var ReactionBox = require('../modules/reaction-box').ReactionBox;
 var tabs = require('../vendor/tablist');
 
 function PlotChart(selector, type, index) {
@@ -29,28 +28,12 @@ PlotChart.prototype.init = function() {
   this.initialized = true;
 };
 
-window.reactionBoxes = {};
-
-window.submitReactionspent = function(token) {
-  window.reactionBoxes['spent'].handleSubmit(token);
-};
-
-window.submitReactionraised = function(token) {
-  window.reactionBoxes['raised'].handleSubmit(token);
-};
-
 $(document).ready(function() {
   tabs.onShow($('#raising'), function() {
     new PlotChart('.js-raised-overview', 'raised', 1).init();
-    window.reactionBoxes['raised'] = new ReactionBox(
-      '[data-name="raised"][data-location="browse-data"]'
-    );
   });
 
   tabs.onShow($('#spending'), function() {
     new PlotChart('.js-spent-overview', 'spent', 2).init();
-    window.reactionBoxes['spent'] = new ReactionBox(
-      '[data-name="spent"][data-location="browse-data"]'
-    );
   });
 });

--- a/fec/fec/static/js/pages/reaction-box.js
+++ b/fec/fec/static/js/pages/reaction-box.js
@@ -1,16 +1,14 @@
 'use strict';
 
-// THIS MODULE IS CURRENTLY NOT IN USE.
-//
-// This requires modifications to `/data/views.py` feedback view
-// to post as a Github issue.
-//
-// Previously implemented here (needs a port to this Django project):
-// https://github.com/18F/openFEC-web-app/blob/develop/openfecwebapp/views.py#L302
+// // This required modifications to `/data/views.py`
+// // to post as a Github issue.
+// //
+// // Previously implemented here (ported to this Django project):
+// // https://github.com/18F/openFEC-web-app/blob/develop/openfecwebapp/views.py#L302
 
 var $ = require('jquery');
-var helpers = require('./helpers');
-var analytics = require('./analytics'); // TODO - move this to Tag Manager?
+var helpers = require('../modules/helpers');
+var analytics = require('../modules/analytics'); // TODO - move this to Tag Manager?
 
 function ReactionBox(selector) {
   this.$element = $(selector);
@@ -111,4 +109,34 @@ ReactionBox.prototype.handleReset = function() {
   this.$textarea.val('');
 };
 
-module.exports = { ReactionBox: ReactionBox };
+/* To implement a reaction box:
+- Add a reaction-box jinja macro to a template
+- Include a reference to this JS file in the parent template(preferably in extra JS block)
+(The below function will use the name/location values of any
+reaction box on the page to initiate it as a new ReactionBox())
+*/
+
+$(document).ready(function() {
+  //find any reaction box(es) on the page
+  var reactionBoxes = document.querySelectorAll('.reaction-box');
+  var names = [];
+  //iterate over the reaction box(es)
+  for (const box of reactionBoxes) {
+    var name = box.getAttribute('data-name');
+    var location = box.getAttribute('data-location');
+    //push name to names array
+    names.push(name);
+    //inititailize new ReactionBox
+    window[name] = new ReactionBox(
+      `[data-name="${name}"][data-location="${location}"]`
+    );
+  }
+  //use names array to define the submitReaction*() for each
+  names.forEach(function(nm) {
+    window['submitReaction' + nm] = function(token) {
+      window[nm].handleSubmit(token);
+    };
+  });
+});
+
+new ReactionBox();

--- a/fec/fec/static/js/pages/reaction-box.js
+++ b/fec/fec/static/js/pages/reaction-box.js
@@ -140,7 +140,7 @@ $(document).ready(function() {
   var reactionBoxes = document.querySelectorAll('.reaction-box');
   var names = [];
   //iterate over the reaction box(es)
-  for (const box of reactionBoxes) {
+  for (var box of reactionBoxes) {
     var name = box.getAttribute('data-name');
     var location = box.getAttribute('data-location');
     //push name to names array

--- a/fec/fec/static/js/pages/reaction-box.js
+++ b/fec/fec/static/js/pages/reaction-box.js
@@ -1,11 +1,10 @@
 'use strict';
 
-// // This required modifications to `/data/views.py`
-// // to post as a Github issue.
-// //
-// // Previously implemented here (ported to this Django project):
-// // https://github.com/18F/openFEC-web-app/blob/develop/openfecwebapp/views.py#L302
-
+/**
+ * This calls `reactionFeedback(request)` in `/data/views.py `to post as a Github issue.
+ * Previously implemented here (ported to this Django project):
+ * https://github.com/18F/openFEC-web-app/blob/develop/openfecwebapp/views.py#L302
+ */
 var $ = require('jquery');
 var helpers = require('../modules/helpers');
 var analytics = require('../modules/analytics'); // TODO - move this to Tag Manager?
@@ -28,6 +27,12 @@ function ReactionBox(selector) {
   this.$element.on('click', '.js-reaction', this.submitReaction.bind(this));
   this.$element.on('click', '.js-reset', this.handleReset.bind(this));
 }
+/**
+ * Submits step1 of the reaction form with the button chosen.
+ * @param {e} event
+ * captures value of button clicked as `reaction`
+ * passes `location` and `name` along
+ */
 
 ReactionBox.prototype.submitReaction = function(e) {
   this.reaction = $(e.target).data('reaction');
@@ -43,6 +48,9 @@ ReactionBox.prototype.submitReaction = function(e) {
   this.showTextarea();
 };
 
+/**
+ * Show step2 of reaction form, the textarea.
+ */
 ReactionBox.prototype.showTextarea = function() {
   this.$step1.attr('aria-hidden', true);
   this.$step2.attr('aria-hidden', false);
@@ -57,6 +65,13 @@ ReactionBox.prototype.showTextarea = function() {
   this.$step2.find('label').text(labelMap[this.reaction]);
 };
 
+/**
+ * Submits step2 of the reaction form with the recaptcha token.
+ * @param {token} csrf token
+ * passes `feedback` :textarea.val
+ * passes `reaction` : from step1
+ * captures `path` : window.location.pathname || null
+ */
 ReactionBox.prototype.handleSubmit = function(token) {
   $.ajaxSetup({
     beforeSend: function(xhr, settings) {
@@ -109,13 +124,17 @@ ReactionBox.prototype.handleReset = function() {
   this.$textarea.val('');
 };
 
-/* To implement a reaction box:
-- Add a reaction-box jinja macro to a template
-- Include a reference to this JS file in the parent template(preferably in extra JS block)
-(The below function will use the name/location values of any
-reaction box on the page to initiate it as a new ReactionBox())
-*/
+/**
+ * To implement a reaction box:
+ * Add a reaction-box jinja macro to a template
+ * Include a reference to this JS file in the parent template(preferably in extra JS block)
+ * (The below function will use the name/location values of any
+ *  reaction box on the page to initiate it as a new ReactionBox())
+ */
 
+/**
+ * Document ready function called when document is loaded
+ */
 $(document).ready(function() {
   //find any reaction box(es) on the page
   var reactionBoxes = document.querySelectorAll('.reaction-box');

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/the-branch-name'),
+    #('feature', lambda _, branch: branch == 'feature/the-branch-name'),
 )
 
 


### PR DESCRIPTION
## Summary
- Resolves #3237 

- Implement the reaction box  under WCCF widget on data/raising-by-the-numbers
- Simplify the process for adding/ removing reaction boxes which now only requires including the macro and a reference to `reaction-box.js` in a template.
- Add comments with instructions in `reaction-box.js`
- Remove residual code leftover from since-removed reaction boxes
- Put WCCF-reaction-box under feature flag (the flag is nested in the WCCF flag, so they do not have to be turned on/off separately. 

- [ ] Add `FEC_FEATURE_WCCF_REACTION` env var to all environments using CF Update-User-Provided-Service (UUPS)  **Note:** The env var has been set on feature-space only for testing
- [ ] Should we consider implementing a simple `templatetag` for reaction boxes in templates other than Jinja templates (html Django templates). With this PR, a reaction box could be added to non Jinja tempates by simply hardcoding the macro's html into a template and replacing its `{{ }}` tags with hardcoded values . But a Django templatetag would be more convenient for developers and a more permanent solution.

## Impacted areas of the application
Contributions by State widget (WCCF) on `data/raising-bythenumbers/`

	modified:   data/templates/browse-data.jinja
	modified:   data/templates/landing.jinja
	modified:   data/templates/partials/browse-data/raising.jinja
	modified:   data/templates/partials/browse-data/spending.jinja
	deleted:    fec/static/js/modules/reaction-box.js
	modified:   fec/static/js/pages/bythenumbers.js
	modified:   fec/static/js/pages/data-browse-data.js
	modified:   fec/static/js/pages/reaction-box.js

## How to test
  - checkout branch `feature/3237-reaction-box-to-wccf`
 -  `npm run build`
 -  `export FEC_FEATURE_WCCF_REACTION=1`
 -  `export FEC_FEATURE_CONTRIBUTIONS_BY_STATE=1`
 -  `./manage.py runserver`
-  Go to http://localhost:8000/data/raising-bythenumbers/ and try to submit a reaction
   - You must use `localhost:8000`, because the recaptcha does not work on `127.0.0.1:8000`
   - Submissions will return a 500 error locally and you will get the, "Oops, something went wrong..." message", but this means the form is actually working
- You can test submitting a real test reaction on feature space at:
 https://fec-feature-cms.app.cloud.gov/data/raising-bythenumbers/ . 
  - See https://github.com/fecgov/fec/issues to confirm submission and close the test issue

In addition to implementing the reaction-box for WCCF, this PR also simplifies the process for adding reaction-boxes to Jinja templates. 
- You can test this by:
  - Adding one or more reaction-box macros to a template
  - Including `reaction-box.js` in the template (preferably in an the extra js block at the bottom)

One last important test is to confirm that, with this new technique,  two (or more) reaction boxes on one page, work properly. This can be tested  at:
 - https://fec-feature-cms.app.cloud.gov/data/browse-data/?tab=raising
 - https://fec-feature-cms.app.cloud.gov/data/browse-data/?tab=raising
