### PR TITLE
[Merging to release branch] Display presidential map data for 2020 (Deploy on 1/29)

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -397,7 +397,7 @@ def load_presidential_map_candidate_data(cycle):
 
         if response['results']:
             # There are no presidential map files for the excluded states list.
-            excluded_states = ['AA','AE','AP','ZZ',]
+            excluded_states = ['AA','AE','AP','AS','GU','MP','PR','VI','ZZ',]
             for result in response['results']:
                 # Don't append excluded states to the state list
                 if result['state'] not in excluded_states:

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -380,14 +380,6 @@ def load_presidential_map_candidate_data(cycle):
 
     for candidate_id, name in candidate_ids.items():
         candidate_name_states[candidate_id] = { "name": name, "states": []}
-
-    # excluded_states = [
-    #     'AF',
-    #     'ZZ',
-    # ]
-        
-    # if state in excluded_states:
-    #     candidate_name_states[candidate_id]['states'].remove(['ZZ','AF'])
         
         # Get candidate's states that had contributions
         response = _call_api(
@@ -404,8 +396,12 @@ def load_presidential_map_candidate_data(cycle):
         )
 
         if response['results']:
+            # There are no presidential map files for the excluded states list.
+            excluded_states = ['AA','AE','AP','ZZ',]
             for result in response['results']:
-                candidate_name_states[candidate_id]['states'].append(result['state'])
+                # Don't append excluded states to the state list
+                if result['state'] not in excluded_states:
+                    candidate_name_states[candidate_id]['states'].append(result['state'])
 
     return candidate_name_states
 

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -418,8 +418,8 @@ def load_presidential_map_candidate_data():
                 # Ex: [2020, 2016]
                 for year in candidate_result['rounded_election_years']:
 
