### PR TITLE
Handle mid-cycle candidates who have transferred committees

### DIFF
--- a/fec/data/templates/macros/missing-transferred.jinja
+++ b/fec/data/templates/macros/missing-transferred.jinja
@@ -1,13 +1,6 @@
 {% macro missing_transferred_candidate_message(entity, cycle, converted_committee_name, converted_committee_id, former_committee_name) %}
     <div class="message message--info">
-        <p>
-        We don't have
-        <span class="t-bold">
-            {{ entity }}
-        </span>
-        for <span class="t-bold">{{ cycle | fmt_year_range }}</span>.
-        </p>
-        <p>Financial data for this candidate now appears under the committee name <strong><a href="/data/committee/{{ converted_committee_id }}">{{ converted_committee_name }}</a></strong>, following the committee's conversion to a <span class="term" data-term="political action committee (pac)">PAC</span> from a <span class="term" data-term="principal campaign committee">principal campaign committee</span>. Before its conversion the candidate's committee was named <strong>{{ former_committee_name }}</strong>.</p>
+        <p><span class="t-bold">{{ cycle | fmt_year_range }}</span> financial data for <strong><span class="t-bold">{{ entity }}</span></strong> now appears under the committee name <strong><a href="/data/committee/{{ converted_committee_id }}">{{ converted_committee_name }}</a></strong>, following the committee's conversion to a <span class="term" data-term="political action committee (pac)">PAC</span> from a <span class="term" data-term="principal campaign committee">principal campaign committee</span>. Prior to its conversion to a PAC the candidate's principal campaign committee was named <strong>{{ former_committee_name }}</strong>.</p>
         <div class="message--alert__bottom">
         <p>Think this result is a mistake or have questions?</p>
         <p>

--- a/fec/data/templates/macros/missing-transferred.jinja
+++ b/fec/data/templates/macros/missing-transferred.jinja
@@ -1,4 +1,4 @@
-{% macro missing(entity, cycle) %}
+{% macro missing(entity, cycle, converted_committee_name) %}
     <div class="message message--info">
         <p>
         We don't have
@@ -7,10 +7,7 @@
         </span>
         for <span class="t-bold">{{ cycle | fmt_year_range }}</span>.
         </p>
-        <p>This can be because:</p>
-        <ul class="list--bulleted">
-        <li>Funds have been moved to another committee.</li>
-        </ul>
+        <p>Financial data for this candidate now appears under the committee name {{ converted_committee_name }}, following the committee's conversion to a <span class="term" data-term="political action committee (pac)">PAC</span> from a <span class="term" data-term="principal campaign committee">principal campaign committee</span>.</p>
         <div class="message--alert__bottom">
         <p>Think this result is a mistake or have questions?</p>
         <p>

--- a/fec/data/templates/macros/missing-transferred.jinja
+++ b/fec/data/templates/macros/missing-transferred.jinja
@@ -1,4 +1,4 @@
-{% macro missing(entity, cycle, converted_committee_name, converted_committee_id, former_committee_name) %}
+{% macro missing_transferred_candidate_message(entity, cycle, converted_committee_name, converted_committee_id, former_committee_name) %}
     <div class="message message--info">
         <p>
         We don't have
@@ -8,6 +8,19 @@
         for <span class="t-bold">{{ cycle | fmt_year_range }}</span>.
         </p>
         <p>Financial data for this candidate now appears under the committee name <strong><a href="/data/committee/{{ converted_committee_id }}">{{ converted_committee_name }}</a></strong>, following the committee's conversion to a <span class="term" data-term="political action committee (pac)">PAC</span> from a <span class="term" data-term="principal campaign committee">principal campaign committee</span>. Before its conversion the candidate's committee was named <strong>{{ former_committee_name }}</strong>.</p>
