### PR TITLE
Fix candidate profile server error in 1988 for Trump

### DIFF
--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -199,3 +199,83 @@ class TestCandidate(TestCase):
         assert candidate["election_years"] == [2018, 2024]
         assert candidate["election_year"] == 2024
         assert candidate["max_cycle"] == 2020
+
+    def test_candidate_not_in_election_max_cycle(
+        self,
+        load_with_nested_mock,
+        load_first_row_data_mock,
+        load_candidate_statement_of_candidacy_mock,
+    ):
+        # test candidate election year(one or more of election_years)
+        # is not exist in fec_cycles_in_election ex:P80001571/1988
+        test_candidate = copy.deepcopy(self.STOCK_CANDIDATE)
+        test_candidate["candidate_id"] = ["P001"]
+        test_candidate["fec_cycles_in_election"] = [2016, 2018, 2020]
+        test_candidate["election_years"] = [1988, 2016, 2020]
+        test_candidate["rounded_election_years"] = [1988, 2016, 2020]
+
+        test_committee_list = copy.deepcopy(self.STOCK_COMMITTEE_LIST)
+        test_committee_list[0] = (
+            {
+                'designation': 'P',
+                'cycles': [2016, 2014, 2012, 2018, 2020],
+                'name': 'My Primary Campaign Committee',
+                'cycle': 2018,
+                'committee_id': 'C001',
+            },
+        )
+        test_committee_list.append(
+            {
+                'designation': 'P',
+                'cycles': [2016, 2014, 2012, 2018, 2020],
+                'name': 'My Primary Campaign Committee',
+                'cycle': 1988,
+                'committee_id': 'C001',
+            }
+        )
+
+        load_with_nested_mock.return_value = (test_candidate, mock.MagicMock(), 1988)
+        candidate = get_candidate('P001', 1988, True)
+        assert candidate["election_years"] == [1988, 2016, 2020]
+        assert candidate["election_year"] == 1988
+        assert candidate["max_cycle"] == 1988
+
+    def test_null_fec_cycles_in_election_max_cycle(
+        self,
+        load_with_nested_mock,
+        load_first_row_data_mock,
+        load_candidate_statement_of_candidacy_mock,
+    ):
+        # test candidate only file F2. fec_cycles_in_election=null.
+        # ex:P00012799 (2020)
+        test_candidate = copy.deepcopy(self.STOCK_CANDIDATE)
+        test_candidate["candidate_id"] = ["P002"]
+        test_candidate["fec_cycles_in_election"] = None
+        test_candidate["election_years"] = [2020]
+        test_candidate["rounded_election_years"] = [2020]
+
+        test_committee_list = copy.deepcopy(self.STOCK_COMMITTEE_LIST)
+        test_committee_list[0] = (
+            {
+                'designation': 'P',
+                'cycles': [2016, 2014, 2012, 2018, 2020],
+                'name': 'My Primary Campaign Committee',
+                'cycle': 2018,
+                'committee_id': 'C001',
+            },
+        )
+        test_committee_list.append(
+            {
+                'designation': 'P',
+                'cycles': [2016, 2014, 2012, 2018, 2020],
+                'name': 'My Primary Campaign Committee',
+                'cycle': 2020,
+                'committee_id': 'C001',
+            }
+        )
+
+        load_with_nested_mock.return_value = (test_candidate, mock.MagicMock(), 2020)
+        candidate = get_candidate('P002', 2020, True)
+        assert candidate["election_years"] == [2020]
+        assert candidate["election_year"] == 2020
+        assert candidate["max_cycle"] == 2020

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -147,7 +147,7 @@ def get_candidate(candidate_id, cycle, election_full):
     #   to even number. (ex:2017=>2018)
     # even_election_years = candidate.get('rounded_election_years')
 
-    # if cycle = null, set cycle = the latest item in rounded_election_years.
+    # if cycle = null, set cycle = the last of rounded_election_years.
     if not cycle:
         cycle = max(candidate.get('rounded_election_years'))
 
@@ -176,11 +176,12 @@ def get_candidate(candidate_id, cycle, election_full):
         'candidateID': candidate['candidate_id'],
     }
 
-    # Grab the most recent two-year period with data within this cycle
-    # Used for raising/spending tabs
-    max_cycle = max(
-        year for year in candidate['fec_cycles_in_election'] if year <= cycle
-    )
+    # Check if cycle > latest_fec_cycles_in_election, such as:future candidate.
+    latest_fec_cycles_in_election = max(candidate['fec_cycles_in_election'])
+    if int(cycle) > latest_fec_cycles_in_election:
+        max_cycle = int(latest_fec_cycles_in_election)
+    else:
+        max_cycle = int(cycle)
 
     # Annotate committees with most recent available cycle
     aggregate_cycles = (

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -176,12 +176,12 @@ def get_candidate(candidate_id, cycle, election_full):
         'candidateID': candidate['candidate_id'],
     }
 
+    max_cycle = int(cycle)
     # Check if cycle > latest_fec_cycles_in_election, such as:future candidate.
-    latest_fec_cycles_in_election = max(candidate['fec_cycles_in_election'])
-    if int(cycle) > latest_fec_cycles_in_election:
-        max_cycle = int(latest_fec_cycles_in_election)
-    else:
-        max_cycle = int(cycle)
+    if candidate['fec_cycles_in_election']:
+        latest_fec_cycles_in_election = max(candidate['fec_cycles_in_election'])
+        if int(cycle) > latest_fec_cycles_in_election:
+            max_cycle = latest_fec_cycles_in_election
 
     # Annotate committees with most recent available cycle
     aggregate_cycles = (


### PR DESCRIPTION
## Summary (required)
This ticket will fix two issues:
1) one or more of candidate election_years is not exist in fec_cycles_in_election 
ex:Trump P80001571 / 1988, receive a server error page
https://www.fec.gov/data/candidate/P80001571/?cycle=1988&election_full=true

https://fec-dev-api.app.cloud.gov/v1/candidate/P80001571/history/
<img width="363" alt="P80001571" src="https://user-images.githubusercontent.com/24395751/68325352-2fc93a80-0097-11ea-816d-9167b0cbcfc7.png">


2) candidate only file F2. never in election yet, so fec_cycles_in_election=null.
receive a server error page. ex:P00012799 (2020)
https://www.fec.gov/data/candidate/P00012799/


https://fec-dev-api.app.cloud.gov/v1/candidate/P00012799/history/
<img width="355" alt="P00012799" src="https://user-images.githubusercontent.com/24395751/68325359-3657b200-0097-11ea-926c-8aff6c3ad4a1.png">



- Resolves [https://github.com/fecgov/fec-cms/issues/3318]( https://github.com/fecgov/fec-cms/issues/3318)
and [https://github.com/fecgov/fec-cms/issues/3326](https://github.com/fecgov/fec-cms/issues/3326)


## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile page.

## How to test
1) checkout branch
2) point to dev api
3) run test:
npm run test-single
pytest
 ./manage.py test

4) Test Example candidates and compare with production website.

(1) P80001571 (TRUMP)
prod (get error)
https://www.fec.gov/data/candidate/P80001571/?cycle=1988&election_full=true
local ( message)
http://127.0.0.1:8000/data/candidate/P80001571/?cycle=1988&election_full=true

(2) S2TX00312 (future candidate)
prod:
https://www.fec.gov/data/candidate/S2TX00312/
local (should same as prod)
http://127.0.0.1:8000/data/candidate/S2TX00312/

(3) P00012799 
prod (get error)
https://www.fec.gov/data/candidate/P00012799/
local ( message)
http://127.0.0.1:8000/data/candidate/P00012799/


