### PR TITLE
Remove 'None' value from list cycles_has_activity in ofec_committee_h…

### DIFF
--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -551,7 +551,8 @@ class TestCommitteeApiCalls(TestCase):
             'party_full': 'OTHER',
             'designation_full': 'Principal campaign committee',
             'cycles': [],
-            'cycles_has_activity': [2018],
+            # make sure we clean 'None' value in cycles_has_activity correctly
+            'cycles_has_activity': [2018, None],
             'committee_type': 'P',
             'party': 'OTH',
             'designation': 'P',
@@ -571,11 +572,16 @@ class TestCommitteeApiCalls(TestCase):
         assert all_candidates == []
         assert committee == first_row_data
 
+        # check if cycles_has_activity include 'None' item
+        # in function load_committee_history() in views.py (line 524)
+        # we remove 'None' value in cycles_has_activity
+        # so make sure cycles_has_activity not include 'None' value anymore,
+        assert None not in committee['cycles_has_activity']
         cycle_out_of_range, fallback_cycle, cycles = views.load_cycle_data(
             committee, cycle
         )
 
-        assert cycle_out_of_range == False
+        assert cycle_out_of_range is False
         assert fallback_cycle == 2018
         assert cycles == [2018]
 
@@ -624,7 +630,6 @@ class TestCommitteeApiCalls(TestCase):
         cycle_out_of_range, fallback_cycle, cycles = views.load_cycle_data(
             committee, cycle
         )
-
-        assert cycle_out_of_range == True
+        assert cycle_out_of_range is True
         assert fallback_cycle == 2018
         assert cycles == [2018]

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -518,7 +518,12 @@ def load_committee_history(committee_id, cycle=None):
     # (2)call committee/{committee_id}/candidates/history/{cycle}
     # under: candidate, get all candidates associated with that commitee
     path = '/committee/' + committee_id + '/candidates/history/' + str(cycle)
-    all_candidates = api_caller.load_endpoint_results(path, election_full=False)
+    all_candidates = api_caller.load_endpoint_results(
+        path, election_full=False)
+
+    # clean cycles_has_activity, remove 'None' value in cycles_has_activity
+    committee['cycles_has_activity'] = list(
+        filter(None, committee.get('cycles_has_activity')))
 
     return committee, all_candidates, cycle
 


### PR DESCRIPTION
## Summary (required)
C00140590 committee profile page is throwing a server error.

- Resolves #[[_3426_](https://github.com/fecgov/fec-cms/issues/3426)]
_Include a summary of proposed changes._
modify cms load_committee_history function in views.py
to clean cycles_has_activity, remove 'None' value in cycles_has_activity
committee['cycles_has_activity'] = list(filter(None, committee.get('cycles_has_activity')))

## Impacted areas of the application
committee profile page
 

## How to test
1) checkout branch
2)pytest
./manage.py test
3)npm run test-single
4) test url, compare with prod.
(wrong one)
prod: https://www.fec.gov/data/committee/C00140590/
local: http://127.0.0.1:8000/data/committee/C00140590/

(correct one should not affected)
prod: https://www.fec.gov/data/committee/C00105668/
local: http://127.0.0.1:8000/data/committee/C00105668/

We should create an separated issue to fix ofec_committee_history_mv