### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Fix MUR document param

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -154,7 +154,7 @@ def load_legal_mur(mur_no):
 
         documents_by_type = OrderedDict()
         try:
-            mur_docs = mur["document"]
+            mur_docs = mur["documents"]
             if len(mur_docs) > 0:
                 for doc in mur["documents"]:
                     if doc["category"] in documents_by_type:


### PR DESCRIPTION
## Summary

_Fixed misspelling in query._

## Impacted areas of the application

- MUR canonical page

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
feature/3772-handle-missing-mur-docs | [link](https://github.com/fecgov/fec-cms/pull/3813)

## How to test
- [x] Checkout this branch
- [x] `./manage.py runserver`
- [x] Check documents are loading on [current MUR](http://localhost:8000/data/legal/matter-under-review/7620/) page, archive MUR with a [single document](http://localhost:8000/data/legal/matter-under-review/565/) and an archive [MUR with multiple document parts](http://localhost:8000/data/legal/matter-under-review/1252/). 
