### PR TITLE
Add leadership PACs to about this candidate section of candidate profile pages

### DIFF
--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -64,10 +64,11 @@
       </div>
     </div>
 
-{% if committee_groups['P'] or committee_groups['A']or committee_groups['J'] %}
+    {% if committee_groups['P'] or committee_groups['A']or committee_groups['J'] or committee_groups['D']%}
     <div class="entity__figure entity__figure--narrow row" id="committees">
-        <h3 class="heading--section">Committees</h3>
-        <h4>Authorized campaign committees:</h4>
+      <h3 class="heading--section">Committees</h3>
+      {% if committee_groups['P']|length > 0 %}
+      <h4>Authorized campaign committees:</h4>
       {% for committee in committee_groups['P'] | reverse %}
       <div class='grid'>
         <div class="grid__item u-no-margin">
@@ -80,6 +81,7 @@
         </div>
       </div>
       {% endfor %}
+      {% endif %}
 
       {% if committee_groups['A']|length > 0 %}
       <div class='grid'>
@@ -93,16 +95,11 @@
           </ul>
         </div>
       </div>
-      {% endif %}
+      {% endif %}     
 
       {% if committee_groups['J'] %}
       <hr class="hr--lighter">
-      {% endif %}
-
-      {% if committee_groups['J'] %}
-
       <h4>Joint fundraising committees:</h4>
-
       <ul class="list--bulleted">
       {% for committee in committee_groups['J'] | reverse %}
         <li>
@@ -111,8 +108,23 @@
       {% endfor %}
       </ul>
       {% endif %}
+
+      {% if committee_groups['P'] and committee_groups['D'] %}
+      <hr class="hr--lighter">
+      {% endif %}
+      
+      {% if committee_groups['D'] %}    
+      <h4>Sponsored Leadership PACs:</h4>
+      <ul class="list--bulleted">
+      {% for committee in committee_groups['D'] | reverse %}
+        <li>
+          <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
+        </li>
+      {% endfor %}
+      </ul>
+      {% endif %}
+
     </div>
     {% endif %}
   </div>
-
 </section>

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -68,7 +68,7 @@
     <div class="entity__figure entity__figure--narrow row" id="committees">
       <h3 class="heading--section">Committees</h3>
       {% if committee_groups['P']|length > 0 %}
-      <h4 class="callout__title term term-inline" data-term="Authorized committee">Authorized campaign committees:</h4>
+      <h4 class="callout__title term term--inline" data-term="Authorized committee">Authorized campaign committees:</h4>
 
       {% for committee in committee_groups['P'] | reverse %}
       <div class='grid'>
@@ -100,7 +100,7 @@
 
       {% if committee_groups['J'] %}
       <hr class="hr--lighter">
-      <h4 class="callout__title term term-inline" data-term="Joint fundraising committee">Joint fundraising committees:</h4>
+      <h4 class="callout__title term term--inline" data-term="Joint fundraising committee">Joint fundraising committees:</h4>
       <ul class="list--bulleted">
       {% for committee in committee_groups['J'] | reverse %}
         <li>
@@ -115,7 +115,7 @@
       {% endif %}
       
       {% if committees_leadership_pac %}    
-      <h4 class="callout__title term term-inline" data-term="Leadership PAC">Sponsored Leadership PACs:</h4>
+      <h4 class="callout__title term term--inline" data-term="Leadership PAC">Sponsored leadership PACs:</h4>
       <ul class="list--bulleted">
       {% for committee in committees_leadership_pac | reverse %}
         <li>

--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -68,7 +68,8 @@
     <div class="entity__figure entity__figure--narrow row" id="committees">
       <h3 class="heading--section">Committees</h3>
       {% if committee_groups['P']|length > 0 %}
-      <h4>Authorized campaign committees:</h4>
+      <h4 class="callout__title term term-inline" data-term="Authorized committee">Authorized campaign committees:</h4>
+
       {% for committee in committee_groups['P'] | reverse %}
       <div class='grid'>
         <div class="grid__item u-no-margin">
@@ -99,7 +100,7 @@
 
       {% if committee_groups['J'] %}
       <hr class="hr--lighter">
-      <h4>Joint fundraising committees:</h4>
+      <h4 class="callout__title term term-inline" data-term="Joint fundraising committee">Joint fundraising committees:</h4>
       <ul class="list--bulleted">
       {% for committee in committee_groups['J'] | reverse %}
         <li>
@@ -113,10 +114,10 @@
       <hr class="hr--lighter">
       {% endif %}
       
-      {% if committee_groups['D'] %}    
-      <h4>Sponsored Leadership PACs:</h4>
+      {% if committees_leadership_pac %}    
+      <h4 class="callout__title term term-inline" data-term="Leadership PAC">Sponsored Leadership PACs:</h4>
       <ul class="list--bulleted">
-      {% for committee in committee_groups['D'] | reverse %}
+      {% for committee in committees_leadership_pac | reverse %}
         <li>
           <a class="t-sans" href="/data/committee/{{ committee.committee_id }}/?cycle={{ committee.related_cycle }}">{{ committee.name }}</a>
         </li>

