### PR TITLE
Add error message close button for downloads

### DIFF
--- a/fec/fec/static/js/modules/download.js
+++ b/fec/fec/static/js/modules/download.js
@@ -189,12 +189,14 @@ DownloadItem.prototype.handleServerError = function(xhr) {
     this.$body.html(
       '<div class="message message--alert message--mini">' +
         'Sorry, you have exceeded your maximum downloads for the hour. Please try again later.' +
+        '<button class="js-close button--cancel download__cancel"><span class="u-visually-hidden">Remove</span></button>' +
         '</div>'
     );
   } else {
     this.$body.html(
       '<div class="message message--alert message--mini">' +
         'Sorry, you have either exceeded your maximum downloads for the hour or encountered a server error. Please try again later.' +
+        '<button class="js-close button--cancel download__cancel"><span class="u-visually-hidden">Remove</span></button>' +
         '</div>'
     );
   }
@@ -209,6 +211,14 @@ DownloadItem.prototype.handleServerError = function(xhr) {
   // Tell the container to subtract an item, but preserve the DOM itself
   // so that the message stays visible
   this.container.subtract(true);
+
+  // Add error close button functionality
+  $(this.$body)
+    .find('.js-close')
+    .on('click', this.handleCloseErrorClick.bind(this));
+};
+DownloadItem.prototype.handleCloseErrorClick = function() {
+  this.container.destroy();
 };
 
 function DownloadContainer(parent) {

--- a/fec/fec/static/scss/components/_downloads.scss
+++ b/fec/fec/static/scss/components/_downloads.scss
@@ -23,6 +23,13 @@
   position: fixed;
   width: 100%;
   z-index: $z-downloads;
+
+  .message--alert {
+    .button--cancel {
+      margin-left: u(2rem);
+      position: static;
+    }
+  }
 }
 
 .downloads__title {


### PR DESCRIPTION
## Summary

- Resolves #3339 
Added a close button for download window error messages.

## Impacted areas of the application
Added it to the error message in the template for the download error message text and styled it

## Screenshots
![image](https://user-images.githubusercontent.com/26720877/70660229-b8576f80-1c2f-11ea-81c0-3b4c1d49be32.png)

## Related PRs
None

## How to test
- Pull the branch
- `npm i` `npm run build`
- Change your API key to one with limits that you can hit, or otherwise ensure you get an error message
- `./manage.py runserver`
- Check an [Individual Contributions page](http://127.0.0.1:8000/data/receipts/individual-contributions/?committee_id=C00577130&committee_id=C00696948&contributor_employer=Amazon&two_year_transaction_period=2020), limit the results so the Export button is active
- Click the Export button at the top right
- The error message should appear at the bottom
- Clicking the X to the right of the message should close the window _and_ re-enable the export button
- We should check elsewhere where that kind of error may be found
- We should check other areas of the site that are similar to the downloads window and error message to make sure they're unaffected
____

