### PR TITLE
fix aligment in IE of candidate column on pres map

### DIFF
--- a/fec/fec/static/scss/widgets/pres-finance-map.scss
+++ b/fec/fec/static/scss/widgets/pres-finance-map.scss
@@ -201,7 +201,8 @@ $info-circle: 'data:image/svg+xml;charset=utf8, %3Csvg%20xmlns%3D%22http%3A%2F%2
       &:last-child {
         flex-grow: 0;
         flex-shrink: 0;
-        width: 100px;
+        width: auto;
+        display:-ms-flexbox;
       }
       &:only-child {
         width: 100%;

--- a/fec/fec/static/scss/widgets/pres-finance-map.scss
+++ b/fec/fec/static/scss/widgets/pres-finance-map.scss
@@ -202,7 +202,7 @@ $info-circle: 'data:image/svg+xml;charset=utf8, %3Csvg%20xmlns%3D%22http%3A%2F%2
         flex-grow: 0;
         flex-shrink: 0;
         width: auto;
-        display:-ms-flexbox;
+        display:-ms-flexbox; //fixes IE alignment problem 
       }
       &:only-child {
         width: 100%;

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    #('feature', lambda _, branch: branch == 'feature/add-legal-citations-to-full-width-template'),
+    ('feature', lambda _, branch: branch == 'feature/fix-IE-alignment-pres-map'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/fix-IE-alignment-pres-map'),
+    #('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 


### PR DESCRIPTION
## Summary 
Fixes IE alignment of candidate column on pres-finance-map
If we just want to add this to second round of edits, I can cancel this PR --OR--  if we think this is important, we can hotfix it.

- Resolves # (No current GH issue) This issue is referenced on page 7 of the MSCW document:
https://docs.google.com/document/d/1CH5-W6QzVF7Zve2P3ttVPK9gdfVNm_x5NBY4gXoV9vQ/edit#

_Include a summary of proposed changes._
- Add MS prefixed rule `display:-ms-flexbox` to last-child TDs of candidate column
- Change width from `100px` to `auto` (@robert - I hope this one  is OK?--did not seem to break anything in desktop or responsive views)

## Impacted areas of the application

modified:   fec/static/scss/widgets/pres-finance-map.scss

## Screenshots

![ie-alignment](https://user-images.githubusercontent.com/5572856/77199794-cb47ce80-6abf-11ea-8066-986dc1d2fd4c.jpg)


## Related PRs
Presidential map branch 5
https://github.com/fecgov/fec-cms/pull/3632


## How to test
**One can test on feature space:**
https://fec-feature-cms.app.cloud.gov/data/candidates/president/presidential-map/

**Or run locally:**
- Checkout and run :
feature/fix-IE-alignment-pres-map
- `npm run build-sass`
- Go to: http://127.0.0.1:8000/data/candidates/president/presidential-map/
- Test in IE to see properly aligned numbers in candidate column 
-If you are so inclined:
   [Testing your local dev server on your MS surface or other Windows machine](https://github.com/fecgov/fec-cms/wiki/Testing-a-dev-branch-on-iPhone,-Internet-Explorer-Windows,-Android)
- Also test in modern browsers to make sure this slight change does not break somewhere else.



____
