### PR TITLE
Jinja autoescape

### DIFF
--- a/fec/data/jinja2.py
+++ b/fec/data/jinja2.py
@@ -5,5 +5,6 @@ from compressor.contrib.jinja2ext import CompressorExtension
 def environment(**options):
     """Create a jinja2 environment with the CompressorExtension added in"""
     options['extensions'] += [CompressorExtension]
+    options['autoescape'] = True  # This was already True but we want to set it explicitly
     env = jinja2.Environment(**options)
     return env

--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -30,13 +30,13 @@
         {% spaceless %}{# for inline blocks #}
         <h1 class="heading__left">{% formatted_title self %}</h1>
         <div class="heading__right">
-          <span class="t-sans">{{ self.date|date:'F j, Y' }}{% if self.end_date %} - {{self.end_date|date:'F j, Y' }}{% endif %}</span><br>
+          <span class="t-sans">{{ self.date|date:'F j, Y' }}{% if self.end_date %} - {{ self.end_date|date:'F j, Y' }}{% endif %}</span><br>
         </div>
         {% endspaceless %}
       </div>
     </header>
     {% if self.additional_information %}
-       <p class="t-bold">{% autoescape off %}{{ self.additional_information}}{% endautoescape %}</p>
+       <p class="t-bold">{{ self.additional_information|safe }}</p>
     {% endif %}
     {% if self.meeting_type == 'O' %}
       <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:00am.</p>
@@ -66,7 +66,7 @@
       {% if self.agenda %}
       <div class="agenda__heading">
         <h2 class="u-padding--top u-no-margin">Agenda</h2>
-        <p>{{ self.date|date:'l, F j, Y' }} {% if self.end_date %}through {{self.end_date|date:'l, F j, Y' }}{% endif %}
+        <p>{{ self.date|date:'l, F j, Y' }} {% if self.end_date %}through {{ self.end_date|date:'l, F j, Y' }}{% endif %}
         &nbsp;|&nbsp; {% if self.time %}{{ self.time|date:'h:i A' }}{% else %}10:00 AM{% endif %}</p>
       </div>
       <ol class="agenda">

--- a/fec/home/templates/partials/jobs.html
+++ b/fec/home/templates/partials/jobs.html
@@ -3,7 +3,7 @@
 <section>
   <div class="message message--alt message--alert">
     <h2 class="message__title">Oops!</h2>
-    <p>{% autoescape off %}{{ error}}{% endautoescape %}</p>
+    <p>{{ error|safe }}</p>
   </div>
 </section>
 {% else %}
@@ -12,7 +12,7 @@
       <ul>
     {% for j in jobData %}
         <li>
-          <h3><a href="{{ j.position_uri }}">{{ j.position_id }} , {{ j.position_title}}</a></h3>
+          <h3><a href="{{ j.position_uri }}">{{ j.position_id }} , {{ j.position_title }}</a></h3>
           <ul class="u-padding--bottom">
             <li class='t-sans'><strong>Open Period:</strong> {{ j.position_start_date }} - {{ j.position_end_date }}</li>
             <li class='t-sans'><strong>Open To:</strong> {{ j.open_to }}</li>


### PR DESCRIPTION
## Summary
Resolves https://github.com/fecgov/fec-accounts/issues/340

Setting Jinja's autoescape to True and changing two instances to use the `safe` filter instead of bypassing autoescape

## Impacted areas of the application

autoescape was already True but we want to explicitly set it. The meeting page and jobs templates each had one place where we were turning off autoescape; we've changed those to use the `safe` filter instead

Could affect any part of the site where we're processing content with Jinja—every Jinja template or component, including *.jinja and *.html

## Screenshots

None

## Related PRs

None

## How to test

- pull the branch like normal
-`npm i`, `npm run build` just in case? Should have zero effect
- `pip install -r requirements.txt` just in case? Likely have zero effect
- `./manage.py runserver`
- Make sure the blog/Wagtail parts of the site behave correctly, specifically checking pages with content that comes from Wagtail (about, legal, etc). I imagine any errors would look like html characters being visible in the browser front-end, like `&lt;` instead of `<` or `&amp;` instead of `&`.

Don't merge this yet—could have a couple more changes

____
