### PR TITLE
Bold "https://" in banner

### DIFF
--- a/fec/fec/templates/partials/usa-banner.html
+++ b/fec/fec/templates/partials/usa-banner.html
@@ -1,11 +1,11 @@
 <header class="usa-banner">
   <div class="js-accordion accordion--neutral" data-content-prefix="gov-banner">
     <div type="button" class="usa-banner-header js-accordion-trigger accordion__button" aria-controls="gov-banner"><span class="u-visually-hidden">Here's how you know</span>
-      
+
       <img src="/static/img/us_flag_small.png" class="flag" alt="US flag signifying that this is a United States Federal Government website">
       <p class="t-inline-block">An official website of the United States government</p>
       <p class="t-inline-block usa-banner-button">Here's how you know</p>
-     
+
     </div>
     <div class="usa-banner-content usa-grid usa-accordion-content accordion-content" id="gov-banner">
       <div class="usa-banner-guidance-gov usa-width-one-half">
@@ -23,7 +23,7 @@
         <div class="usa-media_block-body">
           <strong>The site is secure.</strong>
           <br>
-          <p>The https:// ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.</p>
+          <p>The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary (required)

- Resolves issue in testing - more consistent with USDS example https://designsystem.digital.gov/components/banner/


## Screenshots


## Before
<img width="635" alt="Screen Shot 2020-04-22 at 10 07 24 AM" src="https://user-images.githubusercontent.com/31420082/79992112-153a2080-8481-11ea-8b35-ec394d2dc7cb.png">


## After
<img width="635" alt="Screen Shot 2020-04-22 at 10 03 30 AM" src="https://user-images.githubusercontent.com/31420082/79991880-c68c8680-8480-11ea-928d-3af89ff0f1e3.png">


## Related PRs



branch | PR
------ | ------
`feature/3579-3678-usa-and-env-banners` | https://github.com/fecgov/fec-cms/pull/3700


## How to test

See https://github.com/fecgov/fec-cms/pull/3700 
