### PR TITLE
Update wagtail to 2.7.2 (security update)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ psycopg2==2.8.5
 requests==2.21.0
 slacker==0.8.6
 whitenoise==2.0.3
-wagtail==2.7
-# TODO: pin version
+wagtail==2.7.2
 Jinja2==2.10.1
 django_jinja==2.4.1
 CacheControl==0.11.5


### PR DESCRIPTION
## Summary (required)

- Resolves #3699
Update wagtail to 2.7.2, remove old `TODO` comment

Wagtail 2.7.1 and 2.7.2 changelogs:
- https://docs.wagtail.io/en/v2.8.1/releases/2.7.1.html
- https://docs.wagtail.io/en/v2.8.1/releases/2.7.2.html

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Wagtail


## How to test

- `pip install -r requirements.txt`
- `snyk test --file=requirements.txt`
- Run locally, check H4CC pages, try http://localhost:8000/admin/
- Tesedt with manual deploy, log in to Wagtail ✅ content team said it looked ok