### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Fix homepage event priority

### DIFF
--- a/fec/fec/static/js/modules/home-events.js
+++ b/fec/fec/static/js/modules/home-events.js
@@ -35,6 +35,23 @@ function HomepageEvents() {
       var event = events.results[0];
       var startDate = '';
 
+      if (events.results.length > 1) {
+        event = events.results[0];
+        var min_date = event.start_date;
+
+        // Filters events by location 'FEC'
+        // and checks if the minimum date is equal to the returned start date
+        var filtered = events.results.filter(function(event) {
+          return event.location == 'FEC' && event.start_date == min_date;
+        });
+
+        // Display the location 'FEC' events first,
+        // Otherwise, there's no FEC events and get the first one in the list
+        if (filtered.length > 0) {
+          event = filtered[0];
+        }
+      }
+
       if (typeof event !== 'undefined') {
         startDate = moment(event.start_date).format('MMMM D');
       } else {


### PR DESCRIPTION
## Summary

- Resolves #4139 
_This ensures that general FEC deadlines show up on the homepage first. Otherwise, just show the dates like normal._

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Homepage calendar events

## Screenshots

![Screen Shot 2020-10-21 at 1 15 21 PM](https://user-images.githubusercontent.com/12799132/96754625-8bbbca80-139f-11eb-8ae4-41202d2a778e.png)

## How to test

- Checkout this branch
- `npm run build-js`
- Check the homepage to make sure that the 10/22 event of "12G Pre-Election Report Due" shows up first

**Test a different date after 10/22**
- Try changing the `min_start_date` to a future date past the 10/22 report due date, such as '2020-10-23'. 
- `npm run build-js` again
- Check the homepage and the next report due on the homepage should display "GA 05 Special Post-General Report due"

____
