### PR TITLE
[Before release] Change link to new summary tables landing

### DIFF
--- a/fec/data/templates/partials/browse-data/historical.jinja
+++ b/fec/data/templates/partials/browse-data/historical.jinja
@@ -1,5 +1,5 @@
 <section class="row" id="statistics" aria-hidden="true" role="tabpanel">
   <h2>Campaign finance statistics</h2>
   <p>Data tables that summarize financial activity by election cycle and coverage period for congressional candidates, political parties, political action committees and communication filings (independent expenditures, electioneering communications and communication costs).</p>
-  <a class="button button--cta button--go" href="https://transition.fec.gov/press/campaign_finance_statistics.shtml">Find statistics</a>
+  <a class="button button--cta button--go" href="/campaign-finance-data/campaign-finance-statistics/">Find statistics</a>
 </section>


### PR DESCRIPTION
## Summary
We need to update the button "Find statistics" on the Campaign finance statistics browse data page to the newly created landing page with the 10/26/20 release.

- Resolves #4131

## Impacted areas of the application
modified:   data/templates/partials/browse-data/historical.jinja

## Related PRs
#4132
#4088
