### PR TITLE
Fix committee profile page 404

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -412,7 +412,9 @@ def get_committee(committee_id, cycle):
         filters = {"per_page": 1}
         for sponsor_id in sponsors_candidate_ids:
             sponsor_candidate = load_most_recent_candidate(sponsor_id)
-            sponsors_names.append(sponsor_candidate["name"])
+            # Handle API returning no results
+            if sponsor_candidate:
+                sponsors_names.append(sponsor_candidate.get("name"))
 
         sponsors_str = "; ".join([str(elem) for elem in sponsors_names])
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -414,8 +414,12 @@ def get_committee(committee_id, cycle):
     sponsors_names = []
     sponsors_str = ""
     if sponsors_candidate_ids:
+        path = "/candidate/{}/history/"
+        filters = {"per_page": 1}
         for sponsor_id in sponsors_candidate_ids:
-            sponsor_candidate_data = get_candidate(sponsor_id, cycle, False)
+            sponsor_candidate_data = api_caller.load_first_row_data(
+                path.format(sponsor_id), **filters
+            )
             sponsors_names.append(sponsor_candidate_data["name"])
 
         sponsors_str = "; ".join([str(elem) for elem in sponsors_names])

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -1,17 +1,14 @@
+import requests
+import github3
+import json
+import re
+from distutils.util import strtobool
+from datetime import date, datetime
 from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.http import Http404
 from django.http import JsonResponse
 from django.conf import settings
-
-from distutils.util import strtobool
-
-import requests
-from datetime import date, datetime
-import github3
-import json
-import re
-
 from data import api_caller
 from data import constants
 from data import utils
