### PR TITLE
Update gunicorn to 19.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.11.27
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7
-gunicorn==19.7.1
+gunicorn==19.10.0
 gevent==1.2.1
 lxml==4.2.5
 psycopg2==2.7.3.2

--- a/tasks.py
+++ b/tasks.py
@@ -74,6 +74,7 @@ DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/3466-update-gunicorn'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     #('feature', lambda _, branch: branch == 'feature/add-legal-citations-to-full-width-template'),
 )


### PR DESCRIPTION
## Summary (required)

- Resolves #3466 

Update gunicorn to 19.10.0 See https://snyk.io/vuln/SNYK-PYTHON-GUNICORN-541164

## How to test the changes locally

- Gunicorn is only used in production, so you need to deploy to `dev` to test

## Impacted areas of the application
List general components of the application that this PR will affect:

-  More info about gunicorn: https://gunicorn.org/
- See https://github.com/fecgov/fec-cms/blob/develop/bin/run.sh#L17



