### PR TITLE
Update hosts in CMS

### DIFF
--- a/fec/fec/settings/production.py
+++ b/fec/fec/settings/production.py
@@ -14,8 +14,10 @@ SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_SECURE = True
 CSRF_COOKIE_HTTPONLY = True
 
-# TODO(jmcarp) Update after configuring DNS
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = [
+    '.fec.gov',
+    '.app.cloud.gov'
+]
 
 try:
     from .local import *  # noqa


### PR DESCRIPTION
## Summary (required)

- Resolves 216 (fec-accounts)
_Adds .fec.gov and .app.cloud.gov host names to CMS app._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  CMS application and website

## How to test
- [ ] Deploy this branch to dev and stage environments
- [ ] Try going to CMS app using hostnames like: fec-dev-proxy.app.cloud.gov, fec-stage-proxy.app.cloud.gov, dev.fec.gov, stage.fec.gov
- [ ] Click around and check that major sections of the website still work
____

