### PR TITLE
Add active/terminated indictor on dropdown list.

### DIFF
--- a/fec/fec/static/js/modules/typeahead.js
+++ b/fec/fec/static/js/modules/typeahead.js
@@ -37,6 +37,7 @@ function formatCommittee(result) {
   return {
     name: result.name,
     id: result.id,
+    is_active: result.is_active,
     type: 'committee'
   };
 }
@@ -147,7 +148,9 @@ var committeeDataset = {
       '<span class="tt-suggestion__loading">Loading committees&hellip;</span>',
     notFound: Handlebars.compile(''), // This has to be empty to not show anything
     suggestion: Handlebars.compile(
-      '<span class="tt-suggestion__name">{{ name }} ({{ id }})</span>'
+      '<span class="tt-suggestion__name">{{ name }} ({{ id }})&nbsp;' +
+        '<span class="{{#if is_active}}is-active-status' +
+        '{{else}}is-terminated-status{{/if}}"></span></span>'
     )
   }
 };

--- a/fec/fec/static/scss/base.scss
+++ b/fec/fec/static/scss/base.scss
@@ -6,6 +6,7 @@
 @import "components/contact-form";
 @import "components/contact-items";
 @import "components/cycle-select";
+@import "components/datatables";
 @import "components/documents";
 @import "components/dropdowns";
 @import "components/examples";

--- a/fec/fec/static/scss/calendar.scss
+++ b/fec/fec/static/scss/calendar.scss
@@ -4,6 +4,7 @@
 @import "components/filters";
 @import "components/data-container";
 @import "components/calendar";
+@import "components/datatables";
 @import "components/dropdowns";
 @import "components/tags";
 @import "components/toggles";

--- a/fec/fec/static/scss/data-landing.scss
+++ b/fec/fec/static/scss/data-landing.scss
@@ -10,6 +10,7 @@
 @import "components/maps";
 @import "components/reaction-boxes";
 @import "components/_options";
+@import "components/datatables";
 
 // for spending raising breakdown pages
 @import "components/breakdowns";
@@ -24,3 +25,4 @@
 @import "components/icon-headings";
 @import "components/search-controls";
 @import "components/data-landing-callouts";
+


### PR DESCRIPTION
## Summary (required)
To make it more clear to our users what the status of a committee is, we want to add an indicator on global committee search dropdown list. Should be keyed off the current year.

- Resolves https://github.com/fecgov/fec-cms/issues/3752
_Include a summary of proposed changes._
add logic to typeahead.js  function: committeeDataset()

## How to test
1) checkout branch
2) npm run build
3) run:
./manage.py test
pytest
npm run test-single
4) test green/grey dot on globe search committee dropdown list.

## Impacted areas of the application
globe search dropdown list

## Screenshots
<img width="472" alt="Screen Shot 2020-06-09 at 4 12 08 PM" src="https://user-images.githubusercontent.com/24395751/84195416-88691780-aa6c-11ea-9166-ae37c6bed6a8.png">
