### PR TITLE
Exclude hearings from open mtg tab/fix open mtg search

### DIFF
--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -4,7 +4,7 @@
 <html lang="en">
   <head>
     {% include 'partials/meta-tags.html' %}
-    {% include 'partials/meta-tags-preloads.html %}
+    {% include 'partials/meta-tags-preloads.html' %}
     {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
     {% include 'partials/meta-tags-preconnects.html' %}
     {% endif %}

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -361,7 +361,7 @@ def index_meetings(request):
     if search:
         if active == "open-meetings":
             meetings_query = search
-            meetings = meetings.search(meetings_query)
+            open_meetings = open_meetings.search(meetings_query)
         if active == "hearings":
             hearings_query = search
             hearings = hearings.search(hearings_query)

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -317,9 +317,7 @@ def index_meetings(request):
     Serve 'commission meetings' page under 'about'
     """
     meetings = MeetingPage.objects.live().order_by("-date")
-    open_meetings = meetings.filter(
-        Q(meeting_type="O") | Q(title__icontains="Hearing") | Q(meeting_type="H")
-    )
+    open_meetings = meetings.filter(meeting_type="O").exclude(title__icontains="Hearing")
     executive_sessions = meetings.filter(meeting_type="E")
     hearings = meetings.filter(Q(title__icontains="Hearing") | Q(meeting_type="H"))
     year = request.GET.get("year", "")


### PR DESCRIPTION
## Summary (required)

- Resolves #4349
- Resolves #4473

Change open meeting query to include only open meetings and also to exclude those Hearings pages made using meeting type 'O' (open meeting) by excluding by existence of 'hearing' (case insensitive) in title. 

Limit open meetings free text search to only open meetings


## Impacted areas of the application
modified:   home/views.py

### Screenshot

![Mar-11-2021 02-19-27](https://user-images.githubusercontent.com/5572856/110750386-645f8000-8210-11eb-882c-e766c5972983.gif)



## How to test
- checkout and run `feature/4349/exclude-hearings-from-open-mtg-tab`
- Make sure no hearings show up in Open meetings tab
- Make sure Hearings pages made with with incorrect meeting  type of 'O', like September 14, 2017 audit hearing,  don't show up in Open meeings tab
- Search for Oklahoma democratic party in open meetings tab and confirm results contain those keywords
 - **Note:** in rare instances, Imported html for meetings before May 2017 may have commented-out html that can cause a search result for a keywords that are hidden  on the rendered page. Example: search 'hearing ' on open meeting tab and you get a result for `March 16, 2016`  that does not show the word 'hearing' in the body text (it is in commented html)

Here is the example if incorrectly labeled Hearing in Wagtail:
http://127.0.0.1:8000/admin/pages/9257/edit/

____
