### PR TITLE
[MERGE WITH GITFLOW] Pin PyJWT to v1.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ django-storages==1.7.1
 boto3==1.7.21
 
 cg-django-uaa==2.0.0
+PyJWT==1.7.1 # Pinning this version as version 2.0.0 is breaking cg-django-uaa
 
 # Testing
 coverage==4.5.1


### PR DESCRIPTION
## Summary

- Resolves #4282
[PyJWT](https://pypi.org/project/PyJWT/2.0.0/#history) package had a major breaking change for our Wagtail authentication `cg-django-uaa`. We need to pin at PyJWT v1.7.1 for now.

## Impacted areas of the application

-  Wagtail authentication

## How to test

- `pip install -r requirements.txt`
- `pip freeze`
- Check the version of PyJWT is now v1.7.1
- Temporarily deploy a new branch to dev and check login
- Try logging into Wagtail on dev, it should now work

____
