### PR TITLE
Change to use EC endpoint /electioneering/aggregates/ filter by committee_id

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -617,10 +617,10 @@ $(document).ready(function() {
         });
         break;
       case 'electioneering-committee':
-        path = ['committee', committeeId, 'electioneering', 'by_candidate'];
+        path = ['electioneering', 'aggregates'];
         tables.DataTable.defer($table, {
           path: path,
-          query: query,
+          query: _.extend({}, query, { committee_id: committeeId }),
           columns: electioneeringColumns,
           order: [[1, 'desc']],
           dom: tables.simpleDOM,


### PR DESCRIPTION
## Summary (required)
Fix filter by committee_id for EC on committee profile page. currently return all committee EC.
https://www.fec.gov/data/committee/C30000533/?cycle=2018&tab=spending


- Resolves [#4098]( https://github.com/fecgov/openFEC/pull/4098)
_Include a summary of proposed changes._
Change 
/committee/{committee_id}/electioneering/by_candidate/

to use:
/electioneering/aggregates/?committee_id={committee_id}


## Impacted areas of the application
List general components of the application that this PR will affect:
committee profile page


## How to test
checkout branch
point to dev api
npm run build
npm run test-single
./manage.py test
./manage.py runserver

Test 1:
prod: return all committee electioneering communication:
https://www.fec.gov/data/committee/C30002562/?cycle=2018&tab=spending
local: return no data
http://127.0.0.1:8000/data/committee/C30002562/?tab=spending&cycle=2018

Test 2:
prod: return all committee electioneering communication:
https://www.fec.gov/data/committee/C30002562/?cycle=2016&tab=spending
local: return 1 row
http://127.0.0.1:8000/data/committee/C30002562/?tab=spending&cycle=2016

Test 3:
prod: return all committee electioneering communication:
https://www.fec.gov/data/committee/C30000533/?tab=spending&cycle=2008
local: return 4 rows
http://127.0.0.1:8000/data/committee/C30000533/?tab=spending&cycle=2008