### PR TITLE
Trigger resize when toggling content

### DIFF
--- a/fec/fec/static/js/modules/toggle.js
+++ b/fec/fec/static/js/modules/toggle.js
@@ -16,6 +16,9 @@ module.exports = {
           $('#' + $input.attr('value')).attr('aria-hidden', 'true');
         });
         $('#' + $elm.attr('value')).attr('aria-hidden', 'false');
+        // Since we're toggling content that may not have been visible yet,
+        // let's trigger a resize so the page can adapt to it having a non-zero width:
+        $(document).trigger('resize');
       });
     });
   }


### PR DESCRIPTION
## Summary

If it dynamic content (e.g. datatables) wasn't visible when it was created, its width will be 0px, so we'll trigger a resize when we toggle it on (or off) to trigger its layout to refresh.

- Resolves #3344 

## Impacted areas of the application

- Added a resize event that will fire after any content has been toggled using the `js-panel-toggle-control` class name  

## Screenshots

![image](https://user-images.githubusercontent.com/26720877/72085645-a8d15200-32d3-11ea-8f7a-a870422f54f4.png)

## Related PRs
None

## How to test
- Pull branch, `npm i`, `npm run build`, `./manage.py runserver` like normal.
- Go to a [candidate's raising page](http://127.0.0.1:8000/data/candidate/P60007168/?cycle=2020&election_full=true&tab=raising)
- Under Individual Contributions, switch to the State tab
- Make sure the header for the newly-visible table is the same width as the table content below it (rather than only as wide as the text content requires it to be—see the screenshots from [the original ticket](https://github.com/fecgov/fec-cms/issues/3344))
- Toggle back & forth to make sure nothing else is affected
- Resize the window to make sure that still works fine (can't imagine it wouldn't)
- Check other tabs/toggles that use dynamic content like a datatables table
- Check other tabs/toggles that don't use dynamic content to make sure they're still fine
- Approve
- If you're the last approval, merge, delete

____

