### PR TITLE
[MERGE WITH GIT FLOW] Hotfix/fix coverage dates

### DIFF
--- a/fec/data/tests/test_utils.py
+++ b/fec/data/tests/test_utils.py
@@ -144,25 +144,30 @@ class TestCycles(unittest.TestCase):
 
 
 class TestPresidentialCoverageDate(unittest.TestCase):
-    @mock.patch('data.utils.get_tomorrow')
-    def test_get_presidential_coverage_date(self, get_tomorrow):
+    @mock.patch('data.utils.get_today')
+    def test_get_presidential_coverage_date(self, get_today):
 
-        get_tomorrow.return_value = datetime.datetime(2020, 3, 18)
+        # Day of the M2 deadline - M2's aren't ready yet
+        get_today.return_value = datetime.date(2020, 3, 20)
         assert utils.get_presidential_coverage_date("M") == "January 31, 2020"
         assert utils.get_presidential_coverage_date("Q") == "December 31, 2019"
 
-        get_tomorrow.return_value = datetime.datetime(2020, 3, 22)
+        # Day after M2, should reflect the ending coverage date of M2
+        get_today.return_value = datetime.date(2020, 3, 21)
         assert utils.get_presidential_coverage_date("M") == "February 29, 2020"
         assert utils.get_presidential_coverage_date("Q") == "December 31, 2019"
 
-        get_tomorrow.return_value = datetime.datetime(2020, 4, 17)
+        # Day of the Q1, Q1's aren't ready yet
+        get_today.return_value = datetime.date(2020, 4, 15)
+        assert utils.get_presidential_coverage_date("M") == "February 29, 2020"
+        assert utils.get_presidential_coverage_date("Q") == "December 31, 2019"
+
+        # Day after the Q1 deadline, should reflect ending coverage for Q1
+        get_today.return_value = datetime.date(2020, 4, 16)
         assert utils.get_presidential_coverage_date("M") == "February 29, 2020"
         assert utils.get_presidential_coverage_date("Q") == "March 31, 2020"
 
-        get_tomorrow.return_value = datetime.datetime(2020, 4, 22)
-        assert utils.get_presidential_coverage_date("M") == "March 31, 2020"
-        assert utils.get_presidential_coverage_date("Q") == "March 31, 2020"
-
-        get_tomorrow.return_value = datetime.datetime(2022, 2, 22)
+        # Future date gets most recent coverage dates available
+        get_today.return_value = datetime.date(2022, 2, 25)
         assert utils.get_presidential_coverage_date("M") == "December 31, 2020"
         assert utils.get_presidential_coverage_date("Q") == "December 31, 2020"

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -258,20 +258,31 @@ def get_presidential_coverage_date(filing_frequency):
     else:
         date_lookup = collections.OrderedDict(QUARTERLY_DATES)
 
-    tomorrow = get_tomorrow()
+    today = get_today()
 
     for due_date in date_lookup:
-        if tomorrow > datetime.datetime.strptime(due_date, '%m/%d/%Y'):
+        if today > string_to_date(due_date):
             coverage_end_date = format_date_longform(date_lookup[due_date])
         # don't keep looping after you've found the most recent due date
-        if tomorrow <= datetime.datetime.strptime(due_date, '%m/%d/%Y'):
+        if today < string_to_date(due_date):
             break
 
     return coverage_end_date
 
 
-def get_tomorrow():
-    return datetime.datetime.today() + datetime.timedelta(days=1)
+def get_today():
+    """
+    Make this a separate function for testing. No timestamp
+    """
+    return datetime.date.today()
+
+
+def string_to_date(string_date):
+    """
+    Convert "12/31/2019" to `datetime.date`
+    `strptime` is only a property of `datetime` but we don't want timestamps
+    """
+    return datetime.datetime.strptime(string_date, '%m/%d/%Y').date()
 
 
 def format_date_longform(date):


### PR DESCRIPTION
## Summary (required)

- Resolves issue found in testing
- Remove timestamps from date comparisons, fix coverage dates for presidential bulk files
- Improve test coverage

## Impacted areas of the application

List general components of the application that this PR will affect:

-  http://localhost:8000/data/browse-data/?tab=candidates

## Screenshots

### Before
<img width="683" alt="Screen Shot 2020-03-20 at 10 43 46 AM" src="https://user-images.githubusercontent.com/31420082/77174921-2ebe0600-6a98-11ea-942c-8516d8f095b6.png">

### After
<img width="683" alt="Screen Shot 2020-03-20 at 10 44 58 AM" src="https://user-images.githubusercontent.com/31420082/77174833-10f0a100-6a98-11ea-9459-32cd071f937d.png">


## How to test

-  http://localhost:8000/data/browse-data/?tab=candidates should show 1/31/20 as ending monthly coverage date until tomorrow (1/21/)

Original PR: https://github.com/fecgov/fec-cms/pull/3629