### PR TITLE
Fixed typo on communication costs section

### DIFF
--- a/fec/data/templates/partials/candidate/other-spending-tab.jinja
+++ b/fec/data/templates/partials/candidate/other-spending-tab.jinja
@@ -73,7 +73,7 @@
         <div class="usa-width-one-half">
           <span class="label">Oppose</span>
           <span class="t-big-data js-oppose"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>oppose</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
         </div>
       </div>
       <table


### PR DESCRIPTION
## Summary (required)

- Resolves #3374 
_Fixed typo in candidate profile page communication costs section. Updated Oppose section to have detail language also read "Spent by others to **oppose**..."_

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile page communication costs section: http://localhost:8000/data/candidate/H0PA12181/?tab=other-spending#communication-costs

## Screenshots

![Screen Shot 2019-12-11 at 10 51 55 AM](https://user-images.githubusercontent.com/12799132/70636828-3271ff00-1c04-11ea-988a-1943c76626f1.png)

## How to test
- [x] Checkout this branch
- [x] Make sure the communication costs section text is now correct: http://localhost:8000/data/candidate/H0PA12181/?tab=other-spending#communication-costs
____

