### PR TITLE
Update cf cli to version 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.34.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
             cf install-plugin autopilot -f -r CF-Community
 
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ We use CircleCI for automated deploys after tests pass. If you want to deploy so
 
 If there is a problem with CircleCI and something needs to be deployed, you can do so with the following commands. Though, you will need to pull the environment variables from the space you are deploying to and remake your static assets. That will ensure things like the links are correct. You will also want to clear your dist/ directory. That way, you will not exceed the alloted space.
 
-Before deploying, install the
+Before deploying, install version 7 of the
 [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html)
 and the [autopilot plugin](https://github.com/concourse/autopilot):
 


### PR DESCRIPTION
## Summary (required)

Resolves #4135

**Deploy task changes:**

- With cf cli version 7, `cf api <endpoint>` logs you out - this is a known issue: https://github.com/cloudfoundry/cli/issues/2075. Only set the endpoint if `deploy` task `--login True` (used for CircleCI)
- Cf cli doesn't exit with code 0 anymore, so I had to add it. (not sure where this is documented but you can read between the lines here: https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute)

**Other minor changes**
- Specify version in README because it's specified for other repose - the `--command` change to `cf run-task` is backwards incompatible

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Deploys

## Examples

- Example build: https://app.circleci.com/pipelines/github/fecgov/fec-cms/674/workflows/303ee8ad-6ec5-4447-b51d-cd74c540be6d/jobs/3914

## Reviewers
- One approval required

## How to test

**Through CircleCI**
- Make your own copy of this branch (please don't commit to this branch)
- Modify deploy task to deploy to a space of your choice
- Push to Github, make sure build works

**Locally:**
- Install cf cli version [following this guide](https://github.com/cloudfoundry/cli/wiki/Version-Switching-Guide) or:
```
# Install cf-cli@7. Complete commands
brew install cf-cli@7

# If you run across an error like this: Error: No such keg: /usr/local/Cellar/cf-cli@6, make sure you install cf-cli version 6 with brew
brew install cf-cli@6
 
# Unlink cf-cli version 6 and link cf-cli version 7
brew unlink cf-cli@6 && brew unlink cf-cli@7 && brew link cf-cli@7 && cf version
```
- Do a manual deploy with: 

```
npm i
export DJANGO_SECRET_KEY=<SECRET_KEY>
cf target -s dev
cd to fec-cms directory
invoke deploy --space dev
```