### PR TITLE
Add 2021 and 2022 to datatables

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -4,9 +4,9 @@ import operator
 from data import utils
 
 START_YEAR = 1979
-END_YEAR = 2020
+END_YEAR = 2022
 DEFAULT_TIME_PERIOD = 2020  # Change after the April quarterly report (4/15/21)
-DEFAULT_ELECTION_YEAR = 2020  # Change after election day (11/3/20)
+DEFAULT_ELECTION_YEAR = 2022  # Change after election day (11/8/22)
 DEFAULT_PRESIDENTIAL_YEAR = 2020
 DISTRICT_MAP_CUTOFF = 2018  # The year we show district maps for on election pages
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4378: Add 2022 to datatables

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Datatables (http://localhost:8000/data/browse-data/) such as receipts, filings, reports, candidates

## Screenshots

## Before
![107644482-7b2caa00-6c45-11eb-93a6-87bb93ddb164](https://user-images.githubusercontent.com/31420082/108250255-06b1a980-7124-11eb-8f04-ec0b666aa67b.png)
![107644376-5b958180-6c45-11eb-83b7-149a7af7ff3d](https://user-images.githubusercontent.com/31420082/108250257-07e2d680-7124-11eb-9f6e-056ce48da188.png)

## After 
<img width="304" alt="Screen Shot 2021-02-17 at 1 19 15 PM" src="https://user-images.githubusercontent.com/31420082/108250318-1b8e3d00-7124-11eb-9f06-a9fdab05b04c.png">
<img width="306" alt="Screen Shot 2021-02-17 at 1 29 43 PM" src="https://user-images.githubusercontent.com/31420082/108250428-3eb8ec80-7124-11eb-915b-7bc7ed7fc35b.png">

## How to test

- Datatables (http://localhost:8000/data/browse-data/) such as receipts, filings, reports, candidates
- Make sure 2022 is an option
