### PR TITLE
Use public calendar key for subscriptions only

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -21,7 +21,7 @@ FEC_API_URL = env.get_credential('FEC_API_URL', 'http://localhost:5000')
 FEC_API_KEY_PRIVATE = env.get_credential('FEC_WEB_API_KEY_PRIVATE')
 FEC_API_VERSION = env.get_credential('FEC_API_VERSION', 'v1')
 FEC_API_KEY_PUBLIC = env.get_credential('FEC_WEB_API_KEY_PUBLIC', '')
-FEC_API_KEY_PUBLIC_CALENDAR = env.get_credential('FEC_WEB_API_KEY_PUBLIC_CALENDAR', '')
+FEC_API_KEY_PUBLIC_CALENDAR = env.get_credential('FEC_WEB_API_KEY_PUBLIC_CALENDAR', FEC_API_KEY_PUBLIC)
 FEC_DOWNLOAD_API_KEY = env.get_credential('FEC_DOWNLOAD_API_KEY', '')
 
 FEC_RECAPTCHA_SECRET_KEY = env.get_credential('FEC_RECAPTCHA_SECRET_KEY')

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -21,7 +21,7 @@ FEC_API_URL = env.get_credential('FEC_API_URL', 'http://localhost:5000')
 FEC_API_KEY_PRIVATE = env.get_credential('FEC_WEB_API_KEY_PRIVATE')
 FEC_API_VERSION = env.get_credential('FEC_API_VERSION', 'v1')
 FEC_API_KEY_PUBLIC = env.get_credential('FEC_WEB_API_KEY_PUBLIC', '')
-FEC_API_KEY_PUBLIC_CALENDAR = env.get_credential('FEC_WEB_API_KEY_PUBLIC_CALENDAR', FEC_API_KEY_PUBLIC)
+FEC_API_KEY_PUBLIC_CALENDAR = env.get_credential('FEC_WEB_API_KEY_PUBLIC_CALENDAR', '')
 FEC_DOWNLOAD_API_KEY = env.get_credential('FEC_DOWNLOAD_API_KEY', '')
 
 FEC_RECAPTCHA_SECRET_KEY = env.get_credential('FEC_RECAPTCHA_SECRET_KEY')

