### PR TITLE
Replace 'mark_safe' with 'format_html'

### DIFF
--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -5,7 +5,6 @@ from django import template
 from django.conf import settings
 from django.templatetags.static import static
 from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from wagtail.core.models import Page
 
 register = template.Library()
@@ -71,7 +70,7 @@ def web_app_url(path):
 def highlight_matches(text):
     """Replaces the highlight markers with span tags for digitalgov search results"""
     highlighted_text = text.replace('\ue000', '<span class="t-highlight">').replace('\ue001', '</span>')
-    return mark_safe(highlighted_text)
+    return format_html(highlighted_text)
 
 
 @register.filter(name='splitlines')


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/fec-accounts/issues/342
Replace `mark_safe` with `format_html`

## Impacted areas of the application

Replace `mark_safe` with `format_html` which has string escaping

https://docs.djangoproject.com/en/dev/ref/utils/#django.utils.html.format_html

`format_html` is similar to `str.format()`, except that it is appropriate for building up HTML fragments. All args and kwargs are passed through `conditional_escape()` before being passed to `str.format()`.

>So, instead of writing:
```python
mark_safe("%s <b>%s</b> %s" % (
    some_html,
    escape(some_text),
    escape(some_other_text),
))
```
>You should instead use:
```python
format_html("{} <b>{}</b> {}",
    mark_safe(some_html),
    some_text,
    some_other_text,
)
```

## How to test
**Test functionality**
- Set env vars needed for searches:
`export FEC_DIGITALGOV_KEY="<get from dev with cf env cms>"`
`export SEARCH_GOV_POLICY_GUIDANCE_KEY="<get from dev with cf env cms>"`
- Test sitewide search: http://localhost:8000/search/
- Test policy any other guidance search: http://localhost:8000/legal-resources/policy-and-other-guidance/guidance-documents/
**Make sure bandit doesn't flag this anymore**
- `pip install bandit`
- `bandit -r .` to test current directory