### PR TITLE
Change stylesheet class name to is-active-status and is_terminated_status

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -22,9 +22,9 @@
     <div class="heading--section">
       <span class="t-data t-bold entity__type">
         {% if committee.is_active %}
-          <span class="is-active">Active</span>      
+          <span class="is-active-status">Active</span>      
         {% else %}
-          <span class="is-terminated">Terminated</span>         
+          <span class="is-terminated-status">Terminated</span>         
         {% endif %}
       </span>      
       <span class="t-data t-bold entity__type">

--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -286,7 +286,7 @@
   }
 }
 
-.is-active, .is-terminated  {
+.is-active-status, .is-terminated-status {
   margin-left: u(1.5rem);
   position: relative;
   
@@ -303,10 +303,10 @@
   }
 }
 
-.is-active:before{
+.is-active-status:before{
   background-color: $green-light;
 }
-.is-terminated:before{
+.is-terminated-status:before{
   background-color: $gray;
 }
 


### PR DESCRIPTION
## Summary (required)
Current style sheet class name is is_active and is_terminated, we should change name to
is_active_status and is_terminated_status

Related Issue: [https://github.com/fecgov/fec-cms/issues/3796](https://github.com/fecgov/fec-cms/issues/3796)

## How to test
1) checkout branch
2) point to dev api
3) npm run build-sass
4) ./manage.py test
5) npm run test-single
6) ./manage.py runserver

7) test urls
a) check green dot not show on next to Summery
http://127.0.0.1:8000/data/legal/matter-under-review/4321/

b) active committee:
http://127.0.0.1:8000/data/committee/C00580100/?cycle=2020

c) terminated committee:
http://127.0.0.1:8000/data/committee/C00619411/

d)
http://127.0.0.1:8000/data/committee/C90018904/