### PR TITLE
Add optional `API_KEY_PUBLIC_CALENDAR` setting

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -21,6 +21,7 @@ FEC_API_URL = env.get_credential('FEC_API_URL', 'http://localhost:5000')
 FEC_API_KEY_PRIVATE = env.get_credential('FEC_WEB_API_KEY_PRIVATE')
 FEC_API_VERSION = env.get_credential('FEC_API_VERSION', 'v1')
 FEC_API_KEY_PUBLIC = env.get_credential('FEC_WEB_API_KEY_PUBLIC', '')
+FEC_API_KEY_PUBLIC_CALENDAR = env.get_credential('FEC_WEB_API_KEY_PUBLIC_CALENDAR', FEC_API_KEY_PUBLIC)
 FEC_DOWNLOAD_API_KEY = env.get_credential('FEC_DOWNLOAD_API_KEY', '')
 
 FEC_RECAPTCHA_SECRET_KEY = env.get_credential('FEC_RECAPTCHA_SECRET_KEY')

--- a/fec/fec/static/js/modules/calendar-helpers.js
+++ b/fec/fec/static/js/modules/calendar-helpers.js
@@ -32,7 +32,7 @@ function getUrl(path, params) {
   var url = URI(window.API_LOCATION)
     .path(Array.prototype.concat(window.API_VERSION, path || [], '').join('/'))
     .addQuery({
-      api_key: window.API_KEY_PUBLIC,
+      api_key: window.API_KEY_PUBLIC_CALENDAR,
       per_page: 500
     })
     .addQuery(params || {})

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -144,6 +144,7 @@
       window.API_LOCATION = '{{ settings.FEC_API_URL }}';
       window.API_VERSION = '{{ settings.FEC_API_VERSION }}';
       window.API_KEY_PUBLIC = '{{ settings.FEC_API_KEY_PUBLIC }}';
+      window.API_KEY_PUBLIC_CALENDAR = '{{ settings.FEC_API_KEY_PUBLIC_CALENDAR }}';
       window.TRANSITION_URL = '{{ settings.FEC_TRANSITION_URL }}';
       window.CANONICAL_BASE = '{{ settings.CANONICAL_BASE }}'
     </script>

--- a/fec/fec/tests/js/calendar.js
+++ b/fec/fec/tests/js/calendar.js
@@ -282,7 +282,7 @@ describe('helpers', function() {
   describe('calendarHelpers.getUrl()', function() {
     it('builds the correct url', function() {
       var url = calendarHelpers.getUrl('calendar', {category: 'election'});
-      expect(url).to.equal('/v1/calendar/?api_key=12345&per_page=500&category=election');
+      expect(url).to.equal('/v1/calendar/?api_key=67890&per_page=500&category=election');
     });
   });
 

--- a/fec/fec/tests/js/setup.js
+++ b/fec/fec/tests/js/setup.js
@@ -13,6 +13,7 @@ module.exports = function() {
     API_LOCATION: '',
     API_VERSION: '/v1',
     API_KEY_PUBLIC: '12345',
+    API_KEY_PUBLIC_CALENDAR: '67890',
     DEFAULT_TIME_PERIOD: '2016'
   });
 };


### PR DESCRIPTION
## Summary (required)

Resolves https://github.com/fecgov/fec-accounts/issues/350. Related issue: https://github.com/fecgov/openFEC/issues/1532. 

- Add optional `API_KEY_PUBLIC_CALENDAR` setting, which allows us to separate restrictions for the calendar and the rest of the site.
- If unset, the application will use the `API_KEY_PUBLIC` environment variable, which is the current behavior (so we don't have to create new keys for dev/stage/feature)

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Calendar subscriptions: http://127.0.0.1:8000/calendar/

<img width="451" alt="Screen Shot 2021-01-14 at 3 08 40 PM" src="https://user-images.githubusercontent.com/31420082/104645889-bacf9880-567d-11eb-86ee-d727fa982e84.png">

## Reviewers

One reviewer requested, others appreciated

## How to test

- Make sure you have `FEC_WEB_API_KEY_PUBLIC` set locally
- Go to http://127.0.0.1:8000/calendar/
- Subscribe to any of the three calendar options
- Hover over the links, see the API key used is  `FEC_WEB_API_KEY_PUBLIC`
- Set  `FEC_WEB_API_KEY_PUBLIC_CALENDAR` locally, rebuild JS (`npm run build` or `npm run build-js`)
- Subscribe to any of the three calendar options
- Hover over the links, see the API key used is  `FEC_WEB_API_KEY_PUBLIC_CALENDAR`