### PR TITLE
Correct var name missed in code-cleanup on pres map

### DIFF
--- a/fec/fec/static/js/widgets/pres-finance-map-box.js
+++ b/fec/fec/static/js/widgets/pres-finance-map-box.js
@@ -716,7 +716,7 @@ PresidentialFundsMap.prototype.loadContributionSizes = function() {
  */
 PresidentialFundsMap.prototype.loadCoverageDates = function() {
   document.dispatchEvent(new CustomEvent(ENTER_LOADING_EVENT));
-
+  //Needed for promises and nested functions
   let instance = this;
   let thisQuery = Object.assign({}, this.baseCoverageQuery, {
     candidate_id: this.current_candidateID,

--- a/fec/fec/static/js/widgets/pres-finance-map-box.js
+++ b/fec/fec/static/js/widgets/pres-finance-map-box.js
@@ -1235,7 +1235,6 @@ PresidentialFundsMap.prototype.refreshOverlay = function() {
  * @param {MouseEvent} e
  */
 PresidentialFundsMap.prototype.openDownloads = function() {
-
   //show downloads area on initial click (leave shown after that)
   this.downloadsWrapper.style.height = 'auto';
 

--- a/fec/fec/static/js/widgets/pres-finance-map-box.js
+++ b/fec/fec/static/js/widgets/pres-finance-map-box.js
@@ -1235,7 +1235,6 @@ PresidentialFundsMap.prototype.refreshOverlay = function() {
  * @param {MouseEvent} e
  */
 PresidentialFundsMap.prototype.openDownloads = function() {
-  let instance = this;
 
   //show downloads area on initial click (leave shown after that)
   this.downloadsWrapper.style.height = 'auto';
@@ -1249,7 +1248,7 @@ PresidentialFundsMap.prototype.openDownloads = function() {
       $(this).height('auto');
     }
   );
-  $(instance.toggleRaisingExports).toggleClass('button--close', true);
+  $(this.raisingExportsToggle).toggleClass('button--close', true);
 };
 
 /**


### PR DESCRIPTION
## Summary
During some code cleanup, a variable name-change  was overlooked,  making the initial button-state (open/close ) incorrect on first-load of the `raising exports download area`. The button should be a minus(-), when the accordion is open.

**Commit of original changes:**
7d8cde1 Cleanup (comments, typos, unused, tests)

**Proposed changes, this PR:**

https://github.com/fecgov/fec-cms/blob/fad2446d4a227f3e4da0a676c89b415b7034fddd/fec/fec/static/js/widgets/pres-finance-map-box.js#L1252

  - change the above line to:
 `$(this.raisingExportsToggle).toggleClass('button--close', true);`

 - Also remove unnecessary `instance=this` declaration on line [#1238 ](https://github.com/fecgov/fec-cms/blob/fad2446d4a227f3e4da0a676c89b415b7034fddd/fec/fec/static/js/widgets/pres-finance-map-box.js#L1238)

## Impacted areas of the application

modified:   fec/static/js/widgets/pres-finance-map-box.js


## Screenshots
![plus](https://user-images.githubusercontent.com/5572856/77766229-bc0fd600-7015-11ea-8c8d-cfe2ba3d51d9.gif)

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
[pres map 5](https://github.com/fecgov/fec-cms/tree/feature/3631-presidential-map-5)| https://github.com/fecgov/fec-cms/pull/3632

## How to test
- checkout `fix/correct-variable-name-missed-on-cleanup`
- `npm run-build`
-  go to http://127.0.0.1:8000/data/candidates/president/presidential-map/
- Open the Raising accordion and click on `Export raising data button`
-  Confirm that the open/close toggle button on the raising exports area is in the correct state (plus or minus) based on the state of the accordion. If the accordion  is open, the toggle should be a "minus" , if its closed, it should be a "plus"

____
