### PR TITLE
Update wagtail to 2.7.3, exclude static directories from linting

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ addopts = --cov=fec fec --flake8 --cov-report term-missing
 DJANGO_SETTINGS_MODULE = fec.settings.dev
 flake8-max-line-length = 120
 flake8-ignore = E127 E128 W503
-flake8-exclude = migrations,wagtail_npm_dependencies
-norecursedirs = migrations wagtail_npm_dependencies
+flake8-exclude = migrations,wagtail_npm_dependencies,static
+norecursedirs = migrations wagtail_npm_dependencies static
 # flake8-exclude + norecursedirs are to keep pytest linting from checking
 # auto-generated code and code that isn't ours

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ psycopg2==2.8.5
 requests==2.21.0
 slacker==0.8.6
 whitenoise==2.0.3
-wagtail==2.7.2
+wagtail==2.7.3
 Jinja2==2.10.1
 django_jinja==2.4.1
 CacheControl==0.11.5


### PR DESCRIPTION
## Summary (required)

- Resolves #3777
Update wagtail to 2.7.3, exclude static directories from linting


## How to test

Include any information that may be helpful to the reviewer(s).
_This might include:_

- links to sample pages to test
- Any local environmental setup that is unusual (env vars, API version to point to, etc)

____
