### PR TITLE
Add empty string when null action

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -151,13 +151,11 @@ def load_legal_mur(mur_no):
         for each index in mur["commission_votes"], if there is an empty action then log the mur and the
         particular index
         '''
-        i = 0
-        for d in mur["commission_votes"]:
+        for i, d in enumerate(mur["commission_votes"]):
             if not d["action"]:
-                logger.warning(
+                logger.error(
                     "MUR " + str(mur_no) + ": There were no data for commission_votes action at index " + str(i)
                 )
-            i += 1
         mur["collated_dispositions"] = collate_dispositions(mur["dispositions"])
         mur["complainants"] = complainants
         mur["participants_by_type"] = _get_sorted_participants_by_type(mur)

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -147,6 +147,17 @@ def load_legal_mur(mur_no):
                 complainants.append(participant["name"])
 
         mur["disposition_text"] = [d["action"] if d['action'] else '' for d in mur["commission_votes"]]
+        '''
+        for each index in mur["commission_votes"], if there is an empty action then log the mur and the
+        particular index
+        '''
+        i = 0
+        for d in mur["commission_votes"]:
+            if not d["action"]:
+                logger.warning(
+                    "MUR " + str(mur_no) + ": There were no data for commission_votes action at index " + str(i)
+                )
+            i += 1
         mur["collated_dispositions"] = collate_dispositions(mur["dispositions"])
         mur["complainants"] = complainants
         mur["participants_by_type"] = _get_sorted_participants_by_type(mur)

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -146,8 +146,7 @@ def load_legal_mur(mur_no):
             if "complainant" in participant["role"].lower():
                 complainants.append(participant["name"])
 
-        mur["disposition_text"] = [d["action"] for d in mur["commission_votes"]]
-
+        mur["disposition_text"] = [d["action"] if d['action'] else '' for d in mur["commission_votes"]]
         mur["collated_dispositions"] = collate_dispositions(mur["dispositions"])
         mur["complainants"] = complainants
         mur["participants_by_type"] = _get_sorted_participants_by_type(mur)


### PR DESCRIPTION
## Summary (required)

- Resolves #4033 

## Impacted areas of the application

MURS

List general components of the application that this PR will affect:

- https://www.fec.gov/data/legal/matter-under-review/(mur case number)
 (for example https://www.fec.gov/data/legal/matter-under-review/7594)

## Screenshots

### BEFORE:
<img width="687" alt="Screen Shot 2020-09-10 at 2 25 06 PM" src="https://user-images.githubusercontent.com/49287206/92780683-718ad780-f371-11ea-975f-bd2867d66de9.png">

### AFTER:
<img width="667" alt="Screen Shot 2020-09-10 at 2 20 07 PM" src="https://user-images.githubusercontent.com/49287206/92780725-79e31280-f371-11ea-8e09-38a019e560f1.png">

### COMPARE TO PROD (CASE WHEN DATA UPLOADED PROPERLY):
<img width="670" alt="Screen Shot 2020-09-10 at 2 20 17 PM" src="https://user-images.githubusercontent.com/49287206/92780813-91220000-f371-11ea-8bc3-f5072adb7328.png">

## How to test:
- (@patphongs OR @lbeaufort )
- I added a test as well based on Pat's suggestion to add to logger when we come across a mur with no action. One way to run the test is with: `pytest -o log_cli=true data/tests/test_legal_search.py -s` (thanks Pat for having that in slack history)
- verify server error screen: https://dev.fec.gov/data/legal/matter-under-review/7594/
- check out branch
- run local cms and point to dev api (thanks Laura for explaining this vs local api)
- go to localhost:8000/data/legal/matter-under-review/7594/ and see that page loads (with disposition text not available)