### PR TITLE
Minor edits to usa and env-specific banners

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -82,7 +82,7 @@
 {% include 'partials/warnings.jinja' %}
 
   <a href="#main" class="skip-nav" tabindex="0">skip navigation</a>
-  {# USA banner #} 
+  {# env-specific banner #} 
   {% include 'partials/env-banner.html' %}
   {# .gov banner #}
   {% include 'partials/usa-banner.html' %}

--- a/fec/fec/static/scss/components/_site-header.scss
+++ b/fec/fec/static/scss/components/_site-header.scss
@@ -133,6 +133,10 @@
   background-image: none;
   border:none !important;
   padding: u(.75rem 1rem);
+
+   &[aria-expanded=true] {
+    background-image: none;
+   }
   
   }
 

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -45,7 +45,7 @@
 
     {% wagtailuserbar %}
     <a href="#main" class="skip-nav">skip navigation</a>
-    {# USA banner #} 
+    {# env-specific banner #} 
     {% include 'partials/env-banner.html' %}
     {# .gov banner #}
     {% include 'partials/usa-banner.html' %}

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -45,7 +45,7 @@
 
     {% wagtailuserbar %}
     <a href="#main" class="skip-nav">skip navigation</a>
-    {# USA banner #} 
+    {# env-specific banner #} 
     {% include 'partials/env-banner.html' %}
     {# .gov banner #}
     {% include 'partials/usa-banner.html' %}

--- a/fec/fec/templates/partials/usa-banner.html
+++ b/fec/fec/templates/partials/usa-banner.html
@@ -21,9 +21,11 @@
       <div class="usa-banner-guidance-ssl usa-width-one-half">
         <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-https.svg" alt="SSL">
         <div class="usa-media_block-body">
-          <strong>The site is secure.</strong>
-          <br>
-          <p>The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.</p>
+          <p>
+            <strong>The site is secure.</strong>
+            <br>
+            The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary 
- [x]  Fix font size on the headline adjacent to the https:// icon on the USA banner by wrapping entire text for the https icon in a P tag just like the .gov one.
- [x]  Remove accodion `close (-) button` on Legal pages for usa banner by adding css to _site_header.scss 
- [x]  Change the comment above the env banner include-statement from `{# USA banner #}` --to-- `{# env-specific  banner #}` on base.html, home_base.html, and main.jinja

- Resolves #3733

## Impacted areas of the application
	modified:   data/templates/layouts/main.jinja
	modified:   fec/static/scss/components/_site-header.scss
	modified:   fec/templates/base.html
	modified:   fec/templates/home_base.html
	modified:   fec/templates/partials/usa-banner.html


## How to test
- Checkout and run `fix/minor-edits-usa-env-banners`
- npm run build-sass
- Confirm that font size on "The site is secure." is same as the rest of the text `(1.6rem )` 
- Go to https://www.fec.gov/data/legal/statutes/ and open usa banner, confirm that the accordion close button (minus button) does not show. 

____
