### PR TITLE
latest available based on selected, not on this year

### DIFF
--- a/fec/fec/static/js/pages/statistical-summary.js
+++ b/fec/fec/static/js/pages/statistical-summary.js
@@ -164,8 +164,8 @@ StatisticalSummary.prototype.showTable = function() {
     'message--inline',
     'message--alert'
   );
-  const today = new Date();
-  const thisYear = today.getFullYear();
+
+  const thisYear = this.chooseYear.options[0].value;
 
   //Fire handleLatestAvailableOption() if user selects this year's select option or a URL has this year in querysting year parameter
 


### PR DESCRIPTION
## Summary 
Make latest available tables based on most recent existing year instead of  "this year" (`today.getFullYear();`)

## Impacted areas of the application
modified:   fec/static/js/pages/statistical-summary.js

## Screenshots

![latest-date-period](https://user-images.githubusercontent.com/5572856/103558641-f6e74a00-4e82-11eb-98e6-71fb160d6626.gif)



## Related PRs

https://github.com/fecgov/fec-cms/pull/4088


## How to test
I verified this works based onm screenshot above, but if you want to test:
- checkout branch
- npm run build
- make a page in Wagtail based on this page, or edit it locally if you have it on your local already.
https://www.fec.gov/campaign-finance-data/congressional-candidate-data-summary-tables/?year=2020&segment=21
- In Wagtail, change selected attribute of the year-select to 21 or 24 month
- Make sure everything after the period you chose is disabled (just for the 2020)
- Add 2021-2022 Select to year-selects on Wagtail and do the same as above to make sure those would be disabled
