### PR TITLE
4266 Removing ua-parser-js from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "topojson": "^3.0.2",
     "tough-cookie": "^2.5.0",
     "tunnel-agent": "^0.6.0",
-    "ua-parser-js": "^0.7.22",
     "underscore": "^1.8.3",
     "whatwg-fetch": "^3.5.0"
   },


### PR DESCRIPTION
## Summary

- Resolves #4266 
Removing ua-parser-js from our package.json file because of its redundancy—package pins it to the same version required by fbjs. (This won't alleviate the Snyk alert)

## Impacted areas of the application

Should be no change, to the build, behavior, or appearance.

## Screenshots

None

## Related PRs

None

## How to test

- Pull the branch like normal
- `npm i`
- `npm run build`
- `npm run test-single`
- `./manage.py runserver`
- The build, tests, and site functionality should be unchanged, particularly
  - anything interactive (because it's a JavaScript change)
  - typeaheads (because fields are concerned)
  - Wagtail admin fields (because ua-parser-js is used by draft-js, our Wagtail editor(s))


____
