### PR TITLE
Feature/3620 remove classic url

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -38,7 +38,6 @@ DIGITALGOV_BASE_API_URL = 'https://i14y.usa.gov/api/v1'
 DIGITALGOV_DRAWER_HANDLE = env.get_credential('DIGITALGOV_DRAWER_HANDLE', '')
 
 FEC_TRANSITION_URL = env.get_credential('FEC_TRANSITION_URL', 'https://transition.fec.gov')
-FEC_CLASSIC_URL = env.get_credential('FEC_CLASSIC_URL', 'http://classic.fec.gov')
 
 FEATURES = {
     'record': bool(env.get_credential('FEC_FEATURE_RECORD', '')),
@@ -147,7 +146,6 @@ TEMPLATES = [
                 'FEC_API_URL': FEC_API_URL,
                 'WEBMANAGER_EMAIL': WEBMANAGER_EMAIL,
                 'TRANSITION_URL': FEC_TRANSITION_URL,
-                'CLASSIC_URL': FEC_CLASSIC_URL,
                 'FEC_CMS_ENVIRONMENT': FEC_CMS_ENVIRONMENT,
                 'FEATURES': FEATURES,
             },

--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -157,14 +157,15 @@
               {% else %}
             <div class="message message--info">
               <h2>No results</h2>
-               {% if search %}
-                <p>We didn’t find any pages matching <strong>&ldquo;{{search}}&rdquo;</strong>.</p>
-               {% endif %}
-              <p>
-                <div class="message--alert__bottom">
-                 <p>FEC.gov is in the middle of a redesign, and some pages aren’t included in search results yet. Please try another search. Or, <a href="{{ settings.FEC_CLASSIC_URL }}">search the archive</a> of FEC.gov’s previous design.</p>
-                 <p>If you’d like to contact our team, we’re available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/18f/fec">GitHub</a>.</p>
-               </div>
+              {% if search is null %}
+              <p>We didn’t find any public hearings matching <strong>&ldquo;{{hearings_query}}&rdquo;</strong>.</p>
+              {% endif %}
+              <div class="message--alert__bottom">
+                <p>Think this was a mistake?<br>Try one of the other search tools or submit feedback.</p>
+                <p>
+                  <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}" class="button--standard">Email our team</a>&nbsp;&nbsp; <a href="https://github.com/fecgov/fec/issues/new" class="button--standard">File an issue</a></p>
+                </p>
+              </div>
             </div>
             {% endif %}
           </section>

--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -99,13 +99,18 @@
                {% if search %}
                 <p>We didn’t find any pages matching <strong>&ldquo;{{search}}&rdquo;</strong>.</p>
                 {% endif %}
-              <p>
-                <div class="message--alert__bottom">
-                 <p>FEC.gov is in the middle of a redesign, and some pages aren’t included in search results yet. Please try another search. Or, <a href="{{ settings.FEC_CLASSIC_URL }}">search the archive</a> of FEC.gov’s previous design.</p>
-                 <p>If you’d like to contact our team, we’re available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/18f/fec">GitHub</a>.</p>
-               </div>
             </div>
+              {% if open_meetings is not null %}
+              <p>We didn’t find any open meetings matching your search.</p>
               {% endif %}
+              <div class="message--alert__bottom">
+                <p>Think this was a mistake?<br>Try one of the other search tools or submit feedback.</p>
+                <p>
+                  <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}" class="button--standard">Email our team</a>&nbsp;&nbsp; <a href="https://github.com/fecgov/fec/issues/new" class="button--standard">File an issue</a></p>
+                </p>
+              </div>
+            </div>
+            {% endif %}
           </section>
           <section id="meetings-hearings" role="tabpanel" aria-hidden="true" aria-labelledby="hearings">
             <h2>Public hearings</h2>
@@ -157,8 +162,8 @@
               {% else %}
             <div class="message message--info">
               <h2>No results</h2>
-              {% if search is null %}
-              <p>We didn’t find any public hearings matching <strong>&ldquo;{{hearings_query}}&rdquo;</strong>.</p>
+              {% if hearings_query is not null %}
+              <p>We didn’t find any public hearings matching your search.</p>
               {% endif %}
               <div class="message--alert__bottom">
                 <p>Think this was a mistake?<br>Try one of the other search tools or submit feedback.</p>
