### PR TITLE
Feature/4057 sponsor name to committee profile

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -1,3 +1,5 @@
+{# variables come from fec/data/views.py 'committee' #}
+
 {% extends 'layouts/main.jinja' %}
 {% import 'macros/null.jinja' as null %}
 {% import 'macros/cycle-select.jinja' as select %}

--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -1,3 +1,5 @@
+{# Imported by committees-single.jinja #}
+
 {% import 'macros/cycle-select.jinja' as select %}
 
 <section id="section-2" role="tabpanel" aria-hidden="true" aria-labelledby="section-2-heading">
@@ -73,6 +75,10 @@
             <td class="figure__value">{{ committee.designation_full }}</td>
           {% endif %}
         </tr>
+        <tr>
+            <td class="figure__label">Leadership PAC sponsor:</td>
+            <td class="figure__value">{{ leadership_sponsors_names }}</td>
+        </tr>
         {% if is_SSF %}
           <tr>
             <td class="figure__label">Connected organization:</td>
@@ -108,18 +114,18 @@
                 <h5 class="callout__title t-sans">
                   {% for c in candidates %}
                     {% if c.related_cycle is not none %}
-                      <a href="/data/candidate/{{ c.candidate_id }}/?cycle={{ c.related_cycle }}&election_full=false">{{ c.name }}</a>
+                  <a href="/data/candidate/{{ c.candidate_id }}/?cycle={{ c.related_cycle }}&election_full=false">{{ c.name }}</a>
                     {% else %}
-                      <a href="/data/candidate/{{ c.candidate_id }}/">{{ c.name }}</a>
+                  <a href="/data/candidate/{{ c.candidate_id }}/">{{ c.name }}</a>
                     {% endif %}
                   {% endfor %}
                 </h5>
-                  <span class="entity__type">{{ committee.committee_type_full }} candidate</span>
+                <span class="entity__type">{{ committee.committee_type_full }} candidate</span>
 
                   {% if candidates[0].office == 'S' %}
-                    <span class="entity__type">{{ candidates[0].state|fmt_state_full }}</span>
+                <span class="entity__type">{{ candidates[0].state|fmt_state_full }}</span>
                   {% elif candidates[0].office == 'H' %}
-                      <span class="entity__type">{{ candidates[0].state|fmt_state_full }} - {{ candidates[0].district }}</span>
+                <span class="entity__type">{{ candidates[0].state|fmt_state_full }} - {{ candidates[0].district }}</span>
                   {% endif %}
 
                   {{ candidates[0].party_full|lower|title }}

--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -75,10 +75,12 @@
             <td class="figure__value">{{ committee.designation_full }}</td>
           {% endif %}
         </tr>
+        {% if leadership_sponsors_names %}
         <tr>
             <td class="figure__label">Leadership PAC sponsor:</td>
             <td class="figure__value">{{ leadership_sponsors_names }}</td>
         </tr>
+        {% endif %}
         {% if is_SSF %}
           <tr>
             <td class="figure__label">Connected organization:</td>

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -468,12 +468,6 @@ def get_committee(committee_id, cycle):
 
         sponsors_str = "; ".join([str(elem) for elem in sponsors_names])
 
-    else:
-        sponsors_str = ""
-        # Do we want to set this ^^ to something specific if there's no sponsor, or just leave it blank?
-        # (if blank, we could omit this else)
-        # Another option: we could set the no-value text inside the template
-
     template_variables = {
         "candidates": candidates,
         "committee": committee,

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -455,6 +455,25 @@ def get_committee(committee_id, cycle):
         "lastCycleHasFinancial": fallback_cycle,
     }
 
+    # Sponsors come in as a list of IDs, but we need names
+    # Create a list and string, get the candidate names,
+    # and join that list with semicolons since names are returned as "LAST, FIRST"
+    sponsors_candidate_ids = committee.get("sponsor_candidate_ids")
+    sponsors_names = []
+    sponsors_str = ""
+    if sponsors_candidate_ids:
+        for sponsor_id in sponsors_candidate_ids:
+            sponsor_candidate_data = get_candidate(sponsor_id, cycle, False)
+            sponsors_names.append(sponsor_candidate_data["name"])
+
+        sponsors_str = "; ".join([str(elem) for elem in sponsors_names])
+
+    else:
+        sponsors_str = ""
+        # Do we want to set this ^^ to something specific if there's no sponsor, or just leave it blank?
+        # (if blank, we could omit this else)
+        # Another option: we could set the no-value text inside the template
+
     template_variables = {
         "candidates": candidates,
         "committee": committee,
@@ -477,6 +496,7 @@ def get_committee(committee_id, cycle):
         "social_image_identifier": "data",
         "year": year,
         "timePeriod": time_period_js,
+        "leadership_sponsors_names": sponsors_str,
     }
     # Format the current two-year-period's totals
     if reports and totals:


### PR DESCRIPTION
## Summary

- Resolves #4057 

## Impacted areas of the application

The committee profile pages, the About This Committee section

## Screenshots

![image](https://user-images.githubusercontent.com/26720877/99118296-44eb7a00-25c5-11eb-9262-a4d51eab8c42.png)

## Reviewers
I tagged those who I thought might be interested. Need approvals for
- Appearance
- Python
- Django/Jinja

## Related PRs

[The PR where the back-end functionality was added](https://github.com/fecgov/openFEC/pull/4680)

## How to test

- Set your localhost db path to dev
- Pull the branch, `npm i`, `npm run build`, `./manage.py runserver` like normal
- Check any committee's About this Committee section. These are the two listed in the backend PR: [committee 1](http://127.0.0.1:8000/data/committee/C00432104/?tab=about-committee) | [committee 2](http://127.0.0.1:8000/data/committee/C00497677/?tab=about-committee)
- There should now be a "Leadership PAC sponsor" between "Committee type" and "Statement of organization"
- PACs that aren't nonqualified should still have the sponsor row but with no value in it

## Question
- Current functionality will always show the sponsor line for any committee, though committees without sponsors should have nothing beside the label. Should we make the sponsor row visible for every committee or only those where it should have a value?


____
