### PR TITLE
fix name text for raw efile

### DIFF
--- a/fec/data/templates/partials/receipts-filter.jinja
+++ b/fec/data/templates/partials/receipts-filter.jinja
@@ -19,7 +19,7 @@ Filter receipts
 
 {% block efiling_filters %}
 <div class="filters__inner">
-  {{ typeahead.field('committee_id', 'Contributor name or ID', id_suffix='_raw') }}
+  {{ typeahead.field('committee_id', 'Recipient name or ID', id_suffix='_raw') }}
   {{ text.field('contributor_name', 'Contributor name', id_suffix='_raw') }}
   {{ text.field('contributor_city', 'Contributor city', id_suffix='_raw') }}
   {{ states.field('contributor_state', id_suffix='_raw') }}


### PR DESCRIPTION
## Summary (required)

- Resolves #3371 
## Impacted areas of the application
List general components of the application that this PR will affect:

-  Changes "CONTRIBUTOR NAME OR ID" text to be "RECIPIENT NAME OR ID" for raw efile receipts on https://www.fec.gov/data/receipts/?data_type=efiling&committee_id=C00010603&contributor_name=miller

Fixed version: 
1. check out this branch
2. run local api
3. run local cms
4. view fix at http://localhost:8000/data/receipts/?data_type=efiling&committee_id=C00010603&contributor_name=miller