### PR TITLE
[MERGE WITH GITFLOW - HOTFIX] Update open gov link

### DIFF
--- a/fec/fec/templates/partials/footer-navigation.html
+++ b/fec/fec/templates/partials/footer-navigation.html
@@ -44,7 +44,7 @@
       <div class="grid__item">
         <ul>
           <li>
-            <a href="https://www.data.gov/open-gov/">Open government</a>
+            <a href="/open/">Open government</a>
           </li>
           <li>
             <a href="https://www.fbi.gov/protectedvoices">Protected Voices</a>


### PR DESCRIPTION
## Summary

- Resolves #3412 
_Update open government link in footer from `https://www.data.gov/open-gov/` to `/open/`._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Footer

## How to test
Include any information that may be helpful to the reviewer(s).
  This might include:
  - Add redirect in wagtail for `/open/` to go to the open govt page in wagtail, select the wagtail page instead of using the URL path
  - Go to the footer and click on the "open government" URL. It should redirect to the correct wagtail page locally.
____

