### PR TITLE
add ajv to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -546,11 +546,11 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -5388,9 +5388,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ace-builds": "1.2.2",
     "acorn": "^6.4.1",
     "aria-accordion": "1.0.0",
+    "ajv": "^6.12.3",
     "chroma-js": "1.0.1",
     "colorbrewer": "0.0.2",
     "component-sticky": "1.0.0",


### PR DESCRIPTION
## Summary (required)

- Resolves #3919 
- adds `"ajv": "^6.12.3",` to `package.json` as vulnerability is introduced through upstream `request` package which is deprecated.
- `ajv` is https://ajv.js.org/

## How to test
- [ ] from `fec-cms` dir, run `snyk test --file=package.json` (verify `ajv` vulnerability)
- [ ] checkout this PR branch
- [ ] remove node_modules, reinstall and build
- [ ] from `fec-cms` dir, run `snyk test --file=package.json` (verify no vulnerability shown)
- [ ] run cms locally and verify correct behavior, e.g., http://localhost:8000/data/candidate/P80001571/
- [ ] for consideration, should we open another issue to try and replace `request`  with a non-deprecated library, e.g., `axios` so that we can unpin the `ajv` dependency?

