### PR TITLE
fix guidance search on load

### DIFF
--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -165,10 +165,10 @@ def policy_guidance_search(request):
     results = policy_guidance_search_site(search_query, limit=limit, offset=offset)
     current_page = int(int(offset) / limit) + 1
     num_pages = 1
+    total_count = 0
     if results:
         num_pages = math.ceil(int(results['meta']['count']) / limit)
-
-    total_count = results['meta']['count'] + results['best_bets']['count']
+        total_count = results['meta']['count'] + results['best_bets']['count']
     
     resultset = {}
     resultset['search_query'] = search_query


### PR DESCRIPTION
## Summary

_I noticed that the guidance page was not loading on load. It had this error below. This is because I did not make sure results appear before doing a count, so none was returned. This patch ensures that total_count always has a value._

total_count = results['meta']['count'] + results['best_bets']['count']
TypeError: 'NoneType' object is not subscriptable

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Guidance search

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
feature/3662-add-best-bets-to-count | [https://github.com/fecgov/fec-cms/pull/3663]()

## How to test

- Pull down this PR
- `export SEARCH_GOV_POLICY_GUIDANCE_KEY` in your environment vars. You can grab this API access key by logging into search.gov and accessing the fec_content_s3 site.
- `export FEC_FEATURE_GUIDANCE_SEARCH = true`
- Go to http://localhost:8000/legal-resources/policy-and-other-guidance/guidance-documents/ and make sure it loads
- Try a search that includes best bets search like `citizens united`. The total count should add best bets and results count to give an accurate count 
____
