### PR TITLE
Revert "Update gunicorn to 19.10.0"

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,6 @@ DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
-    ('dev', lambda _, branch: branch == 'feature/3466-update-gunicorn'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     #('feature', lambda _, branch: branch == 'feature/add-legal-citations-to-full-width-template'),
 )


### PR DESCRIPTION
## Summary (required)

@fec-jli @pkfec: This PR removes the manual deploy branch accidentally merged under #3557. As part of the manual deploy/review I added the feature branch to tasks.py and merged before dropping that commit. This PR restores tasks.py.

cc @lbeaufort
