### PR TITLE
Add external page link to "Read next" sidebar on ResourcePage

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -899,7 +899,8 @@ class ResourcePage(Page):
     ], null=True, blank=True)
     sidebar_title = models.CharField(max_length=255, null=True, blank=True)
     related_pages = StreamField([
-        ('related_pages', blocks.ListBlock(blocks.PageChooserBlock()))
+        ('related_pages', blocks.ListBlock(blocks.PageChooserBlock())),
+        ('external_page', blocks.RichTextBlock()),
     ], null=True, blank=True)
     sections = StreamField([
         ('sections', ResourceBlock())

--- a/fec/home/templates/home/resource_page.html
+++ b/fec/home/templates/home/resource_page.html
@@ -17,7 +17,7 @@
   <div class="sidebar-container">
     <aside class="sidebar sidebar--secondary">
       <h4 class="sidebar__title">{{ self.sidebar_title }}</h4>
-<ul class="sidebar__content">
+      <ul class="sidebar__content">
         {% for related_page in self.related_pages %}
           {% if related_page.block_type == "related_pages" %}
             {% for related in related_page.value %}

--- a/fec/home/templates/home/resource_page.html
+++ b/fec/home/templates/home/resource_page.html
@@ -17,11 +17,15 @@
   <div class="sidebar-container">
     <aside class="sidebar sidebar--secondary">
       <h4 class="sidebar__title">{{ self.sidebar_title }}</h4>
-      <ul class="sidebar__content">
-        {% for related_pages in self.related_pages %}
-          {% for related_page in related_pages.value %}
-          <li class="u-padding--bottom"><a href="{{ related_page.url }}">{{ related_page.title }}</a></li>
-          {% endfor %}
+<ul class="sidebar__content">
+        {% for related_page in self.related_pages %}
+          {% if related_page.block_type == "related_pages" %}
+            {% for related in related_page.value %}
+             <li class="u-padding--bottom"><a href="{{ related.url }}">{{ related.title }}</a></li>
+            {% endfor %}
+          {% else %}
+            <li class="u-padding--bottom">{{ related_page.value}}</li>
+          {% endif %}
         {% endfor %}
       </ul>
       {% if self.show_search %}

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/3794-external-related-page-ResourcePage'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/3794-external-related-page-ResourcePage'),
 )
 
 


### PR DESCRIPTION
## Summary (required)
- Add a `RichTextBlock` to the `related_pages` ("Read next") section on `ResourcePage` templates, allowing editors to add an external link in addition to the existing internal PageChooserBlock. 
- Adjust temp[late logic to accommodate
- We chose a `RichTextBlock` to give editors the versatility to add an external link as well as pretty much any other content  they might need to add here. 
- The seemingly extraneous  looping in the template is necessary because the `PageChooserBlock` is  inside a `ListBlock`, requiring looping to separate them into `<li>s` on the front end.. Attempts to simplify template logic by  switching from a `ListBlock` to a singular block in the model would group existing database entries for `PageChooser` `ListBlocks` into one `<li>`  on the front end. 

- Resolves #3794


## Impacted areas of the application
modified:   home/models.py
modified:   home/templates/home/resource_page.html


## Screenshots

### Wagtail admin:
<img width="1394" alt="Screen Shot 2020-08-21 at 7 40 42 PM" src="https://user-images.githubusercontent.com/5572856/90943069-3e929b00-e3e6-11ea-82bb-2ee6704c05e1.png">

<hr>

### Rendered page:

<img width="901" alt="Screen Shot 2020-08-21 at 7 37 16 PM" src="https://user-images.githubusercontent.com/5572856/90942960-d2b03280-e3e5-11ea-8124-c5b5a813819a.png">


## How to test
**Content team:** This is published on feature space at: https://fec-feature-cms.app.cloud.gov/

**Developers:**
- checkout and run `feature/3794-external-related-page-ResourcePage`
- Go to an existing ResourcePage with Read next sidebar , add `Related pages`, and  `External Pages` to the "Related Page" and preview/publish to confirm that both show. 
   - Example page: http://127.0.0.1:8000/admin/pages/9858/edit/
- Create a new `ResourcePage` and confirm Related Pages  section allows  to add both internal and external links in an interspersed  order.

**Note on migrations:** This is an example of a models.py streamfield change that does not require a migration to run properly, but would make a new migration file upon running `makemigrations`., referncing the added block name for the streamfield (but nothing actually changes in the databae) . Rather than push up a migration file  for this,  It can wait and will get picked up/added next time someone does a crucial `makemigrations/migrate` for a more substantial models.py change (i.e: upcoming `CommissoinerItem` model addition. Reference: https://github.com/wagtail/wagtail/issues/3710
____
