### PR TITLE
Remove public app URLs

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -8,7 +8,6 @@ applications:
     buildpacks:
       - python_buildpack
     routes:
-      - route: fec-dev-cms.app.cloud.gov
       - route: fec-dev-cms.apps.internal
     services:
       - cms-creds-dev

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -8,7 +8,6 @@ applications:
     buildpacks:
       - python_buildpack
     routes:
-      - route: fec-prod-cms.app.cloud.gov
       - route: fec-prod-cms.apps.internal
     services:
       - cms-creds-prod

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -8,7 +8,6 @@ applications:
     buildpacks:
       - python_buildpack
     routes:
-      - route: fec-stage-cms.app.cloud.gov
       - route: fec-stage-cms.apps.internal
     services:
       - cms-creds-stage


### PR DESCRIPTION
## Summary (required)

Partial resolution for https://github.com/fecgov/fec-accounts/issues/318

- Merge after https://github.com/fecgov/fec-proxy-redirect/pull/1
- Remove public app URLs - after https://github.com/fecgov/fec-proxy/pull/194 the proxy connects through internal `apps.internal` route

<img width="850" alt="Screen Shot 2020-11-18 at 12 15 36 PM" src="https://user-images.githubusercontent.com/31420082/99563924-c8c3ae80-2997-11eb-8013-09a8c2e83e99.png">

- Note that we'll need to manually remove the routes after deployment due to the [additive-only](https://github.com/cloudfoundry/cloud_controller_ng/issues/1866) nature of deploying with manifests. Example: `cf unmap-route cms app.cloud.gov --hostname fec-dev-cms`

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Routes

## Related PRs

See https://github.com/fecgov/fec-epics/issues/191 for all related work

## How to test

- Manually deploy this branch
- (Assuming https://github.com/fecgov/fec-proxy-redirect/pull/1 has been merged)
- Run `cf unmap-route cms app.cloud.gov --hostname fec-dev-cms` (A cf cli quirk is that manifest changes with rolling deployments are additive-only, but it will only need to be done once per environment. Part of completion criteria here: https://github.com/fecgov/fec-accounts/issues/318)
- Go to old public app URL (ie, fec-dev-cms.app.cloud.gov and get redirected to CDN route (dev.fec.gov)
- Go to dev.fec.gov and make sure it works
- Do a `cf apps` command and see that only the `apps.internal` route remains for the CMS app