### PR TITLE
Upgrade handlebars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7038,9 +7038,9 @@
       }
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
+      "integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -10153,9 +10153,9 @@
       "dev": true
     },
     "node-sass": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
-      "integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "gulp-sourcemaps": "^2.6.5",
     "gulp-svgmin": "^2.1.0",
     "gulp-uglify": "3.0.1",
-    "handlebars": "^4.3.0",
+    "handlebars": "^4.7.2",
     "handlebars-template-loader": "^1.0.0",
     "hbsfy": "2.8.1",
     "istanbul-instrumenter-loader": "^3.0.1",


### PR DESCRIPTION
## Summary

- Resolves #3525 

## Impacted areas of the application
Upgraded the version of handlebars as outlined at https://www.npmjs.com/advisories/1325
Could impact any page / template that used handlebars (Anything with `{{` and `}}`; any template with an `.hbs` extension)

## Screenshots
There were no visual changes

## Related PRs
None

## How to test
- Pull the branch as usual
- `npm i`
- `npm run build`
- `./manage.py runserver`
- Confirm there are no build errors
- Check that different types of pages display as usual:
  - Homepage
  - Data pages (a couple)
  - Legal pages (a couple)
  - Blog pages (a couple)
____

