### PR TITLE
[before cut release]Change to call /communication_cost/aggregates

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -683,18 +683,14 @@ $(document).ready(function() {
         });
         break;
       case 'communication-cost-committee':
-        path = [
-          'committee',
-          committeeId,
-          'communication_costs',
-          'by_candidate'
-        ];
+        path = ['communication_costs', 'aggregates'];
         // For raising/spending tabs, use previous cycle if provided
         cycle = context.cycle || $table.attr('data-cycle');
         tables.DataTable.defer($table, {
           path: path,
           query: _.extend(query, {
-            cycle: cycle
+            cycle: cycle,
+            committee_id: committeeId
           }),
           columns: communicationCostColumns,
           order: [[0, 'desc']],


### PR DESCRIPTION
## Summary (required)
Fix filter by committee_id for CC on committee profile page. currently return all committee's EC.
(passing committee_id=C70000112  cycle=2014, return 1265 records)
[https://www.fec.gov/data/committee/C70000112/?cycle=2014&tab=spending](https://www.fec.gov/data/committee/C70000112/?cycle=2014&tab=spending)



Resolves [#3615]( https://github.com/fecgov/fec-cms/issues/3615)

_Include a summary of proposed changes._
Change 
/committee/{committee_id}/communication_costs/by_candidate/

to use:
/communication_costs/aggregates/?committee_id={committee_id}


## Impacted areas of the application
List general components of the application that this PR will affect:
committee profile page


## How to test
checkout branch
point to dev api
npm run build
npm run test-single
./manage.py test
./manage.py runserver

Test :
one prod: return all committee's communication costs (1265 records):
[https://www.fec.gov/data/committee/C70000112/?cycle=2014&tab=spending
](https://www.fec.gov/data/committee/C70000112/?cycle=2014&tab=spending)

local: return C70000112's CC (161 records)
[http://127.0.0.1:8000/data/committee/C70000112/?tab=spending&cycle=2014](http://127.0.0.1:8000/data/committee/C70000112/?tab=spending&cycle=2014)