### PR TITLE
Replace SA, SB and SE cms calls with the latest  api endpoints

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -398,10 +398,10 @@ $(document).ready(function() {
     };
     switch ($table.attr('data-type')) {
       case 'contribution-size':
-        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_size'];
+        path = ['schedules', 'schedule_a', 'by_size'];
         tables.DataTable.defer($table, {
           path: path,
-          query: query,
+          query: _.extend({}, query, { committee_id: committeeId }),
           columns: sizeColumns,
           callbacks: aggregateCallbacks,
           dom: 't',
@@ -420,19 +420,15 @@ $(document).ready(function() {
         });
         break;
       case 'receipts-by-state':
-        path = [
-          'committee',
-          committeeId,
-          'schedules',
-          'schedule_a',
-          'by_state'
-        ];
-        query = _.extend(query, {
-          per_page: 99
-        });
+        path = ['schedules', 'schedule_a', 'by_state'];
         tables.DataTable.defer($table, {
           path: path,
-          query: query,
+          query: _.extend(
+            {},
+            query,
+            { committee_id: committeeId },
+            { per_page: 99 }
+          ),
           columns: stateColumns,
           callbacks: aggregateCallbacks,
           aggregateExport: true,
@@ -447,18 +443,12 @@ $(document).ready(function() {
 
         break;
       case 'receipts-by-employer':
-        path = [
-          'committee',
-          committeeId,
-          'schedules',
-          'schedule_a',
-          'by_employer'
-        ];
+        path = ['schedules', 'schedule_a', 'by_employer'];
         tables.DataTable.defer(
           $table,
           _.extend({}, tableOpts, {
             path: path,
-            query: query,
+            query: _.extend({}, query, { committee_id: committeeId }),
             columns: employerColumns,
             callbacks: aggregateCallbacks,
             order: [[1, 'desc']],
@@ -472,18 +462,12 @@ $(document).ready(function() {
         );
         break;
       case 'receipts-by-occupation':
-        path = [
-          'committee',
-          committeeId,
-          'schedules',
-          'schedule_a',
-          'by_occupation'
-        ];
+        path = ['schedules', 'schedule_a', 'by_occupation'];
         tables.DataTable.defer(
           $table,
           _.extend({}, tableOpts, {
             path: path,
-            query: query,
+            query: _.extend({}, query, { committee_id: committeeId }),
             columns: occupationColumns,
             callbacks: aggregateCallbacks,
             order: [[1, 'desc']],
@@ -523,18 +507,12 @@ $(document).ready(function() {
         );
         break;
       case 'disbursements-by-recipient':
-        path = [
-          'committee',
-          committeeId,
-          'schedules',
-          'schedule_b',
-          'by_recipient'
-        ];
+        path = ['schedules', 'schedule_b', 'by_recipient'];
         tables.DataTable.defer(
           $table,
           _.extend({}, tableOpts, {
             path: path,
-            query: query,
+            query: _.extend({}, query, { committee_id: committeeId }),
             columns: disbursementRecipientColumns,
             callbacks: aggregateCallbacks,
             order: [[1, 'desc']],
@@ -598,18 +576,12 @@ $(document).ready(function() {
         );
         break;
       case 'disbursements-by-recipient-id':
-        path = [
-          'committee',
-          committeeId,
-          'schedules',
-          'schedule_b',
-          'by_recipient_id'
-        ];
+        path = ['schedules', 'schedule_b', 'by_recipient_id'];
         tables.DataTable.defer(
           $table,
           _.extend({}, tableOpts, {
             path: path,
-            query: query,
+            query: _.extend({}, query, { committee_id: committeeId }),
             columns: disbursementRecipientIDColumns,
             callbacks: aggregateCallbacks,
             order: [[1, 'desc']],
@@ -623,16 +595,10 @@ $(document).ready(function() {
         );
         break;
       case 'independent-expenditure-committee':
-        path = [
-          'committee',
-          committeeId,
-          'schedules',
-          'schedule_e',
-          'by_candidate'
-        ];
+        path = ['schedules', 'schedule_e', 'by_candidate'];
         tables.DataTable.defer($table, {
           path: path,
-          query: query,
+          query: _.extend({}, query, { committee_id: committeeId }),
           columns: expendituresColumns,
           order: [[0, 'desc']],
           dom: tables.simpleDOM,
@@ -853,19 +819,11 @@ $(document).ready(function() {
 
   // Set up state map
   var $map = $('.state-map');
-  var mapUrl = helpers.buildUrl(
-    [
-      'committee',
-      $map.data('committee-id'),
-      'schedules',
-      'schedule_a',
-      'by_state'
-    ],
-    {
-      cycle: $map.data('cycle'),
-      per_page: 99
-    }
-  );
+  var mapUrl = helpers.buildUrl(['schedules', 'schedule_a', 'by_state'], {
+    committee_id: $map.data('committee-id'),
+    cycle: $map.data('cycle'),
+    per_page: 99
+  });
 
   var query = URI.parseQuery(window.location.search);
 


### PR DESCRIPTION
## Summary (required)
Replace SA, SB and SE api calls with the latest api endpoints. A total of  7 endpoints are updated

- Resolves https://github.com/fecgov/fec-cms/issues/3285

## Impacted areas of the application
Committee Raising (SA), Spending (SB) and Independent Expenditure (SE) api calls (endpoints).

## Screenshots
**Committee raising tab screen:**

<img width="1430" alt="Screen Shot 2019-11-08 at 3 40 00 PM" src="https://user-images.githubusercontent.com/11650355/68509072-17dfeb00-023e-11ea-9d8c-3e07e2564a96.png">
#########################################################################

** Raising tab api calls:** ::: #4 endpoints are updated
#########################################################################
Before:
https://fec-dev-api.app.cloud.gov/v1/committee/C00448696/schedules/schedule_a/by_state/?api_key=pjE98TJBLgSA1XyqNHVMgt1TK88S7qtpIklwztqW&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=99&page=1&cycle=2020&election_full=false

After:
https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_a/by_state/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=99&page=1&cycle=2020&election_full=false&committee_id=C00448696
#########################################################################
Before:
https://fec-dev-api.app.cloud.gov/v1/committee/C00448696/schedules/schedule_a/by_size/?api_key=pjE98TJBLgSA1XyqNHVMgt1TK88S7qtpIklwztqW&sort_hide_null=false&sort_nulls_last=true&per_page=10&page=1&cycle=2020&election_full=false

After:
https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_a/by_size/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&per_page=10&page=1&committee_id=C00448696&cycle=2020
#########################################################################
Before:
https://fec-dev-api.app.cloud.gov/v1/committee/C00448696/schedules/schedule_a/by_employer/?api_key=pjE98TJBLgSA1XyqNHVMgt1TK88S7qtpIklwztqW&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=10&page=1&cycle=2020&election_full=false

After:
https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_a/by_employer/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=10&page=1&committee_id=C00448696&cycle=2020
#########################################################################
Before:
https://fec-dev-api.app.cloud.gov/v1/committee/C00448696/schedules/schedule_a/by_occupation/?api_key=pjE98TJBLgSA1XyqNHVMgt1TK88S7qtpIklwztqW&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=10&page=1&cycle=2020&election_full=false

After:
https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_a/by_occupation/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=10&page=1&committee_id=C00448696&cycle=2020

#########################################################################

**Spending tab screen**:
<img width="1420" alt="Screen Shot 2019-11-08 at 4 01 12 PM" src="https://user-images.githubusercontent.com/11650355/68513695-ae65d980-0249-11ea-8040-32264b57ab21.png">

**Spending tab api calls:** ::: #3 endpoints are updated
########################################################################
Before:
https://fec-dev-api.app.cloud.gov/v1/committee/C00448696/schedules/schedule_e/by_candidate/?api_key=pjE98TJBLgSA1XyqNHVMgt1TK88S7qtpIklwztqW&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=30&page=1&cycle=2020&election_full=false

After:
https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_e/by_candidate/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=30&page=1&committee_id=C00448696&cycle=2020&election_full=false
#########################################################################
Before:
https://fec-dev-api.app.cloud.gov/v1/committee/C00448696/schedules/schedule_b/by_recipient/?api_key=pjE98TJBLgSA1XyqNHVMgt1TK88S7qtpIklwztqW&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=10&page=1&cycle=2020&election_full=false

After:
https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_b/by_recipient/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=10&page=1&committee_id=C00448696&cycle=2020

#########################################################################
Before:
https://fec-dev-api.app.cloud.gov/v1/committee/C00448696/schedules/schedule_b/by_recipient_id/?api_key=pjE98TJBLgSA1XyqNHVMgt1TK88S7qtpIklwztqW&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=10&page=1&cycle=2020&election_full=false

After:
https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_b/by_recipient_id/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&sort=-total&per_page=10&page=1&committee_id=C00448696&cycle=2020

#########################################################################

## How to test
- checkout the branch
- export FEC_API_URL to `dev` or `stage` api
- run server
-  search for a committee and look at the raising, spending tabs results should load. Observe the api calls in the console. 
