### PR TITLE
Upgrade jquery to 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eventemitter2": "0.4.14",
     "fullcalendar": "3.3.1",
     "glossary-panel": "1.0.0",
-    "jquery": "^3.4.1",
+    "jquery": "^3.5.1",
     "jquery.inputmask": "^3.3.4",
     "leaflet-providers": "1.8.0 ",
     "lodash": "^4.17.14",


### PR DESCRIPTION
## Summary

- Resolves #3698 
_Upgrades jquery to 3.5.1 and remediates XSS vulnerabilities._

See jquery docs on what was released for 3.5.1: https://blog.jquery.com/2020/05/04/jquery-3-5-1-released-fixing-a-regression/

## Impacted areas of the application

Upgraded jQuery from 3.4.1 to 3.5.1
modified: ../package-lock.json
modified: ../package.json

## How to test

- `npm i`
- `npm run build`
- `./manage.py runserver`
- Spot check pages that use jquery

____
