### PR TITLE
Add sponsor link in committee profile

### DIFF
--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -124,6 +124,7 @@
         </tr>
         {% endif %}
     <!-- For Committee sponsor: -->
+        {% if sponsor_candidates %}
         <tr>
             <td class="figure__label">Committee sponsor:</td>
             <td class="figure__value">
@@ -146,6 +147,7 @@
               {% endfor %}
           </td>
         </tr>
+        {% endif %}
       </table>
     </div>
     {% endif %}

--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -75,20 +75,7 @@
             <td class="figure__value">{{ committee.designation_full }}</td>
           {% endif %}
         </tr>
-        {% if leadership_sponsors_names %}
-        <tr>
-            <td class="figure__label">Leadership PAC sponsor:</td>
-            <td class="figure__value">{{ leadership_sponsors_names }}</td>
-        </tr>
-        {% endif %}
-        {% if is_SSF %}
-          <tr>
-            <td class="figure__label">Connected organization:</td>
-            <td class="figure__value">
-                {{ committee.affiliated_committee_name }}
-            </td>
-          </tr>
-        {% endif %}
+    <!-- For Statement of organization: -->
         {% if statement_of_organization %}
         <tr>
           <td class="figure__label">Statement of organization:</td>
@@ -108,33 +95,57 @@
           </td>
         </tr>
         {% endif %}
+    <!-- For Authorizing candidaten: -->
         {% if candidates %}
-          <tr>
-            <td class="figure__label">Authorizing candidate:</td>
-            <td class="figure__value">
-              <div class="callout callout--primary">
-                <h5 class="callout__title t-sans">
-                  {% for c in candidates %}
-                    {% if c.related_cycle is not none %}
-                  <a href="/data/candidate/{{ c.candidate_id }}/?cycle={{ c.related_cycle }}&election_full=false">{{ c.name }}</a>
-                    {% else %}
-                  <a href="/data/candidate/{{ c.candidate_id }}/">{{ c.name }}</a>
-                    {% endif %}
-                  {% endfor %}
-                </h5>
-                <span class="entity__type">{{ committee.committee_type_full }} candidate</span>
-
-                  {% if candidates[0].office == 'S' %}
-                <span class="entity__type">{{ candidates[0].state|fmt_state_full }}</span>
-                  {% elif candidates[0].office == 'H' %}
-                <span class="entity__type">{{ candidates[0].state|fmt_state_full }} - {{ candidates[0].district }}</span>
+        <tr>
+          <td class="figure__label">Authorizing candidate:</td>
+          <td class="figure__value">
+            <div class="callout callout--primary">
+              <h5 class="callout__title t-sans">
+                {% for c in candidates %}
+                  {% if c.related_cycle is not none %}
+                <a href="/data/candidate/{{ c.candidate_id }}/?cycle={{ c.related_cycle }}&election_full=false">{{ c.name }}</a>
+                  {% else %}
+                <a href="/data/candidate/{{ c.candidate_id }}/">{{ c.name }}</a>
                   {% endif %}
+                {% endfor %}
+              </h5>
+              <span class="entity__type">{{ committee.committee_type_full }} candidate</span>
 
-                  {{ candidates[0].party_full|lower|title }}
-              </div>
-            </td>
-          </tr>
+                {% if candidates[0].office == 'S' %}
+              <span class="entity__type">{{ candidates[0].state|fmt_state_full }}</span>
+                {% elif candidates[0].office == 'H' %}
+              <span class="entity__type">{{ candidates[0].state|fmt_state_full }} - {{ candidates[0].district }}</span>
+                {% endif %}
+
+                {{ candidates[0].party_full|lower|title }}
+            </div>
+          </td>
+        </tr>
         {% endif %}
+    <!-- For Committee sponsor: -->
+        <tr>
+            <td class="figure__label">Committee sponsor:</td>
+            <td class="figure__value">
+              {% for candidate in sponsor_candidates | reverse %}
+              <div class='grid'>
+                <div class="grid__item u-no-margin">
+                  <div class="callout callout--primary{% if loop.last %} u-no-margin{% endif %}" style="width: 100%; max-width: 300px">
+                    <h5 class="callout__title t-sans">
+                      <a href="/data/candidate/{{ candidate.candidate_id }}/?cycle={{ candidate.related_cycle }}&election_full=false">{{ candidate.name }}</a>
+                    </h5>
+                {% if candidate.office == 'P' %}
+                    <p class="callout__subtitle u-no-margin">Presidential candidate | {{ candidate.party_full |capitalize}}</p>
+                {% elif candidate.office == 'S' or candidate.office == 'H' %}
+                    <p class="callout__subtitle u-no-margin">Candidate for {{ constants.house_senate_types[candidate.office] }} |</p>
+                    <p class="callout__subtitle u-no-margin">{{ constants.states[candidate.state] }} | {{ candidate.party_full |capitalize}}</p>
+                {% endif %}
+                  </div>
+                </div>
+              </div>
+              {% endfor %}
+          </td>
+        </tr>
       </table>
     </div>
     {% endif %}

--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -100,7 +100,7 @@
         <tr>
           <td class="figure__label">Authorizing candidate:</td>
           <td class="figure__value">
-            <div class="callout callout--primary">
+            <div class="callout callout--primary" style="width: 100%; max-width: 300px">
               <h5 class="callout__title t-sans">
                 {% for c in candidates %}
                   {% if c.related_cycle is not none %}


### PR DESCRIPTION
## Summary (required)
Currently, we only show Leadership PAC sponsor name string on about-committee section in committee profile page and don't have the link to candidate profile page.
ex: https://www.fec.gov/data/committee/C00326439/?cycle=2022&tab=about-committee
<img width="544" alt="before" src="https://user-images.githubusercontent.com/24395751/107275714-1e9c7580-6a20-11eb-81e0-07b10f1911ed.png">


after this PR, we change sponsor name to name card and link to candidate profile page.

<img width="480" alt="after" src="https://user-images.githubusercontent.com/24395751/107275965-6b804c00-6a20-11eb-88ee-5d62fd010087.png">

- Resolves #4361

_Include a summary of proposed changes._
1) get sponsor_candidates list from get_committees function in view.py, send to front-end. 
2) modify about-committee.jinja, the sponsor_candidate info will be displayed by the way of name card.

## Impacted areas of the application
committee profile page

List general components of the application that this PR will affect:
data/view.py
about-committee.jinja


## How to test
1) checkout branch
2) point any api
3) pytest
./manage.py test
4) ./manage.py runserver
5) compare local and prod urls:
(1) Presidential candidate:
http://127.0.0.1:8000/data/committee/C00693713/?cycle=2020&tab=about-committee
https://www.fec.gov/data/committee/C00693713/?cycle=2020&tab=about-committee

(2) multi-house:(candidate_id=H6LA04138 and candidate_id=H6IN03229
http://127.0.0.1:8000/data/committee/C00326439/?cycle=2022&tab=about-committee
https://www.fec.gov/data/committee/C00326439/?cycle=2022&tab=about-committee

(3) senate:
http://127.0.0.1:8000/data/committee/C00764878/?cycle=2020&tab=about-committee
https://www.fec.gov/data/committee/C00764878/?cycle=2020&tab=about-committee

(4) multi-senate (but same candidate_id=S0PA00434)
http://127.0.0.1:8000/data/committee/C00455741/?cycle=2016&tab=about-committee
https://www.fec.gov/data/committee/C00455741/?cycle=2016&tab=about-committee

## Reviewer
one developer, one design developer