### PR TITLE
Feature/3112 advanced search default message

### DIFF
--- a/fec/fec/static/scss/components/_search-bar.scss
+++ b/fec/fec/static/scss/components/_search-bar.scss
@@ -93,6 +93,13 @@ $search-button-width: u(5.6rem);
     height: u(3.6rem);
     width: u(5.6rem);
   }
+
+  &.no-mar-b input {
+    margin-bottom: 0;
+  }
+}
+.combo--search--mini--example {
+  margin-bottom: u(2rem);
 }
 
 // BREAKPOINT: MEDIUM

--- a/fec/legal/templates/layouts/legal-doc-search-results.jinja
+++ b/fec/legal/templates/layouts/legal-doc-search-results.jinja
@@ -41,6 +41,15 @@
       <div class="data-container__head">
         <h1 class="data-container__title">{{ document_type_display_name }}</h1>
       </div>
+      {% if document_type_display_name == 'Statutes' %}
+      <div class="u-padding--left u-padding--right">
+        <div class="message message--info">
+          <p>
+            The statutes search feature includes the Federal Election Campaign Act (52 U.S.C. §§ 30101 to 30146), the Presidential Election Campaign Fund Act (26 U.S.C. §§ 9001 to 9013) and the Presidential Primary Matching Payment Account Act (26 U.S.C. §§ 9031 to 9042). You can search statutes using keywords and/or statutory citations (full or partial).
+          </p>
+        </div>
+      </div>
+      {% endif %}
       <div class="u-padding--left u-padding--right">
         {% block message %}{% endblock %}
       </div>

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -7,11 +7,14 @@
      <p class="tooltip__content tooltip__content">Refine a keyword search by using AND, OR, “ ”, -, to expand or limit results.</p>
    </div>
   </div>
-  <div class="combo combo--search--mini">
+  <div class="combo combo--search--mini no-mar-b">
     <input id="search-input" type="text" name="search" class="combo__input"{% if query %} value="{{ query }}"{% endif %}>
     <button class="combo__button button--search button--standard" type="submit">
       <span class="u-visually-hidden">Search</span>
     </button>
+  </div>
+  <div class="combo combo--search--mini--example">
+    <span class="t-note t-sans search__example">Examples: spending; 52 U.S.C. §30123</span>
   </div>
   <button type="button" class="button--keywords" aria-controls="keyword-modal" data-a11y-dialog-show="keyword-modal">More keyword options</button>
 


### PR DESCRIPTION
## Summary
- Resolves #3112 
- Added example text under the left-panel search box
- Added message to the top of Statutes search results pages

## Impacted areas of the application
- Added the message to fec/legal/templates/layouts/legal-doc-search-results.jinja
- Added the example text to fec/legal/templates/macros/legal.jinja
- Styled them both

## Screenshots
Current state:
![image](https://user-images.githubusercontent.com/26720877/69351779-d42baf00-0c49-11ea-8076-3869072540f8.png)

Example for message at top of page:
![image](https://user-images.githubusercontent.com/26720877/69351815-e3126180-0c49-11ea-91bd-fc8199e9018b.png)

Example for help text:
![image](https://user-images.githubusercontent.com/26720877/69351833-ea396f80-0c49-11ea-8bd5-3410f1b75251.png)

New, with message and help text:
![image](https://user-images.githubusercontent.com/26720877/69351886-fcb3a900-0c49-11ea-948c-8aefe160147d.png)


## Related PRs
None

## How to test
- Pull branch, `npm i`, `npm run build`, `./manage.py runserver`
- Check the [statutes search page](http://127.0.0.1:8000/data/legal/search/statutes/)
  - Verify that the help text is under the search field on the left
  - Check first and additional pages that the message box is between the page title and data table
- Check related (non-statutes) legal pages that neither the help text nor message box are present
- If you're the last reviewer, remove the Please review label, approve, merge, delete

____

