### PR TITLE
Upgrade Django from 1.11.23 to 1.11.27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.23
+Django==1.11.27
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary

- Resolves #3423 
Upgrading Django from 1.11.23 to 1.11.27

## Impacted areas of the application
Being an upgrade to Django it's a universal change, but it's only patch-level so any changes should be fixes rather than new or tweaked features.

## Screenshots
None

## Related PRs
None

## How to test
- pull the branch
- activate the pyenv instance
- in `/`, run `pip install -r requirements.txt`
- run `npm i` and `npm run build`
- in `/fec/`,  `./manage.py runserver`
- get no errors
- [site](http://127.0.0.1:8000) should load and behave like normal
____

