### PR TITLE
upgrade lxml and move to dev dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ django-libsass==0.7
 gunicorn==19.10.0
 gevent==1.4.0
 greenlet==0.4.16 # pinned 2020-09-22 to fix build problem (parent gevent)
-lxml==4.2.5
 psycopg2==2.8.5
 requests==2.24.0
 urllib3==1.25.9 # pinned 2020-11-01 (parent requests)
@@ -24,6 +23,7 @@ invoke==0.15.0
 GitPython==3.1.0
 requests-mock==1.3.0
 pdbpp==0.9.1
+lxml==4.6.2
 
 
 # Data import


### PR DESCRIPTION
## Summary (required)

- Resolves #4231 
_Upgraded lxml to v4.6.2. Also moved to dev dependencies since we don't need this other than for local scraping._

## Impacted areas of the application

- fec-cms/fec/search/management/commands/scrape_cms_pages.py
- fec-cms/fec/search/management/commands/scrape_transition_pages.py
- fec-cms/fec/search/management/commands/scrape_web_app_pages.py
- fec-cms/fec/search/utils/search_indexing.py

## How to test

- checkout this branch
- `pip install -r requirements.txt`
- Try performing scraping on your local by running the following commands one by one:
   - `fec/manage.py scrape_cms_pages` (when done, check the  fec-cms/fec/search/management/data/output.json to see if it wrote ok)
   - `fec/manage.py scrape_web_app_pages` (when done, check the  fec-cms/fec/search/management/data/output.json to see if it wrote ok)
   - `fec/manage.py scrape_transition_pages` (when done, check the  fec-cms/fec/search/management/data/output.json to see if it wrote ok)

____
