### PR TITLE
Feature/4355 remove size of contributions

### DIFF
--- a/fec/data/templates/raising-bythenumbers.jinja
+++ b/fec/data/templates/raising-bythenumbers.jinja
@@ -24,7 +24,6 @@
     {% else %}
     <li class="side-nav__item"><span class="side-nav__link is-disabled">Where individual contributions come from</span></li>
     {% endif %}
-    <li class="side-nav__item"><span class="side-nav__link is-disabled">The size of contributions</span></li>
   </ul>
   <a class="button button--cta u-margin--top t-left-aligned button--disbursements u-full-width" href="/data/spending-bythenumbers/">Explore spending charts</a>
 </nav>

--- a/fec/data/templates/spending-bythenumbers.jinja
+++ b/fec/data/templates/spending-bythenumbers.jinja
@@ -17,7 +17,6 @@
     <li class="side-nav__item"><a class="side-nav__link" href="#spending-summary">Spending summary</a></li>
     {% endif %}
     <li class="side-nav__item"><a class="side-nav__link" href="#top-spenders">Who&apos;s spending the most</a></li>
-    <li class="side-nav__item"><span class="side-nav__link is-disabled">The size of contributions</span></li>
   </ul>
   <a class="button button--cta u-margin--top t-left-aligned button--raising u-full-width" href="/data/raising-bythenumbers/">Explore raising charts</a>
 </nav>


### PR DESCRIPTION
## Summary

- Resolves #4355 

Removing the "The Size of Contributions" menu items from Raising: By the Numbers and Spending: By the Numbers

## Impacted areas of the application

These menu item should disappear from the side nav for these two pages

## Screenshots

Top left: Raising: By the Numbers, Production
Top right: Raising: By the Numbers, local
Bottom left: Spending: By the Numbers, Production
Bottom right: Spending: By the Numbers, local
![image](https://user-images.githubusercontent.com/26720877/106324168-b511af80-6246-11eb-81ca-2c5846fcbcbd.png)

## Related PRs

None

## How to test

- Pull the branch
- `npm i`, then `npm run build`
- `./manage.py runserver`
- Check that "The Size of Contributions" is no longer in the left/side nav for [Raising: By the Numbers](http://127.0.0.1:8000/data/raising-bythenumbers/)
- Check that "The Size of Contributions" is no longer in the left/side nav for [Spending: By the Numbers](http://127.0.0.1:8000/data/spending-bythenumbers/)

____
