### PR TITLE
Add internal/external links to RecordPage template

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -64,7 +64,9 @@ stream_factory = functools.partial(
         ('image', ImageChooserBlock()),
         ('table', TableBlock(table_options=core_table_options)),
         ('custom_table', CustomTableBlock()),
-        ('contact', ContactInfoBlock())
+        ('contact', ContactInfoBlock()),
+        ('internal_button', InternalButtonBlock()),
+        ('external_button', ExternalButtonBlock()),
     ],
 )
 

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    #('feature', lambda _, branch: branch == 'feature/the-branch-name'),
+    ('feature', lambda _, branch: branch == 'feature/2935-internal-external-link-record-and-example-templates'),
 )
 
 


### PR DESCRIPTION
## Summary 
The `RecordPage` model   inherits from `ContentPage` model with uses `stream_factory` as its body section. So I added internal and external link buttons here.

- Resolves #2935

## Impacted areas of the application
This will effect all page models inheriting from ContentPage model, but only to the extent that they will now also have the new internal and external link buttons.
 - modified:   home/models.py

## Screenshots

![Screen Shot 2019-11-07 at 12 11 55 PM](https://user-images.githubusercontent.com/5572856/68411116-e1c83b80-0157-11ea-87f8-d59ca9a00172.png)


## Related PRs
https://github.com/fecgov/fec-cms/issues/3149:


## How to test
- Checkout and run branch
- Create page of type, RecordPage and confirm and test the external and internal link buttons
- Publish or Preview to confirm it works 
____

