### PR TITLE
Feature/3353 fix statute thumbnail

### DIFF
--- a/fec/data/templates/macros/document.jinja
+++ b/fec/data/templates/macros/document.jinja
@@ -1,7 +1,8 @@
 {% macro thumbnail(title, url, img="", size='', type="PDF") %}
   <div class="grid__item document-thumbnail">
     <a class="document-thumbnail__img" href="{{ url }}" target="_blank">
-      <img src="{{ static(img)}}" alt="{{ title }}">
+    {# Image resource is pulling from CMS image uploads #}
+      <img src="{{ img }}" alt="{{ title }}">
     </a>
     <span class="document-thumbnail__description">
       <a href="{{ url }}" target="_blank">{{ title }}</a>

--- a/fec/fec/settings/production.py
+++ b/fec/fec/settings/production.py
@@ -14,8 +14,10 @@ SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_SECURE = True
 CSRF_COOKIE_HTTPONLY = True
 
-# TODO(jmcarp) Update after configuring DNS
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = [
+    '.fec.gov',
+    '.app.cloud.gov'
+]
 
 try:
     from .local import *  # noqa


### PR DESCRIPTION
## Summary

- Resolves #3353 
_Removes `static` dir path from image thumbnail from document macro. These thumbnails should be controlled via uploads to Wagtail CMS rather than through static images._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Statutes landing page: http://localhost:8000/data/legal/statutes/

## Screenshots

### Before
Image path is `/static/resources/cms-content/images/52usc.original.png`
<img width="1043" alt="Screen Shot 2019-11-14 at 4 59 21 PM" src="https://user-images.githubusercontent.com/12799132/68899659-275ca980-0700-11ea-8d99-aa47b081ace8.png">

### After
Image path is `/resources/cms-content/images/52usc.original.png`
<img width="1008" alt="Screen Shot 2019-11-14 at 4 58 59 PM" src="https://user-images.githubusercontent.com/12799132/68899660-275ca980-0700-11ea-918c-5fe8c6b7c780.png">

## How to test
- [ ] Run the branch
- [ ] Go to the statues landing page: http://localhost:8000/data/legal/statutes/
- [ ] Make sure that the image path for the Federal Election Campaign Laws by the FEC thumbnail is going to `/resources/...`. It should not have `/static/` as part of the path since we are not using static assets for this thumbnail.
____

