### PR TITLE
Adds separating line between features on by the numbers pages

### DIFF
--- a/fec/data/templates/macros/bythenumbers.jinja
+++ b/fec/data/templates/macros/bythenumbers.jinja
@@ -59,6 +59,6 @@
     <li><a class="button button--standard button--table" href="/data/{{ value_field }}">Browse {{value_field}}</a></li>
     <li><button class="button button--alt js-ga-event"  data-a11y-dialog-show="{{ action }}-modal" data-ga-event="{{ action }} methodology modal clicked" aria-controls="{{ action }}-modal">Methodology</button></li>
   </ul>
-  <p><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
+  <p class="u-no-margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
 </div>
 {% endmacro %}

--- a/fec/data/templates/macros/bythenumbers.jinja
+++ b/fec/data/templates/macros/bythenumbers.jinja
@@ -54,13 +54,11 @@
 
 </div>
 
-<div class="content__section row">
+<div class="row">
   <ul class="list--buttons u-float-right">
     <li><a class="button button--standard button--table" href="/data/{{ value_field }}">Browse {{value_field}}</a></li>
     <li><button class="button button--alt js-ga-event"  data-a11y-dialog-show="{{ action }}-modal" data-ga-event="{{ action }} methodology modal clicked" aria-controls="{{ action }}-modal">Methodology</button></li>
-
-
   </ul>
-<p><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
+  <p><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
 </div>
 {% endmacro %}

--- a/fec/data/templates/raising-bythenumbers.jinja
+++ b/fec/data/templates/raising-bythenumbers.jinja
@@ -34,11 +34,12 @@
 {% block sections %}
 {% if FEATURES.aggregatetotals %}
 <section id="raising-summary" class="aggregate-totals-section">
-  <h2>Raising summary</h2>
+  <h2 class="u-padding--top">Raising summary</h2>
   <script defer id="gov_fec_agg_tots_script" data-theme="dark" data-office="{{ office }}" data-year="{{ election_year }}" data-action="raised" src="{{ asset_for_js('widgets/aggregate-totals-box.js') }}"></script>
 </section>
 {% endif %}
 <section id="raising-breakdowns">
+  <hr class="hr--dark">
   <section id="top-raisers" class="content__section">
     <h2>Who&apos;s raising the most</h2>
     {{ breakdowns.top_entities(election_years, election_year, 'raised', office ) }}
@@ -46,7 +47,8 @@
 </section>
 {% if FEATURES.contributionsbystate %}
 <section id="contributions-by-state">
