### PR TITLE
Feature/3304 WCCF coverage dates fix

### DIFF
--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -452,7 +452,7 @@ ContributionsByState.prototype.loadCandidateCoverageDates = function() {
             data.results[0].coverage_start_date.substring(0, 19)
           );
           let coverage_end_date = new Date(
-            data.results[0].coverage_end_date.substring(0, 19)
+            data.results[0].transaction_coverage_date.substring(0, 19)
           );
 
           // Remember the in-page elements

--- a/package-lock.json
+++ b/package-lock.json
@@ -7599,12 +7599,6 @@
         "source-map": "~0.5.3"
       }
     },
-    "inputmask": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-4.0.8.tgz",
-      "integrity": "sha512-y7TbHasd4tGgOxk1PBF6zZLBzfKt3a5qySF3KuKVNaeuptDpp52jhYOmw1tBJwRxrpJ4s+BOFmWKYsQqjp+r/w==",
-      "dev": true
-    },
     "inquirer": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",


### PR DESCRIPTION
## Summary

- Resolves #3304 

Changing which date we're using to populate the coverage date stamp.

## Impacted areas of the application

Only changed which date var we're using for the date stamp.

Also updated package-lock because it's been an ongoing issue, trying to remove that diff.

## Screenshots
A quick way to check it right now:
![image](https://user-images.githubusercontent.com/26720877/67776759-29074b80-fa37-11e9-9897-6216df11d3e5.png)

(Prod shows 30 Sept 2019)


## Related PRs
None

## How to test
- Pull, `npm i`, `npm run build`, `./manage.py runserver`
- Check [Raising by the Numbers](http://127.0.0.1:8000/data/raising-bythenumbers/)
- A quick way to check is the screenshot above (@PaulClark2 may have other examples to check)
- If you're the last approval, remove "Please review", merge, delete
____

