### PR TITLE
[MERGE WITH GITFLOW] Update Vice chair title on homepage, make it so this is auto-updates in the future

### DIFF
--- a/fec/home/templates/blocks/commissioners.html
+++ b/fec/home/templates/blocks/commissioners.html
@@ -3,5 +3,5 @@
 
 <div class="content__section--extra">
   <h3>Current</h3>
-  {% current_commissioners %}
+  {% current_commissioners '2' %}
 </div>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -1,10 +1,8 @@
 {% extends "home_base.html" %}
 {% load wagtailcore_tags %}
 {% load staticfiles %}
-{% load top_entities %}
-{% load elections_lookup %}
-{% load home_page %}
 {% load filters %}
+{% load top_entities elections_lookup home_page commissioners %}
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
 
 {% block content %}
@@ -86,68 +84,7 @@
   <section class="slab">
     <div class="container">
       <h1>Commissioners</h1>
-      <div class="content__section content__section--narrow u-padding--top">
-        <p>Established in 1975, the FEC is composed of six Commissioners who are appointed by the President and confirmed by the Senate. By law, no more than three can represent the same political party.</p>
-        <a class="t-sans" href="/about/mission-and-history">Learn more about the FEC's history and mission »</a>
-      </div>
-
-      <div class="grid grid--3-wide grid--no-border">
-        <div class="grid__item">
-          <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static 'img/headshot--weintraub.jpg' %}" alt="Headshot of Ellen L. Weintraub">
-            <div class="icon-heading__content">
-              <div class="t-lead"><a href="/about/leadership-and-structure/ellen-l-weintraub">Ellen L. Weintraub</a></div>
-              <div class="t-note">Chair</div>
-              <div class="t-sans">Democrat</div>
-            </div>
-          </div>
-        </div>
-        <div class="grid__item">
-          <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static 'img/headshot--hunter.jpg' %}" alt="Headshot of Caroline C. Hunter">
-            <div class="icon-heading__content">
-              <div class="t-lead"><a href="/about/leadership-and-structure/caroline-c-hunter">Caroline C. Hunter</a></div>
-              <div class="t-sans">Republican</div>
-            </div>
-          </div>
-        </div>
-        <div class="grid__item">
-          <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static 'img/headshot--walther.jpg' %}" alt="Headshot of Steven T. Walther">
-            <div class="icon-heading__content">
-              <div class="t-lead"><a href="/about/leadership-and-structure/steven-t-walther">Steven T. Walther</a></div>
-              <div class="t-sans">Independent</div>
-            </div>
-          </div>
-        </div>
-        <div class="grid__item">
-          <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static 'img/headshot--no-photo.jpg' %}" alt="Vacant Position">
-            <div class="icon-heading__content">
-              <div class="t-lead">Vacant seat</div>
-              <div class="t-sans"></div>
-            </div>
-          </div>
-        </div>
-        <div class="grid__item">
-          <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static 'img/headshot--no-photo.jpg' %}" alt="Vacant Position">
-            <div class="icon-heading__content">
-              <div class="t-lead">Vacant seat</div>
-              <div class="t-sans"></div>
-            </div>
-          </div>
-        </div>
-        <div class="grid__item">
-          <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static 'img/headshot--no-photo.jpg' %}" alt="Vacant Position">
-            <div class="icon-heading__content">
-              <div class="t-lead">Vacant seat</div>
-              <div class="t-sans"></div>
-            </div>
-          </div>
-        </div>
-      </div>
+      {% current_commissioners '3' %}
     </div>
   </section>
 {% endblock %}

--- a/fec/home/templates/partials/current-commissioners.html
+++ b/fec/home/templates/partials/current-commissioners.html
@@ -1,10 +1,10 @@
 {% load wagtailimages_tags %}
 {% load staticfiles %}
 {% comment %}
-  This partial is used by the commissioners inclusion tag in commissioners.py
+  This partial is used by the inclusion tag in commissioners.py - current_commissioners(). Set the `grid` argument to control the layout.
   Show the chair, then the vice chair, everyone else and vacant seats
 {% endcomment %}
-<div class="grid grid--2-wide">
+<div class="grid grid--{{grid}}-wide">
 {% if chair_commissioner %}
   {% include 'partials/commissioner.html' with commissioner=chair_commissioner %}
 {% endif %}

--- a/fec/home/templatetags/commissioners.py
+++ b/fec/home/templatetags/commissioners.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 register = template.Library()
 
 @register.inclusion_tag('partials/current-commissioners.html')
-def current_commissioners():
+def current_commissioners(grid):
     current_commissioners = CommissionerPage.objects.filter(term_expiration__isnull=True)
     chair_commissioner = current_commissioners.filter(commissioner_title__startswith='Chair') \
         .exclude(commissioner_title__contains='Vice').first()
@@ -33,4 +33,5 @@ def current_commissioners():
         'vice_commissioner': vice_commissioner,
         'commissioners': other_commissioners,
         'vacant_seats' : vacant_seats,
+        'grid': grid,
     }


### PR DESCRIPTION
## Summary 
This hotfix replaces previously approved PR #3310
- This adds an argument to the `commissioners.py` templatetag  so it can be used in multiple locations including the home page commissioners' listing. 
- With this PR, the homepage commissioner listing will be  updated automatically when their Wagtail commissioner page is edited (as on [leadership-and-structure](leadership-and-structure) and [leadership-and-structure/commissioners](https://www.fec.gov/about/leadership-and-structure/commissioners/) ). We were currently  hardcoding html for home page commissioners' display. 
- Added comments to explain how to use the argument to control the grid layout of the rendered templatetag ( i.e : 2 grid or 3 grid layout )

- Resolves #3308

## Impacted areas of the application
This impacts the commissioners block that appears in streamfields (currently used on about/leadership-and-structure ). Also effects the homepage commissioners' listing.
 - modified:   home/templates/home/home_page.html
 - modified:   home/templates/partials/current-commissioners.html
 - modified:   home/templatetags/home_page.py
 - modified:   home/templates/blocks/commissioners.html


Looks exactly the same as on production, but its not hardcoded:
<img width="1279" alt="Screen Shot 2019-10-30 at 2 13 08 AM" src="https://user-images.githubusercontent.com/5572856/67833419-f30bab00-faba-11e9-9998-11dc61fabab5.png">


- _Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface or front end change, include both a Before and After screenshot._

## Related PRs
- The current  PR takes work done in this PR (https://github.com/fecgov/fec-cms/pull/3131) one step further.
https://github.com/fecgov/fec-cms/pull/3131/files#
- The above related-PR was an enhancement to the logic for this PR (https://github.com/fecgov/fec-cms/pull/963 )to capture term expiration dates and remove commissioners no longer active in addition to vacant seats(I think)


## How to test
- Checkout and run branch
- Verify that the homepage commissioner listing for Vice Chair Hunter includes her title and that others  are correct. (Your local Wagtail page for Hunter must have her title added if it is not already)
- You may not see the images if you do not have them on your local CMS, you can add the these three images to fec-cms/fec/media/images
![headshot--weintraub original](https://user-images.githubusercontent.com/5572856/67833899-52b68600-fabc-11e9-8ac9-fcb2f6d7fb20.png)
![headshot--walther original](https://user-images.githubusercontent.com/5572856/67833900-52b68600-fabc-11e9-9a20-76c6ef8dcb14.png)
![headshot--hunter original](https://user-images.githubusercontent.com/5572856/67833901-534f1c80-fabc-11e9-9dfd-6eed4f9bde88.png)


