### PR TITLE
Update Django to 2.2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.10
+Django==2.2.11
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary (required)

- Resolves #3606 
Update Django one minor version (`2.2.10` > `2.2.11`)
https://docs.djangoproject.com/en/3.0/releases/2.2.11/

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Minor bug and security fixes

## How to test

- Check out this branch
- `pip install -r requirements.txt`
-  Run locally
- Run pytest