+        <div class="message--alert__bottom">
+        <p>Think this result is a mistake or have questions?</p>
+        <p>
+            Send us more information in the feedback box or
+            <a href="https://www.fec.gov/contact/" target="_blank" rel="noopener noreferrer">contact us</a>.
+        </p>
+        </div>
+    </div>
+{% endmacro %}
+
+{% macro missing_transferred_committee_message(former_committee_name, former_authorized_candidate_name, former_authorized_candidate_id) %}
+    <div class="message message--info">
+        <p>Financial data for this committee contains funds raised and spent under the former name  <strong>{{ former_committee_name }}</strong> which, before it was converted, was a <span class="term" data-term="principal campaign committee">principal campaign committee</span>. Before its conversion this committee was authorized by candidate <strong><a href="/data/candidate/{{ former_authorized_candidate_id }}">{{ former_authorized_candidate_name }}</a></strong>.</p>
         <div class="message--alert__bottom">
         <p>Think this result is a mistake or have questions?</p>
         <p>

--- a/fec/data/templates/macros/missing-transferred.jinja
+++ b/fec/data/templates/macros/missing-transferred.jinja
@@ -1,0 +1,22 @@
+{% macro missing(entity, cycle) %}
+    <div class="message message--info">
+        <p>
+        We don't have
+        <span class="t-bold">
+            {{ entity }}
+        </span>
+        for <span class="t-bold">{{ cycle | fmt_year_range }}</span>.
+        </p>
+        <p>This can be because:</p>
+        <ul class="list--bulleted">
+        <li>Funds have been moved to another committee.</li>
+        </ul>
+        <div class="message--alert__bottom">
+        <p>Think this result is a mistake or have questions?</p>
+        <p>
+            Send us more information in the feedback box or
+            <a href="https://www.fec.gov/contact/" target="_blank" rel="noopener noreferrer">contact us</a>.
+        </p>
+        </div>
+    </div>
+{% endmacro %}

--- a/fec/data/templates/macros/missing-transferred.jinja
+++ b/fec/data/templates/macros/missing-transferred.jinja
@@ -1,4 +1,4 @@
-{% macro missing(entity, cycle, converted_committee_name) %}
+{% macro missing(entity, cycle, converted_committee_name, converted_committee_id, former_committee_name) %}
     <div class="message message--info">
         <p>
         We don't have
@@ -7,7 +7,7 @@
         </span>
         for <span class="t-bold">{{ cycle | fmt_year_range }}</span>.
         </p>
-        <p>Financial data for this candidate now appears under the committee name {{ converted_committee_name }}, following the committee's conversion to a <span class="term" data-term="political action committee (pac)">PAC</span> from a <span class="term" data-term="principal campaign committee">principal campaign committee</span>.</p>
+        <p>Financial data for this candidate now appears under the committee name <strong><a href="/data/committee/{{ converted_committee_id }}">{{ converted_committee_name }}</a></strong>, following the committee's conversion to a <span class="term" data-term="political action committee (pac)">PAC</span> from a <span class="term" data-term="principal campaign committee">principal campaign committee</span>. Before its conversion the candidate's committee was named <strong>{{ former_committee_name }}</strong>.</p>
         <div class="message--alert__bottom">
         <p>Think this result is a mistake or have questions?</p>
         <p>

--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -62,8 +62,8 @@
       </div>
     {% else %}
     <div class="entity__figure entity__figure--narrow">
-      {% if candidate_id == 'P00010298' %}
-        {{ missing_transferred.missing(name, cycle) }}
+      {% if converted_committee_name %}
+        {{ missing_transferred.missing(name, cycle, converted_committee_name) }}
       {% else %}
         {{ missing.missing_financials(name, cycle) }}
       {% endif %}

--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -28,7 +28,7 @@
 
     {% if converted_committee_name %}
       <div class="entity__figure entity__figure--narrow">
-        {{ missing_transferred.missing(name, cycle, converted_committee_name, converted_committee_id, former_committee_name) }}
+        {{ missing_transferred.missing_transferred_candidate_message(name, cycle, converted_committee_name, converted_committee_id, former_committee_name) }}
       </div>
     {% endif %}
 

--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -1,4 +1,5 @@
 {% import 'macros/missing.jinja' as missing %}
