### PR TITLE
add package lock file for jquery upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8399,9 +8399,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "jquery.inputmask": {
       "version": "3.3.4",


### PR DESCRIPTION
## Summary

- Add on for #3698 
_Adds package-lock.json for the jquery to 3.5.1 upgrade._

This needs to be added as we are checking hashes for upgrades to packages.
