### PR TITLE
Add best bets count to total count

### DIFF
--- a/fec/search/templates/search/policy_guidance_search_page.html
+++ b/fec/search/templates/search/policy_guidance_search_page.html
@@ -26,7 +26,7 @@
           <div class="heading--section" class="row">
             <h2 class="u-float-left u-no-margin">Results</h2>
             <div class="u-float-right">
-              <span class="t-sans">{{ results.meta.count }} total results</span>
+              <span class="t-sans">{{ total_count }} total results</span>
             </div>
           </div>
           <ul>

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -167,6 +167,8 @@ def policy_guidance_search(request):
     num_pages = 1
     if results:
         num_pages = math.ceil(int(results['meta']['count']) / limit)
+
+    total_count = results['meta']['count'] + results['best_bets']['count']
     
     resultset = {}
     resultset['search_query'] = search_query
@@ -175,5 +177,6 @@ def policy_guidance_search(request):
     resultset['offset'] = offset
     resultset['num_pages'] = num_pages
     resultset['current_page'] = current_page
+    resultset['total_count'] = total_count
 
     return render(request, 'search/policy_guidance_search_page.html', resultset)


### PR DESCRIPTION
## Summary (required)

- Resolves #3662
_Adds best bets count to total count for guidance search._

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Guidance search

## Screenshots

<img width="676" alt="Screen Shot 2020-04-06 at 10 03 30 PM" src="https://user-images.githubusercontent.com/12799132/78622302-cc645400-7852-11ea-901f-883d9d982bd0.png">

## Related PRs

branch | PR
------ | ------
feature/3601-policy-guidance-search | [https://github.com/fecgov/fec-cms/pull/3607]()

## How to test

- Pull down this PR
- `export SEARCH_GOV_POLICY_GUIDANCE_KEY` in your environment vars. You can grab this API access key by logging into search.gov and accessing the fec_content_s3 site.
- `export FEC_FEATURE_GUIDANCE_SEARCH = true`
- Go to http://localhost:8000/legal-resources/policy-and-other-guidance/guidance-documents/
- Try a search that includes best bets search like `citizens united`. The total count should add best bets and results count to give an accurate count 

____