-                    # Only use presidential eleciton years up to 2008. That's all the data we have.
-                    if( year < 2008):
+                    # Only use presidential eleciton years up to 2020 for now. That's all the data we have.
+                    if( year < 2020):
                         continue
 
                     # Make a dictionary of election year to list of states that had contributions.

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -346,7 +346,7 @@ def load_top_candidates(
 #  }
 
 
-def load_presidential_map_candidate_data(cycle):
+def load_presidential_map_candidate_data():
 
     # List of presidential candidates
     #

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -40,7 +40,7 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="all-presidential-map-candidates">
             <button type="button" class="js-accordion-trigger accordion__button">All presidential map candidates</button>
             <div class="accordion__content">
-              <p>This data summarizes financial information disclosed by 2020 presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
               <h6 class="t-no-rules">All contributions</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
@@ -110,16 +110,6 @@
                   <li><a href="/files/bulk-downloads/Presidential_Map/2008/Contributions_by_3Zip.csv">2008</a></li>
                 </ul>
               </div>
-              <h6 class="t-no-rules">Report summaries form 3P</h6>
-              <i class="icon i-download icon--absolute--left"></i>
-              <div class="content__section--indent-left">
-                <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/report_summaries_form_3p.zip">2020</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/report_summaries_form_3p.zip">2016</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/report_summaries_form_3p.zip">2012</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/report_summaries_form_3p.zip">2008</a></li>
-                </ul>
-              </div>
               <h6 class="t-no-rules">All expenditures</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
@@ -130,12 +120,22 @@
                   <li><a href="/files/bulk-downloads/Presidential_Map/2008P00000001/P00000001D-ALL.zip">2008</a></li>
                 </ul>
               </div>
+              <h6 class="t-no-rules">Form 3P report summaries </h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/report_summaries_form_3p.zip">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/report_summaries_form_3p.zip">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/report_summaries_form_3p.zip">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/report_summaries_form_3p.zip">2008</a></li>
+                </ul>
+              </div>
             </div>
           </div>
           <div class="js-accordion accordion--neutral" data-content-prefix="all-presidential-democratic-candidates">
             <button type="button" class="js-accordion-trigger accordion__button">All Democratic presidential map candidates</button>
             <div class="accordion__content">
-              <p>This data summarizes financial information disclosed by 2020 Democratic presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <p>This data summarizes financial information disclosed by Democratic presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
               <h6 class="t-no-rules">All contributions</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
@@ -226,7 +226,7 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="all-presidential-republican-candidates">
             <button type="button" class="js-accordion-trigger accordion__button">All Republican presidential map candidates</button>
             <div class="accordion__content">
-              <p>This data summarizes financial information disclosed by 2020 Republican presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <p>This data summarizes financial information disclosed by Republican presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
               <h6 class="t-no-rules">All contributions</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
@@ -328,11 +328,11 @@
                 </ul>
               </div>
               <h6 class="t-no-rules">Contribution totals by state</h6>
-              <div class="content__section--indent-left">
                 <i class="icon i-download icon--absolute--left"></i>
                 <div class="content__section--indent-left">
                   <p>2020: <a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">All states</a></p>
                 </div>
+              <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
                   {% for state in candidate['states'] %}
                   <li><a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-{{state}}.zip">{{state}}</a></li>
@@ -350,6 +350,7 @@
               {% endfor %}
             </div>
           </div>
+          <p class="u-margin--top"><a href="/campaign-finance-data/presidential-map-help/">Learn how this information is compiled</a> &#187; </p>
         </div>
       </li>
       <li>

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -337,6 +337,7 @@
                   {% for state in candidate['states'] %}
                   <li><a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-{{state}}.zip">{{state}}</a></li>
                   {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-OTHER.zip">Other</a></li>
                 </ul>
               </div>
               <h6 class="t-no-rules">All expenditures</h6>

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -285,7 +285,6 @@
                 <h6 class="t-no-rules">Contribution totals by state</h6>
                 {% for year, states in candidate.states_by_election_year.items() %}
                 <i class="icon i-download icon--absolute--left"></i>
-
                 <div class="content__section--indent-left">
                   <ul class="list--flat-bordered u-no-margin">
                     <li>{{year}}: <a href="/files/bulk-downloads/Presidential_Map/{{year}}/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">All states</a></li>

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -321,38 +321,29 @@
               {% for candidate_id, candidate in load_presidential_map_candidate_data.items() %}
               <h4><a href="/data/candidate/{{ candidate_id }}/">{{ candidate.name }}</a></h4>
               <h6 class="t-no-rules">All contributions</h6>
-              {% for year, states in candidate.states_by_election_year.items() %}
-              <i class="icon i-download icon--absolute--left"></i>
-
-              <div class="content__section--indent-left">
-                <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/Presidential_Map/{{year}}/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">{{year}}</a></li>
-                </ul>
-              </div>
-              {% endfor %}
-
-              <h6 class="t-no-rules">Contribution totals by state</h6>
-              {% for year, states in candidate.states_by_election_year.items() %}
-              <div class="content__section--indent-left">
-                <i class="icon i-download icon--absolute--left"></i>
-                <div class="content__section--indent-left">
-                  <ul class="list--flat-bordered u-no-margin">
-                    <li>{{year}}: <a href="/files/bulk-downloads/Presidential_Map/{{year}}/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">All states</a></li>
-                  </ul>
-                </div>
-                <ul class="list--flat-bordered u-no-margin">
-                  {% for state in states %}
-                  <li><a href="/files/bulk-downloads/Presidential_Map/{{year}}/{{ candidate_id }}/{{ candidate_id }}-{{state}}.zip">{{state}}</a></li>
-                  {% endfor %}
-                </ul>
-              </div>
-              {% endfor %}
-
-              <h6 class="t-no-rules u-margin--top">All expenditures</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
                   <li><a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">2020</a></li>
+                </ul>
+              </div>
+              <h6 class="t-no-rules">Contribution totals by state</h6>
+              <div class="content__section--indent-left">
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <p>2020: <a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">All states</a></p>
+                </div>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for state in candidate['states'] %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-{{state}}.zip">{{state}}</a></li>
+                  {% endfor %}
+                </ul>
+              </div>
+              <h6 class="t-no-rules">All expenditures</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2020/candidate_summary_2020.csv">2020</a></li>
                 </ul>
               </div>
               {% endfor %}

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -40,7 +40,7 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="all-presidential-map-candidates">
             <button type="button" class="js-accordion-trigger accordion__button">All presidential map candidates</button>
             <div class="accordion__content">
-              <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <p>This data summarizes financial information disclosed by 2020 presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
               <h6 class="t-no-rules">All contributions</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
@@ -110,6 +110,16 @@
                   <li><a href="/files/bulk-downloads/Presidential_Map/2008/Contributions_by_3Zip.csv">2008</a></li>
                 </ul>
               </div>
+              <h6 class="t-no-rules">Report summaries form 3P</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/report_summaries_form_3p.zip">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/report_summaries_form_3p.zip">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/report_summaries_form_3p.zip">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/report_summaries_form_3p.zip">2008</a></li>
+                </ul>
+              </div>
               <h6 class="t-no-rules">All expenditures</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
@@ -125,24 +135,26 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="all-presidential-democratic-candidates">
             <button type="button" class="js-accordion-trigger accordion__button">All Democratic presidential map candidates</button>
             <div class="accordion__content">
-              <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <p>This data summarizes financial information disclosed by 2020 Democratic presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
               <h6 class="t-no-rules">All contributions</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000002/P00000002-ALL.zip">2020</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000002/P00000002-ALL.zip">2016</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-ALL.zip">2012</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000002/P00000002-ALL.zip">2008</a></li>
+                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2020/P00000002/">2020</a></li>
+                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2016/P00000002/">2016</a></li>
+                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2012/P00000002/">2012</a></li>
+                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2008/P00000002/">2008</a></li>
                 </ul>
               </div>
               <h6 class="t-no-rules">Contribution totals by state</h6>
-              <i class="icon i-download icon--absolute--left"></i>
-              <div class="content__section--indent-left">
-                <p><a href="">All states</a></p>
-              </div>
               <div class="content__section--indent-left">
                 <h6 class="t-no-rules">2020</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2020: <a href="/files/bulk-downloads/Presidential_Map/2020/P00000002/P00000002-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
                 <ul class="list--flat-bordered u-no-margin">
                   {% for value, label in constants.states.items() %}
                     <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000002/P00000002-{{ value }}.zip">{{ value }}</a></li>
@@ -153,6 +165,12 @@
               </div>
               <div class="content__section--indent-left">
                 <h6 class="t-no-rules">2016</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2016: <a href="/files/bulk-downloads/Presidential_Map/2016/P00000002/P00000002-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
                 <ul class="list--flat-bordered u-no-margin">
                   {% for value, label in constants.states.items() %}
                     <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000002/P00000002-{{ value }}.zip">{{ value }}</a></li>
@@ -163,6 +181,12 @@
               </div>
               <div class="content__section--indent-left">
                 <h6 class="t-no-rules">2012</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2012: <a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
                 <ul class="list--flat-bordered u-no-margin">
                   {% for value, label in constants.states.items() %}
                     <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-{{ value }}.zip">{{ value }}</a></li>
@@ -173,6 +197,12 @@
               </div>
               <div class="content__section--indent-left">
                 <h6 class="t-no-rules">2008</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2020: <a href="/files/bulk-downloads/Presidential_Map/2008/P00000002/P00000002-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
                 <ul class="list--flat-bordered u-no-margin">
                   {% for value, label in constants.states.items() %}
                     <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000002/P00000002-{{ value }}.zip">{{ value }}</a></li>
@@ -196,24 +226,26 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="all-presidential-republican-candidates">
             <button type="button" class="js-accordion-trigger accordion__button">All Republican presidential map candidates</button>
             <div class="accordion__content">
-              <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <p>This data summarizes financial information disclosed by 2020 Republican presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
               <h6 class="t-no-rules">All contributions</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000003/P00000003-ALL.zip">2020</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000003/P00000003-ALL.zip">2016</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000003/P00000003-ALL.zip">2012</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-ALL.zip">2008</a></li>
+                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2020/P00000003/">2020</a></li>
+                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2016/P00000003/">2016</a></li>
+                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2012/P00000003/">2012</a></li>
+                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2008/P00000003/">2008</a></li>
                 </ul>
               </div>
               <h6 class="t-no-rules">Contribution totals by state</h6>
-              <i class="icon i-download icon--absolute--left"></i>
-              <div class="content__section--indent-left">
-                <p><a href="">All states</a></p>
-              </div>
               <div class="content__section--indent-left">
                 <h6 class="t-no-rules">2020</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2020: <a href="/files/bulk-downloads/Presidential_Map/2020/P00000003/P00000003-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
                 <ul class="list--flat-bordered u-no-margin">
                   {% for value, label in constants.states.items() %}
                     <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-{{ value }}.zip">{{ value }}</a></li>
@@ -224,6 +256,12 @@
               </div>
               <div class="content__section--indent-left">
                 <h6 class="t-no-rules">2016</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2016: <a href="/files/bulk-downloads/Presidential_Map/2016/P00000003/P00000003-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
                 <ul class="list--flat-bordered u-no-margin">
                   {% for value, label in constants.states.items() %}
                     <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000003/P00000003-{{ value }}.zip">{{ value }}</a></li>
@@ -234,6 +272,12 @@
               </div>
               <div class="content__section--indent-left">
                 <h6 class="t-no-rules">2012</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2012: <a href="/files/bulk-downloads/Presidential_Map/2012/P00000003/P00000003-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
                 <ul class="list--flat-bordered u-no-margin">
                   {% for value, label in constants.states.items() %}
                     <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000003/P00000003-{{ value }}.zip">{{ value }}</a></li>
@@ -244,6 +288,12 @@
               </div>
               <div class="content__section--indent-left">
                 <h6 class="t-no-rules">2008</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2008: <a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
                 <ul class="list--flat-bordered u-no-margin">
                   {% for value, label in constants.states.items() %}
                     <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-{{ value }}.zip">{{ value }}</a></li>
@@ -267,23 +317,23 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="individual-presidential-candidates">
             <button type="button" class="js-accordion-trigger accordion__button">Individual presidential map candidates</button>
             <div class="accordion__content">
-              <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <p>This data summarizes financial information disclosed by 2020 presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              {% for candidate_id, candidate in load_presidential_map_candidate_data.items() %}
+              <h4><a href="/data/candidate/{{ candidate_id }}/">{{ candidate.name }}</a></h4>
+              <h6 class="t-no-rules">All contributions</h6>
+              {% for year, states in candidate.states_by_election_year.items() %}
+              <i class="icon i-download icon--absolute--left"></i>
+
               <div class="content__section--indent-left">
-                {% for candidate_id, candidate in load_presidential_map_candidate_data.items() %}
-                <h4><a href="/data/candidate/{{ candidate_id }}/">{{ candidate.name }}</a></h4>
-                <h6 class="t-no-rules">All contributions</h6>
-                {% for year, states in candidate.states_by_election_year.items() %}
-                <i class="icon i-download icon--absolute--left"></i>
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/{{year}}/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">{{year}}</a></li>
+                </ul>
+              </div>
+              {% endfor %}
 
-                <div class="content__section--indent-left">
-                  <ul class="list--flat-bordered u-no-margin">
-                    <li><a href="/files/bulk-downloads/Presidential_Map/{{year}}/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">{{year}}</a></li>
-                  </ul>
-                </div>
-                {% endfor %}
-
-                <h6 class="t-no-rules">Contribution totals by state</h6>
-                {% for year, states in candidate.states_by_election_year.items() %}
+              <h6 class="t-no-rules">Contribution totals by state</h6>
+              {% for year, states in candidate.states_by_election_year.items() %}
+              <div class="content__section--indent-left">
                 <i class="icon i-download icon--absolute--left"></i>
                 <div class="content__section--indent-left">
                   <ul class="list--flat-bordered u-no-margin">
@@ -295,17 +345,17 @@
                   <li><a href="/files/bulk-downloads/Presidential_Map/{{year}}/{{ candidate_id }}/{{ candidate_id }}-{{state}}.zip">{{state}}</a></li>
                   {% endfor %}
                 </ul>
-                {% endfor %}
-
-                <h6 class="t-no-rules u-margin--top">All expenditures</h6>
-                <i class="icon i-download icon--absolute--left"></i>
-                <div class="content__section--indent-left">
-                  <ul class="list--flat-bordered u-no-margin">
-                    <li><a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">2020</a></li>
-                  </ul>
-                </div>
-                {% endfor %}
               </div>
+              {% endfor %}
+
+              <h6 class="t-no-rules u-margin--top">All expenditures</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">2020</a></li>
+                </ul>
+              </div>
+              {% endfor %}
             </div>
           </div>
         </div>

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -12,7 +12,7 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="all-candidates">
             <button type="button" class="js-accordion-trigger accordion__button">Download this data as .CSV to use on your own</button>
             <div class="accordion__content">
-              <h6 class="t-no-rules">Candidate summary</h4>
+              <h6 class="t-no-rules">Candidate summary</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
@@ -37,6 +37,233 @@
           <h4><a href="/data/candidates/president/">Presidential candidates</a></h4>
           <p>Search presidential <span class="term" data-term="candidate" title="Click to define" tabindex="0">candidate</span> data including money raised, money spent, cash on hand and debt.</p>
           <p><a href="/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/#reports-and-resources">Find which candidates have applied for presidential public funding</a> &#187; </p>
+          <div class="js-accordion accordion--neutral" data-content-prefix="all-presidential-map-candidates">
+            <button type="button" class="js-accordion-trigger accordion__button">All presidential map candidates</button>
+            <div class="accordion__content">
+              <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <h6 class="t-no-rules">All contributions</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/Contributions_by_State.csv">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/Contributions_by_State.csv">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/Contributions_by_State.csv">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/Contributions_by_State.csv">2008</a></li>
+                </ul>
+              </div>
+              <h6 class="t-no-rules">Contribution totals by size</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/Contributions_by_Size.csv">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/Contributions_by_Size.csv">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/Contributions_by_Size.csv">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/Contributions_by_Size.csv">2008</a></li>
+                </ul>
+              </div>
+              <h6 class="t-no-rules">Contribution totals by state</h6>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2020</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2016</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2012</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2008</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                </ul>
+              </div>
+              <h6 class="t-no-rules">Contribution totals by state and three-digit zip code</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/Contributions_by_3Zip.csv">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/Contributions_by_3Zip.csv">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/Contributions_by_3Zip.csv">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/Contributions_by_3Zip.csv">2008</a></li>
+                </ul>
+              </div>
+              <h6 class="t-no-rules">All expenditures</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020P00000001/P00000001D-ALL.zip">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016P00000001/P00000001D-ALL.zip">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012P00000001/P00000001D-ALL.zip">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008P00000001/P00000001D-ALL.zip">2008</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="js-accordion accordion--neutral" data-content-prefix="all-presidential-democratic-candidates">
+            <button type="button" class="js-accordion-trigger accordion__button">All Democratic presidential map candidates</button>
+            <div class="accordion__content">
+              <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <h6 class="t-no-rules">All contributions</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000002/P00000002-ALL.zip">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000002/P00000002-ALL.zip">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-ALL.zip">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000002/P00000002-ALL.zip">2008</a></li>
+                </ul>
+              </div>
+              <h6 class="t-no-rules">Contribution totals by state</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <p><a href="">All states</a></p>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2020</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000002/P00000002-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2016</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000002/P00000002-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000002/P00000002-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000002/P00000002-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2012</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2008</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000002/P00000002-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000002/P00000002-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000002/P00000002-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <h6 class="t-no-rules">All expenditures</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2020/candidate_summary_2020.csv">2020</a></li>
+                  <li><a href="/files/bulk-downloads/2016/candidate_summary_2016.csv">2016</a></li>
+                  <li><a href="/files/bulk-downloads/2014/candidate_summary_2014.csv">2012</a></li>
+                  <li><a href="/files/bulk-downloads/2014/candidate_summary_2014.csv">2008</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="js-accordion accordion--neutral" data-content-prefix="all-presidential-republican-candidates">
+            <button type="button" class="js-accordion-trigger accordion__button">All Republican presidential map candidates</button>
+            <div class="accordion__content">
+              <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <h6 class="t-no-rules">All contributions</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000003/P00000003-ALL.zip">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000003/P00000003-ALL.zip">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000003/P00000003-ALL.zip">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-ALL.zip">2008</a></li>
+                </ul>
+              </div>
+              <h6 class="t-no-rules">Contribution totals by state</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <p><a href="">All states</a></p>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2020</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2016</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000003/P00000003-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000003/P00000003-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000003/P00000003-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2012</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000003/P00000003-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000003/P00000003-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000003/P00000003-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2008</h6>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <h6 class="t-no-rules">All expenditures</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003D-ALL.zip">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003D-ALL.zip">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003D-ALL.zip">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003D-ALL.zip">2008</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
         </div>
       </li>
       <li>

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -269,7 +269,7 @@
             <div class="accordion__content">
               <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
               <div class="content__section--indent-left">
-                {% for candidate_id, candidate in load_presidential_candidate_data.items() %}
+                {% for candidate_id, candidate in load_presidential_map_candidate_data.items() %}
                 <h4><a href="/data/candidate/{{ candidate_id }}/">{{ candidate.name }}</a></h4>
                 <h6 class="t-no-rules">All contributions</h6>
                 {% for year, states in candidate.states_by_election_year.items() %}

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -264,6 +264,51 @@
               </div>
             </div>
           </div>
+          <div class="js-accordion accordion--neutral" data-content-prefix="individual-presidential-candidates">
+            <button type="button" class="js-accordion-trigger accordion__button">Individual presidential map candidates</button>
+            <div class="accordion__content">
+              <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
+              <div class="content__section--indent-left">
+                {% for candidate_id, candidate in load_presidential_candidate_data.items() %}
+                <h4><a href="/data/candidate/{{ candidate_id }}/">{{ candidate.name }}</a></h4>
+                <h6 class="t-no-rules">All contributions</h6>
+                {% for year, states in candidate.states_by_election_year.items() %}
+                <i class="icon i-download icon--absolute--left"></i>
+
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li><a href="/files/bulk-downloads/Presidential_Map/{{year}}/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">{{year}}</a></li>
+                  </ul>
+                </div>
+                {% endfor %}
+
+                <h6 class="t-no-rules">Contribution totals by state</h6>
+                {% for year, states in candidate.states_by_election_year.items() %}
+                <i class="icon i-download icon--absolute--left"></i>
+
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>{{year}}: <a href="/files/bulk-downloads/Presidential_Map/{{year}}/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for state in states %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/{{year}}/{{ candidate_id }}/{{ candidate_id }}-{{state}}.zip">{{state}}</a></li>
+                  {% endfor %}
+                </ul>
+                {% endfor %}
+
+                <h6 class="t-no-rules u-margin--top">All expenditures</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">2020</a></li>
+                  </ul>
+                </div>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
         </div>
       </li>
       <li>

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -41,14 +41,24 @@
             <button type="button" class="js-accordion-trigger accordion__button">All presidential map candidates</button>
             <div class="accordion__content">
               <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
-              <h6 class="t-no-rules">All contributions</h6>
+              <h6 class="t-no-rules">Overall candidate summary</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/Contributions_by_State.csv">2020</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/Contributions_by_State.csv">2016</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/Contributions_by_State.csv">2012</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/Contributions_by_State.csv">2008</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/2020_overall_summary_now.csv">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/2016_overall_summary_now.csv">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/2012_overall_summary_now.csv">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/2008_overall_summary_now.csv">2008</a></li>
+                </ul>
+              </div>
+              <h6 class="t-no-rules">Summary by report</h6>
+              <i class="icon i-download icon--absolute--left"></i>
+              <div class="content__section--indent-left">
+                <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/report_summaries_form_3p.zip">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/report_summaries_form_3p.zip">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/report_summaries_form_3p.zip">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/report_summaries_form_3p.zip">2008</a></li>
                 </ul>
               </div>
               <h6 class="t-no-rules">Contribution totals by size</h6>
@@ -61,45 +71,6 @@
                   <li><a href="/files/bulk-downloads/Presidential_Map/2008/Contributions_by_Size.csv">2008</a></li>
                 </ul>
               </div>
-              <h6 class="t-no-rules">Contribution totals by state</h6>
-              <div class="content__section--indent-left">
-                <h6 class="t-no-rules">2020</h6>
-                <ul class="list--flat-bordered u-no-margin">
-                  {% for value, label in constants.states.items() %}
-                    <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
-                  {% endfor %}
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-ZZ.zip">ZZ</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-OTHER.zip">Other</a></li>
-                </ul>
-              </div>
-              <div class="content__section--indent-left">
-                <h6 class="t-no-rules">2016</h6>
-                <ul class="list--flat-bordered u-no-margin">
-                  {% for value, label in constants.states.items() %}
-                    <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
-                  {% endfor %}
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-ZZ.zip">ZZ</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-OTHER.zip">Other</a></li>
-                </ul>
-              </div>
-              <div class="content__section--indent-left">
-                <h6 class="t-no-rules">2012</h6>
-                <ul class="list--flat-bordered u-no-margin">
-                  {% for value, label in constants.states.items() %}
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
-                  {% endfor %}
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-ZZ.zip">ZZ</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-OTHER.zip">Other</a></li>
-                </ul>
-              </div>
-              <div class="content__section--indent-left">
-                <h6 class="t-no-rules">2008</h6>
-                <ul class="list--flat-bordered u-no-margin">
-                  {% for value, label in constants.states.items() %}
-                    <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
-                  {% endfor %}
-                </ul>
-              </div>
               <h6 class="t-no-rules">Contribution totals by state and three-digit zip code</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
@@ -110,24 +81,78 @@
                   <li><a href="/files/bulk-downloads/Presidential_Map/2008/Contributions_by_3Zip.csv">2008</a></li>
                 </ul>
               </div>
+              <h6 class="t-no-rules">Contribution totals by state</h6>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2020</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2020: <a href="/files/bulk-downloads/Presidential_Map/2020/P00000001/P00000001-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
+                <ul class="list--flat-bordered u-no-margin">
+                {# Update states list to remove exluded_states #}
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2016</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2016: <a href="/files/bulk-downloads/Presidential_Map/2016/P00000001/P00000001-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2012</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2012: <a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001-OTHER.zip">Other</a></li>
+                </ul>
+              </div>
+              <div class="content__section--indent-left">
+                <h6 class="t-no-rules">2008</h6>
+                <i class="icon i-download icon--absolute--left"></i>
+                <div class="content__section--indent-left">
+                  <ul class="list--flat-bordered u-no-margin">
+                    <li>2008: <a href="/files/bulk-downloads/Presidential_Map/2008/P00000001/P00000001-ALL.zip">All states</a></li>
+                  </ul>
+                </div>
+                <ul class="list--flat-bordered u-no-margin">
+                  {% for value, label in constants.states.items() %}
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000001/P00000001-{{ value }}.zip">{{ value }}</a></li>
+                  {% endfor %}
+                </ul>
+              </div>
               <h6 class="t-no-rules">All expenditures</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2020P00000001/P00000001D-ALL.zip">2020</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2016P00000001/P00000001D-ALL.zip">2016</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012P00000001/P00000001D-ALL.zip">2012</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008P00000001/P00000001D-ALL.zip">2008</a></li>
-                </ul>
-              </div>
-              <h6 class="t-no-rules">Form 3P report summaries </h6>
-              <i class="icon i-download icon--absolute--left"></i>
-              <div class="content__section--indent-left">
-                <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/report_summaries_form_3p.zip">2020</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/report_summaries_form_3p.zip">2016</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/report_summaries_form_3p.zip">2012</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/report_summaries_form_3p.zip">2008</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000001/P00000001D-ALL.zip">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000001/P00000001D-ALL.zip">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000001/P00000001D-ALL.zip">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000001/P00000001D-ALL.zip">2008</a></li>
                 </ul>
               </div>
             </div>
@@ -136,16 +161,6 @@
             <button type="button" class="js-accordion-trigger accordion__button">All Democratic presidential map candidates</button>
             <div class="accordion__content">
               <p>This data summarizes financial information disclosed by Democratic presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
-              <h6 class="t-no-rules">All contributions</h6>
-              <i class="icon i-download icon--absolute--left"></i>
-              <div class="content__section--indent-left">
-                <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2020/P00000002/">2020</a></li>
-                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2016/P00000002/">2016</a></li>
-                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2012/P00000002/">2012</a></li>
-                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2008/P00000002/">2008</a></li>
-                </ul>
-              </div>
               <h6 class="t-no-rules">Contribution totals by state</h6>
               <div class="content__section--indent-left">
                 <h6 class="t-no-rules">2020</h6>
@@ -159,8 +174,8 @@
                   {% for value, label in constants.states.items() %}
                     <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000002/P00000002-{{ value }}.zip">{{ value }}</a></li>
                   {% endfor %}
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-ZZ.zip">ZZ</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002-OTHER.zip">Other</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000002/P00000002-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000002/P00000002-OTHER.zip">Other</a></li>
                 </ul>
               </div>
               <div class="content__section--indent-left">
@@ -200,7 +215,7 @@
                 <i class="icon i-download icon--absolute--left"></i>
                 <div class="content__section--indent-left">
                   <ul class="list--flat-bordered u-no-margin">
-                    <li>2020: <a href="/files/bulk-downloads/Presidential_Map/2008/P00000002/P00000002-ALL.zip">All states</a></li>
+                    <li>2008: <a href="/files/bulk-downloads/Presidential_Map/2008/P00000002/P00000002-ALL.zip">All states</a></li>
                   </ul>
                 </div>
                 <ul class="list--flat-bordered u-no-margin">
@@ -215,10 +230,10 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/2020/candidate_summary_2020.csv">2020</a></li>
-                  <li><a href="/files/bulk-downloads/2016/candidate_summary_2016.csv">2016</a></li>
-                  <li><a href="/files/bulk-downloads/2014/candidate_summary_2014.csv">2012</a></li>
-                  <li><a href="/files/bulk-downloads/2014/candidate_summary_2014.csv">2008</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000002/P00000002D-ALL.zip">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000002/P00000002D-ALL.zip">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000002/P00000002D-ALL.zip">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000002/P00000002D-ALL.zip">2008</a></li>
                 </ul>
               </div>
             </div>
@@ -227,16 +242,6 @@
             <button type="button" class="js-accordion-trigger accordion__button">All Republican presidential map candidates</button>
             <div class="accordion__content">
               <p>This data summarizes financial information disclosed by Republican presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
-              <h6 class="t-no-rules">All contributions</h6>
-              <i class="icon i-download icon--absolute--left"></i>
-              <div class="content__section--indent-left">
-                <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2020/P00000003/">2020</a></li>
-                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2016/P00000003/">2016</a></li>
-                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2012/P00000003/">2012</a></li>
-                  <li><a href="/files/bulk-downloads/index.html?prefix=bulk-downloads/Presidential_Map/2008/P00000003/">2008</a></li>
-                </ul>
-              </div>
               <h6 class="t-no-rules">Contribution totals by state</h6>
               <div class="content__section--indent-left">
                 <h6 class="t-no-rules">2020</h6>
@@ -248,10 +253,10 @@
                 </div>
                 <ul class="list--flat-bordered u-no-margin">
                   {% for value, label in constants.states.items() %}
-                    <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-{{ value }}.zip">{{ value }}</a></li>
+                    <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000003/P00000003-{{ value }}.zip">{{ value }}</a></li>
                   {% endfor %}
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-ZZ.zip">ZZ</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003-OTHER.zip">Other</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000003/P00000003-ZZ.zip">ZZ</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000003/P00000003-OTHER.zip">Other</a></li>
                 </ul>
               </div>
               <div class="content__section--indent-left">
@@ -306,9 +311,9 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003D-ALL.zip">2020</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003D-ALL.zip">2016</a></li>
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003D-ALL.zip">2012</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/P00000003/P00000003D-ALL.zip">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2016/P00000003/P00000003D-ALL.zip">2016</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2012/P00000003/P00000003D-ALL.zip">2012</a></li>
                   <li><a href="/files/bulk-downloads/Presidential_Map/2008/P00000003/P00000003D-ALL.zip">2008</a></li>
                 </ul>
               </div>
@@ -320,13 +325,6 @@
               <p>This data summarizes financial information disclosed by 2020 presidential candidates who have reported at least $100,000 in contributions from individuals other than the candidate.</p>
               {% for candidate_id, candidate in load_presidential_map_candidate_data.items() %}
               <h4><a href="/data/candidate/{{ candidate_id }}/">{{ candidate.name }}</a></h4>
-              <h6 class="t-no-rules">All contributions</h6>
-              <i class="icon i-download icon--absolute--left"></i>
-              <div class="content__section--indent-left">
-                <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}-ALL.zip">2020</a></li>
-                </ul>
-              </div>
               <h6 class="t-no-rules">Contribution totals by state</h6>
                 <i class="icon i-download icon--absolute--left"></i>
                 <div class="content__section--indent-left">
@@ -344,7 +342,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/2020/candidate_summary_2020.csv">2020</a></li>
+                  <li><a href="/files/bulk-downloads/Presidential_Map/2020/{{ candidate_id }}/{{ candidate_id }}D-ALL.zip">2020</a></li>
                 </ul>
               </div>
               {% endfor %}

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -116,7 +116,6 @@ def search(request):
 
 def browse_data(request):
     load_presidential_map_candidate_data = api_caller.load_presidential_map_candidate_data(2020)
-    print(load_presidential_map_candidate_data)
     return render(
         request,
         "browse-data.jinja",

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -115,10 +115,13 @@ def search(request):
 
 
 def browse_data(request):
+    load_presidential_map_candidate_data = api_caller.load_presidential_map_candidate_data(2020)
+    print(load_presidential_map_candidate_data)
     return render(
         request,
         "browse-data.jinja",
-        {"title": "Browse data", "parent": "data", "social_image_identifier": "data"},
+        {"title": "Browse data", "parent": "data", "social_image_identifier": "data",
+         'load_presidential_map_candidate_data': load_presidential_map_candidate_data},
     )
 
 
@@ -654,7 +657,6 @@ def raising(request):
             "social_image_identifier": "data",
         },
     )
-
 
 def spending(request):
     office = request.GET.get("office", "P")

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -115,7 +115,7 @@ def search(request):
 
 
 def browse_data(request):
-    load_presidential_map_candidate_data = api_caller.load_presidential_map_candidate_data(2020)
+    load_presidential_map_candidate_data = api_caller.load_presidential_map_candidate_data()
     print(load_presidential_map_candidate_data)
     return render(
         request,

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -115,7 +115,7 @@ def search(request):
 
 
 def browse_data(request):
-    load_presidential_map_candidate_data = api_caller.load_presidential_map_candidate_data()
+    load_presidential_map_candidate_data = api_caller.load_presidential_map_candidate_data(2020)
     print(load_presidential_map_candidate_data)
     return render(
         request,


### PR DESCRIPTION
## Summary

- Resolves #3486 
_Adds accordions for 2020 presidential map data files._

**This hotfix needs to be deployed on Wednesday 1/29. Please provide feedback ASAP.**

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Browse data candidates tab: https://www.fec.gov/data/browse-data/?tab=candidates

## Screenshots

<img width="726" alt="Screen Shot 2020-01-27 at 8 59 21 PM" src="https://user-images.githubusercontent.com/12799132/73229487-ee04d900-4147-11ea-9668-53a6a12740cc.png">

## How to test
- [ ] Check out this branch
- [ ] Go to http://localhost:8000/data/browse-data/?tab=candidates and check accordions.
- [ ] Ensure links are correct according to this [doc's specs](https://docs.google.com/document/d/1KbPV_v_nxZQOhq75ogrPohM0bNmNyjiFj0fQV1Di1OI/edit?ts=5e2c41f8) 🔒 
- [ ] Ensure the 2020 list of candidates is accurate according to this [spreadsheet's specs](https://docs.google.com/spreadsheets/d/1_oOGQL7jF5bP1VYDuBh3KFRKXRCWPAvwkvb24kJ-CcM/edit#gid=894303291) 🔒 