### PR TITLE
Feature/3573 feature flag cleanup

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -54,11 +54,11 @@ FEATURES = {
     'ierawfilters': bool(env.get_credential('FEC_FEATURE_IE_RAW_FILTERS', '')),
 
     # Functionality
-    'adrs': bool(env.get_credential('FEC_FEATURE_ADRS', '')),
-    'afs': bool(env.get_credential('FEC_FEATURE_AFS', '')),
     'website_status': bool(env.get_credential('FEC_FEATURE_WEBSITE_STATUS', '')),
 
     # Feature flags (hiding or displaying components)
+    'adrs': bool(env.get_credential('FEC_FEATURE_ADRS', '')),
+    'afs': bool(env.get_credential('FEC_FEATURE_AFS', '')),  # Admin fines search
     'aggregatetotals': bool(env.get_credential('FEC_FEATURE_AGGR_TOTS', '')),
     'barcharts': bool(env.get_credential('FEC_FEATURE_HOME_BARCHARTS', '')),
     'contributionsbystate': bool(env.get_credential('FEC_FEATURE_CONTRIBUTIONS_BY_STATE', '')),
@@ -69,6 +69,8 @@ FEATURES = {
 
 # Set feature flags to True for local
 if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:
+    FEATURES['adrs'] = True
+    FEATURES['afs'] = True
     FEATURES['aggregatetotals'] = True
     FEATURES['barcharts'] = True
     FEATURES['contributionsbystate'] = True

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -39,22 +39,8 @@ DIGITALGOV_DRAWER_HANDLE = env.get_credential('DIGITALGOV_DRAWER_HANDLE', '')
 
 FEC_TRANSITION_URL = env.get_credential('FEC_TRANSITION_URL', 'https://transition.fec.gov')
 FEC_CLASSIC_URL = env.get_credential('FEC_CLASSIC_URL', 'http://classic.fec.gov')
+WEBMANAGER_EMAIL = "webmanager@fec.gov"
 
-FEATURES = {
-    'record': bool(env.get_credential('FEC_FEATURE_RECORD', '')),
-    'about': bool(env.get_credential('FEC_FEATURE_ABOUT', '')),
-    'agendas': bool(env.get_credential('FEC_FEATURE_AGENDAS', '')),
-    'tips': bool(env.get_credential('FEC_FEATURE_TIPS', '')),
-    'adrs': bool(env.get_credential('FEC_FEATURE_ADRS', '')),
-    'afs': bool(env.get_credential('FEC_FEATURE_AFS', '')),
-    'aggregatetotals': bool(env.get_credential('FEC_FEATURE_AGGR_TOTS', '')),
-    'map': bool(env.get_credential('FEC_FEATURE_HOME_MAP', '')),
-    'barcharts': bool(env.get_credential('FEC_FEATURE_HOME_BARCHARTS', '')),
-    'contributionsbystate': bool(env.get_credential('FEC_FEATURE_CONTRIBUTIONS_BY_STATE', '')),
-    'ierawfilters': bool(env.get_credential('FEC_FEATURE_IE_RAW_FILTERS', '')),
-    'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
-    'website_status': bool(env.get_credential('FEC_FEATURE_WEBSITE_STATUS', '')),
-}
 ENVIRONMENTS = {
     'local': 'LOCAL',
     'dev': 'DEVELOPMENT',
@@ -62,8 +48,23 @@ ENVIRONMENTS = {
     'prod': 'PRODUCTION',
     'feature': 'FEATURE',
 }
-FEC_CMS_ENVIRONMENT = ENVIRONMENTS.get(env.get_credential('FEC_CMS_ENVIRONMENT'), 'LOCAL')
-WEBMANAGER_EMAIL = "webmanager@fec.gov"
+FEC_CMS_ENVIRONMENT = ENVIRONMENTS.get(env.get_credential('FEC_CMS_ENVIRONMENT'), ENVIRONMENTS['local'])
+
+FEATURES = {
+    'ierawfilters': bool(env.get_credential('FEC_FEATURE_IE_RAW_FILTERS', '')),
+
+    # Functionality
+    'adrs': bool(env.get_credential('FEC_FEATURE_ADRS', '')),
+    'afs': bool(env.get_credential('FEC_FEATURE_AFS', '')),
+    'website_status': bool(env.get_credential('FEC_FEATURE_WEBSITE_STATUS', '')),
+
+    # Feature flags (hiding or displaying components)
+    'aggregatetotals': bool(env.get_credential('FEC_FEATURE_AGGR_TOTS', '')),
+    'barcharts': bool(env.get_credential('FEC_FEATURE_HOME_BARCHARTS', '')),
+    'contributionsbystate': bool(env.get_credential('FEC_FEATURE_CONTRIBUTIONS_BY_STATE', '')),
+    'map': bool(env.get_credential('FEC_FEATURE_HOME_MAP', '')),
+    'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
+}
 
 # Application definition
 INSTALLED_APPS = (
@@ -123,7 +124,7 @@ MIDDLEWARE = (
 )
 
 CSRF_TRUSTED_ORIGINS = ["fec.gov", "app.cloud.gov"]
-if FEC_CMS_ENVIRONMENT == 'LOCAL':
+if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:
     CSRF_TRUSTED_ORIGINS.extend(["127.0.0.1:5000"])
 
 ROOT_URLCONF = 'fec.urls'
@@ -260,8 +261,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
-if FEC_CMS_ENVIRONMENT != 'LOCAL':
+if FEC_CMS_ENVIRONMENT != ENVIRONMENTS['local']:
     AWS_QUERYSTRING_AUTH = False
     AWS_ACCESS_KEY_ID = env.get_credential('access_key_id')
     AWS_SECRET_ACCESS_KEY = env.get_credential('secret_access_key')
@@ -276,8 +276,8 @@ if FEC_CMS_ENVIRONMENT != 'LOCAL':
 UAA_CLIENT_ID = env.get_credential('CMS_LOGIN_CLIENT_ID', 'my-client-id')
 UAA_CLIENT_SECRET = env.get_credential('CMS_LOGIN_CLIENT_SECRET', 'my-client-secret')
 # fake uaa server deploys locally on port 8080.  Will be needed to login for local use
-# TODO: These will have to have a explicit reference until we can figure out how
-# to silence django warnings about the url being http (it expects https).
+# TODO: These will have to have an explicit reference until we can figure out how
+# to silence Django warnings about the url being http (it expects https).
 # UAA_AUTH_URL = env.get_credential('CMS_LOGIN_AUTH_URL', 'http://localhost:8080/oauth/authorize')
 # UAA_TOKEN_URL = env.get_credential('CMS_LOGIN_TOKEN_URL','http://localhost:8080/oauth/token')
 UAA_AUTH_URL = 'https://login.fr.cloud.gov/oauth/authorize'

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -62,6 +62,7 @@ FEATURES = {
     'aggregatetotals': bool(env.get_credential('FEC_FEATURE_AGGR_TOTS', '')),
     'barcharts': bool(env.get_credential('FEC_FEATURE_HOME_BARCHARTS', '')),
     'contributionsbystate': bool(env.get_credential('FEC_FEATURE_CONTRIBUTIONS_BY_STATE', '')),
+    'debts': bool(env.get_credential('FEC_FEATURE_DEBTS', '')),  # (until debts date ranges are clarified)
     'map': bool(env.get_credential('FEC_FEATURE_HOME_MAP', '')),
     'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
 }
@@ -71,6 +72,7 @@ if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:
     FEATURES['aggregatetotals'] = True
     FEATURES['barcharts'] = True
     FEATURES['contributionsbystate'] = True
+    FEATURES['debts'] = True
     FEATURES['map'] = True
     FEATURES['presidential_map'] = True
 

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -66,6 +66,14 @@ FEATURES = {
     'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
 }
 
+# Set feature flags to True for local
+if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:
+    FEATURES['aggregatetotals'] = True
+    FEATURES['barcharts'] = True
+    FEATURES['contributionsbystate'] = True
+    FEATURES['map'] = True
+    FEATURES['presidential_map'] = True
+
 # Application definition
 INSTALLED_APPS = (
     'django.contrib.admin',

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -62,7 +62,7 @@ FEATURES = {
     'aggregatetotals': bool(env.get_credential('FEC_FEATURE_AGGR_TOTS', '')),
     'barcharts': bool(env.get_credential('FEC_FEATURE_HOME_BARCHARTS', '')),
     'contributionsbystate': bool(env.get_credential('FEC_FEATURE_CONTRIBUTIONS_BY_STATE', '')),
-    'debts': bool(env.get_credential('FEC_FEATURE_DEBTS', '')),  # (until debts date ranges are clarified)
+    'debts': bool(env.get_credential('FEC_FEATURE_DEBTS', '')),  # TODO: debts dates
     'map': bool(env.get_credential('FEC_FEATURE_HOME_MAP', '')),
     'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
 }


### PR DESCRIPTION
## Summary

Resolves #3573 

## Reviewers
- Design/UX because of the value of defaulting to True
- Front-end, especially to make sure nothing broke around the removed vars and the flags that don't default to True (because I'm familiar with all of those)

## Impacted areas of the application

Potentially site-wide but likely only features under feature flags.
- Grouped and alphabetized FEATURES settings, hoping to facilitate future maintenance
  - **I welcome comments on the grouping**
- Removed flags that were no longer in the code, searching for `FEATURES.` `FEATURES['` and `FEATURES.get('` followed by the variable names and just the names themselves
  - about
  - agendas
  - record
  - tips
- Added a bit where certain feature flags default to true for local
- **Additionally**:
  - Had to move the ENVIRONMENTS and FEC_CMS_ENVIRONMENT definitions to before FEATURES
  - Changed a couple places where we were comparing to an independent string rather than the defined constant we'd defined in this same document (why define it if we aren't going to use it?) (`if FEC_CMS_ENVIRONMENT == 'LOCAL':` to `if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:`

## Screenshots
Homepage with no feature flags turned on
![image](https://user-images.githubusercontent.com/26720877/106515995-75480380-64a4-11eb-969f-842ef3157326.png)

Homepage with this work
![image](https://user-images.githubusercontent.com/26720877/106515914-547fae00-64a4-11eb-8804-2eb9ffbccfa3.png)


## Related PRs

List related PRs against other branches:

None

## How to test

- Pull **develop** like normal
- Optional npm, most likely unnecessary
  - `npm i`
  - `npm run build`
- Clear your current feature flag vars
  - `unset FEC_FEATURE_ABOUT`
  - `unset FEC_FEATURE_AGGR_TOTS`
  - `unset FEC_FEATURE_AGENDAS`
  - `unset FEC_FEATURE_CONTRIBUTIONS_BY_STATE`
  - `unset FEC_FEATURE_HOME_MAP`
  - `unset FEC_FEATURE_HOME_BARCHARTS`
  - `unset FEC_FEATURE_PRESIDENTIAL_MAP`
  - `unset FEC_FEATURE_RECORD`
  - `unset FEC_FEATURE_TIPS`
- `./manage.py runserver`
- Check the [homepage](http://127.0.0.1:8000/) or any page with a feature-flagged component. _None of the components should display_.
  - [Raising: by the numbers](http://127.0.0.1:8000/data/raising-bythenumbers)
  - [Spending: by the numbers](http://127.0.0.1:8000/data/spending-bythenumbers)
- Stop the server (ctrl-c)
- **Pull this branch** (feature/3573-feature-flag-cleanup)
- Shouldn't need to run the npm scripts again, but knock yourself out
- `./manage.py runserver`
- Check the feature-flagged components again. Now they should _all_ appear

If you need to re-activate any of the above flags before this work is merged, you'll need to `export set FEC_FEATURE_HOME_MAP=True` for each of them
____
