### PR TITLE
Feature/4090 csp updates for wagtail

### DIFF
--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -73,7 +73,7 @@ class AddSecureHeaders(MiddlewareMixin):
 
         # Add specific rules/permissions for users who are logged in (and not for the general site visitor)
         if request.user.is_authenticated:
-            content_security_policy["img-src"] += " https://www.gravatar.com/avatar/"
+            content_security_policy["img-src"] += " http://www.gravatar.com/avatar/dd9a1a05d5c70a0ce8317f4172745459"
             content_security_policy["connect-src"] += " https://releases.wagtail.io/latest.txt"
 
         # Skip CSP reporting in production so we don't clutter up the logs

--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -1,5 +1,6 @@
 from django.utils.deprecation import MiddlewareMixin
 from django.conf import settings
+import re
 
 
 class AddSecureHeaders(MiddlewareMixin):
@@ -37,13 +38,13 @@ class AddSecureHeaders(MiddlewareMixin):
                 'self' \
                 'unsafe-inline' \
                 'unsafe-eval' \
+                https://dap.digitalgov.gov \
+                https://polyfill.io/ \
                 https://www.google.com/recaptcha/ \
                 https://ssl.google-analytics.com \
                 https://www.google-analytics.com \
                 https://www.googletagmanager.com \
                 https://www.gstatic.com/recaptcha/ \
-                https://polyfill.io \
-                https://dap.digitalgov.gov \
             ",  # do we need unsafe-eval? (Doesn't it only allow 'eval()'?)
             "style-src": "\
                 'self' \
@@ -54,8 +55,6 @@ class AddSecureHeaders(MiddlewareMixin):
                 'none' \
             "
             # Google's requirements found at https://developers.google.com/tag-manager/web/csp
-            # TODO: Do we have a way to handle reporting CSP violations,
-            # TODO: like this https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#Enabling_reporting
             #
             # TODO: To get away from unsafe-inline, we could look into hashing our inline script elements:
             # TODO: like this https://content-security-policy.com/hash/
@@ -64,10 +63,15 @@ class AddSecureHeaders(MiddlewareMixin):
             content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"  # TODO: add filesystem?
 
         if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION':  # pre-prod environments
-            content_security_policy["script-src"] += " https://tagmanager.google.com"
-            content_security_policy["style-src"] += " https://tagmanager.google.com https://fonts.googleapis.com"
-            content_security_policy["img-src"] += " https://ssl.gstatic.com https://www.gstatic.com"
-            content_security_policy["font-src"] += " https://fonts.gstatic.com data:"
+            content_security_policy["font-src"] += " https://fonts.gstatic.com/ data:"
+            content_security_policy["img-src"] += " https://ssl.gstatic.com/ https://www.gstatic.com/"
+            content_security_policy["script-src"] += " https://tagmanager.google.com/"
+            content_security_policy["style-src"] += " https://tagmanager.google.com/ https://fonts.googleapis.com/"
+
+        # Add specific rules/permissions for users who are logged in (and not for the general site visitor)
+        if request.user.is_authenticated:
+            content_security_policy["img-src"] += " https://www.gravatar.com/avatar/"
+            content_security_policy["connect-src"] += " https://releases.wagtail.io/latest.txt"
 
         # Skip CSP reporting in production so we don't clutter up the logs
         if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION':
@@ -78,7 +82,7 @@ class AddSecureHeaders(MiddlewareMixin):
             content_security_policy["report-uri"] = report_uri
 
         response["Content-Security-Policy"] = "".join(
-            "{0} {1}; ".format(directive, value)
+            "{0} {1}; ".format(directive, re.sub(' +', ' ', value))
             for directive, value in content_security_policy.items()
         )
         response["cache-control"] = "max-age=600"


### PR DESCRIPTION
## Summary

- Resolves #4090 

Resolving CSP issues, mostly for Wagtail. (Some warnings may still fire otherwise)
Also, collapsing the whitespace in the rules (the `re` parts)

## Impacted areas of the application

Potentially every page on the site but most likely everything in the Wagtail admin areas

## Screenshots

None

## Related PRs

None

## Reviewers

I added a few of you; feel free to add/remove as needed

## How to test

- Pull the branch and run server like you normally would
- Load a page (homepage and datatables pages are good to use), including the admin area
- When the page is loaded, go into Developer Tools (right-click anywhere on the page and choose Inspect or find Developer Tools in your browser's menu (Likely under View or Tools))
- In the Console tab, we're looking at the red entries. Something like:
  > "**Refused to load** the image 'http://www.gravatar.com/avatar/…' **because it violates the following Content Security Policy directive:** "img-src 'self' *.fec.gov *.app.cloud.gov data"
- There should be no errors that mention "Content Security Policy"
- Let us know if you're seeing any other CSP errors!


To double-check permissions:
- In the Developer Tools, switch to the Network tab
- You'll likely need to reload the page (Sources and Network are often blank if they weren't the active tab when the page last loaded)
- In Dev Tools, on the left column, scroll to the top of the list and click the one that looks like "127.0.0.1" or "localhost" or the path to the current page. It's likely the top entry
- Looking at the right column, change its tab to "Headers"
- Under "Response Headers", we're looking at "Content-Security-Policy"
- You can read it in that window or copy it into a text editor so you can add line breaks or whatever to make it easier to read
- CSPs are set up like a rule name with that rule's permissions, a semicolon, then another rule name and its permissions, a semicolon, another rule…
- We're mostly looking at the permissions allowed by `connect-src`, `img-src`
- `img-src` should include `https://www.gravatar.com/avatar/` _but only if you're logged into Wagtail_
- Likewise, `connect-src` should include `https://releases.wagtail.io/latest.txt` _if you're logged into Wagtail_

____
