### PR TITLE
Modify format of archived MURs with one document

### DIFF
--- a/fec/legal/templates/legal-archived-mur.jinja
+++ b/fec/legal/templates/legal-archived-mur.jinja
@@ -83,21 +83,29 @@
     <section id="documents" class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
       {% if 'documents' not in mur %}
-      <!-- Most archived MURs don't have nested documents, and have MUR-level URL PDF details. For these, MUR URL is the PDF link -->
+      <!-- Current MURs don't have nested documents. MUR URL is the PDF link -->
         <div class="content__section">
           <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">Case documents</a>
-          (<a class="t-sans" href="{{ mur.url }}" target="_blank">{{ mur.pdf_size | filesize}}</a>)
+          (<a class="t-sans" href="{{ mur.url }}" target="_blank">{{ mur.pdf_size | filesize }}</a>)
         </div>
+      {% else %}
+      <!-- Archived MURs have nested documents and no MUR-level URL. See issue #2157 -->
+        {% if mur.get('documents', {}) | length == 1 %}
+        <!-- Show one 'case documents' button if there's only one PDF -->
+          <div class="content__section">
+            <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.documents[0].url }}" target="_blank">Case documents</a>
+            (<a class="t-sans" href="{{ mur.documents[0].url }}" target="_blank">{{ mur.documents[0].length | filesize }}</a>)
+          </div>
+        {% else %}
+        <!-- Make a case documents table -->
+          <table class="data-table data-table--text data-table--heading-borders">
+          <tbody>
+            {% for document in mur.documents %}
+              <td><a href="{{ document.url }}">Case documents, part {{ document.document_id }}</a> {{ document.length | filesize }}</td>
+              </tr>
+            {% endfor %}
+        {% endif %}
       {% endif %}
-      {% if 'documents' in mur%}
-      <!-- Some archived MURs have nested documents and no MUR-level URL. For these, MUR URL is the canonical page, to be consistent with current MURs. See issue #2157 -->
-        <table class="data-table data-table--text data-table--heading-borders">
-        <tbody>
-          {% for document in mur.documents %}
-            <td><a href="{{ document.url }}">Case documents, part {{ document.document_id }}</a> {{ document.length | filesize }}</td>
-            </tr>
-          {% endfor %}
-       {% endif %}
       </tbody>
     </table>
     </section>


### PR DESCRIPTION
## Summary (required)

- Resolves #2798 
Modify format of archived MURs with one document

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Archived MUR "documents" section

## Screenshots

### Before
<img width="458" alt="Screen Shot 2019-12-27 at 11 56 41 AM" src="https://user-images.githubusercontent.com/31420082/71525528-04491c00-28a0-11ea-9ba5-7b3e9cc90749.png">

### After
<img width="458" alt="Screen Shot 2019-12-27 at 11 56 45 AM" src="https://user-images.githubusercontent.com/31420082/71525530-090dd000-28a0-11ea-91b0-de0ef9a8d8e3.png">

## How to test

- `export FEC_API_URL="https://fec-dev-api.app.cloud.gov"`

Archived MUR with 1 doc
- http://localhost:8000/data/legal/matter-under-review/1/
- https://dev.fec.gov/data/legal/matter-under-review/1/

Archived MUR with multiple docs
- http://localhost:8000/data/legal/matter-under-review/3485/
- https://dev.fec.gov/data/legal/matter-under-review/3485/

Current MUR
- http://localhost:8000/data/legal/matter-under-review/7000/
- https://dev.fec.gov/data/legal/matter-under-review/7000/