### PR TITLE
update lodash v4.17.19 to fix the synk vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9005,9 +9005,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jquery": "^3.5.1",
     "jquery.inputmask": "^3.3.4",
     "leaflet-providers": "1.8.0 ",
-    "lodash": "^4.17.14",
+    "lodash": "^4.17.19",
     "minimatch": "^3.0.4",
     "moment": "2.20.1",
     "numeral": "^1.5.3",


### PR DESCRIPTION
## Summary (required)

Update lodash v4.17.19
- Resolves #3740

_Include a summary of proposed changes._
- update lodash to the latest v4.17.19 in `package.json` and `package-lock.json`



## Screenshots
on Develop branch lodash v4.17.14
<img width="1128" alt="Screen Shot 2020-07-09 at 1 31 40 PM" src="https://user-images.githubusercontent.com/11650355/87072525-e9aa1500-c1e9-11ea-9666-f52dda4e59d1.png">


on Feature with lodash v4.17.19:

<img width="1139" alt="Screen Shot 2020-07-09 at 1 35 33 PM" src="https://user-images.githubusercontent.com/11650355/87072511-e44cca80-c1e9-11ea-8adc-86dff079ac1d.png">


## How to test

**Following instructions work if `SNYK CLI` is already installed on your workstation:**
- pull the latest code from fec-cms/develop branch.
  - `git checkout develop`
- run `snyk test --file=package.json` on `fec-cms` repo(This should flag the LODASH pkg is vulnerable, in the terminal)
- checkout feature branch  
    - run `git checkout feature/3740-upgrade-lodash`
- create a new python virtual env 
   - run - `pyenv virtualenv 3.7.7 cms377`
- activate virtual env
  - run - pyenv activate cms377
- run `pip install -r requirements.txt`
- run `rm -rf node_modules/`
- run `npm i`
- run `npm run build`
- run `snyk test --file=package.json` 

Note# While testing this PR, if you ran into  `snyk command not found error`, follow the instructions to install `snyk cli` here - https://support.snyk.io/hc/en-us/articles/360003812538-Install-the-Snyk-CLI
____