+{% import 'macros/missing-transferred.jinja' as missing_transferred %}
 {% import 'macros/tables.jinja' as tables %}
 {% import 'macros/cycle-select.jinja' as select %}
 
@@ -61,7 +62,11 @@
       </div>
     {% else %}
     <div class="entity__figure entity__figure--narrow">
-      {{ missing.missing_financials(name, cycle) }}
+      {% if candidate_id == 'P00010298' %}
+        {{ missing_transferred.missing(name, cycle) }}
+      {% else %}
+        {{ missing.missing_financials(name, cycle) }}
+      {% endif %}
     </div>
     {% endif %}
   </div>

--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -26,6 +26,12 @@
     </ul>
     {% endif %}
 
+    {% if converted_committee_name %}
+      <div class="entity__figure entity__figure--narrow">
+        {{ missing_transferred.missing(name, cycle, converted_committee_name, converted_committee_id, former_committee_name) }}
+      </div>
+    {% endif %}
+
     {% if raising_summary %}
       <div class="entity__figure entity__figure--narrow" id="total-raised">
         <div class="heading--section heading--with-action">
@@ -61,13 +67,11 @@
         {{ tables.summary(cash_summary) }}
       </div>
     {% else %}
-    <div class="entity__figure entity__figure--narrow">
-      {% if converted_committee_name %}
-        {{ missing_transferred.missing(name, cycle, converted_committee_name) }}
-      {% else %}
+    {% if not converted_committee_name %}
+      <div class="entity__figure entity__figure--narrow">
         {{ missing.missing_financials(name, cycle) }}
-      {% endif %}
-    </div>
+      </div>
+    {% endif %}
     {% endif %}
   </div>
 

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -1,4 +1,5 @@
 {% import 'macros/missing.jinja' as missing %}
+{% import 'macros/missing-transferred.jinja' as missing_transferred %}
 {% import 'macros/cycle-select.jinja' as select %}
 {% import 'macros/tables.jinja' as tables %}
 
@@ -28,6 +29,11 @@
           {{ tables.summary(inaugural_summary) }}
         </div>
       {% else %}
+        {% if former_committee_name %}
+          <div class="entity__figure entity__figure--narrow">
+            {{ missing_transferred.missing_transferred_committee_message(former_committee_name, former_authorized_candidate_name, former_authorized_candidate_id) }}
+          </div>
+        {% endif %}
         <div class="entity__figure entity__figure--narrow" id="total-raised">
           <div class="heading--section heading--with-action">
             <h3 class="heading__left">Total raised</h3>

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -265,7 +265,27 @@ def get_candidate(candidate_id, cycle, election_full):
     path = "/efile/" + "/filings/"
     raw_filings = api_caller.load_endpoint_results(path, **filters)
     has_raw_filings = True if raw_filings else False
