### PR TITLE
Fix candidate profile pages that have no committees

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -275,10 +275,12 @@ def get_candidate(candidate_id, cycle, election_full):
 
     # Get the latest committee name, former authorized committee name, and committee ID.
     # This will be the first item returned in the committees list
-    if committees[0].get('former_candidate_id'):
-        current_committee_name = committees[0].get('name')
-        converted_committee_id = committees[0].get('committee_id')
-        former_committee_name = committees[0].get('former_committee_name')
+    # If there are no committees, return the normal no results message
+    if len(committees) > 0:
+        if committees[0].get('former_candidate_id'):
+            current_committee_name = committees[0].get('name')
+            converted_committee_id = committees[0].get('committee_id')
+            former_committee_name = committees[0].get('former_committee_name')
 
     return {
         "converted_committee_name": current_committee_name,


### PR DESCRIPTION
## Summary
- Resolves #4234 
_Candidate profile pages that have no committees are broken. This fix will check if there are committees, if not, then it will return the normal no results message for the candidate profile page_

Related API call from candidate profile page: https://api.open.fec.gov/v1/candidate/H2OR01240/committees/history/2022?per_page=100&election_full=True&api_key=DEMO_KEY

## Impacted areas of the application

-  Candidate profile pages with no committees

## Screenshots

### Before
![Screen Shot 2020-12-07 at 9 32 38 AM](https://user-images.githubusercontent.com/12799132/101363258-2f3d3d80-386f-11eb-8d6a-6d5df0f2c4a9.png)

### After
![Screen Shot 2020-12-07 at 9 32 21 AM](https://user-images.githubusercontent.com/12799132/101363260-2fd5d400-386f-11eb-835f-05b673ecd0b6.png)


## Related PRs

branch | PR
------ | ------
feature/3896-pcc-to-pac-from-api | [link](https://github.com/fecgov/fec-cms/pull/4193)

## How to test

- Checkout this branch
- `cd fec && ./manage.py runserver`
- Check any candidate that has no committees linked yet. Examples: http://localhost:8000/data/candidate/H2OR01240/ and http://localhost:8000/data/candidate/S6CA00808/. Make sure the page loads.
- Make sure that the PCC to PAC conversion message still works. Example: http://localhost:8000/data/candidate/P00009092/
- Make sure that any other candidate profile pages should work. Example: http://localhost:8000/data/candidate/P80000722/
____
