### PR TITLE
Raise 404 when committee or candidate is none

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -152,6 +152,8 @@ def get_candidate(candidate_id, cycle, election_full):
     filters = {}
     filters["per_page"] = 1
     candidate = api_caller.load_first_row_data(path, **filters)
+    if candidate is None:
+        raise Http404()
 
     # a)Build List: even_election_years for candidate election dropdown list
     #   on candidate profile page.
@@ -517,6 +519,8 @@ def load_committee_history(committee_id, cycle=None):
         # set cycle = fallback_cycle
         path = "/committee/" + committee_id + "/history/"
         committee = api_caller.load_first_row_data(path, **filters)
+        if committee is None:
+            raise Http404()
         cycle = committee.get("last_cycle_has_financial")
         if not cycle:
             # when committees only file F1.fallback_cycle = null
@@ -527,6 +531,8 @@ def load_committee_history(committee_id, cycle=None):
         # under tag:committee
         path = "/committee/" + committee_id + "/history/" + str(cycle)
         committee = api_caller.load_first_row_data(path, **filters)
+        if committee is None:
+            raise Http404()
 
     # (2)call committee/{committee_id}/candidates/history/{cycle}
     # under: candidate, get all candidates associated with that commitee


### PR DESCRIPTION
## Summary

- Resolves #3747 
_Raises 404 when candidate or committee is none._

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Candidate and committee profile pages

## How to test

- [ ] Checkout this branch
- [ ] Make sure a 404 is raised for each of these scenarios:
    - Go to an invalid committee profile page: http://localhost:8000/data/candidate/C000/
    - Go to an invalid committee profile page with cycle passed: http://localhost:8000/data/committee/C000/?cycle=2020
    - Go to an invalid candidate profile page with cycle: http://localhost:8000/data/candidate/P000/


____
