### PR TITLE
Gracefully fail when there are no MUR docs

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -153,12 +153,19 @@ def load_legal_mur(mur_no):
         mur["participants_by_type"] = _get_sorted_participants_by_type(mur)
 
         documents_by_type = OrderedDict()
-        for doc in mur["documents"]:
-            if doc["category"] in documents_by_type:
-                documents_by_type[doc["category"]].append(doc)
-            else:
-                documents_by_type[doc["category"]] = [doc]
-        mur["documents_by_type"] = documents_by_type
+        try:
+            mur_docs = mur["documents"]
+            if len(mur_docs) > 0:
+                for doc in mur["documents"]:
+                    if doc["category"] in documents_by_type:
+                        documents_by_type[doc["category"]].append(doc)
+                    else:
+                        documents_by_type[doc["category"]] = [doc]
+                mur["documents_by_type"] = documents_by_type
+        except KeyError:
+            logger.error("There are no MUR documents loaded")
+
+
     return mur
 
 

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -154,7 +154,7 @@ def load_legal_mur(mur_no):
 
         documents_by_type = OrderedDict()
         try:
-            mur_docs = mur["documents"]
+            mur_docs = mur["document"]
             if len(mur_docs) > 0:
                 for doc in mur["documents"]:
                     if doc["category"] in documents_by_type:
@@ -163,7 +163,7 @@ def load_legal_mur(mur_no):
                         documents_by_type[doc["category"]] = [doc]
                 mur["documents_by_type"] = documents_by_type
         except KeyError:
-            logger.error("There are no MUR documents loaded")
+            logger.error("MUR " + str(mur_no) + ": There are no MUR documents loaded")
 
 
     return mur

--- a/fec/legal/templates/legal-archived-mur.jinja
+++ b/fec/legal/templates/legal-archived-mur.jinja
@@ -81,23 +81,25 @@
       {% endif %}
     </section>
     <section id="documents" class="content__section">
-      <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
       {% if 'documents' not in mur %}
-      <!-- Current MURs don't have nested documents. MUR URL is the PDF link -->
-        <div class="content__section">
-          <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">Case documents</a>
-          (<a class="t-sans" href="{{ mur.url }}" target="_blank">{{ mur.pdf_size | filesize }}</a>)
-        </div>
+        <!-- Current MURs don't have nested documents. MUR URL is the PDF link -->
+        <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
+          <div class="content__section">
+            <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">Case documents</a>
+            (<a class="t-sans" href="{{ mur.url }}" target="_blank">{{ mur.pdf_size | filesize }}</a>)
+          </div>
       {% else %}
       <!-- Archived MURs have nested documents and no MUR-level URL. See issue #2157 -->
         {% if mur.get('documents', {}) | length == 1 %}
-        <!-- Show one 'case documents' button if there's only one PDF -->
+          <!-- Show one 'case documents' button if there's only one PDF -->
+          <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
           <div class="content__section">
             <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.documents[0].url }}" target="_blank">Case documents</a>
             (<a class="t-sans" href="{{ mur.documents[0].url }}" target="_blank">{{ mur.documents[0].length | filesize }}</a>)
           </div>
         {% elif mur.get('documents', {}) | length > 1 %}
-        <!-- Make a case documents table -->
+          <!-- Make a case documents table -->
+          <h2 class="t-ruled--bold t-ruled--bottom u-no-margin">Documents</h2>
           <table class="data-table data-table--text data-table--heading-borders">
           <tbody>
             {% for document in mur.documents %}
@@ -105,12 +107,13 @@
               </tr>
             {% endfor %}
         {% elif mur.get('documents', {}) | length == 0 %}
-          <div class="content__section">
+          <!-- Show error when there are no documents loaded -->
+          <h2 class="t-ruled--bold t-ruled--bottom u-no-margin">Documents</h2>
+          <table class="data-table data-table--text data-table--heading-borders">
             <tbody>
               <tr>
                 <td>Sorry, there was a problem loading these documents. Please try again later.</td>
               </tr>
-          </div>
         {% endif %}
       {% endif %}
       </tbody>

--- a/fec/legal/templates/legal-archived-mur.jinja
+++ b/fec/legal/templates/legal-archived-mur.jinja
@@ -96,7 +96,7 @@
             <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.documents[0].url }}" target="_blank">Case documents</a>
             (<a class="t-sans" href="{{ mur.documents[0].url }}" target="_blank">{{ mur.documents[0].length | filesize }}</a>)
           </div>
-        {% else %}
+        {% elif mur.get('documents', {}) | length > 1 %}
         <!-- Make a case documents table -->
           <table class="data-table data-table--text data-table--heading-borders">
           <tbody>
@@ -104,6 +104,13 @@
               <td><a href="{{ document.url }}">Case documents, part {{ document.document_id }}</a> {{ document.length | filesize }}</td>
               </tr>
             {% endfor %}
+        {% elif mur.get('documents', {}) | length == 0 %}
+          <div class="content__section">
+            <tbody>
+              <tr>
+                <td>Sorry, there was a problem loading these documents. Please try again later.</td>
+              </tr>
+          </div>
         {% endif %}
       {% endif %}
       </tbody>

--- a/fec/legal/templates/legal-current-mur.jinja
+++ b/fec/legal/templates/legal-current-mur.jinja
@@ -143,6 +143,10 @@
               </tr>
             {% endfor %}
           {% endfor %}
+          {% else %}
+              <tr>
+                <td colspan="3">There was a problem loading documents.</td>
+              </tr>
         {% endif %}
       </tbody>
     </table>

--- a/fec/legal/templates/legal-current-mur.jinja
+++ b/fec/legal/templates/legal-current-mur.jinja
@@ -145,7 +145,7 @@
           {% endfor %}
           {% else %}
               <tr>
-                <td colspan="3">There was a problem loading documents.</td>
+                <td colspan="3">Sorry, there was a problem loading these documents. Please try again later.</td>
               </tr>
         {% endif %}
       </tbody>


### PR DESCRIPTION
## Summary (required)

- Resolves #3772 
_Uses a `try` and `except` to gracefully fail when there are no current MUR docs. Incorporates an input into the logs when there is an exception thrown. Also creates an error message for archived MURs._

## Impacted areas of the application

List general components of the application that this PR will affect:

- Current MUR canonial page
- Archived MUR canonical page

## Screenshots
### MUR canonical page - document loading error
<img width="657" alt="Screen Shot 2020-06-08 at 1 38 51 PM" src="https://user-images.githubusercontent.com/12799132/84062515-6a78b580-a98d-11ea-80d4-281c7457c5d0.png">

## How to test
- [ ] Checkout this branch
- [ ] `npm run build` (technically not needed for this PR, but just in case to make sure it's up to date)
- [ ] `./manage.py runserver`
- [ ] Make some temporary code modifications to check if this works:
    - In `api_caller.py` line 157, change the param name `"documents"` to something that does not exist like `"test"`. Then take a look at a current MUR page like this to check if the error appears: http://localhost:8000/data/legal/matter-under-review/7620/. 
    - In `legal-archive-mur.jinja` lines 93, 100, and 109, change the param name `'documents'` to something that doesn't exist like `'test'`. Then take a look to see if the error appears for an archive MUR with a [single document](http://localhost:8000/data/legal/matter-under-review/565/) and an archive [MUR with multiple document parts](http://localhost:8000/data/legal/matter-under-review/1252/). 
____
