### PR TITLE
[HOT FIX - DON'T MERGE!] Updating chart offices to default to S

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -43,7 +43,7 @@ def to_date(committee, cycle):
 
 
 def aggregate_totals(request):
-    office = request.GET.get("office", "P")
+    office = request.GET.get("office", "S")
 
     election_year = int(
         request.GET.get("election_year", constants.DEFAULT_ELECTION_YEAR)
@@ -690,7 +690,7 @@ def elections(request, office, cycle, state=None, district=None):
 
 
 def raising(request):
-    office = request.GET.get("office", "P")
+    office = request.GET.get("office", "S")
 
     election_year = int(
         request.GET.get("election_year", constants.DEFAULT_ELECTION_YEAR)
@@ -714,7 +714,7 @@ def raising(request):
 
 
 def spending(request):
-    office = request.GET.get("office", "P")
+    office = request.GET.get("office", "S")
 
     election_year = int(
         request.GET.get("election_year", constants.DEFAULT_ELECTION_YEAR)

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -127,7 +127,7 @@
       cleanURI();
     })
     //handle Chrome insconsistency with History API
-    $('.js-office').val('P');
+    $('.js-office').val('S');
     $('.js-election-year').val('2020')
     $('.js-chart-toggle').filter('[value=receipts]').prop('checked', true)
   });

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -128,7 +128,7 @@
     })
     //handle Chrome insconsistency with History API
     $('.js-office').val('S');
-    $('.js-election-year').val('2020')
+    $('.js-election-year').val('2022')
     $('.js-chart-toggle').filter('[value=receipts]').prop('checked', true)
   });
 </script>

--- a/fec/home/templates/partials/oig-most-recent.html
+++ b/fec/home/templates/partials/oig-most-recent.html
@@ -3,7 +3,7 @@
 <ul class="list--spacious">
    {% for item in oig_most_recent %}
   <li>
-    <a class="t-bold" href="{{ item.url  }}">{% formatted_title item %}</a>
+    <a class="t-bold" href="{{ item.file_url }}">{% formatted_title item %}</a>
     <time class="t-sans u-margin--left feed--list__date" datetime="{{ item.date|date:'Y-mm' }}">{{ item.date|date:'F Y' }}</time>
   </li>
   {% endfor %}

--- a/fec/home/templatetags/top_entities.py
+++ b/fec/home/templatetags/top_entities.py
@@ -9,7 +9,7 @@ register = template.Library()
 
 @register.inclusion_tag('partials/raising-spending.html')
 def raising_spending(request):
-    office = request.GET.get('office', 'P')
+    office = request.GET.get('office', 'S')
 
     election_year = int(request.GET.get('election_year', constants.DEFAULT_ELECTION_YEAR))
 


### PR DESCRIPTION
## Summary

- Resolves #4418 

## Impacted areas of the application

Updated the default office for the homepage fundraising chart (top entities) and Raising and Spending by the numbers

Squeezed in a fix for the Most Recent Reports links on the OIG landing page

## Screenshots

![image](https://user-images.githubusercontent.com/26720877/108904507-93f57200-75ec-11eb-9384-a25fe8df19d8.png)

![image](https://user-images.githubusercontent.com/26720877/108904565-a96a9c00-75ec-11eb-8f5e-fc83a597f372.png)

![image](https://user-images.githubusercontent.com/26720877/108904411-732d1c80-75ec-11eb-879f-1f68377d9f93.png)


## Related PRs

None

## How to test

- pull the branch
- `npm i` (just in case)
- `npm run build` (just in case)
- `./manage.py runserver`
- Check the [homepage Who's raising the most](http://127.0.0.1:8000). Default office should be Senate
- Click 'Browse top raising candidates' 
- [Raising by the numbers](http://127.0.0.1:8000/data/raising-bythenumbers/) Aggregate totals and Who's raising the most should default to Senate races
- Same with [Spending by the numbers](http://127.0.0.1:8000/data/spending-bythenumbers/)

**DO NOT MERGE — HOTFIX**

____
