### PR TITLE
[DO NOT MERGE] Feature/3869 commissioner document feed

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -208,20 +208,72 @@ for category in report_category_groups.keys():
     report_child_categories.update(report_category_groups[category])
 
 # TODO
-# commissioner_item_categories = record_page_categories = OrderedDict((x.lower(), x) for x in [
+# commissioner_item_categories are a single taxonomy with a faked hierarchy
 commissioner_item_categories = OrderedDict([
-    ('opinion', 'Opinion'),
-    ('report', 'Report'),
-    ('testimony', 'Testimony'),
+    ('ballot-measures', 'Ballot Measures'),
+    ('best-efforts', '"Best Efforts"'),
+    ('contention-language', 'Contention Language'),
+    ('family-member-contributions', 'Family Member Contributions'),
+    ('coordination', 'Coordination'),
+    ('coordination/super-pacs', '↳ Super PACs'),
+    ('coordination/leadership-pac', '↳ Leadership PAC'),
+    ('coordination/hybrid-pacs', '↳ Hybrid PACs'),
+    ('coordination/corporations', '↳ Corporations'),
+    ('coordination/dark-money-groups-501c4', '↳ Dark Money Groups/501(c)(4)'),
+    ('coordination/state-political-party', '↳ State Political Party'),
+    ('coordination/membership-organization-pacs', '↳ Membership Organization PACs'),
+    ('contract-dispute', 'Contract Dispute'),
+    ('corporate-spending', 'Corporate Spending'),
+    ('corporate-spending/employee-coercion-threats-of-reprisal', '↳ Employee Coercion/Threats of Reprisal'),
+    ('corporate-spending/in-kind-contributions', '↳ In-Kind Contributions'),
+    ('corporate-spending/extending-credit', '↳ Extending Credit'),
+    ('corporate-spending/preparing-mailers', '↳ Preparing Mailers'),
+    ('corporate-spending/business-associations', '↳ Business Associations'),
+    ('corporate-spending/lobbyists-delivering-funds-on-behalf-of-corporation',
+      '↳ Lobbyists Delivering Funds on Behalf of Corporation'),
+    ('corporate-spending/nonprofit-corporation', '↳ Nonprofit Corporation'),
+    ('corporate-spending/salary-payments', '↳ Salary Payments'),
+    ('corporate-spending/improper-refund', '↳ Improper Refund'),
+    ('corporate-spending/express-advocacy', '↳ Express Advocacy'),
+    ('dark-money-501c4-groups', 'Dark Money/501(c)(4) groups'),
+    ('dark-money-501c4-groups/political-committee-status', '↳ Political Committee Status'),
+    ('dark-money-501c4-groups/failing-to-disclose-independent-expenditure',
+      '↳ Failing to Disclose Independent Expenditure'),
+    ('disclaimers', 'Disclaimers'),
+    ('disclaimers/brochure', '↳ Brochure'),
+    ('disclaimers/printed-box-requirement', '↳ Printed Box Requirement'),
+    ('disclaimers/internet', '↳ Internet'),
+    ('disclaimers/newspaper', '↳ Newspaper'),
+    ('disclaimers/mailer', '↳ Mailer'),
+    ('disclaimers/robocall', '↳ Robocall'),
+    ('disclaimers/radio', '↳ Radio'),
+    ('disclaimers/signs', '↳ Signs'),
+    ('disclaimers/television', '↳ Television'),
+    ('electioneering-communications', 'Electioneering Communications'),
+    ('express-advocacy', 'Express Advocacy'),
+    ('failing-to-disclose-independent-expenditure', 'Failing to Disclose Independent Expenditure'),
+    ('foreign-spending', 'Foreign Spending'),
+    ('hloga-air-travel', 'HLOGA/Air Travel'),
+    ('hosting-debates', 'Hosting Debates'),
+    ('increased-activity', 'Increased Activity'),
+    ('lobbyist-activity', 'Lobbyist Activity'),
+    ('membership-communications-exception', 'Membership Communications Exception'),
+    ('mischaracterization-of-party-in-court-filing', 'Mischaracterization of Party in Court Filing'),
+    ('payroll-deduction', 'Payroll Deduction'),
+    ('personal-use', 'Personal Use'),
+    ('press-exemption', 'Press Exemption'),
+    ('soft-money-use-of-non-federal-money-on-federal-expenses',
+      'Soft Money/Use of Non-Federal Money on Federal Expenses'),
+    ('sale-use', 'Sale & Use'),
+    ('straw-donors-conduit-contributions', 'Straw Donors/Conduit Contributions'),
+    ('super-pac-not-disclosing-till-after-election', 'Super PAC not disclosing till after election'),
+    ('testing-the-waters-candidate-status', 'Testing the Waters/Candidate Status'),
+    ('unions', 'Unions'),
+    ('use-of-opponents-name-without-permission', 'Use of Opponent’s Name Without Permission'),
+    ('volunteer-exemption', 'Volunteer Exemption'),
+    ('volunteer-mailers-exemption', 'Volunteer Mailers Exemption'),
 ])
 
-# TODO
-# commissioner_item_categories = record_page_categories = OrderedDict((x.lower(), x) for x in [
-commissioner_item_subjects = OrderedDict([
-    ('comm_subj_0', 'Commissioner Item Subject 0'),
-    ('comm_subj_1', 'Commissioner Item Subject 1'),
-    ('comm_subj_2', 'Commissioner Item Subject 2'),
-])
 
 # Search index constants
 # These are the parent pages for which we want *all* descendants of, not just direct children

