### PR TITLE
Changes to Guidance search

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -55,7 +55,6 @@ FEATURES = {
     'contributionsbystate': bool(env.get_credential('FEC_FEATURE_CONTRIBUTIONS_BY_STATE', '')),
     'ierawfilters': bool(env.get_credential('FEC_FEATURE_IE_RAW_FILTERS', '')),
     'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
-    'guidance_search': bool(env.get_credential('FEC_FEATURE_GUIDANCE_SEARCH', '')),
 }
 
 ENVIRONMENTS = {

--- a/fec/fec/templates/partials/navigation/nav-legal.html
+++ b/fec/fec/templates/partials/navigation/nav-legal.html
@@ -21,6 +21,11 @@
             <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/">Search across all legal resources</a></p>
           </div>
         </div>
+        <div class="usa-width-one-fourth u-padding--left">
+          <div class="icon-heading icon-heading--magnifying-glass-circle">
+            <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/policy-and-other-guidance/guidance-documents/">Search guidance documents</a></p>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     url(r'^help-candidates-and-committees/guides/$', home_views.guides),
     url(r'^meetings/$', home_views.index_meetings, name="meetings_page"),
     url(r'^search/$', search_views.search, name='search'),
+    url(r'^legal-resources/policy-and-other-guidance/guidance-documents/$', search_views.policy_guidance_search, name='policy-guidance-search'),
     url(r'^updates/$', home_views.updates),
     url(r'', include('data.urls')),  # URLs for /data
     url(r'', include('legal.urls')),  # URLs for legal pages
@@ -46,9 +47,6 @@ urlpatterns = [
     ),
 ]
 
-if settings.FEATURES.get('guidance_search'):
-    # Guidance search page
-    urlpatterns.insert(1, url(r'^legal-resources/policy-and-other-guidance/guidance-documents/$', search_views.policy_guidance_search, name='policy-guidance-search'))
 
 if settings.FEC_CMS_ENVIRONMENT != 'LOCAL':
     # admin/login always must come before admin/, so place at beginning of list

--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -143,6 +143,7 @@
             <li><a href="/legal-resources/enforcement/">Enforcement overview</a></li>
             <li><a href="/data/legal/search/enforcement/">Search closed Matters Under Review </a><span class="term" data-term="matter under review (MUR)" title="Click to define" tabindex="0"> (MURs)</span></li>
             <li><a href="/data/legal/search/advisory-opinions/">Search advisory opinions </a><span class="term" data-term="advisory opinion (AO)" title="Click to define" tabindex="0"> (AOs)</span></li>
+            <li><a href="/legal-resources/policy-and-other-guidance/guidance-documents/">Search guidance documents</a></li>
           </ul>
         </div>
       </div>

--- a/fec/search/templates/search/policy_guidance_search_page.html
+++ b/fec/search/templates/search/policy_guidance_search_page.html
@@ -13,7 +13,7 @@
       <button type="submit" class="button--standard combo__button button--search">
         <span class="u-visually-hidden">Search</span>
       </button>
-      <span class="t-note t-sans search__example">Examples: instructions, "interpretive rule"</span>
+      <span class="t-note t-sans search__example">Examples: instructions, "interpretive rule", "52 U.S.C. 30104", "11 CFR 109.10"</span>
     </div>
   </form>
 {% endblock %}

--- a/fec/search/templates/search/policy_guidance_search_page.html
+++ b/fec/search/templates/search/policy_guidance_search_page.html
@@ -2,7 +2,7 @@
 {% load filters %}
 
 {% block intro %}
-  <p>Search or browse guidance documents issued by the Federal Election Commission on this page. This search includes all Commission documents that set forth a policy on a statutory, regulatory or technical issue. Such documents include <a href="https://transition.fec.gov/law/policy.shtml#policy">Statements of Policy</a>, <a href="https://transition.fec.gov/law/policy.shtml#interpretative">interpretive rules</a>, <a href="https://www.fec.gov/help-candidates-and-committees/forms/">FEC forms</a>, <a href="https://www.fec.gov/help-candidates-and-committees/guides/">Campaign Guides</a>, certain press releases and other various Commission publications.</p>
+  <p>Search or browse guidance documents issued by the Federal Election Commission on this page. This search includes all Commission documents that set forth a policy on a statutory, regulatory or technical issue, or interpret a regulation. Such documents include <a href="https://transition.fec.gov/law/policy.shtml#policy">Statements of Policy</a>, <a href="https://transition.fec.gov/law/policy.shtml#interpretative">interpretive rules</a>, <a href="https://www.fec.gov/help-candidates-and-committees/forms/">FEC forms</a>, <a href="https://www.fec.gov/help-candidates-and-committees/guides/">Campaign Guides</a>, certain press releases and other various Commission publications.</p>
 {% endblock %}
 
 {% block filters %}
@@ -75,7 +75,7 @@
       <p class="t-sans">Guidance documents lack the force and effect of law, unless expressly authorized by statute or incorporated into a contract. The agency may not cite, use, or rely on any guidance that is not posted on the website existing under <a href="https://www.federalregister.gov/documents/2019/10/15/2019-22624/promoting-the-rule-of-law-through-transparency-and-fairness-in-civil-administrative-enforcement-and">Executive Order 13892</a>, except to establish historical facts.</p>
     </div>
     <div class="usa-width-one-half">
