### PR TITLE
[Merge after openFEC#4529] Fix candidate name and committee name sort for IE, EC, and CC tables

### DIFF
--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -56,7 +56,7 @@ var expenditureColumns = [
     })
   },
   columns.committeeColumn({
-    data: 'committee',
+    data: 'committee_name',
     className: 'all'
   }),
   columns.supportOpposeColumn
@@ -80,7 +80,7 @@ var communicationCostColumns = [
     })
   },
   columns.committeeColumn({
-    data: 'committee',
+    data: 'committee_name',
     className: 'all'
   }),
   columns.supportOpposeColumn
@@ -102,7 +102,7 @@ var electioneeringColumns = [
     )
   },
   columns.committeeColumn({
-    data: 'committee',
+    data: 'committee_name',
     className: 'all'
   })
 ];

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -255,7 +255,7 @@ var communicationCostColumns = [
   },
   columns.supportOpposeColumn,
   columns.candidateColumn({
-    data: 'candidate',
+    data: 'candidate_name',
     className: 'all'
   })
 ];


### PR DESCRIPTION
## Summary (required)

- Resolves #3921 
- Resolves #3945 
_Updates candidate and committee sort parameters to use `committee_name` and `candidate_name`._

Merge after the API work is merged: https://github.com/fecgov/openFEC/pull/4529

## Impacted areas of the application

List general components of the application that this PR will affect:

- Candidate profile page communication costs
- Committee profile page: independent expenditures, communication costs, and electioneering communications datatables

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
feature/fix-communication-cost-sort | [link](https://github.com/fecgov/openFEC/pull/4529)

## How to test

- Run your API off this PR: https://github.com/fecgov/openFEC/pull/4529
- Connect your CMS to your local API
- Run your CMS
- `npm run build-js`
- Go to the candidate profile page: http://localhost:8000/data/candidate/P80001571/?tab=other-spending. Check that you can sort the "Spent by" column for the independent expenditures, communication costs, and electioneering communications datatables
- Go to the committee profile page: http://localhost:8000/data/committee/C70001318/?tab=spending#communication-costs. Check that you can sort the "Spent by" column for the communication costs datatable

____
