### PR TITLE
Upgrade to Wagtail 2.7.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ psycopg2==2.8.5
 requests==2.21.0
 slacker==0.8.6
 whitenoise==2.0.3
-wagtail==2.7.3
+wagtail==2.7.4
 Jinja2==2.10.1
 django_jinja==2.4.1
 CacheControl==0.11.5


### PR DESCRIPTION
## Summary

- Resolves #3942 
Upgrading Wagtail from 2.7.3 to 2.7.4 to address a [SNYK vulnerability](https://snyk.io/vuln/SNYK-PYTHON-WAGTAIL-585980)

## Reviewers
- Someone from front-end,
- someone from content, (we'll make sure to tag you for review when it's ready to test outside of localhost)
- someone from design.

Feel free to remove yourselves.

## Impacted areas of the application

Technically the entire CMS, though it's just a patch-level upgrade, so there should be no noticeable effect.

## Screenshots

No noticeable difference

## Related PRs

There will be another PR for other security issues that rely on this PR. If we're approving that one at the same time, we can delete this PR and branch altogether. The ticket is #3886 

## How to test

- Pull the branch like normal
- Install the upgraded Wagtail: inside pyenv, in the base cms directory, run `pip install -r requirements.txt`
- Should be no errors or warnings
- Run the CMS like normal: inside pyenv, in the fec directory, run `./manage.py runserver`
- Should be no errors or warnings
- Check that the localhost CMS works ([front-end](http://127.0.0.1) and [admin](http://127.0.0.1/admin/))
- Check a few different types of pages in both

____
