### PR TITLE
Updates links to policy and other guidance page

### DIFF
--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -148,7 +148,7 @@
         </a>
       </div>
       <div class="grid__item">
-        <a href="https://transition.fec.gov/law/policy.shtml">
+        <a href="/legal-resources/policy-other-guidance/">
           <aside class="card card--horizontal card--primary">
             <div class="card__image__container">
               <span class="card__icon i-compass"><span class="u-visually-hidden">Icon representing policy and other guidance</span></span>
@@ -178,7 +178,7 @@
       <img src="{% static "img/feature--contributions.jpg" %}" alt="">
     </li>
     <li class="grid__item">
-      <h3><a href="/help-candidates-and-committees/candidate-taking-receipts/contribution-limits-candidates/">Contribution limits</a></h3>
+      <h3><a href="/help-candidates-and-committees/candidate-taking-receipts/contribution-limits/">Contribution limits</a></h3>
       <p>Under the Federal Election Campaign Act, contributions are subject to limits. Those limits differ depending on the type of donor and recipient.</p>
     </li>
      </ul>

--- a/fec/search/templates/search/policy_guidance_search_page.html
+++ b/fec/search/templates/search/policy_guidance_search_page.html
@@ -2,7 +2,7 @@
 {% load filters %}
 
 {% block intro %}
-  <p>Search or browse guidance documents issued by the Federal Election Commission on this page. This search includes all Commission documents that set forth a policy on a statutory, regulatory or technical issue, or interpret a regulation. Such documents include <a href="https://www.fec.gov/legal-resources/policy-other-guidance/#policy-statements">Statements of Policy</a>, <a href="https://www.fec.gov/legal-resources/policy-other-guidance/#interpretive-rules">interpretive rules</a>, <a href="https://www.fec.gov/help-candidates-and-committees/forms/">FEC forms</a>, <a href="https://www.fec.gov/help-candidates-and-committees/guides/">Campaign Guides</a>, certain press releases and other various Commission publications.</p>
+  <p>Search or browse guidance documents issued by the Federal Election Commission on this page. This search includes all Commission documents that set forth a policy on a statutory, regulatory or technical issue, or interpret a regulation. Such documents include <a href="/legal-resources/policy-other-guidance/#policy-statements">Statements of Policy</a>, <a href="/legal-resources/policy-other-guidance/#interpretive-rules">interpretive rules</a>, <a href="/help-candidates-and-committees/forms/">FEC forms</a>, <a href="/help-candidates-and-committees/guides/">Campaign Guides</a>, certain press releases and other various Commission publications.</p>
 {% endblock %}
 
 {% block filters %}
@@ -80,7 +80,7 @@
 <div class="slab slab--neutral footer-disclaimer">
   <div class="container">
     <div class="usa-width-one-half">
-      <p class="t-sans u-no-margin">Note: This search does not include advisory opinions, regulations, statutes, or Matters Under Review. For those items, use the <a href="https://www.fec.gov/legal-resources/">legal resources search</a>.</p>
+      <p class="t-sans u-no-margin">Note: This search does not include advisory opinions, regulations, statutes, or Matters Under Review. For those items, use the <a href="/legal-resources/">legal resources search</a>.</p>
     </div>
   </div>
 </div>

--- a/fec/search/templates/search/policy_guidance_search_page.html
+++ b/fec/search/templates/search/policy_guidance_search_page.html
@@ -2,7 +2,7 @@
 {% load filters %}
 
 {% block intro %}
-  <p>Search or browse guidance documents issued by the Federal Election Commission on this page. This search includes all Commission documents that set forth a policy on a statutory, regulatory or technical issue, or interpret a regulation. Such documents include <a href="https://transition.fec.gov/law/policy.shtml#policy">Statements of Policy</a>, <a href="https://transition.fec.gov/law/policy.shtml#interpretative">interpretive rules</a>, <a href="https://www.fec.gov/help-candidates-and-committees/forms/">FEC forms</a>, <a href="https://www.fec.gov/help-candidates-and-committees/guides/">Campaign Guides</a>, certain press releases and other various Commission publications.</p>
+  <p>Search or browse guidance documents issued by the Federal Election Commission on this page. This search includes all Commission documents that set forth a policy on a statutory, regulatory or technical issue, or interpret a regulation. Such documents include <a href="https://www.fec.gov/legal-resources/policy-other-guidance/#policy-statements">Statements of Policy</a>, <a href="https://www.fec.gov/legal-resources/policy-other-guidance/#interpretive-rules">interpretive rules</a>, <a href="https://www.fec.gov/help-candidates-and-committees/forms/">FEC forms</a>, <a href="https://www.fec.gov/help-candidates-and-committees/guides/">Campaign Guides</a>, certain press releases and other various Commission publications.</p>
 {% endblock %}
 
 {% block filters %}


### PR DESCRIPTION
## Summary (required)

Part of #4115  - Updates the links in the introductory text to point to the newly migrated policy page.

## Impacted areas of the application

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
Updates legal resources drop down menu | [link](https://github.com/fecgov/fec-cms/pull/4147)

## How to test

Guidance Search intro text:
Make sure the link to the policy statements points to https://www.fec.gov/legal-resources/policy-other-guidance/#policy-statements and the link to the interpretive rules points to https://www.fec.gov/legal-resources/policy-other-guidance/#interpretive-rules

Legal resources landing page:
Make sure box for policy points to https://www.fec.gov/legal-resources/policy-other-guidance/
Make sure contribution limits link under "You might also like" points to https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/contribution-limits/