### PR TITLE
Fix try fec.gov  btn on legal no-results page

### DIFF
--- a/fec/fec/static/js/legal/SearchResults.js
+++ b/fec/fec/static/js/legal/SearchResults.js
@@ -124,16 +124,16 @@ function SearchResults(props) {
         <div className="message message--no-icon">
           <h2 className="message__title">No results</h2>
           <p>
-            Sorry, we didn&rsquo;t find any documents matching {props.query}.
+            Sorry, we didn&rsquo;t find any documents matching your search {props.q}.
           </p>
           <div className="message--alert__bottom">
             <p>Think this was a mistake?</p>
             <ul className="list--buttons">
-              {props.query && (
+              {props.q && (
                 <li>
                   <a
                     className="button button--standard"
-                    href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources=Administrative_Fine%2CAdvisory_Opinion%2CAlternative_Dispute_Resolution%2CAudit_Reports%2CMatters_Under_Review%2CMatters_Under_Review_Archived%2CRulemaster%2CCandidate_Summary%2CCommittee_Summary%2Cfec.gov&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&"
+                    href={'/search/?query='+ props.q}
                   >
                     Try FEC.gov
                   </a>
@@ -165,8 +165,8 @@ function SearchResults(props) {
 
 SearchResults.propTypes = {
   advisory_opinion: PropTypes.array,
-  loading: PropTypes.string,
-  query: PropTypes.string
+  loading: PropTypes.bool,
+  query: PropTypes.object
 };
 
 module.exports = SearchResults;

--- a/fec/fec/static/js/legal/SearchResults.js
+++ b/fec/fec/static/js/legal/SearchResults.js
@@ -123,9 +123,7 @@ function SearchResults(props) {
       return (
         <div className="message message--no-icon">
           <h2 className="message__title">No results</h2>
-          <p>
-            Sorry, we didn&rsquo;t find any documents matching your search.
-          </p>
+          <p>Sorry, we didn&rsquo;t find any documents matching your search.</p>
           <div className="message--alert__bottom">
             <p>Think this was a mistake?</p>
             <ul className="list--buttons">

--- a/fec/fec/static/js/legal/SearchResults.js
+++ b/fec/fec/static/js/legal/SearchResults.js
@@ -124,8 +124,7 @@ function SearchResults(props) {
         <div className="message message--no-icon">
           <h2 className="message__title">No results</h2>
           <p>
-            Sorry, we didn&rsquo;t find any documents matching your search{' '}
-            {props.q}.
+            Sorry, we didn&rsquo;t find any documents matching your search.
           </p>
           <div className="message--alert__bottom">
             <p>Think this was a mistake?</p>

--- a/fec/fec/static/js/legal/SearchResults.js
+++ b/fec/fec/static/js/legal/SearchResults.js
@@ -124,7 +124,8 @@ function SearchResults(props) {
         <div className="message message--no-icon">
           <h2 className="message__title">No results</h2>
           <p>
-            Sorry, we didn&rsquo;t find any documents matching your search {props.q}.
+            Sorry, we didn&rsquo;t find any documents matching your search{' '}
+            {props.q}.
           </p>
           <div className="message--alert__bottom">
             <p>Think this was a mistake?</p>
@@ -133,7 +134,7 @@ function SearchResults(props) {
                 <li>
                   <a
                     className="button button--standard"
-                    href={'/search/?query='+ props.q}
+                    href={'/search/?query=' + props.q}
                   >
                     Try FEC.gov
                   </a>

--- a/fec/fec/static/js/legal/filters/TooltipHelp.js
+++ b/fec/fec/static/js/legal/filters/TooltipHelp.js
@@ -9,9 +9,7 @@ class TooltipHelp extends React.Component {
           <span className="u-visually-hidden">Learn more</span>
         </button>
         <div
-          className={`tooltip tooltip--${
-            this.props.verticalPosition
-          } tooltip--${this.props.horizontalPosition}`}
+          className={`tooltip tooltip--${this.props.verticalPosition} tooltip--${this.props.horizontalPosition}`}
         >
           <p className="tooltip__content tooltip__content">
             {this.props.message}

--- a/fec/legal/templates/layouts/legal-doc-search-results.jinja
+++ b/fec/legal/templates/layouts/legal-doc-search-results.jinja
@@ -65,7 +65,7 @@
           <p>Think this was a mistake?</p>
           <ul class="list--buttons">
             {% if query %}
-            <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources=Administrative_Fine%2CAdvisory_Opinion%2CAlternative_Dispute_Resolution%2CAudit_Reports%2CMatters_Under_Review%2CMatters_Under_Review_Archived%2CRulemaster%2CCandidate_Summary%2CCommittee_Summary%2Cfec.gov&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
+            <li><a class="button button--standard" href="/search/?query={{ query }}">Try FEC.gov</a></li>
             {% endif %}
             <li><a class="button button--standard" href="mailto:{{ WEBMANAGER_EMAIL }}">Email our team</a></li>
             <li><a class="button button--standard" href="https://github.com/fecgov/fec/issues">File an issue</a></li>

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -108,7 +108,7 @@
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">
       {% if query %}
-      <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources={{ '%2C'.join(fec_resources or []) }}&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
+       <li><a class="button button--standard" href="https://www.fec.gov/search/?query={{ query }}">Try FEC.gov</a></li>
       {% endif %}
       <li><a class="button button--standard" href="mailto:{{ WEBMANAGER_EMAIL }}">Email our team</a></li>
       <li><a class="button button--standard" href="https://github.com/fecgov/fec/issues">File an issue</a></li>

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -108,7 +108,7 @@
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">
       {% if query %}
-       <li><a class="button button--standard" href="https://www.fec.gov/search/?query={{ query }}">Try FEC.gov</a></li>
+       <li><a class="button button--standard" href="/search/?query={{ query }}">Try FEC.gov</a></li>
       {% endif %}
       <li><a class="button button--standard" href="mailto:{{ WEBMANAGER_EMAIL }}">Email our team</a></li>
       <li><a class="button button--standard" href="https://github.com/fecgov/fec/issues">File an issue</a></li>


### PR DESCRIPTION
## Summary 
Point `Try FEC.gov` link on legal search no-results page to fec.gov search, passing the  search query

- Resolves #3618

## Impacted areas of the application
modified:   legal/templates/macros/legal.jinja
modified:   fec/static/js/legal/SearchResults.js
modified:   legal/templates/layouts/legal-doc-search-results.jinja

## Screenshots
![Apr-25-2020 23-49-47](https://user-images.githubusercontent.com/5572856/80297258-89a9e380-874f-11ea-96b7-a44fdb1a7f16.gif)

## How to test
checkout `feature/fix-try-fec-link-legal-srch`

Runserver:
- Go to: http://127.0.0.1:8000/data/legal/search/?search_type=all
- Type in a nonsense search string
- Click on `Try FEC.gov` button
- Confirm that it goes to the main fec.gov search page, passing your query along
- Also test :
  - http://localhost:8000/data/legal/search/enforcement/ , - - - -- 
  - http://localhost:8000/data/legal/search/advisory-opinions/?type=advisory_opinions&ao_category=F
  - http://localhost:8000/data/legal/search/statutes/
  - http://localhost:8000/data/legal/search/regulations/


   
____
