### PR TITLE
Change Audit Reports to title case in data table only

### DIFF
--- a/fec/fec/static/js/pages/datatable-audit.js
+++ b/fec/fec/static/js/pages/datatable-audit.js
@@ -28,7 +28,7 @@ $(document).ready(function() {
   var $table = $('#results');
   new tables.DataTable($table, {
     autoWidth: false,
-    title: 'Audit reports',
+    title: 'Audit Reports',
     path: ['audit-case'],
     columns: columns.audit,
     order: [1, 'desc'],


### PR DESCRIPTION
## Summary (required)

- Resolves #4302 
- Update Audit Reports to title casing 

## Impacted areas of the application

List general components of the application that this PR will affect:

- Title of the Audits data table


## Screenshots


- Audits data table before:
<img width="1024" alt="datatable-audit js 31-25 before" src="https://user-images.githubusercontent.com/66386084/110171373-9fedea80-7dc9-11eb-97bd-98d29d4def67.png">

- Audits data table after:
<img width="1024" alt="datatable-audit 31-25 after" src="https://user-images.githubusercontent.com/66386084/110171401-ab411600-7dc9-11eb-9849-efc3aa767a95.png">



## How to test

Include any information that may be helpful to the reviewer(s).
_This might include:_
https://github.community/t/checkout-a-branch-from-a-fork/276/2
- links to sample pages to test
- https://127.0.0.1:8000/legal-resources/enforcement/audit-search/
- Any local environmental setup that is unusual (env vars, API version to point to, etc)

____
