### PR TITLE
4390 bump lodash from 4.17.20 to 4.17.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9037,9 +9037,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jquery": "^3.5.1",
     "jquery.inputmask": "^3.3.4",
     "leaflet-providers": "1.8.0 ",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "minimatch": "^3.0.4",
     "moment": "2.20.1",
     "numeral": "^1.5.3",


### PR DESCRIPTION
## Summary

- Resolves #4390 

## Impacted areas of the application

Bumped the version of lodash from 4.17.20 to 4.17.21, just a patch-level change

## Screenshots

None

## Related PRs

None

## How to test

- pull branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- while Lodash could be used anywhere, `npm ls lodash` is telling me that only devDependencies are using it
  - `npm run build` should work fine
  - `npm run build-js` and `npm run build-sass` are both included with `npm run build` but they should work independently, too
  - `npm run test-single` should run without errors

____
