### PR TITLE
Include self in connect-src

### DIFF
--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -15,6 +15,9 @@ class AddSecureHeaders(MiddlewareMixin):
                 *.app.cloud.gov \
             ",
             "connect-src": "\
+                'self' \
+                *.fec.gov \
+                *.app.cloud.gov \
                 https://www.google-analytics.com \
             ",
             "font-src": "\


### PR DESCRIPTION
## Summary

- Resolves #4084 

@jason-upchurch found an issue with our csp on localhost. This adds our domains to our CSP. Good catch!

Targeting the next release.

## Impacted areas of the application

Every data call should fail without this.

## Screenshots

None

## Related PRs

None

## How to test

- Pull and build like normal
- 127.0.0.1:8000 datatable pages should work again

____
