### PR TITLE
Set python get request timeout

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -29,7 +29,8 @@ def _call_api(*path_parts, **filters):
 
     path = os.path.join(settings.FEC_API_VERSION, *[x.strip("/") for x in path_parts])
     url = parse.urljoin(settings.FEC_API_URL, path)
-    results = session.get(url, params=filters)
+    timeout = 90
+    results = session.get(url, params=filters, timeout=timeout)
 
     # Log the caller function and API endpoint
     current_frame = inspect.currentframe()

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -29,7 +29,9 @@ def _call_api(*path_parts, **filters):
 
     path = os.path.join(settings.FEC_API_VERSION, *[x.strip("/") for x in path_parts])
     url = parse.urljoin(settings.FEC_API_URL, path)
-    timeout = 90
+    # Timeout is set in seconds 
+    timeout = 90 
+    
     results = session.get(url, params=filters, timeout=timeout)
 
     # Log the caller function and API endpoint


### PR DESCRIPTION
## Summary

- Resolves https://github.com/fecgov/fec-accounts/issues/248
_Sets python get requests timeout to 90 seconds. This will ensure that requests are closed at a regular interval so that CMS PG connections do not build. If timeout is reached a 500 error page will come up and, this will appear in the logs:

```
raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPConnectionPool(host=‘localhost’, port=5000): Read timed out. (read timeout=90)
```

## Impacted areas of the application

List general components of the application that this PR will affect:

-  FEC python requests in api_caller.py

## How to test

- Follow instructions here to create local API load https://github.com/fecgov/fec-accounts/issues/248#issuecomment-618541364
- Connect local CMS to local API
- Run the CMS and try a page that uses a GET request from the api_caller such as a candidate page: http://localhost:8000/data/candidate/P80006117/
- Result should have timeouts after 90 seconds as seen in notes above

____
