### PR TITLE
[HOTFIX - Merge with gitflow] Fix connected organization on committee profile page

### DIFF
--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -77,7 +77,7 @@
           <tr>
             <td class="figure__label">Connected organization:</td>
             <td class="figure__value">
-                {{ affiliated_committee_name }}
+                {{ committee.affiliated_committee_name }}
             </td>
           </tr>
         {% endif %}


### PR DESCRIPTION
## Summary (required)

- Resolves #3435 
_This fixes the connected organization field inside SSF about this committee page._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  SSF about this committee profile page: http://localhost:8000/data/committee/C00062224/?tab=about-committee

## Screenshots

<img width="598" alt="Screen Shot 2020-01-02 at 3 07 56 PM" src="https://user-images.githubusercontent.com/12799132/71690201-06b0e780-2d72-11ea-8057-20151eb3619b.png">

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/fix_committee_profile_not_show | [link](https://github.com/fecgov/fec-cms/pull/3299)

## How to test
- [ ] Go to an SSF page like this one: http://localhost:8000/data/committee/C00062224/?tab=about-committee
- [ ] Make sure the connected organization field now shows
____