--- a/fec/fec/static/js/modules/calendar-helpers.js
+++ b/fec/fec/static/js/modules/calendar-helpers.js
@@ -29,9 +29,9 @@ function getGoogleUrl(event) {
 }
 
 function getUrl(path, params, type) {
+  //if 'type' arg is present and set to 'sub', use API_KEY_PUBLIC_CALENDAR as api_key, otherwise use API_KEY_PUBLIC;
   var apiKey =
     type == 'sub' ? window.API_KEY_PUBLIC_CALENDAR : window.API_KEY_PUBLIC;
-  //if (type == "cal") {
   var url = URI(window.API_LOCATION)
     .path(Array.prototype.concat(window.API_VERSION, path || [], '').join('/'))
     .addQuery({

--- a/fec/fec/static/js/modules/calendar-helpers.js
+++ b/fec/fec/static/js/modules/calendar-helpers.js
@@ -28,20 +28,20 @@ function getGoogleUrl(event) {
     .toString();
 }
 
-function getUrl(path, params) {
+function getUrl(path, params, type) {
+  var apiKey =
+    type == 'sub' ? window.API_KEY_PUBLIC_CALENDAR : window.API_KEY_PUBLIC;
+  //if (type == "cal") {
   var url = URI(window.API_LOCATION)
     .path(Array.prototype.concat(window.API_VERSION, path || [], '').join('/'))
     .addQuery({
-      api_key: window.API_KEY_PUBLIC_CALENDAR,
+      api_key: apiKey,
       per_page: 500
     })
     .addQuery(params || {})
     .toString();
-
-  // Decode in order to preserve + signs
   return URI.decode(url);
 }
-
 function className(event) {
   var start = event.start_date ? moment(event.start_date).format('M D') : null;
   var end = event.end_date ? moment(event.end_date).format('M D') : null;

--- a/fec/fec/static/js/modules/calendar.js
+++ b/fec/fec/static/js/modules/calendar.js
@@ -189,7 +189,7 @@ Calendar.prototype.success = function(response) {
     };
     _.extend(processed, {
       google: calendarHelpers.getGoogleUrl(processed),
-      download: self.exportUrl
+      download: self.subscribeUrl
         .clone()
         .addQuery({ event_id: event.event_id })
         .toString()

--- a/fec/fec/static/js/modules/calendar.js
+++ b/fec/fec/static/js/modules/calendar.js
@@ -47,6 +47,7 @@ function Calendar(opts) {
   this.$head = $('.data-container__head');
   this.$calendar.fullCalendar(this.opts.calendarOpts);
   this.url = URI(this.opts.url);
+  this.subscribeUrl = URI(this.opts.subscribeUrl);
   this.exportUrl = URI(this.opts.exportUrl);
   this.filterPanel = this.opts.filterPanel;
   this.filterSet = this.filterPanel.filterSet;
@@ -199,6 +200,7 @@ Calendar.prototype.success = function(response) {
 
 Calendar.prototype.updateLinks = function(params) {
   var url = this.exportUrl.clone().addQuery(params || {});
+  var subscribeURL = this.subscribeUrl.clone().addQuery(params || {});
   var urls = {
     ics: url.toString(),
     csv: url
@@ -215,7 +217,17 @@ Calendar.prototype.updateLinks = function(params) {
           .protocol('http')
           .toString()
       ),
-    calendar: url.protocol('webcal').toString()
+    calendar: url.protocol('webcal').toString(),
+
+    googleSubscribe:
+      'https://calendar.google.com/calendar/render?cid=' +
+      encodeURIComponent(
+        subscribeURL
+          .clone()
+          .protocol('http')
+          .toString()
+      ),
+    calendarSubscribe: subscribeURL.protocol('webcal').toString()
   };
   this.$download.html(templates.download(urls));
   this.$subscribe.html(templates.subscribe(urls));

--- a/fec/fec/static/js/pages/calendar-page.js
+++ b/fec/fec/static/js/pages/calendar-page.js
@@ -23,6 +23,12 @@ new Calendar({
   download: '#calendar-download',
   subscribe: '#calendar-subscribe',
   url: calendarHelpers.getUrl(['calendar-dates']),
-  exportUrl: calendarHelpers.getUrl(['calendar-dates', 'export']),
+  exportUrl: calendarHelpers.getUrl(['calendar-dates', 'export'], [], ['cal']),
+  subscribeUrl: calendarHelpers.getUrl(
+    ['calendar-dates', 'export'],
+    [],
+    ['sub']
+  ),
   filterPanel: filterPanel
 });
+

--- a/fec/fec/static/js/pages/calendar-page.js
+++ b/fec/fec/static/js/pages/calendar-page.js
@@ -23,11 +23,9 @@ new Calendar({
   download: '#calendar-download',
   subscribe: '#calendar-subscribe',
   url: calendarHelpers.getUrl(['calendar-dates']),
-  exportUrl: calendarHelpers.getUrl(['calendar-dates', 'export'], [], ['cal']),
-  subscribeUrl: calendarHelpers.getUrl(
-    ['calendar-dates', 'export'],
-    [],
-    ['sub']
-  ),
+  exportUrl: calendarHelpers.getUrl(['calendar-dates', 'export']),
+  subscribeUrl: calendarHelpers.getUrl(['calendar-dates', 'export'], '', [
+    'sub'
+  ]),
   filterPanel: filterPanel
 });

--- a/fec/fec/static/js/pages/calendar-page.js
+++ b/fec/fec/static/js/pages/calendar-page.js
@@ -31,4 +31,3 @@ new Calendar({
   ),
   filterPanel: filterPanel
 });
-

--- a/fec/fec/static/js/templates/calendar/subscribe.hbs
+++ b/fec/fec/static/js/templates/calendar/subscribe.hbs
@@ -1,8 +1,9 @@
 <div class="dropdown">
   <button class="button button--standard dropdown__button button--subscribe">Subscribe</button>
   <ul class="dropdown__panel dropdown__panel--right" aria-hidden="true">
-    <li class="dropdown__item"><a class="dropdown__value" href="{{calendar}}">Apple calendar</a></li>
-    <li class="dropdown__item"><a class="dropdown__value" href="{{google}}">Google calendar</a></li>
-    <li class="dropdown__item"><a class="dropdown__value" href="{{calendar}}">Microsoft Outlook calendar</a></li>
+    <li class="dropdown__item"><a class="dropdown__value" href="{{calendarSubscribe}}">Apple calendar</a></li>
+    <li class="dropdown__item"><a class="dropdown__value" href="{{googleSubscribe}}">Google calendar</a></li>
+    <li class="dropdown__item"><a class="dropdown__value" href="{{calendarSubscribe}}">Microsoft Outlook calendar</a></li>
   </ul>
 </div>
+

--- a/fec/fec/tests/js/calendar.js
+++ b/fec/fec/tests/js/calendar.js
@@ -295,7 +295,7 @@ describe('helpers', function() {
   });
 
   describe('calendar.updateLinks()', function() {
-      it('builds the correct, encoded googlerSubscribe url', function() {
+      it('builds the correct, encoded googleSubscribe url', function() {
       var subscribeUrl = calendarHelpers.getUrl('calendar-dates/export', {category: 'election'}, 'sub').toString();
        var googleSubscribe =
       'https://calendar.google.com/calendar/render?cid=' + 

--- a/fec/fec/tests/js/calendar.js
+++ b/fec/fec/tests/js/calendar.js
@@ -1,305 +1,313 @@
-// 'use strict';
+'use strict';
 
-// var chai = require('chai');
-// var sinon = require('sinon');
-// var sinonChai = require('sinon-chai');
-// var expect = chai.expect;
-// chai.use(sinonChai);
+var chai = require('chai');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+var expect = chai.expect;
+chai.use(sinonChai);
 
-// var $ = require('jquery');
-// var moment = require('moment');
+var $ = require('jquery');
+var moment = require('moment');
 
-// require('./setup')();
+require('./setup')();
 
-// var helpers = require('../../static/js/modules/helpers');
-// var Calendar = require('../../static/js/modules/calendar').Calendar;
-// var calendarTooltip = require('../../static/js/modules/calendar-tooltip');
-// var calendarHelpers = require('../../static/js/modules/calendar-helpers');
+var helpers = require('../../static/js/modules/helpers');
+var Calendar = require('../../static/js/modules/calendar').Calendar;
+var calendarTooltip = require('../../static/js/modules/calendar-tooltip');
+var calendarHelpers = require('../../static/js/modules/calendar-helpers');
 
-// var tooltipContent = require('../../static/js/templates/calendar/details.hbs');
+var tooltipContent = require('../../static/js/templates/calendar/details.hbs');
 
-// describe('calendar', function() {
-//   before(function() {
-//     this.$fixture = $('<div id="fixtures"></div>');
-//     $('body').append(this.$fixture);
-//   });
+describe('calendar', function() {
+  before(function() {
+    this.$fixture = $('<div id="fixtures"></div>');
+    $('body').append(this.$fixture);
+  });
 
-//   before(function() {
-//     this.server = sinon.fakeServer.create();
-//   });
+  before(function() {
+    this.server = sinon.fakeServer.create();
+  });
 
-//   after(function() {
-//     this.server.restore();
-//   });
+  after(function() {
+    this.server.restore();
+  });
 
-//   beforeEach(function() {
-//     this.$fixture.empty().append(
-//       '<div id="calendar"></div>' +
-//       '<div id="download"></div>' +
-//       '<div id="subscribe"></div>'
-//     );
-//     this.calendar = new Calendar({
-//       selector: '#calendar',
-//       download: '#download',
-//       subscribe: '#subscribe',
-//       url: 'http://test.calendar',
-//       exportUrl: 'http://test.calendar/export',
-//       filterPanel: {
-//         $form: {on: function() {}},
-//         filterSet: {
-//           serialize: function() {},
-//           fields: {}
-//         }
-//       }
-//     });
-//     this.server.respond();
-//   });
+  beforeEach(function() {
+    this.$fixture.empty().append(
+      '<div id="calendar"></div>' +
+      '<div id="download"></div>' +
+      '<div id="subscribe"></div>'
+    );
+    this.calendar = new Calendar({
+      selector: '#calendar',
+      download: '#download',
+      subscribe: '#subscribe',
+      url: 'http://test.calendar',
+      exportUrl: 'http://test.calendar/export',
+      subscribeUrl: 'http://test.calendar/export',
+      filterPanel: {
+        $form: {on: function() {}},
+        filterSet: {
+          serialize: function() {},
+          fields: {}
+        }
+      }
+    });
+    this.server.respond();
+  });
 
-//   beforeEach(function() {
-//     $(document.body).width(helpers.BREAKPOINTS.MEDIUM);
-//   });
+  beforeEach(function() {
+    $(document.body).width(helpers.BREAKPOINTS.MEDIUM);
+  });
 
-//   describe('constructor()', function() {
-//     it('memorizes options', function() {
-//       expect(this.calendar.opts.url).to.equal('http://test.calendar');
-//       expect(this.calendar.opts.exportUrl).to.equal('http://test.calendar/export');
-//     });
+  describe('constructor()', function() {
+    it('memorizes options', function() {
+      expect(this.calendar.opts.url).to.equal('http://test.calendar');
+      expect(this.calendar.opts.exportUrl).to.equal('http://test.calendar/export');
+    });
 
-//     it('finds dom nodes', function() {
-//       expect(this.calendar.$download.is($('#download'))).to.be.true;
-//       expect(this.calendar.$subscribe.is($('#subscribe'))).to.be.true;
-//     });
+    it('finds dom nodes', function() {
+      expect(this.calendar.$download.is($('#download'))).to.be.true;
+      expect(this.calendar.$subscribe.is($('#subscribe'))).to.be.true;
+    });
 
-//     it('initializes a fullCalendar', function() {
-//       expect(moment.isMoment(this.calendar.$calendar.fullCalendar('getDate'))).to.be.true;
-//     });
+    it('initializes a fullCalendar', function() {
+      expect(moment.isMoment(this.calendar.$calendar.fullCalendar('getDate'))).to.be.true;
+    });
 
-//     it('styles the buttons', function() {
-//       expect(this.calendar.$calendar.find('.button button--alt')).to.exist;
-//     });
-//   });
+    it('styles the buttons', function() {
+      expect(this.calendar.$calendar.find('.button button--alt')).to.exist;
+    });
+  });
 
-//   describe('filter()', function() {
-//     before(function() {
-//       this.response = {
-//         results: [
-//           {
-//             category: 'election',
-//             title: 'the big one',
-//             start_date: moment().format()
-//           }
-//         ]
-//       };
-//       this.server.respondWith(
-//         [200, {'Content-Type': 'application/json'}, JSON.stringify(this.response)]
-//       );
-//     });
+  describe('filter()', function() {
+    before(function() {
+      this.response = {
+        results: [
+          {
+            category: 'election',
+            title: 'the big one',
+            start_date: moment().format()
+          }
+        ]
+      };
+      this.server.respondWith(
+        [200, {'Content-Type': 'application/json'}, JSON.stringify(this.response)]
+      );
+    });
 
-//     beforeEach(function() {
-//       sinon.stub(this.calendar.filterSet, 'serialize');
-//       this.calendar.filterSet.serialize.returns({category: ['election-P']});
-//     });
+    beforeEach(function() {
+      sinon.stub(this.calendar.filterSet, 'serialize');
+      this.calendar.filterSet.serialize.returns({category: ['election-P']});
+    });
 
-//     afterEach(function() {
-//       this.calendar.filterSet.serialize.restore();
-//     });
+    afterEach(function() {
+      this.calendar.filterSet.serialize.restore();
+    });
 
-//     it('fetches events', function() {
-//       this.calendar.params = null;
-//       this.calendar.filter();
-//       this.server.respond();
-//       expect(this.calendar.filterSet.serialize).to.have.been.called;
-//       expect(this.calendar.params).to.deep.equal(this.calendar.filterSet.serialize());
-//       var events = this.calendar.$calendar.fullCalendar('getEvents');
-//       expect(events.length).to.equal(1);
-//     });
-//   });
+    it('fetches events', function() {
+      this.calendar.params = null;
+      this.calendar.filter();
+      this.server.respond();
+      expect(this.calendar.filterSet.serialize).to.have.been.called;
+      expect(this.calendar.params).to.deep.equal(this.calendar.filterSet.serialize());
+      var events = this.calendar.$calendar.fullCalendar('getEvents');
+      expect(events.length).to.equal(1);
+    });
+  });
 
-//   describe('handleRender()', function() {
-//     it('triggers a render event', function() {
-//       var callback = sinon.stub();
-//       $(document.body).on('calendar:rendered', callback);
-//       this.calendar.handleRender({name: 'month'});
-//       expect(callback).to.have.been.called;
-//     });
+  describe('handleRender()', function() {
+    it('triggers a render event', function() {
+      var callback = sinon.stub();
+      $(document.body).on('calendar:rendered', callback);
+      this.calendar.handleRender({name: 'month'});
+      expect(callback).to.have.been.called;
+    });
 
-//     it('calls manageListToggles() on list views', function() {
-//       sinon.stub(this.calendar, 'manageListToggles');
-//       this.calendar.handleRender({name: 'monthTime'});
-//       expect(this.calendar.manageListToggles).to.have.been.called;
-//       this.calendar.manageListToggles.restore();
-//     });
+    it('calls manageListToggles() on list views', function() {
+      sinon.stub(this.calendar, 'manageListToggles');
+      this.calendar.handleRender({name: 'monthTime'});
+      expect(this.calendar.manageListToggles).to.have.been.called;
+      this.calendar.manageListToggles.restore();
+    });
 
-//     it('does not call manageListToggles() toggles on grid view', function() {
-//       sinon.stub(this.calendar, 'manageListToggles');
-//       this.calendar.handleRender({name: 'month'});
-//       expect(this.calendar.manageListToggles).to.not.have.been.called;
-//       this.calendar.manageListToggles.restore();
-//     });
+    it('does not call manageListToggles() toggles on grid view', function() {
+      sinon.stub(this.calendar, 'manageListToggles');
+      this.calendar.handleRender({name: 'month'});
+      expect(this.calendar.manageListToggles).to.not.have.been.called;
+      this.calendar.manageListToggles.restore();
+    });
 
-//     it('removes list toggles on grid view', function() {
-//       this.calendar.handleRender({name: 'monthTime'});
-//       this.calendar.handleRender({name: 'month'});
-//       expect($('.cal-list__toggles').length).to.equal(0);
-//       expect(this.calendar.$listToggles).to.not.exist;
-//     });
-//   });
+    it('removes list toggles on grid view', function() {
+      this.calendar.handleRender({name: 'monthTime'});
+      this.calendar.handleRender({name: 'month'});
+      expect($('.cal-list__toggles').length).to.equal(0);
+      expect(this.calendar.$listToggles).to.not.exist;
+    });
+  });
 
-//   describe('manageListToggles()', function() {
-//     it('adds them to the dom if they do not exist', function() {
-//       this.calendar.manageListToggles({name: 'monthTime'});
-//       expect(this.calendar.$calendar.find('.cal-list__toggles')).to.exist;
-//     });
+  describe('manageListToggles()', function() {
+    it('adds them to the dom if they do not exist', function() {
+      this.calendar.manageListToggles({name: 'monthTime'});
+      expect(this.calendar.$calendar.find('.cal-list__toggles')).to.exist;
+    });
 
-//     it('highlights the active button', function() {
-//       var opts = {
-//         duration: 'month',
-//         sortBy: 'time'
-//       };
-//       this.calendar.manageListToggles({name: 'monthTime', options: opts});
-//       var $monthToggle = this.calendar.$calendar.find('button[data-trigger-view="monthTime"]');
-//       expect($monthToggle.hasClass('is-active')).to.exist;
-//     });
+    it('highlights the active button', function() {
+      var opts = {
+        duration: 'month',
+        sortBy: 'time'
+      };
+      this.calendar.manageListToggles({name: 'monthTime', options: opts});
+      var $monthToggle = this.calendar.$calendar.find('button[data-trigger-view="monthTime"]');
+      expect($monthToggle.hasClass('is-active')).to.exist;
+    });
 
-//     it('highlights the list toggle', function() {
-//       this.calendar.manageListToggles({name: 'monthCategory'});
-//       var $listToggle = this.calendar.$calendar.find('.fc-monthTime-button');
-//       expect($listToggle.hasClass('fc-state-active')).to.be.true;
-//     });
-//   });
+    it('highlights the list toggle', function() {
+      this.calendar.manageListToggles({name: 'monthCategory'});
+      var $listToggle = this.calendar.$calendar.find('.fc-monthTime-button');
+      expect($listToggle.hasClass('fc-state-active')).to.be.true;
+    });
+  });
 
-//   describe('handleEventRender()', function() {
-//     it('Applies the correct attributes', function() {
-//       var event = {
-//         category: 'election',
-//         title: 'the big one',
-//         start: moment('2012-11-02')
-//       };
-//       var element = $('<a>Event</a>');
-//       var eventLabel = 'the big one Friday November 2, 2012. Category: election';
-//       this.calendar.handleEventRender(event, element);
-//       expect(element.attr('tabindex')).to.equal('0');
-//       expect(element.attr('aria-describedby')).to.equal(this.calendar.detailsId);
-//       expect(element.attr('aria-label')).to.equal(eventLabel);
-//     });
-//   });
+  describe('handleEventRender()', function() {
+    it('Applies the correct attributes', function() {
+      var event = {
+        category: 'election',
+        title: 'the big one',
+        start: moment('2012-11-02')
+      };
+      var element = $('<a>Event</a>');
+      var eventLabel = 'the big one Friday November 2, 2012. Category: election';
+      this.calendar.handleEventRender(event, element);
+      expect(element.attr('tabindex')).to.equal('0');
+      expect(element.attr('aria-describedby')).to.equal(this.calendar.detailsId);
+      expect(element.attr('aria-label')).to.equal(eventLabel);
+    });
+  });
 
-//   describe('handleDayRender()', function() {
-//     it('Adds the month name to the first of the month', function() {
-//       var cell = $('<td></td>');
-//       this.calendar.handleDayRender(moment('2016-01-01'), cell);
-//       expect(cell.html()).to.equal('January');
-//     });
-//   });
+  describe('handleDayRender()', function() {
+    it('Adds the month name to the first of the month', function() {
+      var cell = $('<td></td>');
+      this.calendar.handleDayRender(moment('2016-01-01'), cell);
+      expect(cell.html()).to.equal('January');
+    });
+  });
 
-//   describe('handleEventClick()', function() {
-//     beforeEach(function() {
-//       sinon.stub(calendarTooltip, 'CalendarTooltip');
-//     });
+  describe('handleEventClick()', function() {
+    beforeEach(function() {
+      sinon.stub(calendarTooltip, 'CalendarTooltip');
+    });
 
-//     afterEach(function() {
-//       calendarTooltip.CalendarTooltip.restore();
-//     });
+    afterEach(function() {
+      calendarTooltip.CalendarTooltip.restore();
+    });
 
-//     it('makes a new tooltip if there is none', function() {
-//       var target = '<a><span class="fc-content"></span></a>';
-//       this.calendar.handleEventClick({}, {target: target});
-//       expect(calendarTooltip.CalendarTooltip).to.have.been.called;
-//     });
+    it('makes a new tooltip if there is none', function() {
+      var target = '<a><span class="fc-content"></span></a>';
+      this.calendar.handleEventClick({}, {target: target});
+      expect(calendarTooltip.CalendarTooltip).to.have.been.called;
+    });
 
-//     it('does not make a tooltip if there is one', function() {
-//       var target = '<a><span class="fc-content"></span></a><div class="tooltip"></div>';
-//       this.calendar.handleEventClick({}, {target: target});
-//       expect(calendarTooltip.CalendarTooltip).to.not.have.been.called;
-//     });
-//   });
+    it('does not make a tooltip if there is one', function() {
+      var target = '<a><span class="fc-content"></span></a><div class="tooltip"></div>';
+      this.calendar.handleEventClick({}, {target: target});
+      expect(calendarTooltip.CalendarTooltip).to.not.have.been.called;
+    });
+  });
 
-//   describe('managePopoverControl()', function() {
-//     it('adds the correct attributes to the popover', function() {
-//       var $popover = $('<div class="fc-popover"><span class="fc-close"></span></div>');
-//       this.calendar.$calendar.append($popover);
-//       this.calendar.managePopoverControl({target: '<a></a>'});
-//       expect($popover.attr('role')).to.equal('tooltip');
-//       expect($popover.attr('id')).to.equal(this.calendar.popoverId);
-//       expect($popover.find('.fc-close').attr('tabindex')).to.equal('0');
-//       expect(document.activeElement.classList[0]).to.equal('fc-close');
-//     });
-//   });
-// });
+  describe('managePopoverControl()', function() {
+    it('adds the correct attributes to the popover', function() {
+      var $popover = $('<div class="fc-popover"><span class="fc-close"></span></div>');
+      this.calendar.$calendar.append($popover);
+      this.calendar.managePopoverControl({target: '<a></a>'});
+      expect($popover.attr('role')).to.equal('tooltip');
+      expect($popover.attr('id')).to.equal(this.calendar.popoverId);
+      expect($popover.find('.fc-close').attr('tabindex')).to.equal('0');
+      expect(document.activeElement.classList[0]).to.equal('fc-close');
+    });
+  });
+});
 
-// describe('calendar tooltip', function() {
-//   beforeEach(function() {
-//     var dom =
-//     '<div class="fc-event-container">' +
-//       '<a class="cal-event" tabindex="0"></a>' +
-//     '</div>';
-//     $(document.body).append($(dom));
-//     var $container = $('.cal-event');
-//     var content = tooltipContent({});
-//     this.calendarTooltip = new calendarTooltip.CalendarTooltip(content, $container);
-//     $container.append(this.calendarTooltip.$content);
-//   });
+describe('calendar tooltip', function() {
+  beforeEach(function() {
+    var dom =
+    '<div class="fc-event-container">' +
+      '<a class="cal-event" tabindex="0"></a>' +
+    '</div>';
+    $(document.body).append($(dom));
+    var $container = $('.cal-event');
+    var content = tooltipContent({});
+    this.calendarTooltip = new calendarTooltip.CalendarTooltip(content, $container);
+    $container.append(this.calendarTooltip.$content);
+  });
 
-//   afterEach(function() {
-//     this.calendarTooltip.close();
-//     $('.cal-event').remove();
-//   });
+  afterEach(function() {
+    this.calendarTooltip.close();
+    $('.cal-event').remove();
+  });
 
-//   it('closes on click away', function() {
-//     $(document.body).click();
-//     expect($('.cal-details').length).to.equal(0);
-//   });
+  it('closes on click away', function() {
+    $(document.body).click();
+    expect($('.cal-details').length).to.equal(0);
+  });
 
-//   it('stays open if you click inside it', function() {
-//     this.calendarTooltip.$content.find('a').click();
-//     expect($('.cal-details').length).to.equal(1);
-//   });
+  it('stays open if you click inside it', function() {
+    this.calendarTooltip.$content.find('a').click();
+    expect($('.cal-details').length).to.equal(1);
+  });
 
-//   it('closes on clicking the close button', function() {
-//     this.calendarTooltip.$content.find('.js-close').click();
-//     expect($('.cal-details').length).to.equal(0);
-//   });
+  it('closes on clicking the close button', function() {
+    this.calendarTooltip.$content.find('.js-close').click();
+    expect($('.cal-details').length).to.equal(0);
+  });
 
-//   it('focuses on the trigger on close', function() {
-//     this.calendarTooltip.close();
-//     expect($(document.activeElement).hasClass('cal-event')).to.be.true;
-//   });
-// });
+  it('focuses on the trigger on close', function() {
+    this.calendarTooltip.close();
+    expect($(document.activeElement).hasClass('cal-event')).to.be.true;
+  });
+});
 
-// describe('helpers', function() {
-//   describe('calendarHelpers.getGoogleurl()', function() {
-//     it('builds the correct Google url', function() {
-//       var googleUrl = calendarHelpers.getGoogleUrl({
-//         title: 'the big one',
-//         summary: 'vote today',
-//         end: moment('2016-11-01'),
-//         start: moment('2016-11-02')
-//       });
-//       expect(googleUrl).to.equal('https://calendar.google.com/calendar/render?action=TEMPLATE&text=the+big+one&details=vote+today&dates=20161102T000000%2F20161101T000000');
-//     });
-//   });
+describe('helpers', function() {
+  describe('calendarHelpers.getGoogleurl()', function() {
+    it('builds the correct Google url', function() {
+      var googleUrl = calendarHelpers.getGoogleUrl({
+        title: 'the big one',
+        summary: 'vote today',
+        end: moment('2016-11-01'),
+        start: moment('2016-11-02')
+      });
+      expect(googleUrl).to.equal('https://calendar.google.com/calendar/render?action=TEMPLATE&text=the+big+one&details=vote+today&dates=20161102T000000%2F20161101T000000');
+    });
+  });
 
-//   describe('calendarHelpers.getUrl()', function() {
-//     it('builds the correct url', function() {
-//       var url = calendarHelpers.getUrl('calendar', {category: 'election'});
-//       expect(url).to.equal('/v1/calendar/?api_key=67890&per_page=500&category=election');
-//     });
-//   });
+  describe('calendarHelpers.getUrl()', function() {
+    it('builds the correct url', function() {
+      var url = calendarHelpers.getUrl('calendar', {category: 'election'});
+      expect(url).to.equal('/v1/calendar/?api_key=12345&per_page=500&category=election');
+    });
 
-//   describe('calendarHelpers.className()', function() {
-//     it('adds a multi-day class for multi-day events', function() {
-//       var multiEvent = {
-//         start_date: moment('2012-11-02'),
-//         end_date: moment('2012-11-03')
-//       };
-//       var singleEvent = {
-//         start_date: moment('2012-11-02'),
-//         end_date: moment('2012-11-02')
-//       };
-//       var multiDayClass = calendarHelpers.className(multiEvent);
-//       var singleDayClass = calendarHelpers.className(singleEvent);
-//       expect(multiDayClass).to.equal('fc-multi-day');
-//       expect(singleDayClass).to.not.equal('fc-multi-day');
-//     });
-//   });
-// });
+    it('builds the correct subscribe url', function() {
+      var subscribeUrl = calendarHelpers.getUrl('calendar', {category: 'election'}, 'sub');
+      expect(subscribeUrl).to.equal('/v1/calendar/?api_key=67890&per_page=500&category=election');
+    
+    });
+
+  });
+
+  describe('calendarHelpers.className()', function() {
+    it('adds a multi-day class for multi-day events', function() {
+      var multiEvent = {
+        start_date: moment('2012-11-02'),
+        end_date: moment('2012-11-03')
+      };
+      var singleEvent = {
+        start_date: moment('2012-11-02'),
+        end_date: moment('2012-11-02')
+      };
+      var multiDayClass = calendarHelpers.className(multiEvent);
+      var singleDayClass = calendarHelpers.className(singleEvent);
+      expect(multiDayClass).to.equal('fc-multi-day');
+      expect(singleDayClass).to.not.equal('fc-multi-day');
+    });
+  });
+});

--- a/fec/fec/tests/js/calendar.js
+++ b/fec/fec/tests/js/calendar.js
@@ -294,6 +294,19 @@ describe('helpers', function() {
 
   });
 
+  describe('calendar.updateLinks()', function() {
+      it('builds the correct, decooded googlerSubscribe url', function() {
+      var subscribeUrl = calendarHelpers.getUrl('calendar-dates/export', {category: 'election'}, 'sub').toString();
+       var googleSubscribe =
+      'https://calendar.google.com/calendar/render?cid=' + 
+      encodeURIComponent(
+        subscribeUrl
+          .toString()
+      );  
+      expect(googleSubscribe).to.equal('https://calendar.google.com/calendar/render?cid=%2Fv1%2Fcalendar-dates%2Fexport%2F%3Fapi_key%3D67890%26per_page%3D500%26category%3Delection')
+     });
+   });
+
   describe('calendarHelpers.className()', function() {
     it('adds a multi-day class for multi-day events', function() {
       var multiEvent = {

--- a/fec/fec/tests/js/calendar.js
+++ b/fec/fec/tests/js/calendar.js
@@ -295,7 +295,7 @@ describe('helpers', function() {
   });
 
   describe('calendar.updateLinks()', function() {
-      it('builds the correct, decooded googlerSubscribe url', function() {
+      it('builds the correct, encoded googlerSubscribe url', function() {
       var subscribeUrl = calendarHelpers.getUrl('calendar-dates/export', {category: 'election'}, 'sub').toString();
        var googleSubscribe =
       'https://calendar.google.com/calendar/render?cid=' + 

--- a/fec/fec/tests/js/calendar.js
+++ b/fec/fec/tests/js/calendar.js
@@ -1,305 +1,305 @@
-'use strict';
+// 'use strict';
 
-var chai = require('chai');
-var sinon = require('sinon');
-var sinonChai = require('sinon-chai');
-var expect = chai.expect;
-chai.use(sinonChai);
+// var chai = require('chai');
+// var sinon = require('sinon');
+// var sinonChai = require('sinon-chai');
+// var expect = chai.expect;
+// chai.use(sinonChai);
 
-var $ = require('jquery');
-var moment = require('moment');
+// var $ = require('jquery');
+// var moment = require('moment');
 
-require('./setup')();
+// require('./setup')();
 
-var helpers = require('../../static/js/modules/helpers');
-var Calendar = require('../../static/js/modules/calendar').Calendar;
-var calendarTooltip = require('../../static/js/modules/calendar-tooltip');
-var calendarHelpers = require('../../static/js/modules/calendar-helpers');
+// var helpers = require('../../static/js/modules/helpers');
+// var Calendar = require('../../static/js/modules/calendar').Calendar;
+// var calendarTooltip = require('../../static/js/modules/calendar-tooltip');
+// var calendarHelpers = require('../../static/js/modules/calendar-helpers');
 
-var tooltipContent = require('../../static/js/templates/calendar/details.hbs');
+// var tooltipContent = require('../../static/js/templates/calendar/details.hbs');
 
-describe('calendar', function() {
-  before(function() {
-    this.$fixture = $('<div id="fixtures"></div>');
-    $('body').append(this.$fixture);
-  });
+// describe('calendar', function() {
+//   before(function() {
+//     this.$fixture = $('<div id="fixtures"></div>');
+//     $('body').append(this.$fixture);
+//   });
 
-  before(function() {
-    this.server = sinon.fakeServer.create();
-  });
+//   before(function() {
+//     this.server = sinon.fakeServer.create();
+//   });
 
-  after(function() {
-    this.server.restore();
-  });
+//   after(function() {
+//     this.server.restore();
+//   });
 
-  beforeEach(function() {
-    this.$fixture.empty().append(
-      '<div id="calendar"></div>' +
-      '<div id="download"></div>' +
-      '<div id="subscribe"></div>'
-    );
-    this.calendar = new Calendar({
-      selector: '#calendar',
-      download: '#download',
-      subscribe: '#subscribe',
-      url: 'http://test.calendar',
-      exportUrl: 'http://test.calendar/export',
-      filterPanel: {
-        $form: {on: function() {}},
-        filterSet: {
-          serialize: function() {},
-          fields: {}
-        }
-      }
-    });
-    this.server.respond();
-  });
+//   beforeEach(function() {
+//     this.$fixture.empty().append(
+//       '<div id="calendar"></div>' +
+//       '<div id="download"></div>' +
+//       '<div id="subscribe"></div>'
+//     );
+//     this.calendar = new Calendar({
+//       selector: '#calendar',
+//       download: '#download',
+//       subscribe: '#subscribe',
+//       url: 'http://test.calendar',
+//       exportUrl: 'http://test.calendar/export',
+//       filterPanel: {
+//         $form: {on: function() {}},
+//         filterSet: {
+//           serialize: function() {},
+//           fields: {}
+//         }
+//       }
+//     });
+//     this.server.respond();
+//   });
 
-  beforeEach(function() {
-    $(document.body).width(helpers.BREAKPOINTS.MEDIUM);
-  });
+//   beforeEach(function() {
+//     $(document.body).width(helpers.BREAKPOINTS.MEDIUM);
+//   });
 
-  describe('constructor()', function() {
-    it('memorizes options', function() {
-      expect(this.calendar.opts.url).to.equal('http://test.calendar');
-      expect(this.calendar.opts.exportUrl).to.equal('http://test.calendar/export');
-    });
+//   describe('constructor()', function() {
+//     it('memorizes options', function() {
+//       expect(this.calendar.opts.url).to.equal('http://test.calendar');
+//       expect(this.calendar.opts.exportUrl).to.equal('http://test.calendar/export');
+//     });
 
-    it('finds dom nodes', function() {
-      expect(this.calendar.$download.is($('#download'))).to.be.true;
-      expect(this.calendar.$subscribe.is($('#subscribe'))).to.be.true;
-    });
+//     it('finds dom nodes', function() {
+//       expect(this.calendar.$download.is($('#download'))).to.be.true;
+//       expect(this.calendar.$subscribe.is($('#subscribe'))).to.be.true;
+//     });
 
-    it('initializes a fullCalendar', function() {
-      expect(moment.isMoment(this.calendar.$calendar.fullCalendar('getDate'))).to.be.true;
-    });
+//     it('initializes a fullCalendar', function() {
+//       expect(moment.isMoment(this.calendar.$calendar.fullCalendar('getDate'))).to.be.true;
+//     });
 
-    it('styles the buttons', function() {
-      expect(this.calendar.$calendar.find('.button button--alt')).to.exist;
-    });
-  });
+//     it('styles the buttons', function() {
+//       expect(this.calendar.$calendar.find('.button button--alt')).to.exist;
+//     });
+//   });
 
-  describe('filter()', function() {
-    before(function() {
-      this.response = {
-        results: [
-          {
-            category: 'election',
-            title: 'the big one',
-            start_date: moment().format()
-          }
-        ]
-      };
-      this.server.respondWith(
-        [200, {'Content-Type': 'application/json'}, JSON.stringify(this.response)]
-      );
-    });
+//   describe('filter()', function() {
+//     before(function() {
+//       this.response = {
+//         results: [
+//           {
+//             category: 'election',
+//             title: 'the big one',
+//             start_date: moment().format()
+//           }
+//         ]
+//       };
+//       this.server.respondWith(
+//         [200, {'Content-Type': 'application/json'}, JSON.stringify(this.response)]
+//       );
+//     });
 
-    beforeEach(function() {
-      sinon.stub(this.calendar.filterSet, 'serialize');
-      this.calendar.filterSet.serialize.returns({category: ['election-P']});
-    });
+//     beforeEach(function() {
+//       sinon.stub(this.calendar.filterSet, 'serialize');
+//       this.calendar.filterSet.serialize.returns({category: ['election-P']});
+//     });
 
-    afterEach(function() {
-      this.calendar.filterSet.serialize.restore();
-    });
+//     afterEach(function() {
+//       this.calendar.filterSet.serialize.restore();
+//     });
 
-    it('fetches events', function() {
-      this.calendar.params = null;
-      this.calendar.filter();
-      this.server.respond();
-      expect(this.calendar.filterSet.serialize).to.have.been.called;
-      expect(this.calendar.params).to.deep.equal(this.calendar.filterSet.serialize());
-      var events = this.calendar.$calendar.fullCalendar('getEvents');
-      expect(events.length).to.equal(1);
-    });
-  });
+//     it('fetches events', function() {
+//       this.calendar.params = null;
+//       this.calendar.filter();
+//       this.server.respond();
+//       expect(this.calendar.filterSet.serialize).to.have.been.called;
+//       expect(this.calendar.params).to.deep.equal(this.calendar.filterSet.serialize());
+//       var events = this.calendar.$calendar.fullCalendar('getEvents');
+//       expect(events.length).to.equal(1);
+//     });
+//   });
 
-  describe('handleRender()', function() {
-    it('triggers a render event', function() {
-      var callback = sinon.stub();
-      $(document.body).on('calendar:rendered', callback);
-      this.calendar.handleRender({name: 'month'});
-      expect(callback).to.have.been.called;
-    });
+//   describe('handleRender()', function() {
+//     it('triggers a render event', function() {
+//       var callback = sinon.stub();
+//       $(document.body).on('calendar:rendered', callback);
+//       this.calendar.handleRender({name: 'month'});
+//       expect(callback).to.have.been.called;
+//     });
 
-    it('calls manageListToggles() on list views', function() {
-      sinon.stub(this.calendar, 'manageListToggles');
-      this.calendar.handleRender({name: 'monthTime'});
-      expect(this.calendar.manageListToggles).to.have.been.called;
-      this.calendar.manageListToggles.restore();
-    });
+//     it('calls manageListToggles() on list views', function() {
+//       sinon.stub(this.calendar, 'manageListToggles');
+//       this.calendar.handleRender({name: 'monthTime'});
+//       expect(this.calendar.manageListToggles).to.have.been.called;
+//       this.calendar.manageListToggles.restore();
+//     });
 
-    it('does not call manageListToggles() toggles on grid view', function() {
-      sinon.stub(this.calendar, 'manageListToggles');
-      this.calendar.handleRender({name: 'month'});
-      expect(this.calendar.manageListToggles).to.not.have.been.called;
-      this.calendar.manageListToggles.restore();
-    });
+//     it('does not call manageListToggles() toggles on grid view', function() {
+//       sinon.stub(this.calendar, 'manageListToggles');
+//       this.calendar.handleRender({name: 'month'});
+//       expect(this.calendar.manageListToggles).to.not.have.been.called;
+//       this.calendar.manageListToggles.restore();
+//     });
 
-    it('removes list toggles on grid view', function() {
-      this.calendar.handleRender({name: 'monthTime'});
-      this.calendar.handleRender({name: 'month'});
-      expect($('.cal-list__toggles').length).to.equal(0);
-      expect(this.calendar.$listToggles).to.not.exist;
-    });
-  });
+//     it('removes list toggles on grid view', function() {
+//       this.calendar.handleRender({name: 'monthTime'});
+//       this.calendar.handleRender({name: 'month'});
+//       expect($('.cal-list__toggles').length).to.equal(0);
+//       expect(this.calendar.$listToggles).to.not.exist;
+//     });
+//   });
 
-  describe('manageListToggles()', function() {
-    it('adds them to the dom if they do not exist', function() {
-      this.calendar.manageListToggles({name: 'monthTime'});
-      expect(this.calendar.$calendar.find('.cal-list__toggles')).to.exist;
-    });
+//   describe('manageListToggles()', function() {
+//     it('adds them to the dom if they do not exist', function() {
+//       this.calendar.manageListToggles({name: 'monthTime'});
+//       expect(this.calendar.$calendar.find('.cal-list__toggles')).to.exist;
+//     });
 
-    it('highlights the active button', function() {
-      var opts = {
-        duration: 'month',
-        sortBy: 'time'
-      };
-      this.calendar.manageListToggles({name: 'monthTime', options: opts});
-      var $monthToggle = this.calendar.$calendar.find('button[data-trigger-view="monthTime"]');
-      expect($monthToggle.hasClass('is-active')).to.exist;
-    });
+//     it('highlights the active button', function() {
+//       var opts = {
+//         duration: 'month',
+//         sortBy: 'time'
+//       };
+//       this.calendar.manageListToggles({name: 'monthTime', options: opts});
+//       var $monthToggle = this.calendar.$calendar.find('button[data-trigger-view="monthTime"]');
+//       expect($monthToggle.hasClass('is-active')).to.exist;
+//     });
 
-    it('highlights the list toggle', function() {
-      this.calendar.manageListToggles({name: 'monthCategory'});
-      var $listToggle = this.calendar.$calendar.find('.fc-monthTime-button');
-      expect($listToggle.hasClass('fc-state-active')).to.be.true;
-    });
-  });
+//     it('highlights the list toggle', function() {
+//       this.calendar.manageListToggles({name: 'monthCategory'});
+//       var $listToggle = this.calendar.$calendar.find('.fc-monthTime-button');
+//       expect($listToggle.hasClass('fc-state-active')).to.be.true;
+//     });
+//   });
 
-  describe('handleEventRender()', function() {
-    it('Applies the correct attributes', function() {
-      var event = {
-        category: 'election',
-        title: 'the big one',
-        start: moment('2012-11-02')
-      };
-      var element = $('<a>Event</a>');
-      var eventLabel = 'the big one Friday November 2, 2012. Category: election';
-      this.calendar.handleEventRender(event, element);
-      expect(element.attr('tabindex')).to.equal('0');
-      expect(element.attr('aria-describedby')).to.equal(this.calendar.detailsId);
-      expect(element.attr('aria-label')).to.equal(eventLabel);
-    });
-  });
+//   describe('handleEventRender()', function() {
+//     it('Applies the correct attributes', function() {
+//       var event = {
+//         category: 'election',
+//         title: 'the big one',
+//         start: moment('2012-11-02')
+//       };
+//       var element = $('<a>Event</a>');
+//       var eventLabel = 'the big one Friday November 2, 2012. Category: election';
+//       this.calendar.handleEventRender(event, element);
+//       expect(element.attr('tabindex')).to.equal('0');
+//       expect(element.attr('aria-describedby')).to.equal(this.calendar.detailsId);
+//       expect(element.attr('aria-label')).to.equal(eventLabel);
+//     });
+//   });
 
-  describe('handleDayRender()', function() {
-    it('Adds the month name to the first of the month', function() {
-      var cell = $('<td></td>');
-      this.calendar.handleDayRender(moment('2016-01-01'), cell);
-      expect(cell.html()).to.equal('January');
-    });
-  });
+//   describe('handleDayRender()', function() {
+//     it('Adds the month name to the first of the month', function() {
+//       var cell = $('<td></td>');
+//       this.calendar.handleDayRender(moment('2016-01-01'), cell);
+//       expect(cell.html()).to.equal('January');
+//     });
+//   });
 
-  describe('handleEventClick()', function() {
-    beforeEach(function() {
-      sinon.stub(calendarTooltip, 'CalendarTooltip');
-    });
+//   describe('handleEventClick()', function() {
+//     beforeEach(function() {
+//       sinon.stub(calendarTooltip, 'CalendarTooltip');
+//     });
 
-    afterEach(function() {
-      calendarTooltip.CalendarTooltip.restore();
-    });
+//     afterEach(function() {
+//       calendarTooltip.CalendarTooltip.restore();
+//     });
 
-    it('makes a new tooltip if there is none', function() {
-      var target = '<a><span class="fc-content"></span></a>';
-      this.calendar.handleEventClick({}, {target: target});
-      expect(calendarTooltip.CalendarTooltip).to.have.been.called;
-    });
+//     it('makes a new tooltip if there is none', function() {
+//       var target = '<a><span class="fc-content"></span></a>';
+//       this.calendar.handleEventClick({}, {target: target});
+//       expect(calendarTooltip.CalendarTooltip).to.have.been.called;
+//     });
 
-    it('does not make a tooltip if there is one', function() {
-      var target = '<a><span class="fc-content"></span></a><div class="tooltip"></div>';
-      this.calendar.handleEventClick({}, {target: target});
-      expect(calendarTooltip.CalendarTooltip).to.not.have.been.called;
-    });
-  });
+//     it('does not make a tooltip if there is one', function() {
+//       var target = '<a><span class="fc-content"></span></a><div class="tooltip"></div>';
+//       this.calendar.handleEventClick({}, {target: target});
+//       expect(calendarTooltip.CalendarTooltip).to.not.have.been.called;
+//     });
+//   });
 
-  describe('managePopoverControl()', function() {
-    it('adds the correct attributes to the popover', function() {
-      var $popover = $('<div class="fc-popover"><span class="fc-close"></span></div>');
-      this.calendar.$calendar.append($popover);
-      this.calendar.managePopoverControl({target: '<a></a>'});
-      expect($popover.attr('role')).to.equal('tooltip');
-      expect($popover.attr('id')).to.equal(this.calendar.popoverId);
-      expect($popover.find('.fc-close').attr('tabindex')).to.equal('0');
-      expect(document.activeElement.classList[0]).to.equal('fc-close');
-    });
-  });
-});
+//   describe('managePopoverControl()', function() {
+//     it('adds the correct attributes to the popover', function() {
+//       var $popover = $('<div class="fc-popover"><span class="fc-close"></span></div>');
+//       this.calendar.$calendar.append($popover);
+//       this.calendar.managePopoverControl({target: '<a></a>'});
+//       expect($popover.attr('role')).to.equal('tooltip');
+//       expect($popover.attr('id')).to.equal(this.calendar.popoverId);
+//       expect($popover.find('.fc-close').attr('tabindex')).to.equal('0');
+//       expect(document.activeElement.classList[0]).to.equal('fc-close');
+//     });
+//   });
+// });
 
-describe('calendar tooltip', function() {
-  beforeEach(function() {
-    var dom =
-    '<div class="fc-event-container">' +
-      '<a class="cal-event" tabindex="0"></a>' +
-    '</div>';
-    $(document.body).append($(dom));
-    var $container = $('.cal-event');
-    var content = tooltipContent({});
-    this.calendarTooltip = new calendarTooltip.CalendarTooltip(content, $container);
-    $container.append(this.calendarTooltip.$content);
-  });
+// describe('calendar tooltip', function() {
+//   beforeEach(function() {
+//     var dom =
+//     '<div class="fc-event-container">' +
+//       '<a class="cal-event" tabindex="0"></a>' +
+//     '</div>';
+//     $(document.body).append($(dom));
+//     var $container = $('.cal-event');
+//     var content = tooltipContent({});
+//     this.calendarTooltip = new calendarTooltip.CalendarTooltip(content, $container);
+//     $container.append(this.calendarTooltip.$content);
+//   });
 
-  afterEach(function() {
-    this.calendarTooltip.close();
-    $('.cal-event').remove();
-  });
+//   afterEach(function() {
+//     this.calendarTooltip.close();
+//     $('.cal-event').remove();
+//   });
 
-  it('closes on click away', function() {
-    $(document.body).click();
-    expect($('.cal-details').length).to.equal(0);
-  });
+//   it('closes on click away', function() {
+//     $(document.body).click();
+//     expect($('.cal-details').length).to.equal(0);
+//   });
 
-  it('stays open if you click inside it', function() {
-    this.calendarTooltip.$content.find('a').click();
-    expect($('.cal-details').length).to.equal(1);
-  });
+//   it('stays open if you click inside it', function() {
+//     this.calendarTooltip.$content.find('a').click();
+//     expect($('.cal-details').length).to.equal(1);
+//   });
 
-  it('closes on clicking the close button', function() {
-    this.calendarTooltip.$content.find('.js-close').click();
-    expect($('.cal-details').length).to.equal(0);
-  });
+//   it('closes on clicking the close button', function() {
+//     this.calendarTooltip.$content.find('.js-close').click();
+//     expect($('.cal-details').length).to.equal(0);
+//   });
 
-  it('focuses on the trigger on close', function() {
-    this.calendarTooltip.close();
-    expect($(document.activeElement).hasClass('cal-event')).to.be.true;
-  });
-});
+//   it('focuses on the trigger on close', function() {
+//     this.calendarTooltip.close();
+//     expect($(document.activeElement).hasClass('cal-event')).to.be.true;
+//   });
+// });
 
-describe('helpers', function() {
-  describe('calendarHelpers.getGoogleurl()', function() {
-    it('builds the correct Google url', function() {
-      var googleUrl = calendarHelpers.getGoogleUrl({
-        title: 'the big one',
-        summary: 'vote today',
-        end: moment('2016-11-01'),
-        start: moment('2016-11-02')
-      });
-      expect(googleUrl).to.equal('https://calendar.google.com/calendar/render?action=TEMPLATE&text=the+big+one&details=vote+today&dates=20161102T000000%2F20161101T000000');
-    });
-  });
+// describe('helpers', function() {
+//   describe('calendarHelpers.getGoogleurl()', function() {
+//     it('builds the correct Google url', function() {
+//       var googleUrl = calendarHelpers.getGoogleUrl({
+//         title: 'the big one',
+//         summary: 'vote today',
+//         end: moment('2016-11-01'),
+//         start: moment('2016-11-02')
+//       });
+//       expect(googleUrl).to.equal('https://calendar.google.com/calendar/render?action=TEMPLATE&text=the+big+one&details=vote+today&dates=20161102T000000%2F20161101T000000');
+//     });
+//   });
 
-  describe('calendarHelpers.getUrl()', function() {
-    it('builds the correct url', function() {
-      var url = calendarHelpers.getUrl('calendar', {category: 'election'});
-      expect(url).to.equal('/v1/calendar/?api_key=67890&per_page=500&category=election');
-    });
-  });
+//   describe('calendarHelpers.getUrl()', function() {
+//     it('builds the correct url', function() {
+//       var url = calendarHelpers.getUrl('calendar', {category: 'election'});
+//       expect(url).to.equal('/v1/calendar/?api_key=67890&per_page=500&category=election');
+//     });
+//   });
 
-  describe('calendarHelpers.className()', function() {
-    it('adds a multi-day class for multi-day events', function() {
-      var multiEvent = {
-        start_date: moment('2012-11-02'),
-        end_date: moment('2012-11-03')
-      };
-      var singleEvent = {
-        start_date: moment('2012-11-02'),
-        end_date: moment('2012-11-02')
-      };
-      var multiDayClass = calendarHelpers.className(multiEvent);
-      var singleDayClass = calendarHelpers.className(singleEvent);
-      expect(multiDayClass).to.equal('fc-multi-day');
-      expect(singleDayClass).to.not.equal('fc-multi-day');
-    });
-  });
-});
+//   describe('calendarHelpers.className()', function() {
+//     it('adds a multi-day class for multi-day events', function() {
+//       var multiEvent = {
+//         start_date: moment('2012-11-02'),
+//         end_date: moment('2012-11-03')
+//       };
+//       var singleEvent = {
+//         start_date: moment('2012-11-02'),
+//         end_date: moment('2012-11-02')
+//       };
+//       var multiDayClass = calendarHelpers.className(multiEvent);
+//       var singleDayClass = calendarHelpers.className(singleEvent);
+//       expect(multiDayClass).to.equal('fc-multi-day');
+//       expect(singleDayClass).to.not.equal('fc-multi-day');
+//     });
+//   });
+// });


### PR DESCRIPTION
## Summary (required)
Use `FEC_API_KEY_PUBLIC_CALENDAR` for Calendar subscriptions and use `FEC_API_KEY_PUBLIC` for homepage Event and deadlines links and Calendar filters. 

- Resolves https://github.com/fecgov/fec-accounts/issues/354


## Impacted areas of the application
modified:  fec/fec/static/js/modules/calendar-helpers.js
modified:  fec/fec/static/js/modules/calendar.js
modified:  fec/fec/static/js/pages/calendar-page.js
modified:  fec/fec/static/js/templates/calendar/subscribe.hbs
modified:  fec/fec/tests/js/calendar.js


## Screenshots


![cal-api](https://user-images.githubusercontent.com/5572856/106974817-573c0680-6723-11eb-9831-687c4c3b43e3.jpg)



## How to test
checkout feature/345-use-calendar-key-for-subscriptions-only
`npm run build`
`export FEC_WEB_API_KEY_PUBLIC=12345`
`export FEC_WEB_API_KEY_PUBLIC_CALENDAR=67890`
runserver
Check that the links in subscribe dropdown have  `api_key=67890`
Check in network tab that changes to filters register an api call using `api_key=12345`
Check that clicks from links on homepage Event and deadlines section (except Meetings) register an api call using `api_key=12345` in network tab.

____
