### PR TITLE
Display committee section only when cmte_dsgn is of type P, A or J.

### DIFF
--- a/fec/data/templates/candidates-single.jinja
+++ b/fec/data/templates/candidates-single.jinja
@@ -58,7 +58,9 @@
             href="#section-2">About this candidate</a>
             <ul>
               <li><a href="#information">Candidate information</a></li>
-              <li><a href="#committees">Committees</a></li>
+              {% if committee_groups['P'] or committee_groups['A'] or committee_groups['J'] %}
+                <li><a href="#committees">Committees</a></li>
+              {% endif %}
             </ul>
         </li>
         {% if two_year_totals %}

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -64,12 +64,10 @@
       </div>
     </div>
 
+{% if committee_groups['P'] or committee_groups['A']or committee_groups['J'] %}
     <div class="entity__figure entity__figure--narrow row" id="committees">
-
-      <h3 class="heading--section">Committees</h3>
-
-      {% if committee_groups['P'] or committee_groups['A'] %}
-      <h4>Authorized campaign committees:</h4>
+        <h3 class="heading--section">Committees</h3>
+        <h4>Authorized campaign committees:</h4>
       {% for committee in committee_groups['P'] | reverse %}
       <div class='grid'>
         <div class="grid__item u-no-margin">
@@ -101,8 +99,6 @@
       <hr class="hr--lighter">
       {% endif %}
 
-      {% endif %}
-
       {% if committee_groups['J'] %}
 
       <h4>Joint fundraising committees:</h4>
@@ -116,6 +112,7 @@
       </ul>
       {% endif %}
     </div>
+    {% endif %}
   </div>
 
 </section>


### PR DESCRIPTION
## Summary (required)

In candidate profile page, under About this candidate section, display committees information only when cmte_dsgn is of type P, A or J. 

- Resolves #4303

_Include a summary of proposed changes._

Display  candidate affiliated committee only when the committee designation is of type P, A or J. 
1. candidates-single.jinja 
2. about-candidate.jinja

## Impacted areas of the application
Candidate profile page/ About this candidate section

## Screenshots

### **Before the fix:**

![Screen Shot 2021-01-04 at 3 33 44 PM](https://user-images.githubusercontent.com/12799132/103584675-c538a800-4eaf-11eb-9ae7-35d381bbfd00.png)

### After the fix:
<img width="1123" alt="Screen Shot 2021-01-21 at 10 38 10 PM" src="https://user-images.githubusercontent.com/11650355/105443298-5db58300-5c39-11eb-9a52-53e14de683b1.png">


## How to test

- checkout `feature/4303-cand-profile-without-cmte`
- point local cms to `dev` api : `export  FEC_API_URL=https://fec-dev-api.app.cloud.gov` 
- start server  : `./manage.py runserver`
- copy & paste url in a browser :  `http://localhost:8000/data/candidate/P00010298/?tab=about-candidate`
- verify that under About the candidate section, committee heading shouldnt appear 
- test another candidate(cand_id=S2NM00088 ) that has a affiliated committee. committees section appear in this example : `http://localhost:8000/data/candidate/S2NM00088/?tab=about-candidate`

____
