### PR TITLE
SNYK - 3983 Update lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9005,9 +9005,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jquery": "^3.5.1",
     "jquery.inputmask": "^3.3.4",
     "leaflet-providers": "1.8.0 ",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.20",
     "minimatch": "^3.0.4",
     "moment": "2.20.1",
     "numeral": "^1.5.3",


### PR DESCRIPTION
## Summary

- Resolves #3983 

Updating lodash by a patch level to address a [Snyk vulnerability](https://app.snyk.io/vuln/SNYK-JS-LODASH-590103)

## Impacted areas of the application

If there were any effect, it would appear in the older interactive parts of the site. i.e. datatables, and interactive elements built before 2019.
The upgrade is only a patch-level step, though, so should be easy.

## Screenshots

No noticeable changes

## Related PRs

None

## How to test

- pull the branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- check that the pre-2019 interactive elements on the site work as expected (datatables, graphs, etc)

____