--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -207,6 +207,21 @@ report_child_categories = OrderedDict()
 for category in report_category_groups.keys():
     report_child_categories.update(report_category_groups[category])
 
+# TODO
+# commissioner_item_categories = record_page_categories = OrderedDict((x.lower(), x) for x in [
+commissioner_item_categories = OrderedDict([
+    ('opinion', 'Opinion'),
+    ('report', 'Report'),
+    ('testimony', 'Testimony'),
+])
+
+# TODO
+# commissioner_item_categories = record_page_categories = OrderedDict((x.lower(), x) for x in [
+commissioner_item_subjects = OrderedDict([
+    ('comm_subj_0', 'Commissioner Item Subject 0'),
+    ('comm_subj_1', 'Commissioner Item Subject 1'),
+    ('comm_subj_2', 'Commissioner Item Subject 2'),
+])
 
 # Search index constants
 # These are the parent pages for which we want *all* descendants of, not just direct children

--- a/fec/fec/templates/partials/commissioner-item.html
+++ b/fec/fec/templates/partials/commissioner-item.html
@@ -10,25 +10,19 @@
   <div class="row">
     <div class="usa-width-three-fourths">
         <h3>
-            item.url: {{ item.link_doc }}<br>
-            <!-- item.related_document: {{ item.related_document }}<br> -->
-            <!-- item.related_document.url: {{ item.related_document.url }}<br> -->
-            <!-- item.url: {{ item.url }}<br> -->
-            {% if item.url is not "" %}
-        <a href="{{ item.url }}">{{ item.title }}</a> (PDF)
-            {% else %}
-                {{ item.title }}
-                {% if item.link_html %}
-                <a href="{{ item.link_html }}">(HTML)</a>
-                {% endif %}
-                {% if item.link_pdf %}
-                <a href="{{ item.link_pdf }}">(PDF)</a>
-                {% endif %}
-                {% if item.link_video %}
-                <a href="{{ item.link_video }}">(video)</a>
-                {% endif %}
+          {% if item.links_count == 1 %}
+            {% if item.link_doc %}
+          <a href="{{ item.link_doc }}">{{ item.title }}</a> <i class="icon icon--inline--right icon--inline--left i-document"></i> (PDF)
+            {% elif item.link_html %}
+          <a href="{{ item.link_html }}">{{ item.title }}</a> <i class="icon icon--inline--right icon--inline--left i-share"></i> (HTML)
+            {% elif item.link_pdf %}
+          <a href="{{ item.link_pdf }}">{{ item.title }}</a> <i class="icon icon--inline--right icon--inline--left i-document"></i> (PDF)
+            {% elif item.link_video %}
+          <a href="{{ item.link_video }}">{{ item.title }}</a> <i class="icon icon--inline--right icon--inline--left i-share"></i> (HTML)
             {% endif %}
-
+          {% else %}
+              {{ item.title }} {{ item.links_string|safe }}
+          {% endif %}
         </h3>
       {% if item.category %}
         <div class="post__meta t-sans">

--- a/fec/fec/templates/partials/commissioner-item.html
+++ b/fec/fec/templates/partials/commissioner-item.html
@@ -32,9 +32,9 @@
         </h3>
       {% if item.category %}
         <div class="post__meta t-sans">
-          <a class="tag tag--secondary" href="./?category={{item.category|slugify}}">{{item.category}}</a>
-          {% if item.subject %}
-            in: <a href="./?subject={{item.subject|slugify}}">{{ item.subject|capfirst }}</a>
+          <a class="tag tag--secondary" href="./?category={{item.slug_category}}">{{item.pretty_category}}</a>
+          {% if item.pretty_subject %}
+            in: <a href="./?category={{item.slug_category}}&subject={{item.slug_subject}}">{{ item.pretty_subject|capfirst }}</a>
           {% endif %}
         </div>
       {% endif %}

