### PR TITLE
4027 Upgrade Django from 2.2.13 to 2.2.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.13
+Django==2.2.16
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary

- Resolves #4027 

Upgrades Django from 2.2.13 to 2.2.16 to address Snyk vulnerabilities [609368](https://app.snyk.io/vuln/SNYK-PYTHON-DJANGO-609368) and [609369](https://app.snyk.io/vuln/SNYK-PYTHON-DJANGO-609369)

## Impacted areas of the application

The entire site, but also only the requirements file and running the site generally.

## Screenshots

No visible changes

## Related PRs

No related PRs

## How to test

- pull the branch
- `pip install -r requirements.txt`
- `cd fec`, `./manage.py runserver`

Site should run normally, Snyk should not find vulnerabilities [609368](https://app.snyk.io/vuln/SNYK-PYTHON-DJANGO-609368) or [609369](https://app.snyk.io/vuln/SNYK-PYTHON-DJANGO-609369)



____
