### PR TITLE
Updates link to the policy page

### DIFF
--- a/fec/fec/templates/partials/navigation/nav-legal.html
+++ b/fec/fec/templates/partials/navigation/nav-legal.html
@@ -12,7 +12,7 @@
             <li class="mega__item"><a href="/legal-resources/legislation">Legislation</a></li>
             <li class="mega__item"><a href="/legal-resources/regulations">Regulations</a></li>
             <li class="mega__item"><a href="/legal-resources/court-cases">Court cases</a></li>
-            <li class="mega__item"><a href="https://transition.fec.gov/law/policy.shtml">Policy and other guidance</a></li>
+            <li class="mega__item"><a href="/legal-resources/policy-other-guidance/">Policy and other guidance</a></li>
           </ul>
         </div>
         <div class="u-padding--left col-md-3 col-lg-4">


### PR DESCRIPTION
Changes the link for the policy page to point to the new page at https://www.fec.gov/legal-resources/policy-other-guidance/

## Summary (required)

Related to work at #4115 

## Impacted areas of the application

List general components of the application that this PR will affect:
Navigation menu for legal resources


## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
Update links on guidance search page | [link](https://github.com/fecgov/fec-cms/pull/4145)


## How to test

Link to Policy and other guidance should point to https://www.fec.gov/legal-resources/policy-other-guidance/