### PR TITLE
Updated the language for no search results found

### DIFF
--- a/fec/search/templates/search/search.html
+++ b/fec/search/templates/search/search.html
@@ -186,10 +186,11 @@
           <div class="message message--info">
             <h2>No results</h2>
             <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong>.</p>
-            <p>Try changing your search term or using one of our other specialized search tools.</p>
             <div class="message--alert__bottom">
-              <p>FEC.gov is in the middle of a redesign, and some pages aren’t included in search results yet. Please try another search. Or, <a href="{{ settings.FEC_CLASSIC_URL }}">search an archive</a> of the old FEC.gov design.</p>
-              <p>If you'd like to contact our team, we're available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/fecgov/fec">GitHub</a>.</p>
+              <p>Think this was a mistake?<br>Try one of the other search tools or submit feedback</p>
+              <p>
+                <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}" class="button--standard">Email our team</a>&nbsp;&nbsp; <a href="https://github.com/fecgov/fec" class="button--standard">File an issue</a></p>
+              </p>
             </div>
           </div>
         {% endif %}


### PR DESCRIPTION
## Summary

- Resolves #3619
Updated the message for when no search results are found:

## Impacted areas of the application
Changed the language on the search results page when nothing is found

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/26720877/84078404-dfa4b480-a9a6-11ea-8092-14db570870b2.png)

Updated:
![image](https://user-images.githubusercontent.com/26720877/84078420-e59a9580-a9a6-11ea-9555-0cf7ef2a5635.png)

## Related PRs

None

## How to test

Not sure who should test so I added a few of you. Feel free to bail or swap. Dorothy, I figured you can approve with the screenshot and/or dev

- Pull the branch
- `npm i`
- `npm run build`
- `/manage.py runserver`
- Search for [gibberish](http://127.0.0.1:8000/search/?query=asdfasdfasdf&type=candidates&type=committees&type=site)
  - Should see the new message
- Search for something legit
  - Should see results and _not_ the no-results-found message

____
