### PR TITLE
ARIA/accessibility fixes for mobile menu and search/typeahead

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -83,6 +83,7 @@
             <input type="hidden" name="type" value="committees">
             <input type="hidden" name="type" value="site">
             <label class="u-visually-hidden" for="query">Search</label>
+             <div class="combo combo--search">
             <input
               class="js-site-search combo__input"
               autocomplete="off"
@@ -93,6 +94,7 @@
             <button type="submit" class="button--standard combo__button button--search">
               <span class="u-visually-hidden">Search</span>
             </button>
+           </div>
           </form>
         </li>
       </ul>

--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -2,6 +2,7 @@
 
 var $ = require('jquery');
 require('perfect-scrollbar/jquery')($);
+const accessibility = require('./accessibility');
 
 var listeners = require('./listeners');
 
@@ -84,6 +85,7 @@ Dropdown.prototype.toggle = function(e) {
 };
 
 Dropdown.prototype.show = function() {
+  accessibility.restoreTabindex(this.$panel);
   this.$panel.attr('aria-hidden', 'false');
   this.$panel.perfectScrollbar({ suppressScrollX: true });
   this.$panel.find('input[type="checkbox"]:first').focus();
@@ -92,6 +94,7 @@ Dropdown.prototype.show = function() {
 };
 
 Dropdown.prototype.hide = function() {
+  accessibility.removeTabindex(this.$panel);
   this.$panel.attr('aria-hidden', 'true');
   this.$button.removeClass('is-active');
   this.isOpen = false;

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -122,6 +122,12 @@ FilterTypeahead.prototype.handleAutocomplete = function(e, datum) {
 };
 
 FilterTypeahead.prototype.handleKeypress = function(e) {
+  if (this.$elm.find('.tt-suggestion').length > 0) {
+    this.$field.attr('aria-expanded', 'true');
+  } else {
+    this.$field.attr('aria-expanded', 'false');
+  }
+
   this.handleChange();
 
   if (e.keyCode === 13) {
@@ -193,7 +199,6 @@ FilterTypeahead.prototype.clearInput = function() {
 };
 
 FilterTypeahead.prototype.enableButton = function() {
-  this.$field.attr('aria-expanded', 'true');
   this.searchEnabled = true;
   this.$button
     .removeClass('is-disabled')
@@ -202,7 +207,6 @@ FilterTypeahead.prototype.enableButton = function() {
 };
 
 FilterTypeahead.prototype.disableButton = function() {
-  this.$field.attr('aria-expanded', 'false');
   this.searchEnabled = false;
   this.$button
     .addClass('is-disabled')

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -100,6 +100,7 @@ FilterTypeahead.prototype.setFirstItem = function() {
   $(this.$elm.find('.tt-suggestion')[0]).addClass('tt-cursor');
   if (this.$elm.find('.tt-suggestion').length > 0) {
     this.enableButton();
+    this.$field.attr('aria-expanded', 'true');
   }
 };
 
@@ -122,13 +123,13 @@ FilterTypeahead.prototype.handleAutocomplete = function(e, datum) {
 };
 
 FilterTypeahead.prototype.handleKeypress = function(e) {
+  this.handleChange();
+
   if (this.$elm.find('.tt-suggestion').length > 0) {
     this.$field.attr('aria-expanded', 'true');
   } else {
     this.$field.attr('aria-expanded', 'false');
   }
-
-  this.handleChange();
 
   if (e.keyCode === 13) {
     this.handleSubmit(e);

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -88,6 +88,8 @@ FilterTypeahead.prototype.typeaheadInit = function() {
   }
 
   this.$elm.find('.tt-menu').attr('aria-live', 'polite');
+  this.$elm.find('.tt-input').removeAttr('aria-readonly');
+  this.$elm.find('.tt-input').attr('aria-expanded', 'false');
 };
 
 FilterTypeahead.prototype.setFirstItem = function() {
@@ -191,6 +193,7 @@ FilterTypeahead.prototype.clearInput = function() {
 };
 
 FilterTypeahead.prototype.enableButton = function() {
+  this.$field.attr('aria-expanded', 'true');
   this.searchEnabled = true;
   this.$button
     .removeClass('is-disabled')
@@ -199,6 +202,7 @@ FilterTypeahead.prototype.enableButton = function() {
 };
 
 FilterTypeahead.prototype.disableButton = function() {
+  this.$field.attr('aria-expanded', 'false');
   this.searchEnabled = false;
   this.$button
     .addClass('is-disabled')

--- a/fec/fec/static/js/modules/site-nav.js
+++ b/fec/fec/static/js/modules/site-nav.js
@@ -2,6 +2,7 @@
 
 var $ = require('jquery');
 var helpers = require('./helpers');
+const accessibility = require('./accessibility');
 
 window.$ = window.jQuery = $;
 
@@ -20,6 +21,7 @@ function SiteNav(selector) {
   this.$element = $(selector);
   this.$menu = this.$element.find('#site-menu');
   this.$toggle = this.$element.find('.js-nav-toggle');
+  this.$searchbox = this.$body.find('.utility-nav__search');
 
   this.assignAria();
 
@@ -27,6 +29,7 @@ function SiteNav(selector) {
 
   // Open and close the menu on mobile
   this.$toggle.on('click', this.toggleMenu.bind(this));
+  //$(window).on('resize', this.hideMenu.bind(this));
 }
 
 SiteNav.prototype.initMenu = function() {
@@ -66,6 +69,7 @@ SiteNav.prototype.assignAria = function() {
   if (helpers.getWindowWidth() < helpers.BREAKPOINTS.LARGE) {
     this.$toggle.attr('aria-haspopup', true);
     this.$menu.attr('aria-hidden', true);
+    accessibility.removeTabindex(this.$menu);
   }
 };
 
@@ -80,7 +84,9 @@ SiteNav.prototype.showMenu = function() {
   });
   this.$element.addClass('is-open');
   this.$toggle.addClass('active');
+  $('.site-nav__panel').prepend(this.$searchbox);
   this.$menu.attr('aria-hidden', false);
+  accessibility.restoreTabindex(this.$menu);
   this.isOpen = true;
 };
 
@@ -91,6 +97,9 @@ SiteNav.prototype.hideMenu = function() {
   this.$element.removeClass('is-open');
   this.$toggle.removeClass('active');
   this.$menu.attr('aria-hidden', true);
+  accessibility.removeTabindex(this.$menu);
+  $('.utility-nav.list--flat').append(this.$searchbox);
+
   this.isOpen = false;
   if (this.isMobile) {
     this.$element.find('[aria-hidden=false]').attr('aria-hidden', true);

--- a/fec/fec/static/js/modules/site-nav.js
+++ b/fec/fec/static/js/modules/site-nav.js
@@ -29,7 +29,16 @@ function SiteNav(selector) {
 
   // Open and close the menu on mobile
   this.$toggle.on('click', this.toggleMenu.bind(this));
-  //$(window).on('resize', this.hideMenu.bind(this));
+
+  /*matchMedia is used belowto ensure searchbox is appended to correct location when 
+  user resizes screen while mobile menu is open */
+
+  //Define min-width media query that matches our med('mobile') breakpoint
+  const mql = window.matchMedia('screen and (min-width: 860px)');
+  // call listener function explicitly at run time
+  this.mediaQueryResponse(mql);
+  // attach listener function to listen for change in mediaQuery list
+  mql.addListener(this.mediaQueryResponse);
 }
 
 SiteNav.prototype.initMenu = function() {
@@ -73,6 +82,27 @@ SiteNav.prototype.assignAria = function() {
   }
 };
 
+//Append searchbox to correct location uponn user screen resize
+SiteNav.prototype.mediaQueryResponse = function(mql) {
+  //If large
+  if (mql.matches) {
+    $('body')
+      .find('.utility-nav__search')
+      .appendTo('.utility-nav.list--flat');
+  }
+  //if mobile
+  else {
+    $('body')
+      .find('.utility-nav__search')
+      .prependTo('.site-nav__panel');
+    if ($('.js-site-nav').hasClass('is-open')) {
+      accessibility.restoreTabindex($('.utility-nav__search'));
+    } else {
+      accessibility.removeTabindex($('.utility-nav__search'));
+    }
+  }
+};
+
 SiteNav.prototype.toggleMenu = function() {
   var method = this.isOpen ? this.hideMenu : this.showMenu;
   method.apply(this);
@@ -84,9 +114,11 @@ SiteNav.prototype.showMenu = function() {
   });
   this.$element.addClass('is-open');
   this.$toggle.addClass('active');
-  $('.site-nav__panel').prepend(this.$searchbox);
   this.$menu.attr('aria-hidden', false);
+  //append seacrh to mobile menu uponn opening
+  $('.site-nav__panel').prepend(this.$searchbox);
   accessibility.restoreTabindex(this.$menu);
+
   this.isOpen = true;
 };
 
@@ -97,8 +129,9 @@ SiteNav.prototype.hideMenu = function() {
   this.$element.removeClass('is-open');
   this.$toggle.removeClass('active');
   this.$menu.attr('aria-hidden', true);
+  //append search to header
+  $('.utility-nav.list--flat').prepend(this.$searchbox);
   accessibility.removeTabindex(this.$menu);
-  $('.utility-nav.list--flat').append(this.$searchbox);
 
   this.isOpen = false;
   if (this.isMobile) {

--- a/fec/fec/static/js/modules/typeahead.js
+++ b/fec/fec/static/js/modules/typeahead.js
@@ -273,6 +273,8 @@ function Typeahead(selector, type, url) {
   this.init();
 
   events.on('searchTypeChanged', this.handleChangeEvent.bind(this));
+
+  this.$input.on('keyup', this.setAria.bind(this));
 }
 
 Typeahead.prototype.init = function() {
@@ -283,11 +285,22 @@ Typeahead.prototype.init = function() {
   this.$element = this.$input.parent('.twitter-typeahead');
   this.$element.css('display', 'block');
   this.$element.find('.tt-menu').attr('aria-live', 'polite');
+  this.$element.find('.tt-input').removeAttr('aria-readonly');
+  this.$element.find('.tt-input').attr('aria-expanded', 'false');
   this.$input.on('typeahead:select', this.select.bind(this));
 };
 
 Typeahead.prototype.handleChangeEvent = function(data) {
   this.init(data.type);
+};
+
+Typeahead.prototype.setAria = function() {
+  if (this.$element.find('.tt-menu').attr('aria-expanded') == 'false') {
+    this.$element.find('.tt-input').attr('aria-expanded', 'false');
+  } else {
+    this.$element.find('.tt-input').attr('aria-expanded', 'true');
+  }
+  //alert('closed')
 };
 
 Typeahead.prototype.select = function(event, datum) {

--- a/fec/fec/static/scss/components/_nav.scss
+++ b/fec/fec/static/scss/components/_nav.scss
@@ -266,18 +266,18 @@
   }
 }
 
-.mobile-search.utility-nav__search {
-  width: u(30rem);
-  padding: u(1rem);
-  display: block;
+.utility-nav__search {
+  /*width: u(30rem);*/
+  padding: 0 u(1rem);
+/*  display: block;*/
  }
 
-
+/*
 @include media($lg) {
   .mobile-search.utility-nav__search {
     display: none;
   }
-}
+}*/
 
 
 // Grid overhaul, using _grid.scss breakpoints but Bootstrap naming as inspiration,

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -50,16 +50,20 @@
               <input type="hidden" name="type" value="committees">
               <input type="hidden" name="type" value="site">
               <label class="u-visually-hidden" for="query">Search</label>
-              <input
-                class="js-site-search combo__input"
-                autocomplete="off"
-                id="query"
-                name="query"
-                type="text"
-                aria-label="Search FEC.gov">
-              <button type="submit" class="button--standard combo__button button--search">
-                <span class="u-visually-hidden">Search</span>
-              </button>
+              <div class="combo combo--search">
+                <input
+                  class="js-site-search combo__input"
+                  autocomplete="off"
+                  aria-expanded="false"
+                  aria-controls="query_listbox"
+                  id="query"
+                  name="query"
+                  type="text"
+                  aria-label="Search FEC.gov">
+                <button type="submit" class="button--standard combo__button button--search">
+                  <span class="u-visually-hidden">Search</span>
+                </button>
+              </div>
             </form>
           </li>
         </ul>
@@ -73,23 +77,27 @@
         <a title="Home" href="/" class="site-title" rel="home"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
         <ul class="utility-nav list--flat">
           <li class="utility-nav__item{% if self.content_section == 'calendar' %} is-active{% endif %}"><a href="/calendar/">Calendar</a></li>
-          <li class="utility-nav__item"><a class="js-glossary-toggle glossary__toggle">Glossary</a></li>
+           <li class="utility-nav__item"><a class="js-glossary-toggle glossary__toggle">Glossary</a></li>
           <li class="utility-nav__search">
             <form accept-charset="UTF-8" action="/search" id="search_form" class="combo" method="get" role="search">
               <input type="hidden" name="type" value="candidates">
               <input type="hidden" name="type" value="committees">
               <input type="hidden" name="type" value="site">
               <label class="u-visually-hidden" for="query">Search</label>
-              <input
-                class="js-site-search combo__input"
-                autocomplete="off"
-                id="query"
-                name="query"
-                type="text"
-                aria-label="Search FEC.gov">
-              <button type="submit" class="button--standard combo__button button--search">
-                <span class="u-visually-hidden">Search</span>
-              </button>
+              <div class="combo combo--search">
+                <input
+                  class="js-site-search combo__input"
+                  autocomplete="off"
+                  aria-expanded="false"
+                  aria-controls="query_listbox"
+                  id="query"
+                  name="query"
+                  type="text"
+                  aria-label="Search FEC.gov">
+                <button type="submit" class="button--standard combo__button button--search">
+                  <span class="u-visually-hidden">Search</span>
+                </button>
+              </div>
             </form>
           </li>
         </ul>

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -50,16 +50,19 @@
               <input type="hidden" name="type" value="committees">
               <input type="hidden" name="type" value="site">
               <label class="u-visually-hidden" for="query">Search</label>
-              <input
-                class="js-site-search combo__input"
-                autocomplete="off"
-                id="query"
-                name="query"
-                type="text"
-                aria-label="Search FEC.gov">
-              <button type="submit" class="button--standard combo__button button--search">
-                <span class="u-visually-hidden">Search</span>
-              </button>
+              <div class="combo combo--search">
+                <input
+                  class="js-site-search combo__input"
+                  autocomplete="off"
+                  aria-controls="query_listbox"
+                  id="query"
+                  name="query"
+                  type="text"
+                  aria-label="Search FEC.gov">
+                <button type="submit" class="button--standard combo__button button--search">
+                  <span class="u-visually-hidden">Search</span>
+                </button>
+              </div>
             </form>
           </li>
         </ul>
@@ -80,6 +83,7 @@
               <input type="hidden" name="type" value="committees">
               <input type="hidden" name="type" value="site">
               <label class="u-visually-hidden" for="query">Search</label>
+              <div class="combo combo--search">
               <input
                 class="js-site-search combo__input"
                 autocomplete="off"
@@ -90,7 +94,8 @@
               <button type="submit" class="button--standard combo__button button--search">
                 <span class="u-visually-hidden">Search</span>
               </button>
-            </form>
+            </div>
+           </form>
           </li>
         </ul>
       </div>

--- a/fec/fec/templates/partials/navigation/navigation.html
+++ b/fec/fec/templates/partials/navigation/navigation.html
@@ -1,7 +1,8 @@
 <nav class="site-nav js-site-nav">
+ <button class="js-nav-toggle site-nav__button" aria-controls="site-menu">Menu</button>
   <div id="site-menu" class="site-nav__container">
     <ul class="site-nav__panel site-nav__panel--main">
-      <li class="mobile-search utility-nav__search">
+      <!-- <li class="mobile-search utility-nav__search">
         <form accept-charset="UTF-8" action="/search" id="search_form" class="combo" method="get" role="search">
           <input type="hidden" name="type" value="candidates">
           <input type="hidden" name="type" value="committees">
@@ -20,7 +21,7 @@
             </button>
          </div>
         </form>
-      </li>
+      </li> -->
       <li><h2 class="site-nav__title u-under-lg-only">Menu</h2></li>
       <li class="site-nav__item u-under-lg-only">
         <a class="site-nav__link" href="/" rel="home">
@@ -28,26 +29,26 @@
         </a>
       </li>
       <li class="site-nav__item" data-submenu="data">
-        <a class="site-nav__link {% if self.content_section == 'data' or parent == 'data' %}is-parent{% endif %}" href="/data/" tabindex="0">
+        <a class="site-nav__link {% if self.content_section == 'data' or parent == 'data' %}is-parent{% endif %}" href="/data/" >
           <span class="site-nav__link__title">
           Campaign finance data</span>
         </a>
         {% include 'partials/navigation/nav-data.html' %}
       </li>
       <li class="site-nav__item site-nav__item--secondary" data-submenu="help">
-        <a href="/help-candidates-and-committees/" tabindex="0" class="site-nav__link {% if self.content_section == 'help' %}is-parent{% endif %}">
+        <a href="/help-candidates-and-committees/" class="site-nav__link {% if self.content_section == 'help' %}is-parent{% endif %}">
           <span class="site-nav__link__title">Help for candidates and committees</span>
         </a>
         {% include 'partials/navigation/nav-help.html' %}
       </li>
       <li class="site-nav__item" data-submenu="legal">
-        <a href="/legal-resources/" tabindex="0" class="site-nav__link {% if self.content_section == 'legal' or parent == 'legal' %}is-parent{% endif %}">
+        <a href="/legal-resources/" class="site-nav__link {% if self.content_section == 'legal' or parent == 'legal' %}is-parent{% endif %}">
           <span class="site-nav__link__title">Legal resources</span>
         </a>
         {% include 'partials/navigation/nav-legal.html' %}
       </li>
       <li class="site-nav__item site-nav__item--secondary" data-submenu="about">
-        <a href="/about/" tabindex="0" class="site-nav__link {% if self.content_section == 'about' %}is-parent{% endif %}">
+        <a href="/about/" class="site-nav__link {% if self.content_section == 'about' %}is-parent{% endif %}">
           <span class="site-nav__link__title">About</span>
         </a>
         {% include 'partials/navigation/nav-about.html' %}
@@ -55,6 +56,5 @@
 
     </ul>
   </div>
-  <button class="js-nav-toggle site-nav__button" aria-controls="site-menu">Menu</button>
   <a title="Home" href="/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
 </nav>


### PR DESCRIPTION
## Summary (required)

The work for this PR was originally to address issue [4183](https://github.com/fecgov/fec-cms/issues/4183) `aria-hidden="true"] elements contain focusable descendants` on the homepage. 

Since the mobile menu and its child global search filed appear on every page of the site, I decided to combine the fixes for these into one PR. This also extended to datable search fields that use typeahead.

- Resolves #4183 - [aria-hidden="true"] elements contain focusable descendants
- Resolves #4186 -  ARIA IDs are not unique`

Also partially addressed:
#4185 [aria-*] attributes do not have valid values

[aria-*] attributes do not match their roles

[role]s do not have all required [aria-*] attributes

<hr>

### Failing elements and their fixes:
1) The mobile menu failed `aria-hidden="true"] elements contain focusable descendants` ([4183](https://github.com/fecgov/fec-cms/issues/4183)) because it  maintains focusability on child elements when closed(aria-hidden='true') 

      - **Fix**: Use the utility in [static/js/accessibility.js](https://github.com/fecgov/fec-cms/blob/develop/fec/fec/static/js/modules/accessibility.js) to set tabindex to `-1` on mobile menu links while ,menu is closed and add tab index to `0` when menu is expanded. ( `site-nav.js`)

2) The global site search failed for `ARIA IDs are not unique` ([4186](https://github.com/fecgov/fec-cms/issues/4186)) because there are two search boxes on the page, one being hidden/shown based on screen size. Followup issue to come.

      - **Fix**: Remove the second site search box that resides in the mobile menu and  was hidden/shown based on screen size and instead  use the same field for both mobile and desktop by moving the field to the correct location based on screen size. ( `site-nav.js`)
      - **Note:** To handle a scenario where a user resizes the screen from mobile to desktop when the menu is left open, I employ the followinng techniques that I hope would have a lower overhead than a window.resize listener:
 [MediaQueryList](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/media)
 [matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia)
 [Testing media queries programmatically](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries)
  This allows us to handle the two locations of the global searchbox until we can redesign the header to persist one searchbox regardless of screen/device size. not supported inn IE, just giving the user a searchbox in different, but not ugly location the rare scenario that a user resizes with mobile menu open.

3) The global site search field typeahead dropdown and datable search fields that use the typeahead  failed  for `[aria-*] attributes do not have valid values `([4185,](https://github.com/fecgov/fec-cms/issues/4185)) and two that did not have corresponding tickets `[aria-*] attributes do not match their roles` AND `[role]s do not have all required [aria-*] attributes`
      - **Fix**: Add or alter necessary Aria attributes to the site search field and datatable typeahead search fields  and remove incorrect Aria attributes on this fields. (`typeahead.js`, `filter-typeahead.js`)

4) Additional fix was also made based on documented ARIA requirements although they may not have triggered a Lighthouse failing flag. The typeahead fields have a role of combobox and require `aria-expanded` roles to be set based on the state of the typeahead suggestion popup.

      - **Fix**:  Programmatically add `aria-expanded` tags based on the state of the search field and associated typeahead popup. (`typeahead.js`, `filter-typeahead.js`)

5) Another accessibility issue that was brought to light by this work was the inconsistent  tab navigation for the mobile menu which could translate to lack of navigability for screen readers. 

    - **Fix**:This was fixed by moving the toggle to above the menu in the html template, allowing tabbed navigation through the mobile menu, once opened. (`navigation.html`)

6) The "More" dropdown checkbox list for Report Time Period on datatables  `.dropdown__panel`  starts with `aria-hidden=false`, but has focusable elements with tabindex=0. This did not get flagged by Lighthouse but seems to violate `aria-hidden="true"] elements contain focusable descendants`.

    - **Fix**: Use the utility in [static/js/accessibility.js](https://github.com/fecgov/fec-cms/blob/develop/fec/fec/static/js/modules/accessibility.js) similar to item 1 above.( `dropdown.js`)

<hr>



## Impacted areas of the application

	modified:   data/templates/layouts/main.jinja
	modified:   fec/static/js/modules/dropdowns.js
	modified:   fec/static/js/modules/filters/filter-typeahead.js
	modified:   fec/static/js/modules/site-nav.js
	modified:   fec/static/js/modules/typeahead.js
	modified:   fec/static/scss/components/_nav.scss
	modified:   fec/templates/base.html
	modified:   fec/templates/home_base.html
	modified:   fec/templates/partials/navigation/navigation.html


## Screenshots

### BEFORE:
![Screen Shot 2021-03-08 at 11 33 33 AM](https://user-images.githubusercontent.com/5572856/110350937-3c9acd00-8002-11eb-9521-45b7a2755174.png)

### AFTER:
![Screen Shot 2021-03-08 at 11 33 53 AM](https://user-images.githubusercontent.com/5572856/110350959-47556200-8002-11eb-84f3-f60b8b4a8f1d.png)


### How to test
- Checkout feature/aria-fixes-for-search-typeahead-mobilemenu
- npm run-build, ./manage.py runserver
- Test that site search box gets `aria-expanded=true` when the typeahead suggestion box is visible and `aria-expanded=false` when it is collapsed
- Test that you can tab to , open and tab through the mobile menu
- Run a lighthouse scan on Home page and a datatable page  and confirm that there are no failing ARIA flags  on:
     - Site searchbox (.js-site-search.combo__input.tt-input) 
     - RECIPIENT NAME OR ID (input#committee_id.combo__input.tt-input)
     - CONTRIBUTOR DETAILS (input#contributor_name.combo__input.tt-input)
 - Test that the global searchbox get appended to the mobile-menu on mobile view and appended back to site header in desktop view. 
 
 **Note:** The mobile toggle  button may be missing  at certain screen widths on your local  because if the env specific banner --  you could resize until you see the button or remove the banner in the inspector
____
