### PR TITLE
[MERGE WITH GITFLOW - HOTFIX] Do not cache CMS admin

### DIFF
--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -86,7 +86,15 @@ class AddSecureHeaders(MiddlewareMixin):
             "{0} {1}; ".format(directive, " ".join(value))
             for directive, value in content_security_policy.items()
         )
-        response["cache-control"] = "max-age=600"
+
+        if request.path.startswith('/admin'):
+            # Do not cache cms admin
+            response['cache-control'] = 'no-cache, no-store, must-revalidate'
+            response['Pragma'] = 'no-cache'
+            response['Expires'] = '0'
+        else:
+            # Cache everything else
+            response["cache-control"] = "max-age=600"
 
         # Expect-CT header
         expect_ct_max_age = 60 * 60 * 24  # 1 day


### PR DESCRIPTION
## Summary (required)

- Resolves #4281 
_Adds headers in the CMS admin console so that it is not cached._

## Impacted areas of the application

-  Wagtail admin

## How to test

- [ ] Checkout this branch with a new name and do a test deploy to the development environment
- [ ] Do a curl to the dev environment URL `curl -I https://[development_url]/`. You should see `x-cache: Miss from cloudfront`. Run the command again and now you should see `x-cache: Hit from cloudfront`. This is expected as we want the normal website pages to cache. You should also see the following header:
   - [ ] `cache-control: max-age=600`
- [ ] Do a curl to the dev environment URL `curl -I https://[development_url]/admin/`. You should see `x-cache: Miss from cloudfront`. Run the command again and now you should still see `x-cache: Miss from cloudfront`. This is expected as we DO NOT want the cms admin to cache. You also should see the following headers:
   - [ ] `cache-control: no-cache, no-store, must-revalidate`
   - [ ] `pragma: no-cache`
   - [ ] `cache-control: max-age=600`
   - [ ] `expires: 0`

____
