### PR TITLE
Fix RTE mobile image resize , example-img, and table-spacing bugs.

### DIFF
--- a/fec/fec/static/scss/components/_articles.scss
+++ b/fec/fec/static/scss/components/_articles.scss
@@ -20,12 +20,19 @@
       border-radius: 2px;
     }
   }
+
+  .block-paragraph + .block-table {
+     margin-top: u(-4rem);
+    }
+
 }
   .block-table {
     table {
       @extend .simple-table-cms;
     }
   }
+
+
 
 
 // Author-list component

--- a/fec/fec/static/scss/components/_examples.scss
+++ b/fec/fec/static/scss/components/_examples.scss
@@ -58,8 +58,19 @@
   height: auto;
 }
 
+
+
+
 .example__caption {
-  @include span-columns(4);
+  width:100%;
   font-family: $serif;
   font-style: italic;
+  display: inline-block;
+  margin-top: u(2rem);
+  
+  @include media($med) {
+    @include span-columns(4);
+    margin-top: 0;
+
+  }
 }

--- a/fec/fec/static/scss/components/_richtext.scss
+++ b/fec/fec/static/scss/components/_richtext.scss
@@ -24,7 +24,7 @@
     clear: both;
     float: none;
     margin-bottom: u(2rem);
-    height: inherit;
+    height: initial;
   }
 }
 

--- a/fec/fec/static/scss/components/_richtext.scss
+++ b/fec/fec/static/scss/components/_richtext.scss
@@ -24,6 +24,7 @@
     clear: both;
     float: none;
     margin-bottom: u(2rem);
+    height: inherit;
   }
 }
 

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/example-image-height-bug'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/example-image-height-bug'),
+    #('feature', lambda _, branch: branch == '<BRANCH NAME>'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    #('feature', lambda _, branch: branch == '<BRANCH NAME>'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 


### PR DESCRIPTION
## Summary :
This PR addresses three Wagtail wishlist items:
1)  #3445, Images in RTE (Rich Text Editor)  not resizing proportionally in mobile sizes by observing the height html attribute ([Example &#187;](https://www.fec.gov/help-candidates-and-committees/making-disbursements-pac/nonconnected-coordinated-communication-example/))
2)  #3968,  `ExampleImage captions` do not respond properly in mobile sizes. They should move under the image in mobile.
See screenshot below. ([Example &#187;](https://www.fec.gov/help-candidates-and-committees/making-disbursements/advertising/candidate-committee-yard-sign-example/))
3)  #3541,  There is too much space under headlines above tables using `TableBlock` ([Example &#187;](https://www.fec.gov/updates/march-25-webinar-candidate-committees-2020/))

- Resolves: #3445
- Resolves: #3968
- Resolves: #3541


## Impacted areas of the application


modified:   fec/static/scss/components/_richtext.scss
modified:   fec/static/scss/components/_articles.scss
modified:   fec/static/scss/components/_examples.scss


## Screenshots
### RTE responsive image bug  (#3445)

![rte-image-bug](https://user-images.githubusercontent.com/5572856/89931092-bf2cec80-dbd9-11ea-9b1e-e40b11fb1e13.gif)

<hr>

### **Caption Bug ( #3968)**
![caption-resize-fix-bug](https://user-images.githubusercontent.com/5572856/89930532-e59e5800-dbd8-11ea-8ccf-e5727f5bfa2a.gif)

<hr>

### Table spacing bug (#3541)
![Screen Shot 2020-08-11 at 2 46 50 PM](https://user-images.githubusercontent.com/5572856/89936372-898c0180-dbe1-11ea-8087-e2a13b82d9ec.png)

<hr>

## How to test

### **Content team:** This has been deployed to feature space. 
- Confirm that the Wagtail wishlist items have been corrected. 
-  **RTE responsive image bug  (see #3445)**
https://fec-feature-cms.app.cloud.gov/help-candidates-and-committees/making-disbursements-political-party/party-committee-independent-expenditure-billboard-disclaimer-example/

- **Caption Bug (see #3968)**
https://fec-feature-cms.app.cloud.gov/help-candidates-and-committees/making-disbursements/advertising/candidate-committee-yard-sign-example/

- **Table-spacing bug (see #3541):**
    https://fec-feature-cms.app.cloud.gov/updates/march-25-webinar-candidate-committees-2020/

- it might  also be good  to test creating pages in feature with the example-images to make sure any scenario you might create works the way you would expect.

### **Developers**
- checkout `feature/example-image-height-bug`
- `npm run build-sass`
- `./manage.py runserver`
- Confirm that the Wagtail wishlist items have been corrected. 
***Images wont render locally unless you put them on your local `fec-cms/fec/media/images/` directory. Please see Note and images provided below.**
-  **RTE responsive image bug  (see #3445)**
http://127.0.0.1:8000/help-candidates-and-committees/making-disbursements-political-party/party-committee-independent-expenditure-billboard-disclaimer-example/
https://fec-feature-cms.app.cloud.gov/


- **Caption Bug (see #3968)**
http://127.0.0.1:8000/help-candidates-and-committees/making-disbursements/advertising/candidate-committee-yard-sign-example/

- **Table-spacing bug (see #3541):**
    http://127.0.0.1:8000/updates/march-25-webinar-candidate-committees-2020/

This page has links to other example images that can be tested to confirm fixes:
http://127.0.0.1:8000/help-candidates-and-committees/advertising-and-disclaimers/

***Note:** So you can view  images on your local CMS, you can put the below two images  into the `fec-cms/fec/media/images/` directory for your local CMS: Then they will render when viewing locally. You must rename them:
`Candidate_yard_sign_example.original.jpg`, `Party_Billboard.width-800.jpg` respectively.


<details>

<summary>Expand to get images</summary>

![Candidate_yard_sign_example original](https://user-images.githubusercontent.com/5572856/90041925-f9f55a00-dc97-11ea-8e97-f19d2810b7b6.jpg)
![Party_Billboard width-800](https://user-images.githubusercontent.com/5572856/90041928-f9f55a00-dc97-11ea-88a9-0f84ffa97c3a.jpg)


</details>
____
