### PR TITLE
update circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,16 @@ jobs:
             pip install -r requirements.txt
 
       - run:
-          name: Install Node.js dependencies
+          name: Install node dependencies
           command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+            echo ". ~/.nvm/nvm.sh" >> $BASH_ENV
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+            nvm install 10.16.0
+            nvm use 10.16.0
+            nvm alias default 10.16.0
             sudo npm install -g npm
             npm install webpack
             npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             pip install -r requirements.txt
 
       - run:
-          name: Install node dependencies
+          name: Install node and build web assets
           command: |
             curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
             echo ". ~/.nvm/nvm.sh" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,13 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.7.8-stretch-node-browsers
+      - image: circleci/python:3.7.9-stretch-node-browsers
         environment:
           TZ: America/New_York
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test
 
       # PostgreSQL
-      - image: circleci/postgres:10.11
+      - image: circleci/postgres:11.9
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: "trust"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,16 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.7.4-stretch-node-browsers
+      - image: circleci/python:3.7.8-stretch-node-browsers
         environment:
           TZ: America/New_York
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test
 
       # PostgreSQL
-      - image: circleci/postgres:9.6.8
+      - image: circleci/postgres:10.11
         environment:
           POSTGRES_USER: postgres
+          POSTGRES_HOST_AUTH_METHOD: "trust"
           POSTGRES_DB: cfdm_cms_test
 
     working_directory: ~/repo
@@ -31,7 +32,7 @@ jobs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
             sudo apt-get update -qq && sudo apt-get install -y build-essential postgresql-client
-            echo 'export PATH=/usr/lib/postgresql/9.6/bin/:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/lib/postgresql/10.11/bin/:$PATH' >> $BASH_ENV
             echo "en_US.UTF-8 UTF-8" | sudo tee /etc/locale.gen
             sudo locale-gen en_US.UTF-8
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ jobs:
             nvm use 10.16.0
             nvm alias default 10.16.0
             sudo npm install -g npm
-            npm install webpack
             npm install
             npm run build
 


### PR DESCRIPTION
## Summary (required)

1. Update python docker image version to match the python version given in the runtime.txt file
2. Update Postgres docker image version to match the DB version in our cloud.gov (medium-gp-psql-redundant) environment
3. Set POSTGRES_HOST_AUTH_METHOD: "trust" environment variable. Builds fail without this env variable. 
 See: 
https://discuss.circleci.com/t/postgresql-image-password-not-specified-issue/34555?utm_medium=SEM&utm_source=gnb&utm_campaign=SEM-gb-DSA-Eng-uscan&utm_content=&utm_term=dynamicSearch-&gclid=CjwKCAjw_NX7BRA1EiwA2dpg0hsoFeu7z02id7KLIrJiImZpUfDShDzw7DbAwJJdL75bstnqP4914RoCoWAQAvD_BwE

- Resolves #3978 
_Include a summary of proposed changes._

- Update docker images in **circleci/config.yml file** : 

1. Python  from 3.7.4-stretch-node-browsers to 3.7.9-stretch-node-browsers
2. Postgres from 9.6.8 to 11.9
3. Add script to accommodate node upgrades in circleci

## Screenshots
Before upgrade:
<img width="947" alt="Screen Shot 2020-10-02 at 10 06 47 AM" src="https://user-images.githubusercontent.com/11650355/94932428-0f685280-0497-11eb-815b-09c333ad93a7.png">

<img width="956" alt="Screen Shot 2020-10-02 at 10 07 06 AM" src="https://user-images.githubusercontent.com/11650355/94932456-18f1ba80-0497-11eb-9f98-e4c663d2f896.png">


After upgrade:
![Screen Shot 2020-10-06 at 12 57 02 PM](https://user-images.githubusercontent.com/11650355/95234726-7eb1af80-07d3-11eb-9484-60cefdaed796.png)


<img width="931" alt="Screen Shot 2020-10-02 at 10 05 46 AM" src="https://user-images.githubusercontent.com/11650355/94932477-20b15f00-0497-11eb-8ea4-a095c3f44eed.png">

## How to test the changes ~locally~
 - Rebuild or Rerun _feature/3978-update-circleci-config_ branch on circleci  and notice  **Spin up  environment** and **Container** circleci tasks downloading the upgraded python and postgres docker images.
