### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Fix env banner for 500 error page

### DIFF
--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -72,3 +72,5 @@ if settings.DEBUG:
 
     # hide django-admin unless DEBUG=True
     urlpatterns.insert(1, url(r'^django-admin/', admin.site.urls))
+
+handler500 = 'home.views.error_500'

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -3,10 +3,12 @@ from itertools import chain
 from operator import attrgetter
 
 from django.conf import settings
+from django.http import HttpResponse
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
+from django.views.defaults import server_error
 from wagtail.documents.models import Document
 
 from fec.forms import ContactRAD, form_categories
@@ -399,3 +401,11 @@ def guides(request):
         "home/candidate-and-committee-services/guides.html",
         {"self": page_context},
     )
+
+def error_500(request, template_name="500.html"):
+    cms_env = request.GET.get("FEC_CMS_ENVIRONMENT", "")
+    return render(
+        request,
+        template_name,
+        {'FEC_CMS_ENVIRONMENT' : cms_env })
+        


### PR DESCRIPTION
## Summary (required)
Resolves #3760
_500 page environment specific banners will now only display on local, dev, and stage. Prod 500 error page will not display this banner._

## Impacted areas of the application

List general components of the application that this PR will affect:

-  500 error page

## Screenshots

### Before
<img width="1148" alt="Screen Shot 2020-05-14 at 1 47 46 PM" src="https://user-images.githubusercontent.com/31420082/81977186-a4a5a000-95f7-11ea-9b31-fcdc9e7d84b5.png">

### After
<img width="1672" alt="Screen Shot 2020-05-14 at 3 09 04 PM" src="https://user-images.githubusercontent.com/12799132/81975346-df5a0900-95f4-11ea-8229-b221bb20233c.png">

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
feature/3742-static-status-page | [link](https://github.com/fecgov/fec-cms/pull/3750)

## How to test

- Pull down the branch
- Turn off DEBUG mode inside of the dev.py file. Change to `DEBUG = False`. Also add `ALLOWED_HOSTS = ['*']`. These will be temporary changes to test out the 500 error messaging.
- Build assets using collectstatic so that scripts and styles will work on site: `./manage.py collectstatic --noinput -v 0`
- Set your local CMS environment to prod: `export FEC_CMS_ENVIRONMENT=prod`
- Set the django secret key to whatever you want: `export DJANGO_SECRET_KEY=whatever` 
- Pick a jinja template or a HTML template (our templates all use jinja as the framework even though the extension is .html). 
- Modify that chosen jinja template's extends to reference an invalid file name. Example: `{% extends 'layouts/invalid_name.jinja' %}`
- Run the server using production settings: `./manage.py runserver --settings=fec.settings.production`
- Go to the page that uses that modified jinja template. You should see the 500 error message. Ensure that the environment specific banner is NOT present at the top of the 500 error message page.
- Now try running this with stage environment and settings: 
     `export FEC_CMS_ENVIRONMENT=stage`
     `./manage.py runserver --settings=fec.settings.production`
- Ensure that the environment specific banner appears at the top and is set to stage.

Note: You may need to try a new incognito window or hard refresh to see differing banners after setting env vars--they tend to be heavily cached by the browsers.
____
