### PR TITLE
Update ua-parser-js@0.7.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13622,9 +13622,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
+      "version": "0.7.22",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
     },
     "uglify-js": {
       "version": "3.6.7",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "accessible-mega-menu": "git+https://github.com/noahmanger/Accessible-Mega-Menu.git",
     "ace-builds": "1.2.2",
     "acorn": "^6.4.1",
-    "aria-accordion": "1.0.0",
     "ajv": "^6.12.3",
+    "aria-accordion": "1.0.0",
     "chroma-js": "1.0.1",
     "colorbrewer": "0.0.2",
     "component-sticky": "1.0.0",
@@ -61,6 +61,7 @@
     "topojson": "^3.0.2",
     "tough-cookie": "^2.5.0",
     "tunnel-agent": "^0.6.0",
+    "ua-parser-js": "^0.7.22",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary (required)

- Resolves #4065 

## How to test:
- check out develop
- `snyk test --file=package.json`
- note the vulnerability and remediation path for ua-parser-js
- check out this branch
- `snyk test --file=package.json`
- verify the vulnerability no longer appears
- `pytest`
- run local cms and verify that glossary works (I believe this package is a subdependency of packages that work with our glossary, i.e., `draft-js`: https://github.com/fecgov/fec-cms/blob/fdd0ea49f1047f46ea266e244d8bf882518c4766/fec/fec/static/js/draftail/Glossary.js)