### PR TITLE
removed extra lines causing flake8 error

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -164,8 +164,6 @@ def load_legal_mur(mur_no):
                 mur["documents_by_type"] = documents_by_type
         except KeyError:
             logger.error("MUR " + str(mur_no) + ": There are no MUR documents loaded")
-
-
     return mur
 
 


### PR DESCRIPTION
## Summary

_Resolves failed flake8 in pytest by removing extra lines._

## Impacted areas of the application

-  api_caller.py

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
feature/3772-handle-missing-mur-docs | [link](https://github.com/fecgov/fec-cms/pull/3813)
feature/3651-flake8-linting | [link](https://github.com/fecgov/fec-cms/pull/3824)

## How to test

- Run `pytest` and check if there are any failures

____
