### PR TITLE
disable two year period on candidate page when cycles is null

### DIFF
--- a/fec/fec/static/js/modules/cycle-select.js
+++ b/fec/fec/static/js/modules/cycle-select.js
@@ -41,10 +41,11 @@ CycleSelect.prototype.initCyclesMulti = function(selected) {
       max: cycle,
       electionFull: false,
       cycleId: cycleId,
+      // Two year period buttons are only active if there are fec_cycles_in_election
       active:
         typeof context !== 'undefined' && context.cycles
           ? context.cycles.indexOf(cycle) !== -1
-          : true,
+          : false,
       checked:
         cycle.toString() === params.cycle && params.electionFull === 'false'
     };
@@ -64,7 +65,13 @@ CycleSelect.prototype.initCyclesMulti = function(selected) {
     return bin.checked === true;
   });
 
-  this.setTimePeriod(selectedCycle[0].min, selectedCycle[0].max);
+  if (
+    selectedCycle.length > 0 &&
+    selectedCycle[0].min &&
+    selectedCycle[0].max
+  ) {
+    this.setTimePeriod(selectedCycle[0].min, selectedCycle[0].max);
+  }
 };
 
 CycleSelect.prototype.initCyclesSingle = function(selected) {

--- a/fec/fec/tests/js/cycle-select.js
+++ b/fec/fec/tests/js/cycle-select.js
@@ -107,6 +107,15 @@ describe('cycle select', function() {
       expectDisabled(labels.eq(1), true);
       expectDisabled(labels.eq(2), false);
     });
+
+    it('disables all two year periods if context cycles is null', function() {
+      window.context = {cycles: null};
+      this.cycleSelect.initCyclesMulti(null);
+      var labels = this.cycleSelect.$cycles.find('label');
+      expectDisabled(labels.eq(0), false);
+      expectDisabled(labels.eq(1), true);
+      expectDisabled(labels.eq(2), true);
+    });
   });
 
   describe('path cycle select', function() {


### PR DESCRIPTION
## Summary

- Resolves #3805 
_This change will disable all two year periods on the candidate profile page if fec_cycles_in_election is null._

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Candidate profile pages with no two year transaction periods in election

## Screenshots

![Screen Shot 2020-09-10 at 1 30 27 PM](https://user-images.githubusercontent.com/12799132/92772563-d5110700-f369-11ea-8ff0-21a98d39d36f.png)

## How to test

- `npm run build-js`
- `./manage.py runserver`
- Go to a candidate profile page with null fec cyles in election, such as this candidate: http://localhost:8000/data/candidate/P00010298/. There are additional test cases that you can click around in this [spreadsheet](https://docs.google.com/spreadsheets/d/1KJXrGS45HoC7B2vzAHg3tOEb15PeIdqkfyiGepIr60s/edit#gid=0) too. 
- Make sure that all individual two year election periods are all disabled and the All years button is selected.
- `npm run test-single` make sure tests pass

____
