### PR TITLE
[Before release] Add one converted committee manually

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -56,6 +56,7 @@ candidate_to_committee_linkage = {
     "P00014407": "C00727156",
     "H0CO03157": "C00723338",
     "S0KY00420": "C00733261",
+    "P00009183": "C00693713",
 }
 
 committee_to_candidate_linkage = {
@@ -79,6 +80,7 @@ former_committee_names = {
     "C00727156": "DEVAL FOR ALL",
     "C00723338": "JAMES FOR COLORADO",
     "C00733261": "BOOKER FOR KENTUCKY, LTD.",
+    "C00693713": "TULSI NOW",
 }
 
 


### PR DESCRIPTION
## Summary (required)

- Partial resolution for #4038
Add one converted PCC -> PAC committee manually


## Impacted areas of the application

List general components of the application that this PR will affect:

-  Add more candidates to manual conversion list
- Committee and candidate profile pages should have explanatory text:

https://www.fec.gov/data/committee/C00693713

https://www.fec.gov/data/candidate/P00009183


## Reviewers

- One approval needed

## How to test

- Committee and candidate profile pages should have explanatory text:

http://localhost:8000/data/committee/C00693713

**EXAMPLE**
<img width="834" alt="Screen Shot 2020-09-04 at 1 03 53 PM" src="https://user-images.githubusercontent.com/31420082/92267760-2ecb8a00-eeaf-11ea-94ae-92d7a123f586.png">


http://localhost:8000/data/candidate/P00009183

**EXAMPLE**
<img width="857" alt="Screen Shot 2020-09-04 at 1 04 11 PM" src="https://user-images.githubusercontent.com/31420082/92267769-34c16b00-eeaf-11ea-9fe9-bd42c5b81504.png">



