### PR TITLE
Feature/3160 tag manager updates

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -177,6 +177,9 @@
     ga('create', 'UA-16134356-1', 'auto');
     ga('send', 'pageview');
   </script>
+{% endif %}
+
+{% if (FEC_CMS_ENVIRONMENT == 'PRODUCTION') %}
   <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
 {% endif %}
 

--- a/fec/data/templates/layouts/widgets.jinja
+++ b/fec/data/templates/layouts/widgets.jinja
@@ -93,6 +93,9 @@
     ga('create', 'UA-16134356-1', 'auto');
     ga('send', 'pageview');
   </script>
+{% endif %}
+
+{% if (FEC_CMS_ENVIRONMENT == 'PRODUCTION') %}
   <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
 {% endif %}
 

--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -17,6 +17,9 @@ class AddSecureHeaders(MiddlewareMixin):
             "connect-src": "\
                 https://www.google-analytics.com \
             ",
+            "font-src": "\
+                'self' \
+            ",
             "frame-src": "\
                 'self' \
                 https://www.google.com/recaptcha/ \

--- a/fec/fec/templates/500-status.html
+++ b/fec/fec/templates/500-status.html
@@ -100,7 +100,7 @@
     {% endblock %}
 
     {# Google Analytics and DAP without Tag Manager and only for production #}
-    {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not settings.FEATURES.use_tag_manager %}}
+    {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not settings.FEATURES.use_tag_manager %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -112,6 +112,9 @@
       ga('create', 'UA-16134356-1', 'auto');
       ga('send', 'pageview');
     </script>
+    {% endif %}
+
+    {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
     {% endif %}
   </body>

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -189,7 +189,7 @@
     {% endblock %}
 
     {# Google Analytics and DAP without Tag Manager and only for production #}
-    {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not settings.FEATURES.use_tag_manager %}}
+    {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not settings.FEATURES.use_tag_manager %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -201,6 +201,9 @@
       ga('create', 'UA-16134356-1', 'auto');
       ga('send', 'pageview');
     </script>
+    {% endif %}
+
+    {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
     {% endif %}
   </body>

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -190,9 +190,10 @@
       ga('create', 'UA-16134356-1', 'auto');
       ga('send', 'pageview');
     </script>
+    {% endif %}
 
+    {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
-
     {% endif %}
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Will resolve part of 3160; I named the branch poorly. Merging this shouldn't close 3160 so I intentionally didn't connect that ticket.

PR is to move the GSA/DAP so that it's always in the page (for Production), regardless of GTM environment variable.

Also reformatted middleware.py so it's a little more human-friendly


## Impacted areas of the application

Technically every page on the site on every environment will be affected but will only affect whether DAP goes into the page with GTM or without. Reformatting the middleware file could change content permissions but I think they're fine.

## Screenshots

Nothing to show

## Related PRs

None

## How to test

Will need to check the source for Feature, Dev, and Stage to make sure DAP isn't going into the page regardless of GTM. Will need to check Production to make sure DAP loads regardless of GTM environment variable

Would like to mention #3160 to make a non-resolving connection between that ticket and this PR

____
