### PR TITLE
Consolidate GTM code, update to use environments

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -23,16 +23,7 @@
     </script>
   {% endblock %}
 
-  {# Google Tag Manager #}
-  {% if FEATURES.use_tag_manager %}
-    {% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-      {# Google Tag Manager for Production #}
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
-    {% else %}
-      {# Google Tag Manager for not-Production: #}
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PMSLNL3');</script>
-    {% endif %}
-  {% endif %}
+  {% include 'partials/google-tag-manager-script.jinja' %}
 
   <script>
     BASE_PATH = '/data';
@@ -67,16 +58,8 @@
   </script>
 </head>
 <body>
-  {# Google Tag Manager (noscript) #}
-  {% if FEATURES.use_tag_manager %}
-    {% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-      {# Google Tag Manager for Production #}
-      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    {% else %}
-      {# Google Tag Manager for NOT Production #}
-      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PMSLNL3" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    {% endif %}
-  {% endif %}
+
+  {% include 'partials/google-tag-manager-noscript.jinja' %}
 
 {% import 'macros/search.jinja' as search %}
 {% include 'partials/warnings.jinja' %}

--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -147,7 +147,7 @@
   <script defer type="text/javascript" src='https://www.google.com/recaptcha/api.js'></script>
 {% block scripts %}{% endblock %}
 
-{# Google Analytics and DAP without Tag Manager and only for production #}
+{# Google Analytics without Tag Manager and only for Production #}
 {% if (FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not FEATURES.use_tag_manager) %}
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -162,6 +162,7 @@
   </script>
 {% endif %}
 
+{# DAP for Production #}
 {% if (FEC_CMS_ENVIRONMENT == 'PRODUCTION') %}
   <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
 {% endif %}

--- a/fec/data/templates/layouts/widgets.jinja
+++ b/fec/data/templates/layouts/widgets.jinja
@@ -21,16 +21,7 @@
     </script>
   {% endblock %}
 
-  {# Google Tag Manager #}
-  {% if FEATURES.use_tag_manager %}
-    {% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-      {# Google Tag Manager for Production #}
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
-    {% else %}
-      {# Google Tag Manager for not-Production: #}
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PMSLNL3');</script>
-    {% endif %}
-  {% endif %}
+{% include 'partials/google-tag-manager-script.jinja' %}
   
   <script>
     BASE_PATH = '/data';
@@ -60,16 +51,8 @@
   </script>
 </head>
 <body>
-  {# Google Tag Manager (noscript) #}
-  {% if FEATURES.use_tag_manager %}
-    {% if FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-      {# Google Tag Manager for Production #}
-      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    {% else %}
-      {# Google Tag Manager for NOT Production #}
-      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PMSLNL3" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    {% endif %}
-  {% endif %}
+
+  {% include 'partials/google-tag-manager-noscript.jinja' %}
 
   <main id="main" {% if section %} data-section="{{section}}"{% endif %}>
     {% block body %}{% endblock %}
@@ -80,7 +63,7 @@
 {# {% block modals %}{% endblock %} #}
 {% block scripts %}{% endblock %}
 
-{# Google Analytics and DAP without Tag Manager and only for production #}
+{# Google Analytics without Tag Manager and only for production #}
 {% if (FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not FEATURES.use_tag_manager) %}
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -95,6 +78,7 @@
   </script>
 {% endif %}
 
+{# DAP for production #}
 {% if (FEC_CMS_ENVIRONMENT == 'PRODUCTION') %}
   <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
 {% endif %}

--- a/fec/data/templates/layouts/widgets.jinja
+++ b/fec/data/templates/layouts/widgets.jinja
@@ -63,7 +63,7 @@
 {# {% block modals %}{% endblock %} #}
 {% block scripts %}{% endblock %}
 
-{# Google Analytics without Tag Manager and only for production #}
+{# Google Analytics without Tag Manager and only for Production #}
 {% if (FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not FEATURES.use_tag_manager) %}
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -78,7 +78,7 @@
   </script>
 {% endif %}
 
-{# DAP for production #}
+{# DAP for Production #}
 {% if (FEC_CMS_ENVIRONMENT == 'PRODUCTION') %}
   <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
 {% endif %}

--- a/fec/data/templates/partials/google-tag-manager-noscript.jinja
+++ b/fec/data/templates/partials/google-tag-manager-noscript.jinja
@@ -4,10 +4,8 @@
     {% set gtm_url_params = 'gtm_auth=EDR0yhH3jo_lEfiev6nbSQ&gtm_preview=env-17&gtm_cookies_win=x' %}
     {% set gtm_container_id = 'GTM-T5HPRLH' %}
 
-    {% if FEC_CMS_ENVIRONMENT == 'STAGE' %}
-      {% set gtm_url_params = 'gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x' %}
   
-    {% elif FEC_CMS_ENVIRONMENT == 'DEV' %}
+    {% if FEC_CMS_ENVIRONMENT == 'DEV' %}
       {% set gtm_url_params = 'gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x' %}
 
     {% elif FEC_CMS_ENVIRONMENT == 'FEATURE' %}
@@ -15,6 +13,9 @@
     
     {% elif FEC_CMS_ENVIRONMENT == 'LOCAL' %}
       {% set gtm_url_params = 'gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x' %}
+
+    {% elif FEC_CMS_ENVIRONMENT == 'STAGE' %}
+      {% set gtm_url_params = 'gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x' %}
 
     {% endif %}
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_container_id }}&{{ gtm_url_params|safe }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/fec/data/templates/partials/google-tag-manager-noscript.jinja
+++ b/fec/data/templates/partials/google-tag-manager-noscript.jinja
@@ -1,0 +1,21 @@
+{# Google Tag Manager noscript tag #}
+  {% if FEATURES.use_tag_manager %}
+    {# default to Production #}
+    {% set gtm_url_params = 'gtm_auth=EDR0yhH3jo_lEfiev6nbSQ&gtm_preview=env-17&gtm_cookies_win=x' %}
+    {% set gtm_container_id = 'GTM-T5HPRLH' %}
+
+    {% if FEC_CMS_ENVIRONMENT == 'STAGE' %}
+      {% set gtm_url_params = 'gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x' %}
+  
+    {% elif FEC_CMS_ENVIRONMENT == 'DEV' %}
+      {% set gtm_url_params = 'gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x' %}
+
+    {% elif FEC_CMS_ENVIRONMENT == 'FEATURE' %}
+      {% set gtm_url_params = 'gtm_auth=9iWFPNOm8OoMRZtvxWB-tA&gtm_preview=env-18&gtm_cookies_win=x' %}
+    
+    {% elif FEC_CMS_ENVIRONMENT == 'LOCAL' %}
+      {% set gtm_url_params = 'gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x' %}
+
+    {% endif %}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_container_id }}&{{ gtm_url_params|safe }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  {% endif %}

--- a/fec/data/templates/partials/google-tag-manager-script.jinja
+++ b/fec/data/templates/partials/google-tag-manager-script.jinja
@@ -4,10 +4,8 @@
     {% set gtm_url_params = 'gtm_auth=EDR0yhH3jo_lEfiev6nbSQ&gtm_preview=env-17&gtm_cookies_win=x' %}
     {% set gtm_container_id = 'GTM-T5HPRLH' %}
 
-    {% if FEC_CMS_ENVIRONMENT == 'STAGE' %}
-      {% set gtm_url_params = 'gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x' %}
   
-    {% elif FEC_CMS_ENVIRONMENT == 'DEV' %}
+    {% if FEC_CMS_ENVIRONMENT == 'DEV' %}
       {% set gtm_url_params = 'gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x' %}
 
     {% elif FEC_CMS_ENVIRONMENT == 'FEATURE' %}
@@ -15,6 +13,9 @@
     
     {% elif FEC_CMS_ENVIRONMENT == 'LOCAL' %}
       {% set gtm_url_params = 'gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x' %}
+
+    {% elif FEC_CMS_ENVIRONMENT == 'STAGE' %}
+      {% set gtm_url_params = 'gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x' %}
 
     {% endif %}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&{{ gtm_url_params|safe }}';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','{{ gtm_container_id }}');</script>

--- a/fec/data/templates/partials/google-tag-manager-script.jinja
+++ b/fec/data/templates/partials/google-tag-manager-script.jinja
@@ -1,0 +1,21 @@
+{# Google Tag Manager script tag #}
+  {% if FEATURES.use_tag_manager %}
+    {# default to Production #}
+    {% set gtm_url_params = 'gtm_auth=EDR0yhH3jo_lEfiev6nbSQ&gtm_preview=env-17&gtm_cookies_win=x' %}
+    {% set gtm_container_id = 'GTM-T5HPRLH' %}
+
+    {% if FEC_CMS_ENVIRONMENT == 'STAGE' %}
+      {% set gtm_url_params = 'gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x' %}
+  
+    {% elif FEC_CMS_ENVIRONMENT == 'DEV' %}
+      {% set gtm_url_params = 'gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x' %}
+
+    {% elif FEC_CMS_ENVIRONMENT == 'FEATURE' %}
+      {% set gtm_url_params = 'gtm_auth=9iWFPNOm8OoMRZtvxWB-tA&gtm_preview=env-18&gtm_cookies_win=x' %}
+    
+    {% elif FEC_CMS_ENVIRONMENT == 'LOCAL' %}
+      {% set gtm_url_params = 'gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x' %}
+
+    {% endif %}
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&{{ gtm_url_params|safe }}';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','{{ gtm_container_id }}');</script>
+  {% endif %}

--- a/fec/fec/templates/500-status.html
+++ b/fec/fec/templates/500-status.html
@@ -81,7 +81,7 @@
     {# Override this in templates to add extra javascript #}
     {% endblock %}
 
-    {# Google Analytics and DAP without Tag Manager and only for production #}
+    {# Google Analytics without Tag Manager and only for Production #}
     {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not settings.FEATURES.use_tag_manager %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -96,6 +96,7 @@
     </script>
     {% endif %}
 
+    {# DAP for Production #}
     {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
     {% endif %}

--- a/fec/fec/templates/500-status.html
+++ b/fec/fec/templates/500-status.html
@@ -7,16 +7,7 @@
 
     <title>Website status error | FEC</title>
 
-    {# Google Tag Manager #}
-    {% if settings.FEATURES.use_tag_manager %}
-      {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-        {# Google Tag Manager for Production #}
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
-      {% else %}
-        {# Google Tag Manager for NOT Production #}
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PMSLNL3');</script>
-      {% endif %}
-    {% endif %}
+    {% include 'partials/google-tag-manager-script.html' %}
 
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
@@ -32,16 +23,7 @@
     </div>
     <![endif]-->
 
-    {# Google Tag Manager (noscript) #}
-    {% if settings.FEATURES.use_tag_manager %}
-      {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-        {# Google Tag Manager for Production #}
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      {% else %}
-        {# Google Tag Manager for NOT Production #}
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PMSLNL3" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      {% endif %}
-    {% endif %}
+    {% include 'partials/google-tag-manager-noscript.html' %}
 
     {% wagtailuserbar %}
     {# env-specific banner #} 
@@ -119,4 +101,3 @@
     {% endif %}
   </body>
 </html>
-

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -7,16 +7,7 @@
 
     <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }} | FEC {% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
 
-    {# Google Tag Manager #}
-    {% if settings.FEATURES.use_tag_manager %}
-      {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-        {# Google Tag Manager for Production #}
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
-      {% else %}
-        {# Google Tag Manager for NOT Production #}
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PMSLNL3');</script>
-      {% endif %}
-    {% endif %}
+    {% include 'partials/google-tag-manager-script.html' %}
 
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
@@ -32,16 +23,7 @@
     </div>
     <![endif]-->
 
-    {# Google Tag Manager (noscript) #}
-    {% if settings.FEATURES.use_tag_manager %}
-      {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-        {# Google Tag Manager for Production #}
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      {% else %}
-        {# Google Tag Manager for NOT Production #}
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PMSLNL3" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      {% endif %}
-    {% endif %}
+    {% include 'partials/google-tag-manager-noscript.html' %}
 
     {% wagtailuserbar %}
     <a href="#main" class="skip-nav">skip navigation</a>

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -170,7 +170,7 @@
     {# Override this in templates to add extra javascript #}
     {% endblock %}
 
-    {# Google Analytics and DAP without Tag Manager and only for production #}
+    {# Google Analytics without Tag Manager and only for Production #}
     {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not settings.FEATURES.use_tag_manager %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -185,6 +185,7 @@
     </script>
     {% endif %}
 
+    {# DAP for Production #}
     {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
     {% endif %}

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -8,16 +8,7 @@
 
     <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }} | FEC {% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
 
-    {# Google Tag Manager #}
-    {% if settings.FEATURES.use_tag_manager %}
-      {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-        {# Google Tag Manager for Production #}
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
-      {% else %}
-        {# Google Tag Manager for NOT Production #}
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PMSLNL3');</script>
-      {% endif %}
-    {% endif %}
+    {% include 'partials/google-tag-manager-script.html' %}
 
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'elections.css' %}" />
@@ -32,16 +23,7 @@
     </div>
     <![endif]-->
 
-    {# Google Tag Manager (noscript) #}
-    {% if settings.FEATURES.use_tag_manager %}
-      {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-        {# Google Tag Manager for Production #}
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      {% else %}
-        {# Google Tag Manager for NOT Production #}
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PMSLNL3" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      {% endif %}
-    {% endif %}
+    {% include 'partials/google-tag-manager-noscript.html' %}
 
     {% wagtailuserbar %}
     <a href="#main" class="skip-nav">skip navigation</a>

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -159,7 +159,7 @@
     {# Override this in templates to add extra javascript #}
     {% endblock %}
 
-    {# Google Analytics and DAP without Tag Manager and only for production #}
+    {# Google Analytics without Tag Manager and only for Production #}
     {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' and not settings.FEATURES.use_tag_manager %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -174,6 +174,7 @@
     </script>
     {% endif %}
 
+    {# DAP for Production #}
     {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
     {% endif %}

--- a/fec/fec/templates/partials/google-tag-manager-noscript.html
+++ b/fec/fec/templates/partials/google-tag-manager-noscript.html
@@ -1,0 +1,20 @@
+{# Google Tag Manager noscript tag #}
+    {% if settings.FEATURES.use_tag_manager %}
+      {% if settings.FEC_CMS_ENVIRONMENT == 'DEV' %}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH&gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    
+      {% elif settings.FEC_CMS_ENVIRONMENT == 'FEATURE' %}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH&gtm_auth=9iWFPNOm8OoMRZtvxWB-tA&gtm_preview=env-18&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    
+      {% elif settings.FEC_CMS_ENVIRONMENT == 'LOCAL' %}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH&gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    
+      {% elif settings.FEC_CMS_ENVIRONMENT == 'STAGE' %}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH&gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+      {% else %}
+      {# default to Production #}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH&gtm_auth=EDR0yhH3jo_lEfiev6nbSQ&gtm_preview=env-17&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      {% endif %}
+    {% endif %}
+    

--- a/fec/fec/templates/partials/google-tag-manager-script.html
+++ b/fec/fec/templates/partials/google-tag-manager-script.html
@@ -1,0 +1,21 @@
+{# Google Tag Manager script tag #}
+    {% if settings.FEATURES.use_tag_manager %}
+      {% if settings.FEC_CMS_ENVIRONMENT == 'STAGE' %}
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+      
+      {% elif settings.FEC_CMS_ENVIRONMENT == 'DEV' %}
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+  
+      {% elif settings.FEC_CMS_ENVIRONMENT == 'FEATURE' %}
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=9iWFPNOm8OoMRZtvxWB-tA&gtm_preview=env-18&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+      
+      {% elif settings.FEC_CMS_ENVIRONMENT == 'LOCAL' %}
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+
+      {% else %}
+        {# default to Production #}
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=EDR0yhH3jo_lEfiev6nbSQ&gtm_preview=env-17&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+  
+      {% endif %}
+    {% endif %}
+    

--- a/fec/fec/templates/partials/google-tag-manager-script.html
+++ b/fec/fec/templates/partials/google-tag-manager-script.html
@@ -1,16 +1,16 @@
 {# Google Tag Manager script tag #}
     {% if settings.FEATURES.use_tag_manager %}
-      {% if settings.FEC_CMS_ENVIRONMENT == 'STAGE' %}
-        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
-      
-      {% elif settings.FEC_CMS_ENVIRONMENT == 'DEV' %}
-        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
-  
+      {% if settings.FEC_CMS_ENVIRONMENT == 'DEV' %}
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+    
       {% elif settings.FEC_CMS_ENVIRONMENT == 'FEATURE' %}
-        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=9iWFPNOm8OoMRZtvxWB-tA&gtm_preview=env-18&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
-      
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=9iWFPNOm8OoMRZtvxWB-tA&gtm_preview=env-18&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+    
       {% elif settings.FEC_CMS_ENVIRONMENT == 'LOCAL' %}
-        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
+
+      {% elif settings.FEC_CMS_ENVIRONMENT == 'STAGE' %}
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
 
       {% else %}
         {# default to Production #}


### PR DESCRIPTION
## Summary

- Resolves #4083 

- Consolidated the GTM code to a few external files rather than update code site-wide.
- Updated GTM code to use the various environments of our main GTM container rather than rely on separate containers.

## Impacted areas of the application

Source code of every page

## Screenshots

No visible changes

## Related PRs

None

## Reviewers

- Having other eyes is always good, but feel free to add or remove yourself

## How to test

- pull and build branch like normal
- `./manage.py runserver`
- Check each page's source, being sure to include a the homepage, a Wagtail page, a data page, a legal page, and a widget
  - Check with GTM turned on
  - and with GTM turned off
- If `echo $FEC_FEATURE_USE_TAG_MANAGER` tells you `true`, you should see entries for GTM in every page's source code; if not, no page on the site should have 'gtm' in the source code.
  - To turn on GTM, use `export FEC_FEATURE_USE_TAG_MANAGER=true`
  - and `export FEC_FEATURE_USE_TAG_MANAGER=false` will turn it off

____