-      <p class="t-sans u-no-margin">Note: This search does not include advisory opinions, regulations, or statutes. For those items, use the <a href="https://www.fec.gov/legal-resources/">legal resources search</a>.</p>
+      <p class="t-sans u-no-margin">Note: This search does not include advisory opinions, regulations, statutes, or Matters Under Review. For those items, use the <a href="https://www.fec.gov/legal-resources/">legal resources search</a>.</p>
     </div>
   </div>
 </div>

--- a/fec/search/templates/search/policy_guidance_search_page.html
+++ b/fec/search/templates/search/policy_guidance_search_page.html
@@ -8,12 +8,20 @@
 {% block filters %}
   <form class="container" action="{% url 'policy-guidance-search' %}" method="get">
     <div class="combo combo--search content__section">
-      <label for="search" class="label">Search all documents</label>
+      <label for="search" class="label t-inline-block">Search all documents</label>
+      <div class="tooltip__container">
+        <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+        <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
+          <p class="tooltip__content">Refine a keyword search for phrases, statutes, or regulations by using “ ” to limit results.</p>
+        </div>
+      </div>
       <input id="search" type="text" class="combo__input" name="query"{% if search_query %} value="{{ search_query }}"{% endif %}>
       <button type="submit" class="button--standard combo__button button--search">
         <span class="u-visually-hidden">Search</span>
       </button>
-      <span class="t-note t-sans search__example">Examples: instructions, "interpretive rule", "52 U.S.C. 30104", "11 CFR 109.10"</span>
+      <div class="container">
+        <span class="t-note t-sans search__example">Examples: instructions, "interpretive rule", "52 U.S.C. 30104", "11 CFR 109.10"</span>
+      </div>
     </div>
   </form>
 {% endblock %}

--- a/fec/search/templates/search/policy_guidance_search_page.html
+++ b/fec/search/templates/search/policy_guidance_search_page.html
@@ -80,9 +80,6 @@
 <div class="slab slab--neutral footer-disclaimer">
   <div class="container">
     <div class="usa-width-one-half">
-      <p class="t-sans">Guidance documents lack the force and effect of law, unless expressly authorized by statute or incorporated into a contract. The agency may not cite, use, or rely on any guidance that is not posted on the website existing under <a href="https://www.federalregister.gov/documents/2019/10/15/2019-22624/promoting-the-rule-of-law-through-transparency-and-fairness-in-civil-administrative-enforcement-and">Executive Order 13892</a>, except to establish historical facts.</p>
-    </div>
-    <div class="usa-width-one-half">
       <p class="t-sans u-no-margin">Note: This search does not include advisory opinions, regulations, statutes, or Matters Under Review. For those items, use the <a href="https://www.fec.gov/legal-resources/">legal resources search</a>.</p>
     </div>
   </div>

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -163,7 +163,6 @@ def policy_guidance_search(request):
     offset = request.GET.get('offset', 0)
 
     results = policy_guidance_search_site(search_query, limit=limit, offset=offset)
-    print(results)
     current_page = int(int(offset) / limit) + 1
     num_pages = 1
     total_count = 0

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -163,6 +163,7 @@ def policy_guidance_search(request):
     offset = request.GET.get('offset', 0)
 
     results = policy_guidance_search_site(search_query, limit=limit, offset=offset)
+    print(results)
     current_page = int(int(offset) / limit) + 1
     num_pages = 1
     total_count = 0


### PR DESCRIPTION
## Summary

- Resolves #3671 
- Resolves #3670

- Updated intro and footer text according to OGC requests
- Added links for guidance search on H4CC and Legal resources nav
- Added helper tool tip next to guidance search label
- Removed feature flag as it's unneeded now.

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Guidance search page

## Screenshots
<img width="1289" alt="Screen Shot 2020-04-21 at 12 16 35 PM" src="https://user-images.githubusercontent.com/12799132/79909770-8b8c4380-83eb-11ea-96f0-49d404796c43.png">

<img width="1473" alt="Screen Shot 2020-04-21 at 12 15 55 PM" src="https://user-images.githubusercontent.com/12799132/79909771-8b8c4380-83eb-11ea-8701-3536de63001e.png">

<img width="618" alt="Screen Shot 2020-04-21 at 12 13 37 PM" src="https://user-images.githubusercontent.com/12799132/79909772-8b8c4380-83eb-11ea-9e97-1ad2838cc394.png">

<img width="616" alt="Screen Shot 2020-04-21 at 4 17 29 PM" src="https://user-images.githubusercontent.com/12799132/79909841-a52d8b00-83eb-11ea-8277-cc02517acd56.png">

<img width="1323" alt="Screen Shot 2020-04-22 at 9 19 27 AM" src="https://user-images.githubusercontent.com/12799132/79986859-aeb20400-847a-11ea-944b-463c2abe1cbb.png">

<img width="1275" alt="Screen Shot 2020-04-21 at 12 13 20 PM" src="https://user-images.githubusercontent.com/12799132/79915699-71576300-83f5-11ea-993e-da1a0d8c148d.png">







## How to test

- Pull down this PR
- `export SEARCH_GOV_POLICY_GUIDANCE_KEY` in your environment vars. You can grab this API access key by logging into search.gov and accessing the fec_content_s3 site.
- Go to http://localhost:8000/legal-resources/policy-and-other-guidance/guidance-documents/ and make sure it loads
- Try a search that includes best bets search like `citizens united`. The total count should add best bets and results count to give an accurate count 

____
