### PR TITLE
redirect to default most_recent to true on load

### DIFF
--- a/fec/data/templates/macros/filters/version-status.jinja
+++ b/fec/data/templates/macros/filters/version-status.jinja
@@ -4,7 +4,7 @@
     <legend class="label">Version</legend>
     <ul>
       <li>
-        <input id="most_recent_true{{ id_suffix }}" name="most_recent" type="checkbox" checked value="true">
+        <input id="most_recent_true{{ id_suffix }}" name="most_recent" type="checkbox" value="true">
         <label for="most_recent_true{{ id_suffix }}">Current version</label>
       </li>
       {% if methodology %}

--- a/fec/data/views_datatables.py
+++ b/fec/data/views_datatables.py
@@ -109,6 +109,9 @@ def electioneering_communications(request):
 
 
 def independent_expenditures(request):
+    if len(request.GET) == 0:
+        return redirect('/data/independent-expenditures/?most_recent=true')
+
     return render(request, 'datatable.jinja', {
         'parent': 'data',
         'slug': 'independent-expenditures',


### PR DESCRIPTION
## Summary

- Resolves #3538 
_The current version checkbox needs to be checked on load instead of always checked. This applies a redirect to the independent expenditures datatable, consistent with other implementations to load a filter on default._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Independent expenditures datatable

## How to test
- checkout this branch
- go to IE datatable: http://localhost:8000/data/independent-expenditures/
- check to make sure on load, the current version checkbox is checked
- uncheck the current version checkbox to make sure it will apply correctly
____