@@ -211,15 +216,16 @@
               {% else %}
             <div class="message message--info">
               <h2>No results</h2>
-               {% if search %}
-                <p>We didn’t find any pages matching <strong>&ldquo;{{search}}&rdquo;</strong>.</p>
-               {% endif %}
-              <p>
-                <div class="message--alert__bottom">
-                 <p>FEC.gov is in the middle of a redesign, and some pages aren’t included in search results yet. Please try another search. Or, <a href="{{ settings.FEC_CLASSIC_URL }}">search the archive</a> of FEC.gov’s previous design.</p>
-                 <p>If you’d like to contact our team, we’re available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/18f/fec">GitHub</a>.</p>
-               </div>
-             </div>
+              {% if executive_query is not null %}
+              <p>We didn’t find any executive sessions matching your search.</p>
+              {% endif %}
+              <div class="message--alert__bottom">
+                <p>Think this was a mistake?<br>Try one of the other search tools or submit feedback.</p>
+                <p>
+                  <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}" class="button--standard">Email our team</a>&nbsp;&nbsp; <a href="https://github.com/fecgov/fec/issues/new" class="button--standard">File an issue</a></p>
+                </p>
+              </div>
+            </div>
             {% endif %}
           </section>
       </div>

--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -7,7 +7,7 @@
 
 {% include 'partials/breadcrumbs.html' with page=self links=self.get_ancestors style='secondary' %}
 <div class="container">
- <header class="heading--main u-padding--top">
+  <header class="heading--main u-padding--top">
     <h1>{{ self.title }}</h1>
   </header>
 </div>
@@ -48,58 +48,54 @@
         <div class="main__content--right">
           <section id="meetings-open-meetings" role="tabpanel" aria-hidden="true" aria-labelledby="open-meetings">
             <h2>Open meetings</h2>
-             <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:00am. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
+            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:00am. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
             <div class="filters--horizontal">
