### PR TITLE
Revert tasks.py, remove redundant block from ExamplePage model

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -1154,7 +1154,6 @@ class ExamplePage(Page):
         ('paragraph', blocks.RichTextBlock()),
         ('example_image', ExampleImage()),
         ('reporting_example_cards', ReportingExampleCards()),
-        ('reporting_example_cards', ReportingExampleCards()),
         ('internal_button', InternalButtonBlock()),
         ('external_button', ExternalButtonBlock()),
         ('image', ImageChooserBlock()),

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/2935-internal-external-link-record-and-example-templates'),
+    #('feature', lambda _, branch: branch == 'feature/the-branch-name'),
 )
 
 


### PR DESCRIPTION
## Summary (required)
 `../tasks.py` got inadvertently pushed  up with uncommented feature deploy task (My fault.)
Although, this would not have any effect if the branch name had been deleted after merge, I want to revert it to the expected state, just to be safe.
This file keeps getting pushed up with the task uncommented (with a non-existent placeholder branch name)--maybe there is a better way to control deploys to feature that don't open us up to possible unintended overwrites of feature space. But for now,  an just reverting.


This PR also removes extra, redundant `reporting_example_cards` block from ExamplePage model. This did NOT make it show up twice in steramfield, but it should obviously be removed anyway.


## Impacted areas of the application
modified:   ../tasks.py
modified:   home/models.py