+
+    converted_candidate_committees = {
+        "H0CA08069": "C00698894", 
+        "H0IL01178": "C00697128", 
+        "P00010298": "C00697441", 
+        "P00009092": "C00693044", 
+        "H8CA25074": "C00634212", 
+        "H0CA04167": "C00691790",
+    }
+
+    converted_committee_name = None
+    if cycle == 2020 and converted_candidate_committees.get(candidate_id):
+        # Call committee/{committee_id}/history/{cycle}/
+        filters = {"per_page": 1}
+        path = "/committee/" + converted_candidate_committees.get(candidate_id) + "/history/" + str(cycle)
+        committee = api_caller.load_first_row_data(path, **filters)
+        # Get the converted committee's name
+        converted_committee_name = committee.get('name')
+
     return {
+        "converted_committee_name": converted_committee_name,
         "aggregate": aggregate,
         "aggregate_cycles": aggregate_cycles,
         "candidate": candidate,

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -38,7 +38,8 @@ validListUrlParamValues = ["P", "S", "H"]
 # INITIALLY USED BY raising() AND spending() FOR VALIDATING URL PARAMETERS,
 # THE list URL PARAM
 
-
+# List of candidates who have changed their candidate committees during a 
+# recent two year time period
 candidate_to_committee_linkage = {
     "H0CA08069": "C00698894", 
     "H0IL01178": "C00697128", 
@@ -52,6 +53,7 @@ committee_to_candidate_linkage = {
     v: k for k, v in candidate_to_committee_linkage.items()
     }
 
+# List of names for former candidate committees
 former_committee_names = {
     "C00698894": "JOHN DENNIS FOR CONGRESS", 
     "C00697128": "FRIENDS TO ELECT ROBERT EMMONS JR.", 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -39,6 +39,28 @@ validListUrlParamValues = ["P", "S", "H"]
 # THE list URL PARAM
 
 
+candidate_to_committee_linkage = {
+    "H0CA08069": "C00698894", 
+    "H0IL01178": "C00697128", 
+    "P00010298": "C00697441", 
+    "P00009092": "C00693044", 
+    "H8CA25074": "C00634212", 
+    "H0CA04167": "C00691790",
+}
+
+committee_to_candidate_linkage = {
+    v: k for k, v in candidate_to_committee_linkage.items()
+    }
+
+former_committee_names = {
+    "C00698894": "JOHN DENNIS FOR CONGRESS", 
+    "C00697128": "FRIENDS TO ELECT ROBERT EMMONS JR.", 
+    "C00697441": "PETE FOR AMERICA, INC.", 
+    "C00693044": "JULIAN FOR THE FUTURE PRESIDENTIAL EXPLORATORY COMMITTEE", 
+    "C00634212": "KATIE HILL FOR CONGRESS", 
+    "C00691790": "SEAN FRAME FOR CONGRESS",
+}
+
 def to_date(committee, cycle):
     if committee["committee_type"] in ["H", "S", "P"]:
         return None
@@ -266,32 +288,15 @@ def get_candidate(candidate_id, cycle, election_full):
     raw_filings = api_caller.load_endpoint_results(path, **filters)
     has_raw_filings = True if raw_filings else False
 
-    converted_candidate_committees = {
-        "H0CA08069": "C00698894", 
-        "H0IL01178": "C00697128", 
-        "P00010298": "C00697441", 
-        "P00009092": "C00693044", 
-        "H8CA25074": "C00634212", 
-        "H0CA04167": "C00691790",
-    }
-
-    former_committee_names = {
-        "C00698894": "JOHN DENNIS FOR CONGRESS", 
-        "C00697128": "FRIENDS TO ELECT ROBERT EMMONS JR.", 
-        "C00697441": "PETE FOR AMERICA, INC.", 
-        "C00693044": "JULIAN FOR THE FUTURE PRESIDENTIAL EXPLORATORY COMMITTEE", 
-        "C00634212": "KATIE HILL FOR CONGRESS", 
-        "C00691790": "SEAN FRAME FOR CONGRESS",
-    }
-
+    # Add message for when a candidate converts their candidate committee to an unauthorized committee
     current_committee_name = None
     converted_committee_id = None
     former_committee_name = None
 
-    if cycle == 2020 and converted_candidate_committees.get(candidate_id):
+    if cycle == 2020 and candidate_to_committee_linkage.get(candidate_id):
         # Call committee/{committee_id}/history/{cycle}/
         filters = {"per_page": 1}
-        path = "/committee/" + converted_candidate_committees.get(candidate_id) + "/history/" + str(cycle)
+        path = "/committee/" + candidate_to_committee_linkage.get(candidate_id) + "/history/" + str(cycle)
         committee = api_caller.load_first_row_data(path, **filters)
         # Get the converted committee's name, committee ID, and former committee name
         current_committee_name = committee.get('name')
@@ -506,6 +511,29 @@ def get_committee(committee_id, cycle):
         )
 
     template_variables["statement_of_organization"] = statement_of_organization
+
+    # Add message for a committee that was formerly an authorized candidate committee.
+    # These committees are now unauthorized committees.
+    converted_committee_id = None
+    former_committee_name = None
+    former_authorized_candidate_id = None
+    former_authorized_candidate_name = None
+
+    if cycle == 2020 and committee_to_candidate_linkage.get(committee_id):
+        # Call /candidate/{candidate_id}/history/
+        converted_committee_id = committee.get('committee_id')
+        former_authorized_candidate_id = committee_to_candidate_linkage.get(converted_committee_id)
+        path = "/candidate/" + str(former_authorized_candidate_id) + "/history/"
+        filters = {}
+        filters["per_page"] = 1
+        candidate = api_caller.load_first_row_data(path, **filters)
+        # Get the converted committee's former name and candidate name
+        former_committee_name = former_committee_names.get(converted_committee_id)
+        former_authorized_candidate_name = candidate.get('name')
+
+    template_variables["former_committee_name"] = former_committee_name
+    template_variables["former_authorized_candidate_name"] = former_authorized_candidate_name
+    template_variables["former_authorized_candidate_id"] = former_authorized_candidate_id
 
     return template_variables
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -275,17 +275,33 @@ def get_candidate(candidate_id, cycle, election_full):
         "H0CA04167": "C00691790",
     }
 
-    converted_committee_name = None
+    former_committee_names = {
+        "C00698894": "JOHN DENNIS FOR CONGRESS", 
+        "C00697128": "FRIENDS TO ELECT ROBERT EMMONS JR.", 
+        "C00697441": "PETE FOR AMERICA, INC.", 
+        "C00693044": "JULIAN FOR THE FUTURE PRESIDENTIAL EXPLORATORY COMMITTEE", 
+        "C00634212": "KATIE HILL FOR CONGRESS", 
+        "C00691790": "SEAN FRAME FOR CONGRESS",
+    }
+
+    current_committee_name = None
+    converted_committee_id = None
+    former_committee_name = None
+
     if cycle == 2020 and converted_candidate_committees.get(candidate_id):
         # Call committee/{committee_id}/history/{cycle}/
         filters = {"per_page": 1}
         path = "/committee/" + converted_candidate_committees.get(candidate_id) + "/history/" + str(cycle)
         committee = api_caller.load_first_row_data(path, **filters)
-        # Get the converted committee's name
-        converted_committee_name = committee.get('name')
+        # Get the converted committee's name, committee ID, and former committee name
+        current_committee_name = committee.get('name')
+        converted_committee_id = committee.get('committee_id')
+        former_committee_name = former_committee_names.get(converted_committee_id)
 
     return {
-        "converted_committee_name": converted_committee_name,
+        "converted_committee_name": current_committee_name,
+        "converted_committee_id": converted_committee_id,
+        "former_committee_name": former_committee_name,
         "aggregate": aggregate,
         "aggregate_cycles": aggregate_cycles,
         "candidate": candidate,


### PR DESCRIPTION
## Summary

- Addresses https://github.com/fecgov/openFEC/issues/4292
_Creates a way to handle mid-cycle candidates who have converted committees._

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Candidate profile pages for: H0CA08069, H0IL01178, P00010298, P00009092, H8CA25074, H0CA04167
- Committee profile pages for: C00698894, C00697128, C00697441, C00693044, C00634212, C00691790

## Screenshots

### Candidate profile page
<img width="1116" alt="Screen Shot 2020-06-10 at 4 43 19 PM" src="https://user-images.githubusercontent.com/12799132/84317204-676ef800-ab3a-11ea-9e51-b7d55676cace.png">


### Committee profile page
<img width="1028" alt="Screen Shot 2020-06-10 at 9 26 03 AM" src="https://user-images.githubusercontent.com/12799132/84273519-c31a9080-aafc-11ea-9e0e-3ae8284dcdd2.png">

## How to test

- checkout this branch
- Look at one of the candidate profile pages listed in the impacted areas section above. See if missing financials message is present: http://localhost:8000/data/candidate/P00010298/
- Look at one of the committee profile pages listed in the impacted areas section above. See if former candidate financials message is present: http://localhost:8000/data/committee/C00697441/
- Look at another random 2020 candidate page with no financials to make sure this message does not appear there. 
- Look at another random 2020 candidate committee page with no financials to make sure the this message does not appear there.

____