@@ -146,24 +143,18 @@ def get_candidate(candidate_id, cycle, election_full):
     3) totally call 5-6 endpoints.
     """
 
-    # (1)call candidate/{candidate_id}/history/ under tag:candidate
+    # (1) Call candidate/{candidate_id}/history/ under tag:candidate
     # get rounded_election_years(candidate_election_year).
     candidate = load_most_recent_candidate(candidate_id)
     if candidate is None:
         raise Http404()
 
-    # a)Build List: even_election_years for candidate election dropdown list
-    #   on candidate profile page.
-    # b)rounded_election_years round up any odd year special election_year
-    #   to even number. (ex:2017=>2018)
-    # even_election_years = candidate.get('rounded_election_years')
-
     # if cycle = null, set cycle = the last of rounded_election_years.
     if not cycle:
         cycle = max(candidate.get("rounded_election_years"))
 
-    # (2)call candidate/{candidate_id}/history/{cycle} under tag:candidate
-    # (3)call candidate/{candidate_id}/committees/history/{cycle}
+    # (2) Call candidate/{candidate_id}/history/{cycle} under tag:candidate
+    # (3) Call candidate/{candidate_id}/committees/history/{cycle}
     # under tag:committee.
     candidate, committees, cycle = api_caller.load_with_nested(
         "candidate",
@@ -209,21 +200,24 @@ def get_candidate(candidate_id, cycle, election_full):
 
     committee_ids = [committee["committee_id"] for committee in committees_authorized]
 
-    # (4)call candidate/{candidate_id}/totals/{cycle} under tag:candidate
+    # (4) Call candidate/{candidate_id}/totals/{cycle} under tag:candidate
     # Get aggregate totals for the financial summary
-    filters = {}
-    filters["election_full"] = election_full
-    filters["cycle"] = cycle
+    filters = {
+        "election_full": election_full,
+        "cycle": cycle
+    }
     path = "/candidate/" + candidate_id + "/totals/"
     aggregate = api_caller.load_first_row_data(path, **filters)
 
     if election_full:
-        # (5)if election_full is true, need call
+        # (5) if election_full is true, need call
         # candidate/{candidate_id}/totals/{cycle} second time
         # for showing on raising and spending tabs
         # Get most recent 2-year period totals
-        filters["election_full"] = False
-        filters["cycle"] = max_cycle
+        filters = {
+            "election_full": False,
+            "cycle": max_cycle
+        }
         two_year_totals = api_caller.load_first_row_data(path, **filters)
     else:
         two_year_totals = aggregate
@@ -237,7 +231,7 @@ def get_candidate(candidate_id, cycle, election_full):
         spending_summary = None
         cash_summary = None
 
-    # (6)Call /filings?candidate_id=P00003392&form_type=F2
+    # (6) Call /filings?candidate_id=P00003392&form_type=F2
     # Get the statements of candidacy
     statement_of_candidacy = api_caller.load_candidate_statement_of_candidacy(
         candidate["candidate_id"]
@@ -255,13 +249,15 @@ def get_candidate(candidate_id, cycle, election_full):
         reverse=True,
     )
 
-    # (7)call efile/filings/ under tag:efiling
+    # (7) Call efile/filings/ under tag:efiling
     # Check if there are raw_filings for this candidate
     raw_filing_start_date = utils.three_days_ago()
-    filters["min_receipt_date"] = raw_filing_start_date
-    filters["committee_id"] = candidate["candidate_id"]
-    filters["cycle"] = cycle
-    filters["per_page"] = 100
+    filters = {
+        "min_receipt_date": raw_filing_start_date,
+        "committee_id": candidate["candidate_id"],
+        "cycle": cycle,
+        "per_page": 100,
+    }
     path = "/efile/" + "/filings/"
     raw_filings = api_caller.load_endpoint_results(path, **filters)
     has_raw_filings = True if raw_filings else False
@@ -472,10 +468,11 @@ def get_committee(committee_id, cycle):
     if cycle == utils.current_cycle():
         # (4)call efile/filings under tag: efiling
         path = "/efile/filings/"
-        filters = {}
-        filters["cycle"] = cycle
-        filters["committee_id"] = committee["committee_id"]
-        filters["min_receipt_date"] = template_variables["min_receipt_date"]
+        filters = {
+            "cycle": cycle,
+            "committee_id": committee["committee_id"],
+            "min_receipt_date": template_variables["min_receipt_date"]
+        }
         raw_filings = api_caller.load_endpoint_results(path, **filters)
 
         template_variables["has_raw_filings"] = True if raw_filings else False
@@ -542,7 +539,7 @@ def load_reports_and_totals(committee_id, cycle, cycle_out_of_range, fallback_cy
         "sort_hide_null": True,
     }
 
-    # (3) call /filings? under tag:filings
+    # (3) Call /filings? under tag:filings
     # get reports from filings endpoint filter by form_category=REPORT
     path = "/filings/"
     reports = api_caller.load_first_row_data(


### PR DESCRIPTION
## Summary (required)

Resolves #4221 

- Use `load_first_row_data` instead of `get_candidate` for sponsor candidate information so we can fall back to the most recent cycle and not user-provided cycle (or 2020 when not specified). Also, `get_candidate` does a lot of things that aren't needed here. https://github.com/fecgov/fec-cms/commit/5ff4f77c5ec95cd06f873454e59b36d0b5276d32
- Since `get_candidate` and `get_committee` use the same `load_first_row_data ` functionality to get the most recent candidate information, move it to its own function with a friendlier name https://github.com/fecgov/fec-cms/commit/1858730c3561cc9b61ba7c79673c2db3abeb3db0
- Minor reformatting, don't reuse `filters` for different endpoints/purposes in `get_candidate` https://github.com/fecgov/fec-cms/commit/efdad06124177e4aadd7e78443327d7f827e594f
- Handle missing candidate data due to data issue, IE http://localhost:8000/data/committee/C00760629/?tab=about-committee. https://github.com/fecgov/fec-cms/commit/77d96ea1397770faba0ccd2276d04a108e6b2d9c

## Impacted areas of the application

List general components of the application that this PR will affect:

- Candidate profile page
- Committee profile page

## Reviewers
Two approvals, please

## How to test

- http://localhost:8000/data/committee/C00481242/?tab=about-committee
- http://localhost:8000/data/committee/C00760629/?tab=about-committee
-  http://localhost:8000/data/committee/C00196824/?cycle=2020
-  http://localhost:8000/data/committee/C00588277/?cycle=2018