### PR TITLE
Feature/4168 optimization preloads

### DIFF
--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -94,7 +94,7 @@
           </li>
         </ul>
       </div>
-      {% include 'partials/navigation/navigation.html' %
+      {% include 'partials/navigation/navigation.html' %}
     </header>
     {% endif %}
 

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -11,7 +11,22 @@
     {% include 'partials/google-tag-manager-script.html' %}
 
     {% block css %}
-    <link rel="stylesheet" type="text/css" href="{% asset_for_css 'elections.css' %}" />
+    {#- Preloading fonts / letting the browser know we're going to request them later in the page -#}
+    {#- -#}
+    {#- All fonts are listed here but we're only preloading those we're using on the homepage at this time, -#}
+    {#- with the goal of simplifying preloading another font as needed -#}
+    <link rel="preload" as="font" href="/static/fonts/gandhiserif-bold.woff2" type="font/woff2" crossorigin>
+    {#- <!-- <link rel="preload" as="font" href="/static/fonts/gandhiserif-bolditalic.woff2" type="font/woff2" crossorigin> --> -#}
+    <link rel="preload" as="font" href="/static/fonts/gandhiserif-italic.woff2" type="font/woff2" crossorigin>
+    <link rel="preload" as="font" href="/static/fonts/gandhiserif-regular.woff2" type="font/woff2" crossorigin>
+    <link rel="preload" as="font" href="/static/fonts/karla-bold.woff2" type="font/woff2" crossorigin>
+    <link rel="preload" as="font" href="/static/fonts/karla-regular.woff2" type="font/woff2" crossorigin>
+    {#- <!-- <link rel="preload" as="font" href="/static/fonts/fec-currencymono-bold.woff2" type="font/woff2" crossorigin> --> -#}
+    {#- <!-- <link rel="preload" as="font" href="/static/fonts/fec-currencymono-bolditalic.woff2" type="font/woff2" crossorigin> --> -#}
+    {#- <!-- <link rel="preload" as="font" href="/static/fonts/fec-currencymono-italic.woff2" type="font/woff2" crossorigin> --> -#}
+    <link rel="preload" as="font" href="/static/fonts/fec-currencymono-regular.woff2" type="font/woff2" crossorigin>
+
+    <link rel="stylesheet" type="text/css" href="{% asset_for_css 'elections.css' %}">
     {% endblock %}
   </head>
 

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -5,27 +5,11 @@
 <html lang="en">
   <head>
     {% include './partials/meta-tags.html' %}
-
+    {% include './partials/meta-tags-preloads.html %}
     <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }} | FEC {% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
 
-    {% include 'partials/google-tag-manager-script.html' %}
-
+    {% include './partials/google-tag-manager-script.html' %}
     {% block css %}
-    {#- Preloading fonts / letting the browser know we're going to request them later in the page -#}
-    {#- -#}
-    {#- All fonts are listed here but we're only preloading those we're using on the homepage at this time, -#}
-    {#- with the goal of simplifying preloading another font as needed -#}
-    <link rel="preload" as="font" href="/static/fonts/gandhiserif-bold.woff2" type="font/woff2" crossorigin>
-    {#- <!-- <link rel="preload" as="font" href="/static/fonts/gandhiserif-bolditalic.woff2" type="font/woff2" crossorigin> --> -#}
-    <link rel="preload" as="font" href="/static/fonts/gandhiserif-italic.woff2" type="font/woff2" crossorigin>
-    <link rel="preload" as="font" href="/static/fonts/gandhiserif-regular.woff2" type="font/woff2" crossorigin>
-    <link rel="preload" as="font" href="/static/fonts/karla-bold.woff2" type="font/woff2" crossorigin>
-    <link rel="preload" as="font" href="/static/fonts/karla-regular.woff2" type="font/woff2" crossorigin>
-    {#- <!-- <link rel="preload" as="font" href="/static/fonts/fec-currencymono-bold.woff2" type="font/woff2" crossorigin> --> -#}
-    {#- <!-- <link rel="preload" as="font" href="/static/fonts/fec-currencymono-bolditalic.woff2" type="font/woff2" crossorigin> --> -#}
-    {#- <!-- <link rel="preload" as="font" href="/static/fonts/fec-currencymono-italic.woff2" type="font/woff2" crossorigin> --> -#}
-    <link rel="preload" as="font" href="/static/fonts/fec-currencymono-regular.woff2" type="font/woff2" crossorigin>
-
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'elections.css' %}">
     {% endblock %}
   </head>

--- a/fec/fec/templates/partials/meta-tags-preloads.html
+++ b/fec/fec/templates/partials/meta-tags-preloads.html
@@ -1,0 +1,20 @@
+{% spaceless %}
+{% comment %}
+
+Preloading fonts / letting the browser know we're going to request them later in the page
+
+All fonts are listed here but we're only preloading those we're using on the homepage at this time,
+with the goal of simplifying preloading another font as needed (as of 2021-03)
+
+{% endcomment %}
+<link rel="preload" as="font" href="/static/fonts/gandhiserif-bold.woff2" type="font/woff2" crossorigin>
+{# <!-- <link rel="preload" as="font" href="/static/fonts/gandhiserif-bolditalic.woff2" type="font/woff2" crossorigin> --> #}
+<link rel="preload" as="font" href="/static/fonts/gandhiserif-italic.woff2" type="font/woff2" crossorigin>
+<link rel="preload" as="font" href="/static/fonts/gandhiserif-regular.woff2" type="font/woff2" crossorigin>
+<link rel="preload" as="font" href="/static/fonts/karla-bold.woff2" type="font/woff2" crossorigin>
+<link rel="preload" as="font" href="/static/fonts/karla-regular.woff2" type="font/woff2" crossorigin>
+{# <!-- <link rel="preload" as="font" href="/static/fonts/fec-currencymono-bold.woff2" type="font/woff2" crossorigin> --> #}
+{# <!-- <link rel="preload" as="font" href="/static/fonts/fec-currencymono-bolditalic.woff2" type="font/woff2" crossorigin> --> #}
+{# <!-- <link rel="preload" as="font" href="/static/fonts/fec-currencymono-italic.woff2" type="font/woff2" crossorigin> --> #}
+<link rel="preload" as="font" href="/static/fonts/fec-currencymono-regular.woff2" type="font/woff2" crossorigin>
+{% endspaceless %}


### PR DESCRIPTION
## Summary

- Resolves #4168 

## Impacted areas of the application

Added some link/preload tags to the <head> for the homepage. The font definitions and instructions haven't been touched, only adding the tags as a heads-up so browsers can start those connections before it gets down to where we require the fonts.

Because we're only adding the preload warning, older browsers that don't support preloading will just ignore them and the fonts will load like they always have.

## Reviewers

Just need a couple approvals that the page still works

## Screenshots

No font changes between dev and local:
![image](https://user-images.githubusercontent.com/26720877/109213483-a7d0dd80-777e-11eb-9b1c-d63ea2022892.png)

## Related PRs

None

## How to test

- pull the branch
- `npm i` (just in case)
- `npm run build` (just in case)
- `./manage.py runserver`
- check the [homepage](http://127.0.0.1:8000)
- fonts should load correctly (will be _very_ surprised if they don't)
- check the Lighthouse score and details
  - with a Chromium browser (Chrome, Edge, Vivaldi, etc)
  - right-click the page
  - choose Inspect
  - switch to the Lighthouse tab
  - make sure at least Performance is checked
  - select either Mobile or Desktop
  - click Generate Report
  - wait
  - when Lighthouse is done, the Performance recommendations should not include "Preload key requests"

 Notes: 
- While Lighthouse is running, stay focused on either the Lighthouse window or the browser window it's checking. If you focus on a different tab/window, your tests will be useless
- If you need to run it again, click the grey 🚫 near the top left and start again
- if Lighthouse mentions extensions getting in the way, you might try an incognito window. For this test, though, we're only really looking that the fonts load and that "Preload key requests" goes away

____
