### PR TITLE
Feature/3313 smallest menu height

### DIFF
--- a/fec/fec/static/scss/components/_nav.scss
+++ b/fec/fec/static/scss/components/_nav.scss
@@ -18,14 +18,13 @@
 // div that contains the ul and all panels
 .site-nav__container {
   $top: u(6.3rem);
-  $adjustment: 40px;
   @include transform(translateX(-100%));
   @include transition(left, .2s, ease-out);
-  height: calc(100vh - #{$top} - #{$adjustment});
+  height: calc(100vh - #{$top});
   position: absolute;
   left: 0;
   right: 0;
-  top: $top;
+  top: 4rem;
   overflow-x: hidden;
   z-index: $z-navigation;
 
@@ -33,6 +32,13 @@
   &[aria-hidden='true'] {
     display: block !important; // It's hidden by the transform, so this keeps it visible when it slides in
   }
+}
+
+// If we have the dev banner, we'll need to adjust #site-menu
+.banner-dev + .usa-banner + .site-header nav #site-menu {
+  $devBannerTop: 4rem;
+  top: u($devBannerTop);
+  height: calc(100vh - $devBannerTop);
 }
 
 // Styles for each panel on mobile

--- a/fec/fec/static/scss/components/_nav.scss
+++ b/fec/fec/static/scss/components/_nav.scss
@@ -35,10 +35,15 @@
 }
 
 // If we have the dev banner, we'll need to adjust #site-menu
-.banner-dev + .usa-banner + .site-header nav #site-menu {
+.banner-dev + .usa-banner + .site-header .site-nav .site-nav__container {
   $devBannerTop: 4rem;
-  top: u($devBannerTop);
-  height: calc(100vh - $devBannerTop);
+  height: calc(100vh - 12rem);
+  top: 4rem;
+
+  @include media($lg) {
+    height: auto;
+    top: 0;
+  }
 }
 
 // Styles for each panel on mobile

--- a/fec/fec/static/scss/components/_nav.scss
+++ b/fec/fec/static/scss/components/_nav.scss
@@ -18,9 +18,10 @@
 // div that contains the ul and all panels
 .site-nav__container {
   $top: u(6.3rem);
+  $adjustment: 40px;
   @include transform(translateX(-100%));
   @include transition(left, .2s, ease-out);
-  height: calc(100vh - #{$top});
+  height: calc(100vh - #{$top} - #{$adjustment});
   position: absolute;
   left: 0;
   right: 0;

--- a/fec/fec/static/scss/components/_site-header.scss
+++ b/fec/fec/static/scss/components/_site-header.scss
@@ -359,6 +359,7 @@
 //
 
 .masthead {
+  display: none;
   padding-top: u(2.5rem);
   @include clearfix();
 }
@@ -397,7 +398,8 @@
     background-size: contain;
     display: block;
     height: u(3rem);
-    margin: u(.5rem 1rem);
+    // margin: u(.5rem 1rem);
+    margin: u(.75rem 1rem .25rem);
     width: calc(100% - 15rem);
     max-width: u(40rem);
   }

--- a/fec/fec/static/scss/components/_site-header.scss
+++ b/fec/fec/static/scss/components/_site-header.scss
@@ -2,7 +2,7 @@
 //
 
 // Banner for dev
-.banner {
+.banner-dev {
   background-color: $navy;
   color: $inverse;
   font-family: $sans-serif;

--- a/fec/fec/templates/partials/env-banner.html
+++ b/fec/fec/templates/partials/env-banner.html
@@ -1,6 +1,6 @@
 {% if settings  != undefined %}
     {% if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION' %}   
-      <div class="banner ">
+      <div class="banner-dev">
         {# Uses settings.FEC_CMS_ENVIRONMENT for HTML templates #}
         <p class="t-sans t-small">{{settings.FEC_CMS_ENVIRONMENT}}<br>
         This site is for testing ideas and code. View the most accurate data on the <a href="http://www.fec.gov">live site</a>.
@@ -9,7 +9,7 @@
     {% endif %}
   {% else %}  
     {% if FEC_CMS_ENVIRONMENT != 'PRODUCTION' %}  
-      <div class="banner ">
+      <div class="banner-dev">
         {# Uses FEC_CMS_ENVIRONMENT for Jinja templates #}
         <p class="t-sans t-small">{{FEC_CMS_ENVIRONMENT}}<br>
         This site is for testing ideas and code. View the most accurate data on the <a href="http://www.fec.gov">live site</a>.


### PR DESCRIPTION
## Summary

- Resolves #3313 

Adjusting 

## Impacted areas of the application

List general components of the application that this PR will affect:

-  

## Screenshots

Default open state
![image](https://user-images.githubusercontent.com/26720877/100751860-de809d00-33b5-11eb-93c4-b33b455eaf86.png)

With Campaign finance expanded but with About scrolled into view
![image](https://user-images.githubusercontent.com/26720877/100751972-007a1f80-33b6-11eb-843f-2a281ba5b43f.png)


## Related PRs

None

## How to test

- pull the branch like normal
- `npm i`
- `npm run build`
- `./manage.py runserver`
- On [any page](http://127.0.0.1:8000), shrink the browser window width to as small as possible
- Make sure the menu still opens and the bottom of About is always accessible
- If the "LOCAL" banner is at the top, remove it and test that version
  - right click that top blue banner and choose Inspect or whatever your browser calls it
  - in the developer tools that open, a child element of `<div class="banner-dev">` should be selected
  - click the `banner-dev` element
  - delete it (delete, backspace, whatever)
  - close the developer tools if you'd like
  - check the menu positions again (open different menu options, make sure the bottom of About is still accessible)

____
