### PR TITLE
Add leadership PAC sponsor filter to committees datatable

### DIFF
--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -1,6 +1,6 @@
 {% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
 
-{% macro field(committee_type='committee_type', organization_type='organization_type', designation='designation') %}
+{% macro field(committee_type='committee_type', organization_type='organization_type', designation='designation', display_sponsor_candidate_filter=False) %}
 
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="hsp-committee_type">
@@ -108,12 +108,12 @@
         </li>
       </ul>
     </div>
-    {% if committee_type == 'sponsor_candidate_type' %}
-      <div class="filter sub--filter--indent">
-        {{ typeahead.field('sponsor_candidate_id', 'Leadership PAC sponsor', False, dataset='candidates', allow_text=False) }}
-      </div>
-    {% endif %}
   </fieldset>
+  {% if display_sponsor_candidate_filter %}
+    <div class="filter sub--filter--indent">
+      {{ typeahead.field('sponsor_candidate_id', 'Leadership PAC sponsor', False, dataset='candidates', allow_text=False) }}
+    </div>
+  {% endif %}
 </div>
 
 

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -1,3 +1,5 @@
+{% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
+
 {% macro field(committee_type='committee_type', organization_type='organization_type', designation='designation') %}
 
 <div class="filter">
@@ -106,6 +108,11 @@
         </li>
       </ul>
     </div>
+    {% if committee_type == 'sponsor_candidate_type' %}
+      <div class="filter sub--filter--indent">
+        {{ typeahead.field('sponsor_candidate_id', 'Leadership PAC sponsor', False, dataset='candidates', allow_text=False) }}
+      </div>
+    {% endif %}
   </fieldset>
 </div>
 

--- a/fec/data/templates/partials/committees-filter.jinja
+++ b/fec/data/templates/partials/committees-filter.jinja
@@ -23,7 +23,7 @@
   <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
   <div class="accordion__content">
     {% import 'macros/filters/committee-types.jinja' as committee_type %}
-    {{ committee_type.field() }}
+    {{ committee_type.field(committee_type='sponsor_candidate_type') }}
   </div>
 </div>
 {% endblock %}

--- a/fec/data/templates/partials/committees-filter.jinja
+++ b/fec/data/templates/partials/committees-filter.jinja
@@ -23,7 +23,7 @@
   <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
   <div class="accordion__content">
     {% import 'macros/filters/committee-types.jinja' as committee_type %}
-    {{ committee_type.field(committee_type='sponsor_candidate_type') }}
+    {{ committee_type.field(display_sponsor_candidate_filter=True) }}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Resolves #4061 
_Add Leadership PAC sponsor filter only to committees datatable._

## Impacted areas of the application

List general components of the application that this PR will affect:

- Committees datatable - http://www.fec.gov/data/committees/

## Screenshots

![Screen Shot 2020-12-02 at 11 06 46 AM](https://user-images.githubusercontent.com/12799132/100898312-a13c0e00-348e-11eb-8c7c-733c75efa912.png)

## How to test

- Checkout this branch
- `cd fec && ./manage.py runserver`
- Go to the committees datatable: http://localhost:8000/data/committees/
   - Make sure that the Leadership PAC sponsor filter is present in the filter sets
   - Try searching a sponsor name. Ex: Peters, Gary. You should see an autosuggest pop up, select the name from the autosuggest and the datatable should filter. You can grab a list of additional sponsor names to test from [this CSV from our website](http://www.fec.gov/files/bulk-downloads/2020/leadership2020.csv).
   - Add additional sponsor names to filter additional sponsor candidates

____
