### PR TITLE
Update statute landings page

### DIFF
--- a/fec/legal/templates/legal-statutes-landing.jinja
+++ b/fec/legal/templates/legal-statutes-landing.jinja
@@ -56,8 +56,8 @@
       <li>
         <p>Access the Government Printing Office (GPO) version of Title 52, Subtitle III and Title 26, Subtitle H.</p>
         <div class="grid grid--2-wide">
-          {{ document.thumbnail("Title 52, Voting and Elections, GPO", "https://www.govinfo.gov/content/pkg/USCODE-2017-title52/pdf/USCODE-2017-title52-subtitleIII-chap301.pdf", img="/resources/cms-content/images/thumbnail--title52.jpg", size="395KB") }}
-          {{ document.thumbnail("Title 26, Internal Revenue Code, GPO", "https://www.govinfo.gov/content/pkg/USCODE-2017-title26/pdf/USCODE-2017-title26-subtitleH.pdf", img="/resources/cms-content/images/thumbnail--title26.jpg", size="197KB") }}
+          {{ document.thumbnail("Title 52, Voting and Elections, GPO", "https://www.govinfo.gov/link/uscode/latest/52", img="/resources/cms-content/images/thumbnail--title52.original.jpg", size="395KB") }}
+          {{ document.thumbnail("Title 26, Internal Revenue Code, GPO", "https://www.govinfo.gov/content/pkg/USCODE-2018-title26/pdf/USCODE-2018-title26-subtitleH.pdf", img="/resources/cms-content/images/thumbnail--title26.original.jpg", size="197KB") }}
         </div>
       </li>
   </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #3428 
- Updates the link for Title 52 to the permalink and the link for Title 26, Subtitle H to the latest version available.
- Fixes the filenames used for the images next to Title 52 and Title 26, Subtitle H (the filenames for the images were missing "original" so that may be why they aren't showing up currently).

## Screenshots

- _Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface or front end change, include both a Before and After screenshot._
Before:
![image](https://user-images.githubusercontent.com/24437369/71919561-f8d4db00-3152-11ea-8cf6-95248a859fbc.png)

After: 
Thumbnails should look like this:
![image](https://user-images.githubusercontent.com/24437369/71919644-27eb4c80-3153-11ea-986b-cc80d0a612c5.png)

## How to test
Images are located at:
Title 52: https://www.fec.gov/resources/cms-content/images/thumbnail--title52.original.jpg
Title 26: https://www.fec.gov/resources/cms-content/images/thumbnail--title26.original.jpg

Make sure images show up when tested on landing page.

Ensure the link to the Title 52 points to https://www.govinfo.gov/link/uscode/latest/52/.
Ensure the link to Title 26, Subtitle H points to https://www.govinfo.gov/content/pkg/USCODE-2018-title26/pdf/USCODE-2018-title26-subtitleH.pdf.

