### PR TITLE
Datatables handle >10 committee_ids

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -638,8 +638,9 @@ DataTable.prototype.fetch = function(data, callback) {
       self.filters.committee_id &&
       self.filters.committee_id.length > 10
     ) {
+      $('#exceeded_id_limit').remove();
       $('#committee_id-field ul.dropdown__selected').append(
-        '<div class="message filter__message message--error">' +
+        '<div id="exceeded_id_limit" class="message filter__message message--error">' +
           '<p>You&#39;re trying to search more than 10 committees. Narrow your search to 10 or fewer committees.</p>' +
           '</div>'
       );

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -623,19 +623,31 @@ DataTable.prototype.fetch = function(data, callback) {
     return;
   } else if (self.filterSet && self.filterSet.isValid) {
     urls.updateQuery(self.filterSet.serialize(), self.filterSet.fields);
+    //console.log(self.filterSet);
     self.filters = self.filterSet.serialize();
-    // Only limit to 10 committee ids for processed data
+    // Only limit to 10 committee ids for processed data in specific datatables
+    // Individual contributions does not contain data_type and therefore has a separate check
+    var limitCommitteeIDCheckboxes =
+      (self.filters.data_type == 'processed' &&
+        ['Receipts', 'Disbursements', 'Independent expenditures'].indexOf(
+          self.opts.title
+        ) !== -1) ||
+      self.opts.title === 'Individual contributions';
     if (
+      limitCommitteeIDCheckboxes &&
       self.filters &&
-      self.filters.data_type == 'processed' &&
       self.filters.committee_id &&
       self.filters.committee_id.length > 10
     ) {
-      // insert error message above committee_id field
+      $('#committee_id-field ul.dropdown__selected').append(
+        '<div class="message filter__message message--error">' +
+          '<p>You&#39;re trying to search more than 10 committees. Narrow your search to 10 or fewer committees.</p>' +
+          '</div>'
+      );
       return;
     }
   }
-  console.log('receipts query');
+
   var url = self.buildUrl(data);
   self.$processing.show();
   if (self.xhr) {

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -295,6 +295,9 @@ function filterSuccessUpdates(changeCount) {
       .removeClass('is-disabled-filter')
       .addClass('is-active-filter');
 
+    // Reenable committee ID typeahead input
+    $('#committee_id').removeClass('is-disabled-filter');
+
     if (type === 'checkbox') {
       $label = $('label[for="' + updateChangedEl.id + '"]');
 
@@ -638,7 +641,9 @@ DataTable.prototype.fetch = function(data, callback) {
       self.filters.committee_id &&
       self.filters.committee_id.length > 10
     ) {
-      $('#exceeded_id_limit').remove();
+      // Adds committee id error message and disables filter
+      $('#exceeded_id_limit').remove(); 
+      $('#committee_id').addClass('is-disabled-filter');
       $('#committee_id-field ul.dropdown__selected').append(
         '<div id="exceeded_id_limit" class="message filter__message message--error">' +
           '<p>You&#39;re trying to search more than 10 committees. Narrow your search to 10 or fewer committees.</p>' +

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -624,7 +624,18 @@ DataTable.prototype.fetch = function(data, callback) {
   } else if (self.filterSet && self.filterSet.isValid) {
     urls.updateQuery(self.filterSet.serialize(), self.filterSet.fields);
     self.filters = self.filterSet.serialize();
+    // Only limit to 10 committee ids for processed data
+    if (
+      self.filters &&
+      self.filters.data_type == 'processed' &&
+      self.filters.committee_id &&
+      self.filters.committee_id.length > 10
+    ) {
+      // insert error message above committee_id field
+      return;
+    }
   }
+  console.log('receipts query');
   var url = self.buildUrl(data);
   self.$processing.show();
   if (self.xhr) {

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -623,7 +623,6 @@ DataTable.prototype.fetch = function(data, callback) {
     return;
   } else if (self.filterSet && self.filterSet.isValid) {
     urls.updateQuery(self.filterSet.serialize(), self.filterSet.fields);
-    //console.log(self.filterSet);
     self.filters = self.filterSet.serialize();
     // Only limit to 10 committee ids for processed data in specific datatables
     // Individual contributions does not contain data_type and therefore has a separate check

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -642,7 +642,7 @@ DataTable.prototype.fetch = function(data, callback) {
       self.filters.committee_id.length > 10
     ) {
       // Adds committee id error message and disables filter
-      $('#exceeded_id_limit').remove(); 
+      $('#exceeded_id_limit').remove();
       $('#committee_id').addClass('is-disabled-filter');
       $('#committee_id-field ul.dropdown__selected').append(
         '<div id="exceeded_id_limit" class="message filter__message message--error">' +

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -516,5 +516,32 @@ describe('data table', function() {
         'Expected error message to show'
       ).to.be.above(0);
     });
+
+    it('test committee id errors with processed data type', function() {
+      var serialized = {
+        committee_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        data_type: 'processed'
+      };
+      this.table.opts.title = 'Disbursements';
+      this.table.filterSet = {
+        serialize: function() {
+          return serialized;
+        },
+        fields: ['committee_id', 'data_type']
+      };
+      this.table.filterSet.isValid = true;
+      var callback = sinon.stub();
+      this.table.fetch({}, callback);
+      expect(this.table.filters).to.deep.equal(serialized);
+      expect(this.table.filters.committee_id.length).to.be.above(10);
+      expect(
+        $('#committee_id-field').length,
+        'Expected committee_id-field to exist'
+      ).to.be.above(0);
+      expect(
+        $('#exceeded_id_limit').length,
+        'Expected error message to show'
+      ).to.be.above(0);
+    });
   });
 });

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -506,14 +506,17 @@ describe('data table', function() {
       var callback = sinon.stub();
       this.table.fetch({}, callback);
       expect(this.table.filters).to.deep.equal(serialized);
-      expect(this.table.filters.committee_id.length).to.be.above(10);
+      expect(
+        this.table.filters.committee_id.length,
+        'Expected greater than 10 committee ids'
+      ).to.be.above(10);
       expect(
         $('#committee_id-field').length,
         'Expected committee_id-field to exist'
       ).to.be.above(0);
       expect(
         $('#exceeded_id_limit').length,
-        'Expected error message to show'
+        'Expected error message to exist'
       ).to.be.above(0);
     });
 
@@ -533,14 +536,17 @@ describe('data table', function() {
       var callback = sinon.stub();
       this.table.fetch({}, callback);
       expect(this.table.filters).to.deep.equal(serialized);
-      expect(this.table.filters.committee_id.length).to.be.above(10);
+      expect(
+        this.table.filters.committee_id.length,
+        'Expected greater than 10 committee ids'
+      ).to.be.above(10);
       expect(
         $('#committee_id-field').length,
         'Expected committee_id-field to exist'
       ).to.be.above(0);
       expect(
         $('#exceeded_id_limit').length,
-        'Expected error message to show'
+        'Expected error message to exist'
       ).to.be.above(0);
     });
   });

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -482,4 +482,39 @@ describe('data table', function() {
       expect(results).to.deep.equal(expected);
     });
   });
+
+  describe('limit committee ids', function() {
+    beforeEach(function() {
+      this.table.xhr = null;
+      $('body').append(
+        '<div id="committee_id-field"><ul class="dropdown__selected"></ul><input id="committee_id" /></div>'
+      );
+    });
+
+    it('test committee id errors with individual contributions', function() {
+      var serialized = {
+        committee_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+      };
+      this.table.opts.title = 'Individual contributions';
+      this.table.filterSet = {
+        serialize: function() {
+          return serialized;
+        },
+        fields: ['committee_id']
+      };
+      this.table.filterSet.isValid = true;
+      var callback = sinon.stub();
+      this.table.fetch({}, callback);
+      expect(this.table.filters).to.deep.equal(serialized);
+      expect(this.table.filters.committee_id.length).to.be.above(10);
+      expect(
+        $('#committee_id-field').length,
+        'Expected committee_id-field to exist'
+      ).to.be.above(0);
+      expect(
+        $('#exceeded_id_limit').length,
+        'Expected error message to show'
+      ).to.be.above(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary (required)

- Resolves #3367 
_Added error message for more than 10 committee_ids that are added to the committee id typeahead._

## Impacted areas of the application
List general components of the application that this PR will affect:

- Receipts datatable
- Individual contributions datatable
- Disbursements datatable
- Independent expenditures datatable

## Screenshots

![Screen Shot 2019-11-26 at 11 16 37 AM](https://user-images.githubusercontent.com/12799132/69651537-3c113980-103e-11ea-82e3-9a525dd40924.png)

## How to test
- checkout this branch
- `npm run build`
- Go to Receipts, Individual contributions, Disbursements, and Independent expenditure datatables to add more than 10 committees to `RECIPIENT NAME OR ID` and `SPENDER NAME OR ID` fields. This is the first typeahead filter on these datatables. For convenience, I have added links to these datatables with greater than 10 committee ids already inserted. 
   - http://localhost:8000/data/receipts/?data_type=processed&committee_id=C00034728&committee_id=C00157230&committee_id=C00363853&committee_id=C00390658&committee_id=C00392282&committee_id=C00442103&committee_id=C00481978&committee_id=C00569624&committee_id=C00571000&committee_id=C00609511&committee_id=C00617696&two_year_transaction_period=2020&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020
   - http://localhost:8000/data/receipts/individual-contributions/?committee_id=C00034728&committee_id=C00157230&committee_id=C00363853&committee_id=C00390658&committee_id=C00392282&committee_id=C00442103&committee_id=C00481978&committee_id=C00569624&committee_id=C00571000&committee_id=C00609511&committee_id=C00617696&two_year_transaction_period=2020&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020
   - http://localhost:8000/data/disbursements/?data_type=processed&committee_id=C00034728&committee_id=C00157230&committee_id=C00363853&committee_id=C00390658&committee_id=C00392282&committee_id=C00442103&committee_id=C00481978&committee_id=C00569624&committee_id=C00571000&committee_id=C00609511&committee_id=C00617696&two_year_transaction_period=2020&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020
   - http://localhost:8000/data/independent-expenditures/?data_type=processed&is_notice=true&committee_id=C00034728&committee_id=C00157230&committee_id=C00363853&committee_id=C00390658&committee_id=C00392282&committee_id=C00442103&committee_id=C00481978&committee_id=C00569624&committee_id=C00571000&committee_id=C00609511&committee_id=C00617696
- Try checking and unchecking boxes to make sure the error message goes away when there are 10 or less committee ids. And that the error message remains when there are more than 10 committee ids added
- Toggle between processed and raw to make sure the raw datatable is not restricted by this limitation
- Make sure that other datatables are not restricted by the 10 committee id limitation. This should only be applied to 4 datatables: - Receipts datatable, Individual contributions datatable, Disbursements datatable, Independent expenditures datatable
____

