### PR TITLE
upgrade datatables.net to v1.10.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3602,9 +3602,9 @@
       }
     },
     "datatables.net": {
-      "version": "1.10.22",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.22.tgz",
-      "integrity": "sha512-ujn8GvkQIBYzYH54XY7OrI0Zb35TKRd9ABYfbnXgBfwTGIFT6UsmXrfHU5Yk+MSDoF0sDu2TB+31V6c+zUZ0Pw==",
+      "version": "1.10.23",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.23.tgz",
+      "integrity": "sha512-we3tlNkzpxvgkKKlTxTMXPCt35untVXNg8zUYWpQyC1U5vJc+lT0+Zdc1ztK8d3lh5CfdnuFde2p8n3XwaGl3Q==",
       "requires": {
         "jquery": ">=1.7"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "corejs-typeahead": "^1.2.1",
     "css.escape": "^1.5.1",
     "d3": "3.5.5",
-    "datatables.net": "1.10.22",
+    "datatables.net": "1.10.23",
     "datatables.net-responsive": "^2.2.3",
     "debug": "^3.2.6",
     "draft-js": "^0.11.7",


### PR DESCRIPTION
## Summary

- Resolves #4105 
_Upgrade datatables.net to v 1.10.23._

## Impacted areas of the application

-  Datatables pages

## Related PRs

branch | PR
------ | ------
feature/4105-upgrade-datatables | [link](https://github.com/fecgov/fec-cms/pull/4209)

## How to test

- checkout this branch
- `npm install`
- `npm run build`
- `cd fec && ./manage.py runserver`
- Test out a couple of pages that loads datatables and make sure it still works.

____
