### PR TITLE
update xhr of communication-costs to communication_costs

### DIFF
--- a/fec/fec/static/js/pages/datatable-communication-costs.js
+++ b/fec/fec/static/js/pages/datatable-communication-costs.js
@@ -12,7 +12,7 @@ $(document).ready(function() {
   new tables.DataTable($table, {
     autoWidth: false,
     title: 'Communication costs',
-    path: ['communication-costs'],
+    path: ['communication_costs'],
     columns: columns.communicationCosts,
     rowCallback: tables.modalRenderRow,
     useExport: true,


### PR DESCRIPTION
## Summary

- Resolves #3963 
_Looks like I only needed to change the communication costs datatable page itself. All the others were already referencing the correct `/communication_costs/` endpoint._

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Communication costs datatable: http://localhost:8000/data/communication-costs/

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
feature/4591-update-deprecation-notice | [link](https://github.com/fecgov/openFEC/pull/4594)

## How to test

- checkout this branch
- go to communication-costs datatable page and check the xhr to see that the endpoint path is now using `/communication_costs/`

____
