### PR TITLE
Update Guides.html to shorten link title

### DIFF
--- a/fec/home/templates/home/candidate-and-committee-services/guides.html
+++ b/fec/home/templates/home/candidate-and-committee-services/guides.html
@@ -80,7 +80,7 @@
               <li><a href="/help-candidates-and-committees/handling-loans-debts-and-advances/">Handling candidate loans, debts and advances</a> &#187;</li>
               <li><a href="/help-candidates-and-committees/keeping-records/">Keeping records</a> &#187;</li>
               <li><a href="/help-candidates-and-committees/filing-reports/">Filing candidate reports</a> &#187;</li>
-               <li><a href="/help-candidates-and-committees/understanding-public-funding-presidential-elections/">Understanding public funding of presidential elections</a> &#187;</li>
+               <li><a href="/help-candidates-and-committees/understanding-public-funding-presidential-elections/">Public funding of presidential elections</a> &#187;</li>
               <li><a href="/help-candidates-and-committees/presidential-transition-and-inauguration/">Funding the presidential transition and inauguration</a> &#187;</li>
               <li><a href="/help-candidates-and-committees/winding-down-candidate-campaign/">Winding down a campaign</a> &#187;</li>
             </ul>


### PR DESCRIPTION
## Summary (required)

-Takes out "understanding" from the public funding bucket to shorten link title

## Impacted areas of the application
List general components of the application that this PR will affect: Guides landing page

## How to test

Link title should now be: Public funding of presidential elections

