### PR TITLE
Add committee active/terminated indicator on profile page

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -21,6 +21,14 @@
     <h1 class="entity__name content__section--narrow">{{ committee.name }}</h1>
     <div class="heading--section">
       <span class="t-data t-bold entity__type">
+        {% if committee.is_active %}
+          <span class="is-incumbent t-sans t-note" style="padding-right: 1em">ACTIVE
+          </span>      
+        {% else %}
+          TERMINATED
+        {% endif %}
+      </span>      
+      <span class="t-data t-bold entity__type">
         {% if is_SSF %}
           {{ committee.organization_type_full }} {{ committee.committee_type_full }}
           {% if designation %}

--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -22,10 +22,9 @@
     <div class="heading--section">
       <span class="t-data t-bold entity__type">
         {% if committee.is_active %}
-          <span class="is-incumbent t-sans t-note" style="padding-right: 1em">ACTIVE
-          </span>      
+          <span class="is-active">Active</span>      
         {% else %}
-          TERMINATED
+          <span class="is-terminated">Terminated</span>         
         {% endif %}
       </span>      
       <span class="t-data t-bold entity__type">

--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -286,6 +286,30 @@
   }
 }
 
+.is-active, .is-terminated  {
+  margin-left: u(1.5rem);
+  position: relative;
+  
+  &::before {
+    border-radius: u(1rem);
+    content: '';
+    display: block;
+    height: u(1rem);
+    left: u(-1.5rem);
+    margin-top: u(-0.5rem);
+    position: absolute;
+    top: 50%;
+    width: u(1rem);
+  }
+}
+
+.is-active:before{
+  background-color: $green-light;
+}
+.is-terminated:before{
+  background-color: $gray;
+}
+
 .data-table {
   .is-incumbent::before {
     top: u(0.8rem);


### PR DESCRIPTION
## Summary (required)
To make it more clear to our users what the status of a committee is, we want to add an indicator at the top of the committee profile page.

- Resolves #[3642](https://github.com/fecgov/fec-cms/issues/3642)

## Include a summary of proposed changes._
committees-single.jinja
_datatables.scss

## Impacted areas of the application
committee profile page

## How to test
1) checkout branch
2) point to dev api
3) npm run build-sass
4) ./manage.py test
5) npm run test-single
6) ./manage.py runserver

7) test urls
a) active committee:
http://127.0.0.1:8000/data/committee/C00580100/?cycle=2020

b) terminated committee:
http://127.0.0.1:8000/data/committee/C00619411/

c)
http://127.0.0.1:8000/data/committee/C90018904/