### PR TITLE
Handle ServiceNow API outage or URL change

### DIFF
--- a/fec/fec/forms.py
+++ b/fec/fec/forms.py
@@ -58,7 +58,7 @@ def fetch_categories():
     if base_url:
         category_url = base_url + 'sys_choice?table=u_rad_response&element=u_category'
         r = requests.get(category_url, auth=(username, password))
-        return r.json()['result']
+        return r.json().get('result', [])
     else:
         return []
 

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -44,7 +44,6 @@ FEATURES = {
     'about': bool(env.get_credential('FEC_FEATURE_ABOUT', '')),
     'agendas': bool(env.get_credential('FEC_FEATURE_AGENDAS', '')),
     'tips': bool(env.get_credential('FEC_FEATURE_TIPS', '')),
-    'radform': bool(env.get_credential('FEC_FEATURE_RADFORM', '')),
     'adrs': bool(env.get_credential('FEC_FEATURE_ADRS', '')),
     'afs': bool(env.get_credential('FEC_FEATURE_AFS', '')),
     'aggregatetotals': bool(env.get_credential('FEC_FEATURE_AGGR_TOTS', '')),

--- a/fec/fec/tests/test_form.py
+++ b/fec/fec/tests/test_form.py
@@ -3,11 +3,16 @@ import requests
 
 from unittest import mock
 from django.test import TestCase
-from fec.forms import ContactRAD
+from fec.forms import ContactRAD, fetch_categories
 
 
-def mock_get():
-    requests.patch()
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
 
 
 class TestContactForm(TestCase):
@@ -32,6 +37,13 @@ class TestContactForm(TestCase):
     def test_empty_submission(self):
         form = ContactRAD({})
         self.assertFalse(form.is_valid())
+
+    @mock.patch.object(requests, 'get')
+    def test_fetch_categories(self, get):
+        """Make sure we return an empty list if we can't connect to ServiceNow"""
+        get.return_value = MockResponse({}, 500)
+        categories = fetch_categories()
+        self.assertTrue(categories == [])
 
     @mock.patch.object(fec.forms, 'form_categories')
     @mock.patch.object(fec.forms.requests, 'post')

--- a/fec/home/templates/home/contact-form.html
+++ b/fec/home/templates/home/contact-form.html
@@ -17,7 +17,7 @@
         <div class="main__content">
           <h2>Authorized representatives</h2>
           <p>If you represent a committee or another entity registered with the FEC, RAD staff can help answer your reporting questions.</p>
-          {% if settings.FEATURES.radform %}<p>Submit this form and your committee's RAD analyst will email you, usually within 3 business days. Or, for immediate assistance, use your designated analyst's provided contact information to call the analyst by phone during business hours.</p>{% endif %}
+          {% if form %}<p>Submit this form and your committee's RAD analyst will email you, usually within 3 business days. Or, for immediate assistance, use your designated analyst's provided contact information to call the analyst by phone during business hours.</p>{% endif %}
         </div>
         <div class="sidebar-container">
           <div class="contact-item contact-item--phone">
@@ -30,7 +30,7 @@
         </div>
       </div>
       <div class="main__content">
-        <div class="js-accordion accordion--neutral" data-content-prefix="lookup" {% if not settings.FEATURES.radform %}data-open-first="true"{% endif %}>
+        <div class="js-accordion accordion--neutral" data-content-prefix="lookup" {% if not form %}data-open-first="true"{% endif %}>
           <button class="accordion__button js-accordion-trigger">Find your committee's analyst</button>
           <div class="accordion__content row js-analyst-lookup">
             <div class="contact-form">

--- a/fec/home/templates/home/contact-form.html
+++ b/fec/home/templates/home/contact-form.html
@@ -81,6 +81,14 @@
             <h2 class="message__title">Error</h2>
             <p>Something went wrong. Please try again.</p>
           </div>
+        {% elif not form %}
+        <!-- Unable to contact ServiceNow -->
+           <div class="js-accordion accordion--neutral" data-content-prefix="contact">
+              <button class="accordion__button js-accordion-trigger is-disabled-filter">Submit a question</button>
+           </div>
+          <div class="message message--alt message--alert">
+           The question submission form is currently unavailable; please contact the committee's assigned RAD analyst directly or check back soon.
+          </div>
         {% elif form %}
       <div class="js-accordion accordion--neutral" data-content-prefix="contact" data-open-first="true">
         <button class="accordion__button js-accordion-trigger">Submit a question</button>

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -246,8 +246,8 @@ def contact_rad(request):
         "content_section": "help",
     }
 
-    # The feature is on, and can we get categories from ServiceNow
-    if settings.FEATURES["radform"] and fetch_categories():
+    # Only show contact form if we can contact ServiceNow
+    if fetch_categories():
         # If it's a POST, post to the ServiceNow API
         if request.method == "POST":
             form = ContactRAD(request.POST)

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -9,7 +9,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from wagtail.documents.models import Document
 
-from fec.forms import ContactRAD  # form_categories
+from fec.forms import ContactRAD, fetch_categories  # form_categories
 from home.models import (CommissionerPage, DigestPage, MeetingPage,
                          PressReleasePage, RecordPage, TipsForTreasurersPage)
 
@@ -246,7 +246,8 @@ def contact_rad(request):
         "content_section": "help",
     }
 
-    if settings.FEATURES["radform"]:
+    # The feature is on, and can we get categories from ServiceNow
+    if settings.FEATURES["radform"] and fetch_categories():
         # If it's a POST, post to the ServiceNow API
         if request.method == "POST":
             form = ContactRAD(request.POST)


### PR DESCRIPTION
## Summary (required)

Resolves #3718

- Handle ServiceNow API outage/URL change by only showing analyst lookup 
- Add test coverage 
- Remove feature flag for RAD form
- Add error message when ServiceNow is unavailable

## Impacted areas of the application

Contact RAD page

## How to test

Include any information that may be helpful to the reviewer(s).

### Reproduce error
- Checkout `develop`
- ~Set `FEC_FEATURE_RADFORM=True`~ removed this env var
- Set these, but with bad URL or creds:
- `FEC_SERVICE_NOW_API`: "https://api.open.fec.gov/" or "https://api.open.fec.gov/v1/committees/?api_key=DEMO_KEY&committee_id=C00431445&page=0" until the server error is fixed, or anything that doesn't have a "results" object
- Go to http://localhost:8000/help-candidates-and-committees/question-rad/
➡️ get error `KeyError: 'result'`
### Verify fix
- Checkout this branch
- ~Set `FEC_FEATURE_RADFORM=True`~ removed this env var
- Set these, but with bad URL or creds:
- `FEC_SERVICE_NOW_API`: "https://api.open.fec.gov/" or "https://api.open.fec.gov/v1/committees/?api_key=DEMO_KEY&committee_id=C00431445&page=0" until the server error is fixed, or anything that doesn't have a "results" object
- Go to http://localhost:8000/help-candidates-and-committees/question-rad/
- Should just see RAD analyst lookup, not question submission form
- Set `FEC_SERVICE_NOW_API`, `FEC_SERVICE_NOW_PASSWORD`, and `FEC_SERVICE_NOW_USERNAME` to the values in a cloud.gov environment
- Contact form should appear with categories. If you test a submission, be sure to let the committee's assigned analyst know that it's a test

### Screenshot
<img width="936" alt="Screen Shot 2020-07-28 at 1 59 02 PM" src="https://user-images.githubusercontent.com/31420082/88703304-8588bb80-d0da-11ea-9d6d-3dd7329032f0.png">