-               <form action="" id="openmeetings_form" method="get" class="js-form-nav container">
-                  <div class="filter">
-                      <label for="year" class="label">Year</label>
-                      <select id="year" name="year">
-                        <option value="">All</option>
-                        {% for item in meeting_years %}
-                        <option value="{{ item }}" {% if year == item %}selected {% endif %}>{{ item }}</option>
-                        {% endfor %}
-                      </select>
+              <form action="" id="openmeetings_form" method="get" class="js-form-nav container">
+                <div class="filter">
+                  <label for="year" class="label">Year</label>
+                  <select id="year" name="year">
+                    <option value="">All</option>
+                    {% for item in meeting_years %}
+                    <option value="{{ item }}" {% if year == item %}selected {% endif %}>{{ item }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="filter filter--wide">
+                  <div class="combo combo--filter--mini">
+                    <label for="search" class="label">Search</label>
+                    <input id="search" class="combo__input" name="search" type="text" value="{{ meetings_query }}">
+                    <button type="submit" id="open_sub" class="combo__button button button--standard button--search"><span class="u-visually-hidden">Search</span></button>
+                    <input type="hidden" name="tab" value="open-meetings">
                   </div>
-                  <div class="filter filter--wide">
-                    <div class="combo combo--filter--mini">
-                      <label for="search" class="label">Search</label>
-                      <input id="search" class="combo__input" name="search" type="text" value="{{ meetings_query }}">
-                      <button type="submit" id="open_sub" class="combo__button button button--standard button--search"><span class="u-visually-hidden">Search</span></button>
-                      <input type="hidden" name="tab" value="open-meetings">
-                    </div>
-                  </div>
+                </div>
               </form>
             </div>
             {% if open_meetings %}
-               <table class="simple-table u-no-margin">
-                  <tbody>
-                    {% for open_meeting in open_meetings %}
-                      {% include 'partials/meeting.html' with meeting=open_meeting %}
-                     {% endfor %}
-                  </tbody>
-               </table>
-              <div class="results-info results-info--simple">
-                <div class="t-sans">
-                  {% if open_meetings.has_previous %}
-                    <a class="button button--standard button--previous" href="?page={{ open_meetings.previous_page_number }}&tab=open-meetings&year={{ year }}&search={{ meetings_query }}"><span class="u-visually-hidden">Previous</span></a>
-                  {% else %}
-                    <a class="button button--standard button--previous is-disabled" disabled></a>
-                  {% endif %}
-                  {% if open_meetings.has_next %}
-                    <a class="button button--standard button--next" href="?page={{ open_meetings.next_page_number }}&tab=open-meetings&year={{ year }}&search={{ meetings_query }}"><span class="u-visually-hidden">Next</span></a>
-                  {% else %}
-                    <a class="button button--standard button--next is-disabled" disabled></a>
-                  {% endif %}
-                  <span>Page {{ open_meetings.number }} of {{ open_meetings.paginator.num_pages }}</span>
-                </div>
-             </div>
-              {% else %}
+            <table class="simple-table u-no-margin">
+              <tbody>
+                {% for open_meeting in open_meetings %}
+                  {% include 'partials/meeting.html' with meeting=open_meeting %}
+                  {% endfor %}
+              </tbody>
+            </table>
+            <div class="results-info results-info--simple">
+              <div class="t-sans">
+                {% if open_meetings.has_previous %}
+                <a class="button button--standard button--previous" href="?page={{ open_meetings.previous_page_number }}&tab=open-meetings&year={{ year }}&search={{ meetings_query }}"><span class="u-visually-hidden">Previous</span></a>
+                {% else %}
+                <a class="button button--standard button--previous is-disabled" disabled></a>
+                {% endif %}
+                {% if open_meetings.has_next %}
+                <a class="button button--standard button--next" href="?page={{ open_meetings.next_page_number }}&tab=open-meetings&year={{ year }}&search={{ meetings_query }}"><span class="u-visually-hidden">Next</span></a>
+                {% else %}
+                <a class="button button--standard button--next is-disabled" disabled></a>
+                {% endif %}
+                <span>Page {{ open_meetings.number }} of {{ open_meetings.paginator.num_pages }}</span>
+              </div>
+            </div>
+            {% else %}
             <div class="message message--info">
               <h2>No results</h2>
-               {% if search %}
-                <p>We didn’t find any pages matching <strong>&ldquo;{{search}}&rdquo;</strong>.</p>
-                {% endif %}
-            </div>
               {% if open_meetings is not null %}
               <p>We didn’t find any open meetings matching your search.</p>
               {% endif %}
@@ -116,50 +112,50 @@
             <h2>Public hearings</h2>
             <p>The Commission periodically holds public hearings at its headquarters in Washington, DC. These hearings offer interested persons an opportunity to testify concerning proposed regulations and other matters that come before the Commission. This page lists upcoming public hearings as well as those held from 2005 through the present. Use the <a href="https://sers.fec.gov/fosers/" title="Searchable Electronic Rulemaking System">Searchable Electronic Rulemaking System (SERS)</a> to search for all archived rulemaking hearings.</p>
             <div class="filters--horizontal">
-               <form action="" id="hearings_form" method="get" class="js-form-nav container">
-                  <div class="filter">
-                      <label for="year" class="label">Year</label>
-                      <select id="year" name="year">
-                        <option value="">All</option>
-                        {% for item in hearing_years %}
-                        <option value="{{ item }}" {% if year == item %}selected {% endif %}>{{ item }}</option>
-                        {% endfor %}
-                      </select>
+              <form action="" id="hearings_form" method="get" class="js-form-nav container">
+                <div class="filter">
+                  <label for="year" class="label">Year</label>
+                  <select id="year" name="year">
+                    <option value="">All</option>
+                    {% for item in hearing_years %}
+                    <option value="{{ item }}" {% if year == item %}selected {% endif %}>{{ item }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="filter filter--wide">
+                  <div class="combo combo--filter--mini">
+                    <label for="search" class="label">Search</label>
+                    <input id="search" class="combo__input" name="search" type="text" value="{{ hearings_query }}">
+                    <button type="submit" id="hearings_sub" class="combo__button button button--standard button--search"><span class="u-visually-hidden">Search</span></button>
+                    <input type="hidden" name="tab" value="hearings">
                   </div>
-                  <div class="filter filter--wide">
-                    <div class="combo combo--filter--mini">
-                      <label for="search" class="label">Search</label>
-                      <input id="search" class="combo__input" name="search" type="text" value="{{ hearings_query }}">
-                      <button type="submit" id="hearings_sub" class="combo__button button button--standard button--search"><span class="u-visually-hidden">Search</span></button>
-                      <input type="hidden" name="tab" value="hearings">
-                    </div>
-                  </div>
+                </div>
               </form>
-             </div>
+            </div>
             {% if hearings %}
-               <table class="simple-table u-no-margin" id="hearings_table">
-                  <tbody>
-                    {% for hearing in hearings %}
-                      {% include 'partials/meeting.html' with meeting=hearing %}
-                     {% endfor %}
-                  </tbody>
-               </table>
+              <table class="simple-table u-no-margin" id="hearings_table">
+                <tbody>
+                  {% for hearing in hearings %}
+                    {% include 'partials/meeting.html' with meeting=hearing %}
+                    {% endfor %}
+                </tbody>
+              </table>
               <div class="results-info results-info--simple">
                 <div class="t-sans">
                   {% if hearings.has_previous %}
-                    <a class="button button--standard button--previous" href="?page={{ hearings.previous_page_number }}&tab=hearings&search={{ hearings_query }}&year={{ year }}"><span class="u-visually-hidden">Previous</span></a>
+                  <a class="button button--standard button--previous" href="?page={{ hearings.previous_page_number }}&tab=hearings&search={{ hearings_query }}&year={{ year }}"><span class="u-visually-hidden">Previous</span></a>
                   {% else %}
-                    <a class="button button--standard button--previous is-disabled" disabled></a>
+                  <a class="button button--standard button--previous is-disabled" disabled></a>
                   {% endif %}
                   {% if hearings.has_next %}
-                    <a class="button button--standard button--next" href="?page={{ hearings.next_page_number }}&tab=hearings&search={{ hearings_query }}&year={{ year }}"><span class="u-visually-hidden">Next</span></a>
+                  <a class="button button--standard button--next" href="?page={{ hearings.next_page_number }}&tab=hearings&search={{ hearings_query }}&year={{ year }}"><span class="u-visually-hidden">Next</span></a>
                   {% else %}
-                    <a class="button button--standard button--next is-disabled" disabled></a>
+                  <a class="button button--standard button--next is-disabled" disabled></a>
                   {% endif %}
                   <span>Page {{ hearings.number }} of {{ hearings.paginator.num_pages }}</span>
                 </div>
-             </div>
-              {% else %}
+              </div>
+            {% else %}
             <div class="message message--info">
               <h2>No results</h2>
               {% if hearings_query is not null %}
@@ -178,42 +174,42 @@
             <h2>Executive sessions</h2>
             <p>Confidential and closed to the public. The Commission meets regularly in executive sessions to discuss pending enforcement actions, litigation and other matters that, by law, must be kept confidential.</p>
             <div class="filters--horizontal">
-               <form action="" id="executive_form" method="get" class="js-form-nav container">
-                  <div class="filter">
-                    <label for="year" class="label">Year</label>
-                    <select id="year" name="year">
-                      <option value="">All</option>
-                      {% for item in executive_years %}
-                      <option value="{{ item }}" {% if year == item %}selected {% endif %}>{{ item }}</option>
-                      {% endfor %}
-                    </select>
-                  </div>
-              </form>
-             </div>
-            {% if executive_sessions %}
-               <table class="simple-table u-no-margin">
-                  <tbody>
-                    {% for executive_session in executive_sessions  %}
-                      {% include 'partials/meeting.html' with meeting=executive_session  %}
+              <form action="" id="executive-sessions_form" method="get" class="js-form-nav container">
+                <div class="filter">
+                  <label for="year" class="label">Year</label>
+                  <select id="year" name="year">
+                    <option value="">All</option>
+                    {% for item in executive_years %}
+                    <option value="{{ item }}" {% if year == item %}selected {% endif %}>{{ item }}</option>
                     {% endfor %}
-                  </tbody>
-               </table>
-              <div class="results-info">
-                <div class="t-sans">
-                  {% if executive_sessions.has_previous %}
-                    <a class="button button--standard button--previous" href="?page={{ executive_sessions.previous_page_number }}&tab=executive-sessions&year={{ year }}&search={{ executive_query }}"><span class="u-visually-hidden">Previous</span></a>
-                  {% else %}
-                    <a class="button button--standard button--previous is-disabled" disabled></a>
-                  {% endif %}
-                  {% if executive_sessions.has_next %}
-                    <a class="button button--standard button--next" href="?page={{ executive_sessions.next_page_number }}&tab=executive-sessions&year={{ year }}&search={{ executive_query }}"><span class="u-visually-hidden">Next</span></a>
-                  {% else %}
-                    <a class="button button--standard button--next is-disabled" disabled></a>
-                  {% endif %}
-                  <span>Page {{ executive_sessions.number }} of {{ executive_sessions.paginator.num_pages }}</span>
+                  </select>
                 </div>
-             </div>
-              {% else %}
+              </form>
+            </div>
+            {% if executive_sessions %}
+            <table class="simple-table u-no-margin">
+              <tbody>
+                {% for executive_session in executive_sessions  %}
+                  {% include 'partials/meeting.html' with meeting=executive_session  %}
+                {% endfor %}
+              </tbody>
+            </table>
+            <div class="results-info">
+              <div class="t-sans">
+                {% if executive_sessions.has_previous %}
+                <a class="button button--standard button--previous" href="?page={{ executive_sessions.previous_page_number }}&tab=executive-sessions&year={{ year }}&search={{ executive_query }}"><span class="u-visually-hidden">Previous</span></a>
+                {% else %}
+                <a class="button button--standard button--previous is-disabled" disabled></a>
+                {% endif %}
+                {% if executive_sessions.has_next %}
+                <a class="button button--standard button--next" href="?page={{ executive_sessions.next_page_number }}&tab=executive-sessions&year={{ year }}&search={{ executive_query }}"><span class="u-visually-hidden">Next</span></a>
+                {% else %}
+                <a class="button button--standard button--next is-disabled" disabled></a>
+                {% endif %}
+                <span>Page {{ executive_sessions.number }} of {{ executive_sessions.paginator.num_pages }}</span>
+              </div>
+            </div>
+            {% else %}
             <div class="message message--info">
               <h2>No results</h2>
               {% if executive_query is not null %}
@@ -228,8 +224,9 @@
             </div>
             {% endif %}
           </section>
+        </div>
       </div>
     </section>
- </div>
+  </div>
 </section>
 {% endblock %}

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -68,14 +68,6 @@ def web_app_url(path):
 
 
 @register.filter()
-def classic_url(path):
-    """
-    Appends a path to the classic FEC.gov url as defined in the settings
-    """
-    return "{}{}".format(settings.FEC_CLASSIC_URL, path)
-
-
-@register.filter()
 def highlight_matches(text):
     """Replaces the highlight markers with span tags for digitalgov search results"""
     highlighted_text = text.replace('\ue000', '<span class="t-highlight">').replace('\ue001', '</span>')


### PR DESCRIPTION
## Summary

Resolves #3620

Removed references to `classic` which was down to `FEC_CLASSIC_URL` and `CLASSIC_URL`.

## Impacted areas of the application

- removed the `classic_url` filter
- removed references to the `FEC_CLASSIC_URL` env var
- Updated messaging for [Commission meetings search](http://127.0.0.1:8000/meetings/) as that's the only place that `CLASSIC_URL` was being used

## Screenshots
Current & updated with results:
<img src="https://user-images.githubusercontent.com/26720877/108255944-e6d1b400-712a-11eb-8e9b-1d620135e732.png" width="500">


Open meetings, no results:
<img src="https://user-images.githubusercontent.com/26720877/108255910-da4d5b80-712a-11eb-89de-75fd9cebff96.png" width="500">

Public hearings, no results:
<img src="https://user-images.githubusercontent.com/26720877/108255882-d15c8a00-712a-11eb-95b6-2896ec5453d0.png" width="500">

Executive sessions (almost always has results)
<img src="https://user-images.githubusercontent.com/26720877/108255847-c3a70480-712a-11eb-869d-cbf9b15dedc9.png" width="500">





## Related PRs

List related PRs against other branches:

None

## How to test

- pull the branch like normal
- `npm i`
- `npm run build`
- `./manage.py runserver`
- play with the [Commission meetings page](http://127.0.0.1:8000/meetings/), switch tabs, year filters, and search terms.

Note: it seems like filtering by _all_ years and by text is using an OR search: showing any results of the text search plus any results of all years—basically everything

____
