### PR TITLE
Adds RAD PAC FAQs to guidance search

### DIFF
--- a/fec/search/management/data/sitemap_pdf.xml
+++ b/fec/search/management/data/sitemap_pdf.xml
@@ -222,4 +222,8 @@
 <loc>https://www.fec.gov/resources/cms-content/documents/internal_controls_polcmtes_07_EO13892.pdf</loc>
 <lastmod>2020-04-13T15:30:00+00:00</lastmod>
 </url>
+<url>
+<loc>https://www.fec.gov/resources/cms-content/documents/RAD_FAQs-PACs_EO13892.pdf</loc>
+<lastmod>2020-09-21T15:30:00+00:00</lastmod>
+</url>
 </urlset>


### PR DESCRIPTION
Adds RAD PAC FAQs PDF to guidance search sitemap (lines 225-228)

## Summary (required)

- Resolves #4053 

Adds the RAD PAC FAQ PDF - https://www.fec.gov/resources/cms-content/documents/RAD_FAQs-PACs_EO13892.pdf to the xml sitemap for the PDFs in guidance search database.

