### PR TITLE
Upgrade datatables.net to v1.10.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3586,9 +3586,9 @@
       }
     },
     "datatables.net": {
-      "version": "1.10.10",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.10.tgz",
-      "integrity": "sha1-g6ugVkz9sZo3gJer3KYu7XNS89k=",
+      "version": "1.10.22",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.22.tgz",
+      "integrity": "sha512-ujn8GvkQIBYzYH54XY7OrI0Zb35TKRd9ABYfbnXgBfwTGIFT6UsmXrfHU5Yk+MSDoF0sDu2TB+31V6c+zUZ0Pw==",
       "requires": {
         "jquery": ">=1.7"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "corejs-typeahead": "^1.2.1",
     "css.escape": "^1.5.1",
     "d3": "3.5.5",
-    "datatables.net": "1.10.10",
+    "datatables.net": "1.10.22",
     "datatables.net-responsive": "^2.2.3",
     "debug": "^3.2.6",
     "draft-js": "^0.10.5",


### PR DESCRIPTION
## Summary

- Resolves #4105 
_Upgrade datatables.net to v1.10.22 to fix vulnerability._

## Impacted areas of the application

-  Any page that loads datatables

## How to test

- checkout this branch
- `npm install`
- `npm run build`
- `cd fec && ./manage.py runserver`
- Test out a couple of pages that loads datatables and make sure it still works.

____