--- a/fec/fec/templates/partials/commissioner-item.html
+++ b/fec/fec/templates/partials/commissioner-item.html
@@ -1,0 +1,43 @@
+{# Template based on /fec/fec/templates/partials/update.html #}
+
+<!-- {% load wagtailimages_tags %} -->
+{% load filters %}
+
+<article class="post">
+  <div class="post__pre">
+    {{ item.display_date }}
+  </div>
+  <div class="row">
+    <div class="usa-width-three-fourths">
+        <h3>
+            item.url: {{ item.link_doc }}<br>
+            <!-- item.related_document: {{ item.related_document }}<br> -->
+            <!-- item.related_document.url: {{ item.related_document.url }}<br> -->
+            <!-- item.url: {{ item.url }}<br> -->
+            {% if item.url is not "" %}
+        <a href="{{ item.url }}">{{ item.title }}</a> (PDF)
+            {% else %}
+                {{ item.title }}
+                {% if item.link_html %}
+                <a href="{{ item.link_html }}">(HTML)</a>
+                {% endif %}
+                {% if item.link_pdf %}
+                <a href="{{ item.link_pdf }}">(PDF)</a>
+                {% endif %}
+                {% if item.link_video %}
+                <a href="{{ item.link_video }}">(video)</a>
+                {% endif %}
+            {% endif %}
+
+        </h3>
+      {% if item.category %}
+        <div class="post__meta t-sans">
+          <a class="tag tag--secondary" href="./?category={{item.category|slugify}}">{{item.category}}</a>
+          {% if item.subject %}
+            in: <a href="./?subject={{item.subject|slugify}}">{{ item.subject|capfirst }}</a>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</article>

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -1,6 +1,7 @@
-from django.conf.urls import include, url
+from django.conf.urls import include, url, re_path
 from django.conf import settings
 from django.contrib import admin
+
 from django.views.generic.base import TemplateView
 
 from wagtail.admin import urls as wagtailadmin_urls
@@ -22,6 +23,10 @@ urlpatterns = [
     url(r'^auth/', include(uaa_urls)),
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^calendar/$', home_views.calendar),
+    re_path(
+        r'^about/leadership-and-structure/(?P<commissioner_slug>[a-z0-9]+-[a-z0-9]+[a-z0-9-]*)/statements-and-opinions/$',
+        home_views.commissioner_statements_and_opinions
+    ),
     url(r'^about/leadership-and-structure/commissioners/$', home_views.commissioners),
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^help-candidates-and-committees/question-rad/$', home_views.contact_rad),

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^calendar/$', home_views.calendar),
     re_path(
-        r'^about/leadership-and-structure/(?P<commissioner_slug>[a-z0-9]+-[a-z0-9]+[a-z0-9-]*)/statements-and-opinions/$',
+        r'^about/leadership-and-structure/(?P<commissioner_slug>[a-z0-9]+-[a-z0-9]+[a-z0-9-]*)/statements-and-opinions/$',  # noqa: E501
         home_views.commissioner_statements_and_opinions
     ),
     url(r'^about/leadership-and-structure/commissioners/$', home_views.commissioners),

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -888,11 +888,6 @@ class CommissionerItem(ContentPage):
         max_length=255,
         null=True
     )
-    subject = models.CharField(
-        choices=constants.commissioner_item_subjects.items(),
-        max_length=255,
-        null=True
-    )
     commissioners = StreamField([
         ('commissioner', blocks.PageChooserBlock(
             page_type=CommissionerPage, required=False, null=True, verbose_name='Connected commissioner(s)'
@@ -908,18 +903,53 @@ class CommissionerItem(ContentPage):
         ),
         MultiFieldPanel(
             [
-                StreamFieldPanel('related_document'),
                 FieldPanel('link_html'),
                 FieldPanel('link_pdf'),
                 FieldPanel('link_video'),
+                StreamFieldPanel('related_document'),
             ],
             heading='Content'
         ),
         FieldPanel('display_date'),
         FieldPanel('category'),
-        FieldPanel('subject'),
         StreamFieldPanel('commissioners', help_text='Not required, but choose as many as needed.'),
     ]
+
+    @property
+    def slug_category(self):
+        categorySlug = ''
+        categorySlug = self.category.split('/')[0]
+        return categorySlug
+
+    @property
+    def slug_subject(self):
+        subjectSlug = ''
+        subjectSlug = self.category.split('/')[1]
+        return subjectSlug
+
+    @property
+    def pretty_category(self):
+        parentCat = ''
+        parentCat = self.category.split('/')[0]
+
+        prettyName = str(constants.commissioner_item_categories[parentCat])
+        return prettyName
+
+    @property
+    def pretty_subject(self):
+        prettyName = str(constants.commissioner_item_categories[self.category])
+        # If there's no slash in the category, we're dealing with a category and not a subject
+        # so return nothing
+        #
+        # The 'secondary' category / taxonomy label starts with two special characters
+        # so they display correctly in the admin pull-downs.
+        # We're going to pull them off for the pretty label
+        if len(self.category.split('/')) == 1:
+            prettyName = ''
+        elif prettyName.find('↳ ') == 0:
+            prettyName = prettyName[2:]
+
+        return prettyName
 
     @property
     def link_doc(self):
@@ -929,19 +959,6 @@ class CommissionerItem(ContentPage):
             rel_doc_url = block.value.url
 
         return rel_doc_url
-
-
-    # @property
-    # def content_section(self):
-    #     return get_content_section(self)
-
-    # @property
-    # def get_category(self):
-    #     return 'commissioner-item'
-
-    # @property
-    # def get_update_type(self):
-    #     return 'commissioner-item'
 
 
 class CollectionPage(Page):

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -917,27 +917,27 @@ class CommissionerItem(ContentPage):
 
     @property
     def slug_category(self):
-        categorySlug = ''
-        categorySlug = self.category.split('/')[0]
-        return categorySlug
+        cat_slug = ''
+        cat_slug = self.category.split('/')[0]
+        return cat_slug
 
     @property
     def slug_subject(self):
-        subjectSlug = ''
-        subjectSlug = self.category.split('/')[1]
-        return subjectSlug
+        subj_slug = ''
+        subj_slug = self.category.split('/')[1]
+        return subj_slug
 
     @property
     def pretty_category(self):
-        parentCat = ''
-        parentCat = self.category.split('/')[0]
+        parent_category = ''
+        parent_category = self.category.split('/')[0]
 
-        prettyName = str(constants.commissioner_item_categories[parentCat])
-        return prettyName
+        pretty_cat = str(constants.commissioner_item_categories[parent_category])
+        return pretty_cat
 
     @property
     def pretty_subject(self):
-        prettyName = str(constants.commissioner_item_categories[self.category])
+        pretty_subj = str(constants.commissioner_item_categories[self.category])
         # If there's no slash in the category, we're dealing with a category and not a subject
         # so return nothing
         #
@@ -945,11 +945,11 @@ class CommissionerItem(ContentPage):
         # so they display correctly in the admin pull-downs.
         # We're going to pull them off for the pretty label
         if len(self.category.split('/')) == 1:
-            prettyName = ''
-        elif prettyName.find('↳ ') == 0:
-            prettyName = prettyName[2:]
+            pretty_subj = ''
+        elif pretty_subj.find('↳ ') == 0:
+            pretty_subj = pretty_subj[2:]
 
-        return prettyName
+        return pretty_subj
 
     @property
     def link_doc(self):
@@ -959,6 +959,42 @@ class CommissionerItem(ContentPage):
             rel_doc_url = block.value.url
 
         return rel_doc_url
+
+    @property
+    def links_count(self):
+        count = 0
+        count = count + 1 if self.link_doc else count
+        count = count + 1 if self.link_html else count
+        count = count + 1 if self.link_pdf else count
+        count = count + 1 if self.link_video else count
+        return count
+
+    @property
+    def links_string(self):
+        links = []
+
+        if self.link_doc:
+            links.append(
+                '<i class="icon icon--inline--right icon--inline--left i-document"></i>\
+                <a href="<a href="' + self.link_doc + ' class="t-sans t-normal">PDF</a>'
+            )
+        if self.link_pdf:
+            links.append(
+                '<i class="icon icon--inline--right icon--inline--left i-share"></i>\
+                <a href="<a href="' + self.link_pdf + ' class="t-sans t-normal">PDF</a>'
+            )
+        if self.link_html:
+            links.append(
+                '<i class="icon icon--inline--right icon--inline--left i-share"></i>\
+                <a href="<a href="' + self.link_html + ' class="t-sans t-normal">HTML</a>'
+            )
+        if self.link_video:
+            links.append(
+                '<i class="icon icon--inline--right icon--inline--left i-share"></i>\
+                <a href="<a href="' + self.link_video + ' class="t-sans t-normal">VIDEO</a>'
+            )
+
+        return ' | '.join(links)
 
 
 class CollectionPage(Page):

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -896,9 +896,8 @@ class CommissionerItem(ContentPage):
 
     content_panels = Page.content_panels + [
         HelpPanel(
-            content='<p>This item will automatically be shown under the "Statements and Opinions" list of any linked Commissioners.</p>\
-            <p>If you choose a related document for this item, the title text will link to that document.</p>\
-            <p>If you specify HTML content, only that field will be used for title and link.</p>',
+            content='<p>This item will automatically be included in the "Statements and Opinions"\
+            list of any linked Commissioners.</p>',
             heading='ITEM HELP',
         ),
         MultiFieldPanel(
@@ -976,22 +975,22 @@ class CommissionerItem(ContentPage):
         if self.link_doc:
             links.append(
                 '<i class="icon icon--inline--right icon--inline--left i-document"></i>\
-                <a href="<a href="' + self.link_doc + ' class="t-sans t-normal">PDF</a>'
+                <a href="{}" class="t-sans t-normal">PDF</a>'.format(self.link_doc)
             )
         if self.link_pdf:
             links.append(
                 '<i class="icon icon--inline--right icon--inline--left i-share"></i>\
-                <a href="<a href="' + self.link_pdf + ' class="t-sans t-normal">PDF</a>'
+                <a href="{}" class="t-sans t-normal" target="_blank">PDF</a>'.format(self.link_pdf)
             )
         if self.link_html:
             links.append(
                 '<i class="icon icon--inline--right icon--inline--left i-share"></i>\
-                <a href="<a href="' + self.link_html + ' class="t-sans t-normal">HTML</a>'
+                <a href="{}" class="t-sans t-normal" target="_blank">HTML</a>'.format(self.link_html)
             )
         if self.link_video:
             links.append(
                 '<i class="icon icon--inline--right icon--inline--left i-share"></i>\
-                <a href="<a href="' + self.link_video + ' class="t-sans t-normal">VIDEO</a>'
+                <a href="{}" class="t-sans t-normal" target="_blank">VIDEO</a>'.format(self.link_video)
             )
 
         return ' | '.join(links)

--- a/fec/home/templates/home/commissioner_items_feed.html
+++ b/fec/home/templates/home/commissioner_items_feed.html
@@ -1,0 +1,67 @@
+{# USAGE: Template for the single commissioner pages, #}
+{# /about/leadership-and-structure/[commissioner-name-slug]/ #}
+
+{% extends "home/feed_base.html" %}
+{% load wagtailcore_tags %}
+{% load staticfiles %}
+{% load filters %}
+
+
+{% block intro %}
+  <p class="t-lead">Search or browse the statements and opinions made by Commissioner {{ self.commissioner_name }}.</p>
+  <p>category: {{ self.category }}</p>
+  <p>subject: {{ self.subject }}</p>
+  <p>year: {{ self.year }}</p>
+{% endblock %}
+
+{% block filters %}
+<form action="/about/leadership-and-structure/{{ self.commissioner_slug }}/statements-and-opinions/" class="js-form-nav container">
+    <div class="filter">
+      <label class="label" for="publication-type">Category (Type)</label>
+      <select id="commissioner-item-category" name="category">
+        <option value="">All</option>
+        <option value="opinion" {% if 'opinion' == self.category %}selected{% endif %}>Opinion</option>
+        <option value="report" {% if 'report' == self.category %}selected{% endif %}>Report</option>
+        <option value="testimony" {% if 'testimony' == self.category %}selected{% endif %}>Testimony</option>
+      </select>
+    </div>
+    <div class="filter">
+      <label class="label" for="publication-type">Subject</label>
+      <select id="commissioner-item-category" name="subject">
+        <option value="">All</option>
+        <option value="comm_subj_0" {% if 'comm_subj_0' == self.subject %}selected{% endif %}>Subject 0</option>
+        <option value="comm_subj_1" {% if 'comm_subj_1' == self.subject %}selected{% endif %}>Subject 1</option>
+        <option value="comm_subj_2" {% if 'comm_subj_2' == self.subject %}selected{% endif %}>Subject 2</option>
+      </select>
+    </div>
+    <div class="filter">
+      <div class="combo combo--filter--mini">
+        <label for="year" class="label">Year</label>
+        <input id="year" class="combo__input" name="year" type="text" value="{{ self.year }}" placeholder="YYYY">
+        <button type="submit" class="combo__button button button--standard button--go"><span class="u-visually-hidden">Filter</span></button>
+      </div>
+    </div>
+</form>
+{% endblock %}
+
+{% block feed %}
+  {% if self.items %}
+    {% for item in self.items %}
+      {% include 'partials/commissioner-item.html' with update=update show_tag=True %}
+    {% endfor %}
+    <div class="results-info">
+      <span>Page {{ self.items.number }} of {{ self.items.paginator.num_pages }}</span>
+      {% if self.items.has_previous %}
+          <a class="button button--standard button--previous" href="?page={{ items.previous_page_number }}{% for key,value in request.GET.items %}{% ifnotequal key 'page' %}&amp;{{ key }}={{ value }}{% endifnotequal %}{% endfor %}"><span class="u-visually-hidden">Previous</span></a>
+      {% endif %}
+      {% if self.items.has_next %}
+          <a class="button button--standard button--next" href="?page={{ items.next_page_number }}{% for key,value in request.GET.items %}{% ifnotequal key 'page' %}&amp;{{ key }}={{ value }}{% endifnotequal %}{% endfor %}"><span class="u-visually-hidden">Next</span></a>
+      {% endif %}
+    </div>
+  {% else %}
+  <div class="message message--info">
+    <h2>No results</h2>
+    <p>We didn’t find any statements or opinions by {{ self.commissioner_name }} matching the requested filters.</p>
+  </div>
+  {% endif %}
+{% endblock %}

--- a/fec/home/templates/home/commissioner_items_feed.html
+++ b/fec/home/templates/home/commissioner_items_feed.html
@@ -9,30 +9,100 @@
 
 {% block intro %}
   <p class="t-lead">Search or browse the statements and opinions made by Commissioner {{ self.commissioner_name }}.</p>
-  <p>category: {{ self.category }}</p>
-  <p>subject: {{ self.subject }}</p>
-  <p>year: {{ self.year }}</p>
 {% endblock %}
 
 {% block filters %}
 <form action="/about/leadership-and-structure/{{ self.commissioner_slug }}/statements-and-opinions/" class="js-form-nav container">
     <div class="filter">
-      <label class="label" for="publication-type">Category (Type)</label>
+      <label class="label" for="commissioner-item-category">Category (Type)</label>
       <select id="commissioner-item-category" name="category">
         <option value="">All</option>
-        <option value="opinion" {% if 'opinion' == self.category %}selected{% endif %}>Opinion</option>
-        <option value="report" {% if 'report' == self.category %}selected{% endif %}>Report</option>
-        <option value="testimony" {% if 'testimony' == self.category %}selected{% endif %}>Testimony</option>
+        <option value='ballot-measures' {% if 'ballot-measures' == self.category %}selected{% endif %}>Ballot Measures</option>
+        <option value='best-efforts' {% if 'best-efforts' == self.category %}selected{% endif %}>"Best Efforts"</option>
+        <option value='contention-language' {% if 'contention-language' == self.category %}selected{% endif %}>Contention Language</option>
+        <option value='family-member-contributions' {% if 'family-member-contributions' == self.category %}selected{% endif %}>Family Member Contributions</option>
+        <option value='coordination' {% if 'coordination' == self.category %}selected{% endif %}>Coordination</option>
+        <option value='contract-dispute' {% if 'contract-dispute' == self.category %}selected{% endif %}>Contract Dispute</option>
+        <option value='corporate-spending' {% if 'corporate-spending' == self.category %}selected{% endif %}>Corporate Spending</option>
+        <option value='dark-money-501c4-groups' {% if 'dark-money-501c4-groups' == self.category %}selected{% endif %}>Dark Money/ 501(c)(4) groups</option>
+        <option value='disclaimers' {% if 'disclaimers' == self.category %}selected{% endif %}>Disclaimers</option>
+        <option value='electioneering-communications' {% if 'electioneering-communications' == self.category %}selected{% endif %}>Electioneering Communications</option>
+        <option value='express-advocacy' {% if 'express-advocacy' == self.category %}selected{% endif %}>Express Advocacy</option>
+        <option value='failing-to-disclose-independent-expenditure' {% if 'failing-to-disclose-independent-expenditure' == self.category %}selected{% endif %}>Failing to Disclose Independent Expenditure</option>
+        <option value='foreign-spending' {% if 'foreign-spending' == self.category %}selected{% endif %}>Foreign Spending</option>
+        <option value='hlogaair-travel' {% if 'hlogaair-travel' == self.category %}selected{% endif %}>HLOGA/Air Travel</option>
+        <option value='hosting-debates' {% if 'hosting-debates' == self.category %}selected{% endif %}>Hosting Debates</option>
+        <option value='increased-activity' {% if 'increased-activity' == self.category %}selected{% endif %}>Increased Activity</option>
+        <option value='lobbyist-activity' {% if 'lobbyist-activity' == self.category %}selected{% endif %}>Lobbyist Activity</option>
+        <option value='membership-communications-exception' {% if 'membership-communications-exception' == self.category %}selected{% endif %}>Membership Communications Exception</option>
+        <option value='mischaracterization-of-party-in-court-filing' {% if 'mischaracterization-of-party-in-court-filing' == self.category %}selected{% endif %}>Mischaracterization of Party in Court Filing</option>
+        <option value='payroll-deduction' {% if 'payroll-deduction' == self.category %}selected{% endif %}>Payroll Deduction</option>
+        <option value='personal-use' {% if 'personal-use' == self.category %}selected{% endif %}>Personal Use</option>
+        <option value='press-exemption' {% if 'press-exemption' == self.category %}selected{% endif %}>Press Exemption</option>
+        <option value='soft-money-use-of-non-federal-money-on-federal-expenses' {% if 'soft-money-use-of-non-federal-money-on-federal-expenses' == self.category %}selected{% endif %}>Soft Money/ Use of Non-Federal Money on Federal Expenses</option>
+        <option value='sale--use' {% if 'sale--use' == self.category %}selected{% endif %}>Sale & Use</option>
+        <option value='straw-donors-conduit-contributions' {% if 'straw-donors-conduit-contributions' == self.category %}selected{% endif %}>Straw Donors/ Conduit Contributions</option>
+        <option value='super-pac-not-disclosing-till-after-election' {% if 'super-pac-not-disclosing-till-after-election' == self.category %}selected{% endif %}>Super PAC not disclosing till after election</option>
+        <option value='testing-the-waters-candidate-status' {% if 'testing-the-waters-candidate-status' == self.category %}selected{% endif %}>Testing the Waters/ Candidate Status</option>
+        <option value='unions' {% if 'unions' == self.category %}selected{% endif %}>Unions</option>
+        <option value='use-of-opponents-name-without-permission' {% if 'use-of-opponents-name-without-permission' == self.category %}selected{% endif %}>Use of Opponent’s Name Without Permission</option>
+        <option value='volunteer-exemption' {% if 'volunteer-exemption' == self.category %}selected{% endif %}>Volunteer Exemption</option>
+        <option value='volunteer-mailers-exemption' {% if 'volunteer-mailers-exemption' == self.category %}selected{% endif %}>Volunteer Mailers Exemption</option>
       </select>
     </div>
     <div class="filter">
-      <label class="label" for="publication-type">Subject</label>
-      <select id="commissioner-item-category" name="subject">
+    {% if 'coordination' == self.category %}
+      <label class="label" for="commissioner-item-subject-coordination">Subject</label>
+      <select id="commissioner-item-subject-coordination" name="subject">
         <option value="">All</option>
-        <option value="comm_subj_0" {% if 'comm_subj_0' == self.subject %}selected{% endif %}>Subject 0</option>
-        <option value="comm_subj_1" {% if 'comm_subj_1' == self.subject %}selected{% endif %}>Subject 1</option>
-        <option value="comm_subj_2" {% if 'comm_subj_2' == self.subject %}selected{% endif %}>Subject 2</option>
+        <option value='coordination-super-pacs' {% if 'coordination-super-pacs' == self.category %}selected{% endif %}>Super PACs</option>
+        <option value='coordination-leadership-pac' {% if 'coordination-leadership-pac' == self.category %}selected{% endif %}>Leadership PAC</option>
+        <option value='coordination-hybrid-pacs' {% if 'coordination-hybrid-pacs' == self.category %}selected{% endif %}>Hybrid PACs</option>
+        <option value='coordination-corporations' {% if 'coordination-corporations' == self.category %}selected{% endif %}>Corporations</option>
+        <option value='coordination-dark-money-groups-501c4' {% if 'coordination-dark-money-groups-501c4' == self.category %}selected{% endif %}>Dark Money Groups/ 501(c)(4)</option>
+        <option value='coordination-state-political-party' {% if 'coordination-state-political-party' == self.category %}selected{% endif %}>State Political Party</option>
+        <option value='coordination-membership-organization-pacs' {% if 'coordination-membership-organization-pacs' == self.category %}selected{% endif %}>Membership Organization PACs</option>
       </select>
+    {% elif 'corporate-spending' == self.category %}
+      <label class="label" for="commissioner-item-subject-corporate-spending">Subject</label>
+      <select id="commissioner-item-subject-corporate-spending" name="subject">
+        <option value="">All</option>
+        <option value='corporate-spending-employee-coercion-threats-of-reprisal' {% if 'corporate-spending-employee-coercion-threats-of-reprisal' == self.category %}selected{% endif %}>Employee Coercion/ Threats of Reprisal</option>
+        <option value='corporate-spending-in-kind-contributions' {% if 'corporate-spending-in-kind-contributions' == self.category %}selected{% endif %}>In-Kind Contributions</option>
+        <option value='corporate-spending-extending-credit' {% if 'corporate-spending-extending-credit' == self.category %}selected{% endif %}>Extending Credit</option>
+        <option value='corporate-spending-preparing-mailers' {% if 'corporate-spending-preparing-mailers' == self.category %}selected{% endif %}>Preparing Mailers</option>
+        <option value='corporate-spending-business-associations' {% if 'corporate-spending-business-associations' == self.category %}selected{% endif %}>Business Associations</option>
+        <option value='corporate-spending-lobbyists-delivering-funds-on-behalf-of-corporation' {% if 'corporate-spending-lobbyists-delivering-funds-on-behalf-of-corporation' == self.category %}selected{% endif %}>Lobbyists Delivering Funds on Behalf of Corporation</option>
+        <option value='corporate-spending-nonprofit-corporation' {% if 'corporate-spending-nonprofit-corporation' == self.category %}selected{% endif %}>Nonprofit Corporation</option>
+        <option value='corporate-spending-salary-payments' {% if 'corporate-spending-salary-payments' == self.category %}selected{% endif %}>Salary Payments</option>
+        <option value='corporate-spending-improper-refund' {% if 'corporate-spending-improper-refund' == self.category %}selected{% endif %}>Improper Refund</option>
+        <option value='corporate-spending-express-advocacy' {% if 'corporate-spending-express-advocacy' == self.category %}selected{% endif %}>Express Advocacy</option>
+    {% elif 'dark-money-501c4-groups' == self.category %}
+      <label class="label" for="commissioner-item-subject-dark-money">Subject</label>
+      <select id="commissioner-item-subject-dark-money" name="subject">
+        <option value="">All</option>
+        <option value='dark-money-501c4-groups-political-committee-status' {% if 'dark-money-501c4-groups-political-committee-status' == self.category %}selected{% endif %}>Political Committee Status</option>
+        <option value='dark-money-501c4-groups-failing-to-disclose-independent-expenditure' {% if 'dark-money-501c4-groups-failing-to-disclose-independent-expenditure' == self.category %}selected{% endif %}>Failing to Disclose Independent Expenditure</option>
+    {% elif 'disclaimers' == self.category %}
+      <label class="label" for="commissioner-item-subject-disclaimers">Subject</label>
+      <select id="commissioner-item-subject-disclaimers" name="subject">
+        <option value="">All</option>
+        <option value='disclaimers-brochure' {% if 'disclaimers-brochure' == self.category %}selected{% endif %}>Brochure</option>
+        <option value='disclaimers-printed-box-requirement' {% if 'disclaimers-printed-box-requirement' == self.category %}selected{% endif %}>Printed Box Requirement</option>
+        <option value='disclaimers-internet' {% if 'disclaimers-internet' == self.category %}selected{% endif %}>Internet</option>
+        <option value='disclaimers-newspaper' {% if 'disclaimers-newspaper' == self.category %}selected{% endif %}>Newspaper</option>
+        <option value='disclaimers-mailer' {% if 'disclaimers-mailer' == self.category %}selected{% endif %}>Mailer</option>
+        <option value='disclaimers-robocall' {% if 'disclaimers-robocall' == self.category %}selected{% endif %}>Robocall</option>
+        <option value='disclaimers-radio' {% if 'disclaimers-radio' == self.category %}selected{% endif %}>Radio</option>
+        <option value='disclaimers-signs' {% if 'disclaimers-signs' == self.category %}selected{% endif %}>Signs</option>
+        <option value='disclaimers-television' {% if 'disclaimers-television' == self.category %}selected{% endif %}>Television</option>
+      </select>
+    {% else %}
+      <label class="label" for="commissioner-item-subject">Subject</label>
+      <select id="commissioner-item-subject" name="subject" disabled="disabled">
+        <option value="">All</option>
+      </select>
+    {% endif %}
     </div>
     <div class="filter">
       <div class="combo combo--filter--mini">

--- a/fec/home/templates/home/commissioner_page.html
+++ b/fec/home/templates/home/commissioner_page.html
@@ -1,3 +1,6 @@
+{# USAGE: Template for the single commissioner pages, #}
+{# /about/leadership-and-structure/[commissioner-name-slug]/ #}
+
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}

--- a/fec/home/templates/home/commissioners.html
+++ b/fec/home/templates/home/commissioners.html
@@ -1,3 +1,6 @@
+{# USAGE: The template for the page that lists all commissioners #}
+{# This template tiles /fec/home/templates/partials/commissioner.html #}
+
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
 {% load staticfiles %}

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -119,7 +119,7 @@
     <p>While all press releases, weekly digests and tips for treasurers are searchable, FEC Record articles published before
     2005 exist only in PDF format and are not included in these search results. Please try another search or visit our
     <a href="https://www.fec.gov/updates/record-archive-1975-2004/">archive of Record articles from 1975-2004</a>.</p>
-    <p>
+    <p>&nbsp;</p>
     <div class="message--alert__bottom">
       <p>For assistance, <a href="https://www.fec.gov/contact/">contact the FEC</a>.</p>
     </div>

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -107,7 +107,7 @@ def get_commissioner(slug=None):
 
 
 def get_commissioner_items(commissioner_slug=None, category=None, subject=None, year=None, request=None):
-    items = CommissionerItem.objects.live()
+    items = CommissionerItem.objects.live().order_by('-display_date')  # live objects, most recent first
 
     if category:
         items = items.filter(category__contains=category)
@@ -286,7 +286,7 @@ def commissioners(request):
 
 def commissioner_statements_and_opinions(request, commissioner_slug):
     """
-    TODO
+    TODO: DOCUMENTATION
     """
     # We're only going to look at one requested category, subject, or year
     req_category = request.GET.get("category", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,10 @@ psycopg2==2.8.5
 requests==2.21.0
 slacker==0.8.6
 whitenoise==2.0.3
-wagtail==2.7.3
+wagtail==2.7.4
 Jinja2==2.10.1
 django_jinja==2.4.1
+pillow==7.1.0
 CacheControl==0.11.5
 cachetools==1.0.2
 github3.py==0.9.6


### PR DESCRIPTION
## Summary

- Resolves #3869 
- Adds functionality for new Commissioner Items (statements and opinions)

## Impacted areas of the application
- new page type for the Commissioner Items (models.py)
- new URL structure to support a listing of the new page type items (urls.py)
- new template for that listing page (commissioner_items_feed.html)
- new template for each item on that listing page (commissioner-item.html)
- new view for the new listing page (views.py)
- define the options for the new items' taxonomy (constants.py)
- migration(s) for the new page type
- update documentation for lightly-related templates (commissioner_page.html, commissioners.html)
- closed a previously-unclosed tag (latest_updates.html)
- brought in some recent Snyk vulnerabilities updates to stay in sync w/ develop (requirements.txt)

## Screenshots

Default listing page
![image](https://user-images.githubusercontent.com/26720877/91447817-18865400-e847-11ea-8fdf-ec06559876a3.png)


Administering an item, category list
![image](https://user-images.githubusercontent.com/26720877/91448412-d4478380-e847-11ea-9296-909b8d2643cf.png)

## Related PRs

None

## How to test

Strap in, this one's involved.

May be good to include a pre-set db for this testing (so we don't have to create test items) but right now we'll dupe your local db, switch to the duped db, do the migration(s), create some items, test things, then change back to the previous db.

- pull the branch
- Go into pyenv like normal
- Dupe your current database and switch to the copy
  - Let's find out your current db name/url `echo $DATABASE_URL`
  - **Make a note of that ☝️**, save the part after `postgresql://:@/`. that's the name of the db you're currently using. I think we're all using `cfdm_cms_test`
  - **Think of a name for a new, temporary db**. I used `db_test_comm_items`
  - Make a copy of your current db `createdb -T cfdm_cms_test db_test_comm_items` (change `cfdm_cms_test` to your current db, change `db_test_comm_items` to your new temp db name
  - Switch to your new, temporary db `export DATABASE_URL=postgresql://:@/db_test_comm_items` (change `db_test_comm_items` to your new temp db name)
  - Yay!
- Install requirements `pip install -r requirements.txt` (in the root directory of the repo. For me it's fec-cms)
- Update any Node packages `npm i` (optional. probably not necessary but won't hurt)
- Rebuild the front-end of the site `npm run build` (optional. probably not necessary but won't hurt)
- Go into the fec directory `cd fec`
- Make any migrations `./manage.py makemigrations`
- Apply the migration(s) `./manage.py migrate`
- Start the cms like normal `./manage.py runserver`
- Create some new Commissioner Items
  - Under Home or somewhere, click Create Child Page
  - choose Commissioner Item
  - Give it a title; HTML link, PDF link, Video link and/or choose a Related document [limit 1 related doc]; Display date; Category; and choose a Commissioner(s) (for our examples, we'll choose Commissioner Weintraub but feel free to add others
  - Publish
  - repeat with different combinations of links and categories
- Test the listing page. If you chose Commissioner Weintraub, try [http://127.0.0.1:8000/about/leadership-and-structure/ellen-l-weintraub/statements-and-opinions/](); otherwise, swap the commissioner's page slug with one you chose
- Test the filters (The year is the display year you chose, not the Wagtail go-live date)
- Test for no-results filter results
- Test that the taxonomy button thingy applies the filter accordingly
- Test that the taxonomy link thingy (beside the button thingy) applies _both_ filters accordingly

Feels like I'm forgetting something.

Optionally add a link to the main commissioner page:
- Go into a commissioner's page
- edit to add `<a class="button--cta button--go" href="./statements-and-opinions/">Explore all statements and opinions</a>` where you'd like the button to appear (link will work for any commissioner)

To change back to your non-temp db:
- close the cms server (ctrl-c)
- `export DATABASE_URL=postgresql://:@/cfdm_cms_test` (change `cfdm_cms_test` to your original db name)
- Just for housekeeping, it would be good to delete that temp db (but after we're done testing this PR!)


## ⨂ ⨂ ⨂ DO NOT MERGE ⨂ ⨂ ⨂
TODO:
- documentation
- decide on final terms for the taxonomy
- verify with team that displayed names/labels are cool ("Commissioner Items", "Category", "Subject", urls, etc)

____
