### PR TITLE
[HOTFIX] [MERGE WITH GIT FLOW] Fix download export link

### DIFF
--- a/fec/fec/static/js/widgets/pres-finance-map-box.js
+++ b/fec/fec/static/js/widgets/pres-finance-map-box.js
@@ -23,7 +23,7 @@ const pathFormat_download_contribs =
   '/files/bulk-downloads/Presidential_Map/{election_year}/{candidate_id}/{candidate_id}-{state}.zip';
 // {state} can be the two-letter abbreviation, ALL, or OTHER
 const pathFormat_download_expends =
-  '/files/bulk-downloads/Presidential_Map/{election_year}/{candidate_id}/{candidate_id}-ALL.zip';
+  '/files/bulk-downloads/Presidential_Map/{election_year}/{candidate_id}/{candidate_id}D-ALL.zip';
 const pathFormat_download_summary =
   '/files/bulk-downloads/Presidential_Map/{election_year}/report_summaries_form_3p.zip';
 const pathFormat_download_state =


### PR DESCRIPTION
## Summary (required)

- Resolves #3709
Fix download export link on presidential map

From original issue? 
>When I click on the export spending data button, I receive a contributions file instead of a disbursements file. Here's the URL of the downloadable file https://www.fec.gov/files/bulk-downloads/Presidential_Map/2020/P00000001/P00000001-ALL.zip. It should end with "D-ALL..zip."

> I should have recieved a disbursments file. The naming convention for all disbursement files is D-ALL.zip.

>For example, https://www.fec.gov/files/bulk-downloads/Presidential_Map/2020/P00000001/P00000001D-ALL.zip

## Impacted areas of the application

List general components of the application that this PR will affect:

-  https://www.fec.gov/data/candidates/president/presidential-map/


## How to test

- Go to http://localhost:8000/data/candidates/president/presidential-map/
- Click on any option on the left, or stay on "All candidates"
- Click on the "Spending" accordion on the right
- Click on the "Export spending data" button or mouse over it
- Format should be https://www.fec.gov/files/bulk-downloads/Presidential_Map/2020/P00000001/P00000001D-ALL.zip