--- a/fec/data/tests/test_candidate.py
+++ b/fec/data/tests/test_candidate.py
@@ -49,6 +49,14 @@ class TestCandidate(TestCase):
             "cycle": 2016,
             "committee_id": "C003",
         },
+        {
+            "designation": "D",
+            "cycles": [2016, 2014, 2012, 2018],
+            "name": "Leadership pac Committee",
+            "cycle": 2016,
+            "related_cycle": 2016,
+            "committee_id": "C004",
+        },
     ]
 
     def test_base_case(
@@ -124,6 +132,16 @@ class TestCandidate(TestCase):
                     "cycle": 2016,
                     "related_cycle": 2016,
                     "committee_id": "C003",
+                }
+            ],
+            "D": [
+                {
+                    "designation": "D",
+                    "cycles": [2016, 2014, 2012, 2018],
+                    "name": "Leadership pac Committee",
+                    "cycle": 2016,
+                    "related_cycle": 2016,
+                    "committee_id": "C004",
                 }
             ],
         }

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -208,11 +208,10 @@ def get_candidate(candidate_id, cycle, election_full):
         # remove the duplicate committees with same committees_id.
         # example api call:
         # https://fec-dev-api.app.cloud.gov/v1/candidate/P00009183/committees/history/2020/
-        length_d_committee = len(committees_d)
-        # print(length_d_committee)
+        len_d_cmte = len(committees_d)
         committees_leadership_pac.append(committees_d[0])
-        for i in range(length_d_committee):
-            if (i + 1) < length_d_committee and committees_d[i].get("committee_id") != committees_d[i + 1].get("committee_id"):
+        for i in range(len_d_cmte):
+            if (i + 1) < len_d_cmte and committees_d[i].get("committee_id") != committees_d[i + 1].get("committee_id"):
                 committees_leadership_pac.append(committees_d[i + 1])
 
     # (4) Call candidate/{candidate_id}/totals/{cycle} under tag:candidate

--- a/fec/fec/static/scss/components/_glossary.scss
+++ b/fec/fec/static/scss/components/_glossary.scss
@@ -95,6 +95,9 @@
   margin-right: 2px;
   padding-right: .9em;
 
+  &.term-inline {
+      display: inline-block;
+    }
 
   &:focus,
   &:hover {

--- a/fec/fec/static/scss/components/_glossary.scss
+++ b/fec/fec/static/scss/components/_glossary.scss
@@ -95,10 +95,6 @@
   margin-right: 2px;
   padding-right: .9em;
 
-  &.term-inline {
-      display: inline-block;
-    }
-
   &:focus,
   &:hover {
     box-shadow: 0 0 0 4px rgba($gray, .7);
@@ -111,6 +107,12 @@
 .term--p {
   margin-right: u(.5rem);
   box-shadow: none;
+}
+
+// Used when the term is in next to a heading tag or other block-level tag, makes icon inline
+.term--inline {
+  display: inline-block;
+  margin-bottom: u(1rem) !important;
 }
 
 @media print {


### PR DESCRIPTION
## Summary (required)
Add leadership PACs to the committees section in 'about this candidate' page

- Resolves #4270

## Impacted areas of the application
about this candidat section in Candidate Profile page

List general components of the application that this PR will affect:
1)Add leadership PAC to committees section
2)Add Glossary links to each of the committee subheaders

## Screenshots
<img width="462" alt="Screen Shot 2021-02-01 at 2 37 50 PM" src="https://user-images.githubusercontent.com/24395751/106509244-5ee97a00-649b-11eb-9bbc-ef281bc56559.png">

## How to test
1)checkout branch
npm run build
2)run tests:
pytest
./manage.py test
./manage.py test data.tests
3)compare some examples with prod

(1)P00009092 / 2020  (only have one dsgn=P committee)
http://127.0.0.1:8000/data/candidate/P00009092/?tab=about-candidate
https://www.fec.gov/data/candidate/P00009092/?tab=about-candidate


(2)S4AR00103 /2020 (has P, A, 2J and two leadership pac committees)
http://127.0.0.1:8000/data/candidate/S4AR00103/?tab=about-candidate&cycle=2020&election_full=true
https://www.fec.gov/data/candidate/S4AR00103/?tab=about-candidate&cycle=2020&election_full=true


(3)H0MI08042 / 2014 (only has two leadership pac committees)
http://127.0.0.1:8000/data/candidate/H0MI08042/?tab=about-candidate
https://www.fec.gov/data/candidate/H0MI08042/?tab=about-candidate


(4)P00009183 / 2020  (display only one leadership pac committee)
http://127.0.0.1:8000/data/candidate/P00009183/?tab=about-candidate&election_full=true
https://www.fec.gov/data/candidate/P00009183/?tab=about-candidate


(5)H0OH08029 / 2016(only has one leadership pac committee)
http://127.0.0.1:8000/data/candidate/H0OH08029/?tab=about-candidate
https://www.fec.gov/data/candidate/H0OH08029/?tab=about-candidate

(6)click Glossary links