### PR TITLE
Corrected candidate mentioned query param

### DIFF
--- a/fec/data/templates/partials/independent-expenditures-filter.jinja
+++ b/fec/data/templates/partials/independent-expenditures-filter.jinja
@@ -22,7 +22,7 @@ Filter independent expenditures
 {% block efiling_filters %}
 <div class="filters__inner">
   {{ typeahead.field('committee_id', 'Spender name or ID', id_suffix='_raw') }}
-  {{ text.field('candidate_name', 'Candidate mentioned', id_suffix='_raw')}}
+  {{ text.field('candidate_search', 'Candidate mentioned', id_suffix='_raw')}}
   {{ support_oppose.checkbox('_raw') }}
   {{ date.field('expenditure_date', 'Expenditure date', id_suffix='_raw') }}
 </div>


### PR DESCRIPTION
## Summary

- Resolves #3247 
_Fixes candidate mentioned search field by correcting query param._

While doing this PR, I found a bug that the `candidate_search` query param is not returning all possible results. Although this PR fixes the query on the front end, we should investigate why we don't see all possible results. Issue logged: https://github.com/fecgov/openFEC/issues/4086. 

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Independent expenditures raw filings search

## Screenshots

![Screen Shot 2019-11-12 at 12 11 08 PM](https://user-images.githubusercontent.com/12799132/68693616-9b9f1d80-0545-11ea-9d4f-9cba734a4ae2.png)

## How to test
- [ ] Go to independent expenditures raw efiling: http://localhost:8000/data/independent-expenditures/?data_type=efiling&is_notice=true
- [ ] Enter search term in "Candidate mentioned". It should filter results by the search term entered.

