### PR TITLE
Conditionally disable current version and add report type toggle to raw

### DIFF
--- a/fec/data/templates/macros/filters/version-status.jinja
+++ b/fec/data/templates/macros/filters/version-status.jinja
@@ -1,10 +1,13 @@
-{% macro version(id_suffix, methodology) %}
+{% macro version(id_suffix, methodology, helper_text=False) %}
 <div class="filter">
-  <fieldset class="js-filter" data-filter="checkbox">
+  <fieldset class="js-filter" id="version{{ id_suffix }}" data-filter="checkbox">
     <legend class="label">Version</legend>
+    {% if helper_text %}
+      <label class="label--help u-margin--top">{{ helper_text }}</label>
+    {% endif %}
     <ul>
       <li>
-        <input id="most_recent_true{{ id_suffix }}" name="most_recent" type="checkbox" checked value="true">
+        <input id="most_recent_true{{ id_suffix }}" name="most_recent" type="checkbox" value="true">
         <label for="most_recent_true{{ id_suffix }}">Current version</label>
       </li>
       {% if methodology %}

--- a/fec/data/templates/partials/independent-expenditures-filter.jinja
+++ b/fec/data/templates/partials/independent-expenditures-filter.jinja
@@ -55,7 +55,7 @@ Filter independent expenditures
     {{ years.cycles('cycle', 'Years', show_tooltip=False) }}
     {{ reports.type(id_suffix='_processed') }}
     {{ reports.form(id_suffix='_processed') }}
-    {{ version_status.version(id_suffix='_processed', methodology='True', helper_text = 'Insert helper') }}
+    {{ version_status.version(id_suffix='_processed', methodology='True') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button"  data-content-prefix="candidate_mentioned_processed">Candidate mentioned</button>
   <div class="accordion__content" id="candidate_mentioned_processed_0" aria-controls="candidate_mentioned_processed_0">

--- a/fec/data/templates/partials/independent-expenditures-filter.jinja
+++ b/fec/data/templates/partials/independent-expenditures-filter.jinja
@@ -25,6 +25,8 @@ Filter independent expenditures
   <div class="filters__inner">
     {{ typeahead.field('committee_id', 'Spender name or ID', id_suffix='_raw') }}
     {{ text.field('candidate_search', 'Candidate mentioned', id_suffix='_raw') }}
+    {{ reports.type(id_suffix='_raw') }}
+    {{ reports.form(id_suffix='_raw') }}
     {{ version_status.version(id_suffix='_raw', methodology='True') }}
   </div>
 {# Removing these filters for now until the filter count bug can be fixed #}
@@ -53,7 +55,7 @@ Filter independent expenditures
     {{ years.cycles('cycle', 'Years', show_tooltip=False) }}
     {{ reports.type(id_suffix='_processed') }}
     {{ reports.form(id_suffix='_processed') }}
-    {{ version_status.version(id_suffix='_processed', methodology='True') }}
+    {{ version_status.version(id_suffix='_processed', methodology='True', helper_text = 'Insert helper') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button"  data-content-prefix="candidate_mentioned_processed">Candidate mentioned</button>
   <div class="accordion__content" id="candidate_mentioned_processed_0" aria-controls="candidate_mentioned_processed_0">

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -652,13 +652,6 @@ DataTable.prototype.fetch = function(data, callback) {
       return;
     }
 
-    // Filter by current and unknown versions when current version is checked
-    // API does not allow for null values for most_recent now
-    if (self.filters && self.filters.most_recent) {
-      self.filters.most_recent = 'true';
-      self.filters.most_recent = 'null';
-    }
-
     // If 24- and 48-Hour report is selected, set the filing form to F24.
     // Otherwise, it's a regularly scheduled report, keep the filing
     // form as F3X

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -652,6 +652,13 @@ DataTable.prototype.fetch = function(data, callback) {
       return;
     }
 
+    // Filter by current and unknown versions when current version is checked
+    // API does not allow for null values for most_recent now
+    if (self.filters && self.filters.most_recent) {
+      self.filters.most_recent = 'true';
+      self.filters.most_recent = 'null';
+    }
+
     // If 24- and 48-Hour report is selected, set the filing form to F24.
     // Otherwise, it's a regularly scheduled report, keep the filing
     // form as F3X
@@ -660,6 +667,31 @@ DataTable.prototype.fetch = function(data, callback) {
       if (self.filters.is_notice == 'true' && F3X_index > -1) {
         self.filters.filing_form[F3X_index] = 'F24';
       }
+    }
+
+    // Regularly scheduled reports only have current versions
+    // Therefore, we need to check current version by default
+    // and disable changes.
+    if (
+      self.filters &&
+      self.filters.data_type == 'processed' &&
+      self.filters.is_notice == 'false'
+    ) {
+      self.filters.most_recent = 'true';
+      $('#most_recent_true_processed').prop('checked', true);
+      $(
+        '#version_processed legend, #version_processed li, #version_processed label'
+      )
+        .removeClass('is-active-filter')
+        .addClass('is-disabled-filter');
+    } else if (
+      self.filters &&
+      self.filters.data_type == 'processed' &&
+      self.filters.is_notice == 'true'
+    ) {
+      $(
+        '#version_processed legend, #version_processed li, #version_processed label'
+      ).removeClass('is-disabled-filter');
     }
   }
 


### PR DESCRIPTION
## Summary

- Resolves #3545 
- Resolves #3549  
_This PR disables the version filter when regularly scheduled reports toggle is selected within processed. It also adds the report type toggle to the raw IE data filters. The helper_text option was added to the version filter as an option when the methodology is complete._

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Independent expenditures datatable: http://localhost:8000/data/independent-expenditures/

## Screenshots

Processed only: Disables the version filter when regularly scheduled reports toggle is selected
![Screen Shot 2020-02-13 at 3 42 40 PM](https://user-images.githubusercontent.com/12799132/74476399-3fff6b80-4e77-11ea-983b-3dcf0db2a4e0.png)

## How to test
- checkout this branch
- npm run build
- go to the IE datatable: http://localhost:8000/data/independent-expenditures/
- Ensure that Version is disabled when regularly scheduled report is selected
- Ensure that Report type toggle is present in Raw filings and that counts look ok