### PR TITLE
Add one PCC->PAC converted committee

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -53,6 +53,7 @@ candidate_to_committee_linkage = {
     "H0OH04085": "C00712224",
     "H0GA07265": "C00706564",
     "P00010793": "C00699090",
+    "P00014407": "C00727156",
 }
 
 committee_to_candidate_linkage = {
@@ -73,6 +74,7 @@ former_committee_names = {
     "C00712224": "JEFFREY A. SITES FOR CONGRESS",
     "C00706564": "LERAH LEE FOR CONGRESS",
     "C00699090": "BETO FOR AMERICA",
+    "C00727156": "DEVAL FOR ALL",
 }
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4001
Add one converted committee (PCC to PAC). OK not to hotfix per PM's.

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Add more candidates to manual conversion list
- Committee and candidate profile pages should have explanatory text:

https://www.fec.gov/data/committee/C00727156

https://www.fec.gov/data/candidate/P00014407

## Related PRs

List related PRs against other branches:

https://github.com/fecgov/fec-cms/pull/3953

## How to test

- Would like two approvals, at least one developer please

- If you can run locally: Committee and candidate profile pages should have explanatory text:

http://localhost:8000/data/committee/C00727156

http://localhost:8000/data/candidate/P00014407

- Anyone: Make sure the values match the [tracking spreadsheet](https://docs.google.com/spreadsheets/d/1VypSyRziT-_bgf9PslVNCkVUZ15GovF33AshZ9-f-4s/edit#gid=0)

