### PR TITLE
Remove reaction box from WCCF feature

### DIFF
--- a/fec/data/templates/raising-bythenumbers.jinja
+++ b/fec/data/templates/raising-bythenumbers.jinja
@@ -1,6 +1,5 @@
 {% extends "layouts/sidebar-page.jinja" %}
 {% import "macros/bythenumbers.jinja" as breakdowns %}
-{% import 'macros/reaction-box.jinja' as reaction %}
 
 {% block css %}
 <link rel="stylesheet" type="text/css" href="{{ asset_for_css('data-landing.css') }}" />
@@ -51,9 +50,6 @@
 {# <script defer id="gov_fec_contribs_by_state_script" src="{{ asset_for_js('widgets/contributions-by-state.js') }}"></script> #}
 {# <iframe src="/widgets/contributions-by-state" id="fec-gov-contribs-by-state"></iframe> #}
 {% include 'partials/widgets/contributions-by-state.jinja' %}
-{% if FEATURES.wccf_reaction %}
-{{ reaction.reaction_box('contributions_by_state', 'raising-by-the-numbers') }}
-{% endif %}
 </section>
 {% endif %}
 {% endblock %}
@@ -86,5 +82,4 @@
   }
   </script>
   <script src="{{ asset_for_js('bythenumbers.js') }}"></script>
-  <script src="{{ asset_for_js('reaction-box.js') }}"></script>
 {% endblock %}

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -52,7 +52,6 @@ FEATURES = {
     'barcharts': bool(env.get_credential('FEC_FEATURE_HOME_BARCHARTS', '')),
     'use_tag_manager': bool(env.get_credential('FEC_FEATURE_USE_TAG_MANAGER', '')),
     'contributionsbystate': bool(env.get_credential('FEC_FEATURE_CONTRIBUTIONS_BY_STATE', '')),
-    'wccf_reaction': bool(env.get_credential('FEC_FEATURE_WCCF_REACTION', '')),
 }
 
 ENVIRONMENTS = {


### PR DESCRIPTION
## Summary 
Resolves #3460

- Remove reaction box macro from raisingbythenumbers.jinja
- Remove reaction box script tag from raisingbythenumbers.jinja
- Remove feature flag env var from settings/base.py

- [x] Followup work: remove `FEC_FEATURE_WCCF_REACTION` from `User Provided Service` vars on Cloud Foundry for prod, dev. stage, feature environments


## Impacted areas of the application

modified:   data/templates/raising-bythenumbers.jinja
modified:   fec/settings/base.py

## Related PRs
https://github.com/fecgov/fec-cms/pull/3302

## How to test
Include any information that may be helpful to the reviewer(s).
- checkout `feature/3460-remove-wccf-reaction-box`
- runserver
- confirm that reaction box is NOT under WCCF map on http://127.0.0.1:8000/data/raising-bythenumbers/
____

