### PR TITLE
Update F3X to F24 when 24- and 48-Hour Reports selected

### DIFF
--- a/fec/data/templates/macros/filters/ie-reports.jinja
+++ b/fec/data/templates/macros/filters/ie-reports.jinja
@@ -1,5 +1,5 @@
 {% macro type(id_suffix) %}
-<fieldset class="filter toggles toggles--vertical js-filter" data-filter="toggle" data-remove-on-switch="true" id="is_notice-toggle{{id_suffix}}">
+<fieldset class="toggles toggles--vertical js-filter" data-filter="toggle" data-remove-on-switch="true" id="is_notice-toggle{{id_suffix}}">
   <legend class="label t-inline-block u-float-left">Report type</legend>
   <div class="tooltip__container">
     <button class="tooltip__trigger" type="button" aria-controls="data-type-tooltip"><span class="u-visually-hidden">Learn more</span></button>
@@ -24,7 +24,7 @@
 {% macro form(id_suffix) %}
 <div class="filter">
   <fieldset class="filter js-filter" data-filter="checkbox">
-    <legend class="label">Regularly scheduled report form</legend>
+    <legend class="label">Report form</legend>
     <ul>
       <li>
         <input id="filing-form-f3x{{id_suffix}}" name="filing_form" type="checkbox" value="F3X">

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -651,6 +651,16 @@ DataTable.prototype.fetch = function(data, callback) {
       );
       return;
     }
+    //console.log(self.filterSet);
+    // If 24- and 48-Hour report is selected, set the filing form to F24.
+    // Otherwise, it's a regularly scheduled report, keep the filing
+    // form as F3X
+    if (self.filters && self.filters.filing_form) {
+      var F3X_index = self.filters.filing_form.indexOf('F3X');
+      if (self.filters.is_notice == 'true' && F3X_index > -1) {
+        self.filters.filing_form[F3X_index] = 'F24';
+      }
+    }
   }
 
   var url = self.buildUrl(data);

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -651,7 +651,7 @@ DataTable.prototype.fetch = function(data, callback) {
       );
       return;
     }
-    //console.log(self.filterSet);
+
     // If 24- and 48-Hour report is selected, set the filing form to F24.
     // Otherwise, it's a regularly scheduled report, keep the filing
     // form as F3X

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -550,4 +550,34 @@ describe('data table', function() {
       ).to.be.above(0);
     });
   });
+
+  describe('Update to F24', function() {
+    beforeEach(function() {
+      this.table.xhr = null;
+      $('body').append(
+        '<div id="is_notice-toggle_processed"><ul class="dropdown__selected"></ul><input id="filing-form-f3x_processed" /></div>'
+      );
+    });
+
+    it('filing form updates to F24 when is_notice is true', function() {
+      var serialized = {
+        is_notice: 'true',
+        filing_form: ['F3X']
+      };
+      this.table.filterSet = {
+        serialize: function() {
+          return serialized;
+        },
+        fields: ['is_notice', 'filing_form']
+      };
+      this.table.filterSet.isValid = true;
+      var callback = sinon.stub();
+      this.table.fetch({}, callback);
+      expect(this.table.filters).to.deep.equal(serialized);
+      expect(
+        this.table.filters.filing_form,
+        'Expected filing form to be F24'
+      ).to.deep.equal(['F24']);
+    });
+  });
 });


### PR DESCRIPTION
## Summary (required)

- Resolves #3463 
_Update the regularly scheduled report form from F3X to F24 when 24- and 48-Hour Reports are selected._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Independent expenditures datatable: https://www.fec.gov/data/independent-expenditures/

## Screenshots

-No screenshots, just modified fetch call._

## How to test
- [ ] Checkout this branch
- [ ] npm run build
- [ ] Go to the IE datatable: http://localhost:8000/data/independent-expenditures/
- [ ] Check the Form 3X checkbox under Regularly scheduled report form. Make sure to leave Report type toggle with the `24- and 48-Hour Report` selected.
- [ ] Check the AJAX call in the console to make sure that it's querying for `filing_form=F24`.
- [ ] Change the Report type toggle to have `Regularly scheduled reports` selected.
- [ ] Check the AJAX call in the console to make sure that it's querying for `filing_form=F3X`.
____

