### PR TITLE
[MERGE AFTER openFEC 4220] Fix number for transfers in

### DIFF
--- a/fec/data/templates/widgets/pres-finance-map.jinja
+++ b/fec/data/templates/widgets/pres-finance-map.jinja
@@ -92,7 +92,7 @@
                 <tr><td>&nbsp;&nbsp;Parties</td><td class="t-right-aligned t-mono" data-sum-id="party_contributions_less_refunds">$000</td></tr>
                 <tr><td>&nbsp;&nbsp;Candidates</td><td class="t-right-aligned t-mono" data-sum-id="candidate_contributions_less_repayments">$000</td></tr>
                 <tr><td>Federal funds</td><td class="t-right-aligned t-mono" data-sum-id="federal_funds">CHECK THIS $000</td></tr>
-                <tr><td>Transfers-in</td><td class="t-right-aligned t-mono" data-sum-id="transfers_to_other_authorized_committees">$000</td></tr>
+                <tr><td>Transfers-in</td><td class="t-right-aligned t-mono" data-sum-id="transfers_from_affiliated_committees">$000</td></tr>
                 <tr><td colspan="2">Contributions by size</td></tr>
                 <tr><td>$200 and under</td><td class="t-right-aligned t-mono" data-size_range_id="1">$000</td></tr>
                 <tr><td>$200.01-$499</td><td class="t-right-aligned t-mono" data-size_range_id="2">$000</td></tr>


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/openFEC/issues/4219
Fix number for transfers in

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Presidential map, transfers in

## Screenshots

![Screen Shot 2020-02-19 at 4 12 37 PM](https://user-images.githubusercontent.com/31420082/74877005-b6e2ab80-5332-11ea-9a55-978c088015c0.png)


## Related PRs
https://github.com/fecgov/openFEC/issues/4219 

## How to test
- Connect to `dev` API (after https://github.com/fecgov/openFEC/issues/4219 is merged)
- make sure `FEC_FEATURE_PRESIDENTIAL_MAP` is set to `True`
- Go to http://localhost:8000/data/candidates/president/presidential-map/
- Check that "Transfers in" number for 2020 nationwide matches screenshot
![Screen Shot 2020-02-19 at 4 08 00 PM](https://user-images.githubusercontent.com/31420082/74876776-49367f80-5332-11ea-9f14-26541e72268e.png)


