### PR TITLE
Add internal route to CMS, add network policy to deploy script

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -9,6 +9,7 @@ applications:
       - python_buildpack
     routes:
       - route: fec-dev-cms.app.cloud.gov
+      - route: fec-dev-cms.apps.internal
     services:
       - cms-creds-dev
       - fec-creds-dev

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -9,6 +9,7 @@ applications:
       - python_buildpack
     routes:
       - route: fec-prod-cms.app.cloud.gov
+      - route: fec-prod-cms.apps.internal
     services:
       - cms-creds-prod
       - fec-creds-prod

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -9,6 +9,7 @@ applications:
       - python_buildpack
     routes:
       - route: fec-stage-cms.app.cloud.gov
+      - route: fec-stage-cms.apps.internal
     services:
       - cms-creds-stage
       - fec-creds-stage

--- a/tasks.py
+++ b/tasks.py
@@ -145,6 +145,21 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False):
             else:
                 print("Unable to cancel deploy. Check logs.")
 
+        # Fail the build
+        return sys.exit(1)
+
+    # Allow proxy to connect to CMS via internal route
+    add_network_policy = ctx.run('cf add-network-policy proxy cms'.format(cmd, space),
+        echo=True,
+        warn=True
+    )
+    if not add_network_policy.ok:
+        print(
+            "Unable to add network policy. Make sure the proxy app is deployed.\n"
+            "For more information, check logs."
+        )
+
+        # Fail the build because the CMS will be down until the proxy is can connect
         return sys.exit(1)
 
     # Needed by CircleCI


### PR DESCRIPTION
## Summary (required)
- Partial resolution for https://github.com/fecgov/fec-accounts/issues/316
- Add internal routes to CMS
- Add network policy to build script - should fail if the proxy isn't created

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Routes - will allow proxy to connect to these internally

## Reviewers

- At least two reviewers, please

## How to test

Test the "happy path":
- Do a deploy to `dev` (please don't commit to this branch) and make sure CMS still works
- Check out routes with `cf app cms` and see the two routes, internal and external
- Make sure the proxy can connect by manually deploying https://github.com/fecgov/fec-proxy/pull/187 (https://github.com/fecgov/fec-proxy#deployment) and going to dev.fec.gov
- Make sure you can't access fec-dev-cms.apps.internal

Test a failed build:
- Delete the proxy app in `dev` space
- Redeploy CMS and see that the build fails with an error message that makes sense
- Add the proxy app back with a manual deploy (https://github.com/fecgov/fec-proxy#deployment)
- Rebuild your CMS application to make sure the build now passes