### PR TITLE
4154 Add site status link to footer menu

### DIFF
--- a/fec/fec/templates/partials/footer-navigation.html
+++ b/fec/fec/templates/partials/footer-navigation.html
@@ -72,6 +72,9 @@
           <li>
             <a href="https://github.com/fecgov/FEC/blob/master/release_notes/release_notes.md">Release notes</a>
           </li>
+          <li>
+            <a href="https://www.fec.gov/status">FEC site status</a>
+          </li>
         </ul>
       </div>
 

--- a/fec/fec/templates/partials/footer-navigation.html
+++ b/fec/fec/templates/partials/footer-navigation.html
@@ -73,7 +73,7 @@
             <a href="https://github.com/fecgov/FEC/blob/master/release_notes/release_notes.md">Release notes</a>
           </li>
           <li>
-            <a href="https://www.fec.gov/status">FEC.gov status</a>
+            <a href="https://fecgov.statuspage.io/">FEC.gov status</a>
           </li>
         </ul>
       </div>

--- a/fec/fec/templates/partials/footer-navigation.html
+++ b/fec/fec/templates/partials/footer-navigation.html
@@ -73,7 +73,7 @@
             <a href="https://github.com/fecgov/FEC/blob/master/release_notes/release_notes.md">Release notes</a>
           </li>
           <li>
-            <a href="https://www.fec.gov/status">FEC site status</a>
+            <a href="https://www.fec.gov/status">FEC.gov status</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary

- Resolves #4154 

New link in the site footer: our site status page

## Impacted areas of the application

Every page, but a simple addition to the footer menu

## Reviews
- Design/UX
- Front-end
- Content (via screenshots, then dev later)

Feel free to add/remove individuals

## Screenshots

Wider views
![image](https://user-images.githubusercontent.com/26720877/99826584-92686980-2b26-11eb-8cb6-ca9a7eaa4cba.png)

Narrow views
![image](https://user-images.githubusercontent.com/26720877/99826653-aa3fed80-2b26-11eb-96d3-56e2166b5172.png)


## Related PRs

None

## How to test

- Pull the branch like normal
- `./manage.py runserver`
- Check any page on [localhost](http:127.0.0.1:8000/) to make sure the link is in the footer 
- Click the status link to make sure it directs accordingly.

## Question

- Since it's technically taking users to a different site, should we open in a new tab?
- I added "site" to the link but can easily change it. If it's on fec.gov, why not simply "Site status"? "FEC status" seemed to imply status of the agency instead of only the site(s)/tools (e.g. could "FEC status" be "evacuation order/maximum telework," "without quorum," "in session," whatever other statuses we could be said to have …)

____
