### PR TITLE
Update downloads error message

### DIFF
--- a/fec/fec/static/js/modules/download.js
+++ b/fec/fec/static/js/modules/download.js
@@ -195,7 +195,7 @@ DownloadItem.prototype.handleServerError = function(xhr) {
   } else {
     this.$body.html(
       '<div class="message message--alert message--mini">' +
-        'Sorry, you have either exceeded your maximum downloads for the hour or encountered a server error. Please try again later.' +
+        'Sorry, this data failed to download due to a server error. Please try again later.' +
         '<button class="js-close button--cancel download__cancel"><span class="u-visually-hidden">Remove</span></button>' +
         '</div>'
     );


### PR DESCRIPTION
## Summary

- Resolves #3819 
_Updates the downloads error message for when there is a server error. Normally these server errors are 500 error message._

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Downloads on the website

## Screenshots

### Server error message
<img width="1672" alt="all-other-download-errors" src="https://user-images.githubusercontent.com/12799132/84936150-d4890d00-b0a7-11ea-8628-85a89bde827e.png">

### 429 over limit for downloads error message
<img width="1676" alt="429-over-limit-download-error" src="https://user-images.githubusercontent.com/12799132/84936152-d521a380-b0a7-11ea-8927-2fbe10cfe712.png">

## How to test

To test that messages display when needed, I updated the stage API download key to something very low and kept trying to execute a download until the 429 error displayed. Then I stopped the celery worker app in stage to simulate a server error for downloads. To save testing time, I've already done the testing and put screenshots above. One for when a server error happens and one for when a 429 error happens.

____
