### PR TITLE
Filter to create valid anchors out of numeric titles

### DIFF
--- a/fec/home/templates/blocks/section.html
+++ b/fec/home/templates/blocks/section.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags %}
 {% load filters %}
 
-<section id="{{ value.title | slugify}}" class="option {% if value.hide_title %}option--no-top-border{% endif %}">
+<section id="{{ value.title | prepend_non_digit | slugify}}" class="option {% if value.hide_title %}option--no-top-border{% endif %}">
   {% if not value.hide_title %}<h2>{{ value.title }}</h2>{% endif %}
   {% if value.aside %}
     <div class="option__content">

--- a/fec/home/templates/partials/section-nav.html
+++ b/fec/home/templates/partials/section-nav.html
@@ -6,7 +6,7 @@
       <ul class="sidebar__content">
           {% for section in sections %}
             <li class="side-nav__item">
-              <a class="side-nav__link" href="#{{ section.value.title | slugify }}">{{ section.value.title }}</a>
+              <a class="side-nav__link" href="#{{ section.value.title | prepend_non_digit | slugify }}">{{ section.value.title }}</a>
             </li>
           {% endfor %}
           {% if citations %}

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -52,9 +52,24 @@ def remove_digits(string):
     """
     Strips digits from a string
     Useful in combination with built-in slugify in order to create strings
-    that can be used as HTML IDs, which cannot begin with digits
+    that can be used as HTML IDs, which cannot begin with digits. 
+    Also see 'prepend_non_digit' filter. 
     """
     return re.sub('\d+', '', string)
+
+@register.filter()
+def prepend_non_digit(string):
+    """
+    Prepends non-digit-containing string.
+    Useful in combination with built-in slugify in order to create strings
+    that can be used as HTML IDs but would remain invalid after simply
+    removing digits. (Example: '2017-2018' would become the invalid '#-'). 
+    Also see 'prepend_non_digit' filter.
+    """
+    #if string[0] == re('/d')
+    if string[:1].isdigit():
+       string = "go-to-{0}".format(string)
+    return string
 
 
 @register.filter()

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -48,25 +48,12 @@ def child_page_count(page):
 
 
 @register.filter()
-def remove_digits(string):
-    """
-    Strips digits from a string
-    Useful in combination with built-in slugify in order to create strings
-    that can be used as HTML IDs, which cannot begin with digits. 
-    Also see 'prepend_non_digit' filter. 
-    """
-    return re.sub('\d+', '', string)
-
-@register.filter()
 def prepend_non_digit(string):
     """
     Prepends non-digit-containing string.
     Useful in combination with built-in slugify in order to create strings
-    that can be used as HTML IDs but would remain invalid after simply
-    removing digits. (Example: '2017-2018' would become the invalid '#-'). 
-    Also see 'remove_digits' filter.
+    from titles that can be used as HTML IDs, which cannot begin with digits.
     """
-    #if string[0] == re('/d')
     if string[:1].isdigit():
        string = "go-to-{0}".format(string)
     return string

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -64,7 +64,7 @@ def prepend_non_digit(string):
     Useful in combination with built-in slugify in order to create strings
     that can be used as HTML IDs but would remain invalid after simply
     removing digits. (Example: '2017-2018' would become the invalid '#-'). 
-    Also see 'prepend_non_digit' filter.
+    Also see 'remove_digits' filter.
     """
     #if string[0] == re('/d')
     if string[:1].isdigit():


### PR DESCRIPTION
## Summary
Resolves JS errors that were breaking `sticky menu` and `feedback box` on pages using numeric section titles like `2017-2018`. 
Prepends non-digit-containing string to these titles in order to create strings that can be used as HTML IDs. Note that these strings would remain invalid after simply using the existing `remove_digits` filter. (Example: '2017-2018' would become the invalid '#-'). 

- Resolves #3661

## Impacted areas of the application
	modified:   home/templates/blocks/section.html
	modified:   home/templates/partials/section-nav.html
	modified:   home/templatetags/filters.py

## How to test
- checkout `fix/restore-feedback-box-on-pages`
- runserver
- Go to: http://127.0.0.1:8000/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/  
--AND/OR--
- Any of the pagea linked in the bulleted list on: 
http://127.0.0.1:8000/legal-resources/regulations/explanations-and-justifications/chronological-index-e-j-s/
- Confirm that `section scroll-to links` work and that `feedback box` is present

____