-  <h2 class="heading--section u-padding--top">Where individual contributions come from</h2>
+  <hr class="hr--dark">
+  <h2 class="u-padding--top">Where individual contributions come from</h2>
 {# example of iframe implementation: #}
 {# <script defer id="gov_fec_contribs_by_state_script" src="{{ asset_for_js('widgets/contributions-by-state.js') }}"></script> #}
 {# <iframe src="/widgets/contributions-by-state" id="fec-gov-contribs-by-state"></iframe> #}

--- a/fec/data/templates/raising-bythenumbers.jinja
+++ b/fec/data/templates/raising-bythenumbers.jinja
@@ -34,7 +34,7 @@
 {% block sections %}
 {% if FEATURES.aggregatetotals %}
 <section id="raising-summary" class="aggregate-totals-section">
-  <h2 class="u-padding--top">Raising summary</h2>
+  <h2>Raising summary</h2>
   <script defer id="gov_fec_agg_tots_script" data-theme="dark" data-office="{{ office }}" data-year="{{ election_year }}" data-action="raised" src="{{ asset_for_js('widgets/aggregate-totals-box.js') }}"></script>
 </section>
 {% endif %}

--- a/fec/data/templates/raising-bythenumbers.jinja
+++ b/fec/data/templates/raising-bythenumbers.jinja
@@ -41,7 +41,7 @@
 <section id="raising-breakdowns">
   <hr class="hr--dark">
   <section id="top-raisers" class="content__section">
-    <h2>Who&apos;s raising the most</h2>
+    <h2 class="u-padding--top">Who&apos;s raising the most</h2>
     {{ breakdowns.top_entities(election_years, election_year, 'raised', office ) }}
   </section>
 </section>

--- a/fec/data/templates/raising-bythenumbers.jinja
+++ b/fec/data/templates/raising-bythenumbers.jinja
@@ -38,17 +38,15 @@
   <script defer id="gov_fec_agg_tots_script" data-theme="dark" data-office="{{ office }}" data-year="{{ election_year }}" data-action="raised" src="{{ asset_for_js('widgets/aggregate-totals-box.js') }}"></script>
 </section>
 {% endif %}
-<section id="raising-breakdowns">
-  <hr class="hr--dark">
+<section id="raising-breakdowns" class="option">
   <section id="top-raisers" class="content__section">
-    <h2 class="u-padding--top">Who&apos;s raising the most</h2>
+    <h2>Who&apos;s raising the most</h2>
     {{ breakdowns.top_entities(election_years, election_year, 'raised', office ) }}
   </section>
 </section>
 {% if FEATURES.contributionsbystate %}
-<section id="contributions-by-state">
-  <hr class="hr--dark">
-  <h2 class="u-padding--top">Where individual contributions come from</h2>
+<section id="contributions-by-state" class="option">
+  <h2>Where individual contributions come from</h2>
 {# example of iframe implementation: #}
 {# <script defer id="gov_fec_contribs_by_state_script" src="{{ asset_for_js('widgets/contributions-by-state.js') }}"></script> #}
 {# <iframe src="/widgets/contributions-by-state" id="fec-gov-contribs-by-state"></iframe> #}

--- a/fec/data/templates/spending-bythenumbers.jinja
+++ b/fec/data/templates/spending-bythenumbers.jinja
@@ -30,10 +30,9 @@
   <script defer id="gov_fec_agg_tots_script" data-theme="dark" data-office="{{ office }}" data-year="{{ election_year }}" data-action="spending" src="{{ asset_for_js('widgets/aggregate-totals-box.js') }}"></script>
 </section>
 {% endif %}
-<section id="spending-breakdown">
+<section id="spending-breakdown" class="option">
   <section id="top-spenders" class="content__section">
-    <hr class="hr--dark">
-    <h2 class="u-padding--top">Who&apos;s spending the most</h2>
+    <h2>Who&apos;s spending the most</h2>
     {{ breakdowns.top_entities(election_years, election_year, 'spent', office ) }}
   </section>
 </section>

--- a/fec/data/templates/spending-bythenumbers.jinja
+++ b/fec/data/templates/spending-bythenumbers.jinja
@@ -32,7 +32,8 @@
 {% endif %}
 <section id="spending-breakdown">
   <section id="top-spenders" class="content__section">
-    <h2>Who&apos;s spending the most</h2>
+    <hr class="hr--dark">
+    <h2 class="u-padding--top">Who&apos;s spending the most</h2>
     {{ breakdowns.top_entities(election_years, election_year, 'spent', office ) }}
   </section>
 </section>

--- a/fec/fec/static/scss/data-landing.scss
+++ b/fec/fec/static/scss/data-landing.scss
@@ -9,6 +9,7 @@
 @import "components/type-styles";
 @import "components/maps";
 @import "components/reaction-boxes";
+@import "components/_options";
 
 // for spending raising breakdown pages
 @import "components/breakdowns";


### PR DESCRIPTION
## Summary (required)

- Resolves #3328 
_Adds a horizontal rule between each feature on the raising-bythenumbers and spending-bythenumbers pages._

## Impacted areas of the application
List general components of the application that this PR will affect:

- Raising by the numbers
- Spending by the numbers

## Screenshots

<img width="1045" alt="Screen Shot 2019-11-26 at 7 59 23 PM" src="https://user-images.githubusercontent.com/12799132/69684625-57546700-1087-11ea-8486-8b18ccab4c4c.png">
<img width="1029" alt="Screen Shot 2019-11-26 at 7 59 50 PM" src="https://user-images.githubusercontent.com/12799132/69684624-56bbd080-1087-11ea-81ec-94aa659f7b7b.png">

## How to test
- Go to Raising by the numbers page: http://localhost:8000/data/raising-bythenumbers/
- Go to Spending by the numbers page: http://localhost:8000/data/spending-bythenumbers/
____

