### PR TITLE
Update statutes page

### DIFF
--- a/fec/legal/templates/legal-statutes-landing.jinja
+++ b/fec/legal/templates/legal-statutes-landing.jinja
@@ -50,7 +50,7 @@
       <li>
         <p>Access the FEC’s compilation of statutes. That PDF contains Title 52, Subtitle III, Title 26, Subtitle H and additional provisions of the U.S. Code that aren’t enforced by FEC but are relevant to people involved in federal elections.</p>
         <div class="grid grid--2-wide">
-          {{ document.thumbnail("Federal Election Campaign Laws by the FEC", "https://www.fec.gov/resources/cms-content/documents/feca.pdf", img="/resources/cms-content/images/thumbnail--feca.original.jpg", size="2.58MB") }}
+          {{ document.thumbnail("Federal Election Campaign Laws by the FEC", "https://www.fec.gov/resources/cms-content/documents/feca.pdf", img="/resources/cms-content/images/52usc.original.png", size="2.97MB") }}
         </div>
       </li>
       <li>


### PR DESCRIPTION
Adding new thumbnail and PDF file size to page.

## Summary (required)

- Resolves #3317 by updating the file size of the revised feca pdf that was uploaded, and updating the thumbnail used for the gray book.


## Impacted areas of the application
Legal resources statutes page

## How to test

Image should look like: 
![thumbnail--feca original](https://user-images.githubusercontent.com/24437369/68400793-9e190600-0146-11ea-9631-76a2a3c06c96.png)

File size of PDF should be listed as 2.97 MB.

When you click on the PDF, it should say it's the February 2019 edition.


