### PR TITLE
Fix the sort by candidate and spent by columns on the elections and spending pages.

### DIFF
--- a/fec/fec/static/js/modules/table-columns.js
+++ b/fec/fec/static/js/modules/table-columns.js
@@ -49,9 +49,9 @@ var candidateInformationColumns = [
 ];
 
 var communicationCostColumns = [
-  columns.committeeColumn({ data: 'committee', className: 'all' }),
+  columns.committeeColumn({ data: 'committee_name', className: 'all' }),
   columns.supportOpposeColumn,
-  columns.candidateColumn({ data: 'candidate', className: 'all' }),
+  columns.candidateColumn({ data: 'candidate_name', className: 'all' }),
   {
     data: 'total',
     className: 'all column--number t-mono',
@@ -134,8 +134,8 @@ function createElectionColumns(context) {
 }
 
 var electioneeringColumns = [
-  columns.committeeColumn({ data: 'committee', className: 'all' }),
-  columns.candidateColumn({ data: 'candidate', className: 'all' }),
+  columns.committeeColumn({ data: 'committee_name', className: 'all' }),
+  columns.candidateColumn({ data: 'candidate_name', className: 'all' }),
   {
     data: 'total',
     className: 'all column--number t-mono',
@@ -153,9 +153,9 @@ var electioneeringColumns = [
 ];
 
 var independentExpenditureColumns = [
-  columns.committeeColumn({ data: 'committee', className: 'all' }),
+  columns.committeeColumn({ data: 'committee_name', className: 'all' }),
   columns.supportOpposeColumn,
-  columns.candidateColumn({ data: 'candidate', className: 'all' }),
+  columns.candidateColumn({ data: 'candidate_name', className: 'all' }),
   {
     data: 'total',
     className: 'all column--number t-mono',

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -209,7 +209,7 @@ var expendituresColumns = [
   },
   columns.supportOpposeColumn,
   columns.candidateColumn({
-    data: 'candidate',
+    data: 'candidate_name',
     className: 'all'
   })
 ];


### PR DESCRIPTION
## Summary (required)

- Resolves #3900 
- Related #https://github.com/fecgov/openFEC/issues/4360

_Include a summary of proposed changes._

- in `fec/static/js/modules/table-columns.js`, update independentExpenditureColumns,  communicationCostColumns and electioneeringColumns to include the candidate_name and committee_name. 

## Impacted areas of the application

- IE, CC and EC sections in Election pages
- IE section in Spending pages

## Screenshots

**In Production:**
![Broken_Sort](https://user-images.githubusercontent.com/11650355/87568166-359a0580-c693-11ea-93c1-08dff2e62529.gif)


**After fixing sort in local env:**
![fixed-sortby-candidate_name](https://user-images.githubusercontent.com/11650355/87564466-6e83ab80-c68e-11ea-81c9-fbd3c2ec7e2d.gif)


## How to test

- checkout the branch
   - run  `git checkout feature/3900-fix-sort`
- compile JS 
   - run `npm run build`
- connect your cms to API branch that has the fix (see API pr for details # https://github.com/fecgov/openFEC/pull/4482) 
- start API and CMS servers
    - run  `./manage.py runserver`

Compare and test the following URL:
## Production - On Elections pages

1.  **_sort by candidate column  on independent expenditure section throws an error :_**
 https://www.fec.gov/data/elections/senate/CO/2020/#independent-expenditures

2.  **_sort by candidate column on communication costs section throws an error :_**
 https://www.fec.gov/data/elections/senate/CO/2020/#communication-costs

3.  **_sort by candidate column on electioneering communication section throws an error :_**
https://www.fec.gov/data/elections/senate/CO/2020/#electioneering-communication

## Local  - On Elections pages

1.  **_sort by candidate column  on independent expenditure section works:_**
http://localhost:8000/data/elections/senate/CO/2020/#independent-expenditures

2.  **_sort by candidate column on communication costs section works :_**
http://localhost:8000/data/elections/senate/CO/2020/#communication-costs

3.  **_sort by candidate column on electioneering communication section works :_**
http://localhost:8000/data/elections/senate/CO/2020/#electioneering-communication

## Production - On Committee spending tab:

1. **_sort by candidate column  on independent expenditure section throws an error :_**
https://www.fec.gov/data/committee/C00448696/?tab=spending#independent-expenditures

1. ## Local - On Committee spending tab:
**_sort by candidate column  on independent expenditure works:_**
http://localhost:8000/data/committee/C00448696/?tab=spending#independent-expenditures



