### PR TITLE
Update WCCF PR H elections to four years

### DIFF
--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -52,7 +52,7 @@ function formatAsCurrency(passedValue, roundToWhole = true) {
  * @param {String} stateID Optional. A null value will not filter for any state but show entries for the entire country
  * @returns {String} URL or empty string depending on
  */
-function buildIndividualContributionsUrl(cycle, office, committeeIDs, stateID) {
+function buildIndividualContributionsUrl(cycle, office, committeeIDs, stateID, candidateState) {
   // If we're missing required params, just return '' and be done
   if (!cycle || !office || !committeeIDs) return '';
 
@@ -66,8 +66,8 @@ function buildIndividualContributionsUrl(cycle, office, committeeIDs, stateID) {
   // so we'll add the previous two-year period for presidential races
   //
   // Also, Puerto Rico's House elections are for four years so we'll need to
-  // add the previous two-year period to the query string for H + PR, too.
-  if (office == 'P' || (office == 'H' && stateID == 'PR')) {
+  // add the previous two-year period to the query string for House candidates from Puerto Rico
+  if (office == 'P' || (office == 'H' && candidateState == 'PR')) {
     transactionPeriodsString += '&two_year_transaction_period=' + (cycle - 2);
     // and the two earlier two-year periods for Senate races
   } else if (office == 'S') {
@@ -699,7 +699,8 @@ ContributionsByState.prototype.displayUpdatedData_states = function() {
         this.baseStatesQuery.cycle,
         this.baseStatesQuery.office,
         theCommitteeIDs,
-        theResults[i].state
+        theResults[i].state,
+        this.candidateDetails.state
       );
 
       // Number cell

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -64,10 +64,13 @@ function buildIndividualContributionsUrl(cycle, office, committeeIDs, stateID) {
 
   // The API currently wants a two_year_transaction_period value for each set of two years
   // so we'll add the previous two-year period for presidential races
-  if (office == 'P')
+  //
+  // Also, Puerto Rico's House elections are for four years so we'll need to
+  // add the previous two-year period to the query string for H + PR, too.
+  if (office == 'P' || (office == 'H' && stateID == 'PR')) {
     transactionPeriodsString += '&two_year_transaction_period=' + (cycle - 2);
-  // and the two earlier two-year periods for Senate races
-  else if (office == 'S') {
+    // and the two earlier two-year periods for Senate races
+  } else if (office == 'S') {
     transactionPeriodsString += '&two_year_transaction_period=' + (cycle - 2);
     transactionPeriodsString += '&two_year_transaction_period=' + (cycle - 4);
   }

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -52,7 +52,13 @@ function formatAsCurrency(passedValue, roundToWhole = true) {
  * @param {String} stateID Optional. A null value will not filter for any state but show entries for the entire country
  * @returns {String} URL or empty string depending on
  */
-function buildIndividualContributionsUrl(cycle, office, committeeIDs, stateID, candidateState) {
+function buildIndividualContributionsUrl(
+  cycle,
+  office,
+  committeeIDs,
+  stateID,
+  candidateState
+) {
   // If we're missing required params, just return '' and be done
   if (!cycle || !office || !committeeIDs) return '';
 


### PR DESCRIPTION
## Summary

- Resolves #3290 
- Adjusted the links to Puerto Rico House elections to include both two-year periods rather than only one like the other House elections.

## Impacted areas of the application
Only WCCF, and only the method that builds the URLs for the state totals' links.

## Screenshots
None

## Related PRs
None

## How to test
- Pull, `npm i`, `npm run build`, `./manage.py runserver`
- Check [WCCF](http://127.0.0.1:8000/data/raising-bythenumbers/) for House candidates with contributions that come from Puerto Rico (Gonzalez Colon, Jenniffer is a 2020 candidate with data)
- Find the Puerto Rico line item
- Hover over the linked dollar amount to check that two appropriate `two_year_transaction_period` params are present
- Hover over another state or two to make sure there's only one value for `two_year_transaction_period`
- Check a presidential election that every state has two values for `two_year_transaction_period`
- Check a Senate election to make sure every state has three values for `two_year_transaction_period`
- If you're the last approval, merge, delete
