### PR TITLE
Update sitemap for html guidance pages

### DIFF
--- a/fec/search/management/data/sitemap_html.xml
+++ b/fec/search/management/data/sitemap_html.xml
@@ -2,32 +2,38 @@
 <urlset>
 <url>
 <loc>https://www.fec.gov/updates/fec-provides-guidance-following-us-district-court-decision-crew-v-fec-316-f-supp-3d-349-ddc-2018/</loc>
-<lastmod>2018-04-10T00:00:00+00:00</lastmod>
+<lastmod>2020-04-01T00:00:00+00:00</lastmod>
+<meta property="article:published_time" content="2018-04-10" />
 </url>
 <url>
 <loc>https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/</loc>
-<lastmod>2008-07-25T00:00:00+00:00</lastmod>
+<lastmod>2020-04-06T00:00:00+00:00</lastmod>
 <meta property="article:published_time" content="2010-05-02" />
 </url>
 <url>
 <loc>https://www.fec.gov/updates/fec-statement-on-the-dc-circuit-court-of-appeals-decision-in/</loc>
-<lastmod>2010-01-12T00:00:00+00:00</lastmod>
+<lastmod>2020-04-01T00:00:00+00:00</lastmod>
+<meta property="article:published_time" content="2010-05-01" />
 </url>
 <url>
 <loc>https://www.fec.gov/updates/fec-statement-on-carey-fec/</loc>
-<lastmod>2011-10-05T00:00:00+00:00</lastmod>
+<lastmod>2020-04-01T00:00:00+00:00</lastmod>
+<meta property="article:published_time" content="2011-05-10" />
 </url>
 <url>
 <loc>https://www.fec.gov/updates/fec-statement-on-2/</loc>
-<lastmod>2012-07-27T00:00:00+00:00</lastmod>
+<lastmod>2020-04-01T00:00:00+00:00</lastmod>
+<meta property="article:published_time" content="2012-27-07" />
 </url>
 <url>
 <loc>https://www.fec.gov/updates/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/</loc>
-<lastmod>2015-02-13T00:00:00+00:00</lastmod>
+<lastmod>2020-04-01T00:00:00+00:00</lastmod>
+<meta property="article:published_time" content="2015-15-02" />
 </url>
 <url>
 <loc>https://www.fec.gov/updates/fec-adopts-interim-verification-procedure-for-filings-containing-possibly-false-or-fictitious-information/</loc>
-<lastmod>2016-08-18T00:00:00+00:00</lastmod>
+<lastmod>2020-04-01T00:00:00+00:00</lastmod>
+<meta property="article:published_time" content="2016-16-08" />
 </url>
 <url>
   <loc>https://webforms.fec.gov/wfja/form99</loc>


### PR DESCRIPTION
## Summary (required)

Updates the sitemap of HTML pages to catch changes made this month to those pages


## How to test

- Verify that the dates are in correct format YYYY-MM-DD and are April 2020 (except for the last one).