### PR TITLE
Remove reaction box code from  pres map

### DIFF
--- a/fec/data/templates/pres-finance-map.jinja
+++ b/fec/data/templates/pres-finance-map.jinja
@@ -1,7 +1,6 @@
 {% extends 'layouts/main.jinja' %}
 {# {% import 'macros/cycle-select.jinja' as select %} #}
 {% import 'macros/page-header.jinja' as header %}
-{% import 'macros/reaction-box.jinja' as reaction %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -23,7 +22,6 @@
     <div class="content__section--extra">
       <div class="usa-width-one-whole">
         {% include './widgets/pres-finance-map.jinja' %}
-        {{ reaction.reaction_box('presidential_map', 'presidential-map') }}
       </div>
     </div>
   </div>
@@ -74,7 +72,5 @@
 </div>
 {% endblock %}
 
-
 {% block scripts %}
-  <script src="{{ asset_for_js('reaction-box.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary (required)
Remove reaction box from presidential map

- Resolves #3649 

## Impacted areas of the application

modified:   data/templates/pres-finance-map.jinja

## How to test
Checkout and run branch: `feature/3649-remove-reaction-box`
Confirm pres map reaction box is removed

____
