### PR TITLE
Fix committee terminated bug on committee profile page

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -356,7 +356,6 @@ def get_committee(committee_id, cycle):
     Given a committee_id and cycle, call the API and get the committee
     and committee financial data needed to render the committee profile page
     """
-
     committee, all_candidates, cycle = load_committee_history(committee_id, cycle)
     # When there are multiple candidate records of various offices (H, S, P)
     # linked to a single committee ID,
@@ -581,9 +580,8 @@ def load_reports_and_totals(committee_id, cycle, cycle_out_of_range, fallback_cy
 def load_committee_history(committee_id, cycle=None):
     filters = {"per_page": 1}
     if not cycle:
-        # if no cycle parameter given,
-        # (1.1)call committee/{committee_id}/history/ under tag:committee
-        # set cycle = fallback_cycle
+        # if no cycle parameter passed, use current fec cycle to call
+        # (1)endpoint: committee/{committee_id}/history/ --under tag:committee
         path = "/committee/" + committee_id + "/history/"
         committee = api_caller.load_first_row_data(path, **filters)
         if committee is None:
@@ -593,16 +591,16 @@ def load_committee_history(committee_id, cycle=None):
             # when committees only file F1. fallback_cycle = null
             # set cycle = last_cycle_has_activity
             cycle = committee.get("last_cycle_has_activity")
-    else:
-        # (1.2)call committee/{committee_id}/history/{cycle}/
-        # under tag:committee
-        path = "/committee/" + committee_id + "/history/" + str(cycle)
-        committee = api_caller.load_first_row_data(path, **filters)
-        if committee is None:
-            raise Http404()
 
-    # (2)call committee/{committee_id}/candidates/history/{cycle}
-    # under: candidate, get all candidates associated with that commitee
+    # To get correct committee history, use related cycle value to call
+    # (2)endpoint: committee/{committee_id}/history/{cycle}/ --under tag:committee
+    path = "/committee/" + committee_id + "/history/" + str(cycle)
+    committee = api_caller.load_first_row_data(path, **filters)
+    if committee is None:
+        raise Http404()
+
+    # (3)call endpoint: committee/{committee_id}/candidates/history/{cycle}
+    # --under tag: candidate, get all candidates associated with that commitee
     path = "/committee/" + committee_id + "/candidates/history/" + str(cycle)
     all_candidates = api_caller.load_endpoint_results(path, election_full=False)
 

--- a/fec/legal/templates/legal-archived-mur.jinja
+++ b/fec/legal/templates/legal-archived-mur.jinja
@@ -19,7 +19,11 @@
   <div class="content__section">
     <header class="heading--main">
       <h1>MUR #{{ mur.no }}</h1>
-      <span class="heading__subtitle">{{ mur.name }}</span>
+      <span class="heading__subtitle">
+        {% if mur.name %}
+          {{ mur.name }}
+        {% endif %}
+      </span>
     </header>
   </div>
   <div class="sidebar-container sidebar-container--left js-sticky-side" data-sticky-container="main">

--- a/fec/legal/templates/legal-current-mur.jinja
+++ b/fec/legal/templates/legal-current-mur.jinja
@@ -19,7 +19,11 @@
   <div class="content__section">
     <header class="heading--main">
       <h1>MUR #{{ mur.no }}</h1>
-      <span class="heading__subtitle">{{ mur.name }}</span>
+      <span class="heading__subtitle">
+        {% if mur.name %}
+          {{ mur.name }}
+        {% endif %}
+      </span>
     </header>
   </div>
   <div class="sidebar-container sidebar-container--left js-sticky-side" data-sticky-container="main">


### PR DESCRIPTION
## Summary (required)
TERMINATED/ACTIVE indicator shows wrong when no cycle passed on committee profile page.
ex:  C00409011
https://www.fec.gov/data/committee/C00409011/
shows `TERMINATED`.
It should be `ACTIVE` in 2005-2006 (the last financial cycle)

- Resolves [#4448](https://github.com/fecgov/fec-cms/issues/4448rl)
<img width="300" alt="before" src="https://user-images.githubusercontent.com/24395751/111353782-0097e580-865c-11eb-8550-4b73ef31622c.png">

<img width="300" alt="after" src="https://user-images.githubusercontent.com/24395751/111353826-08f02080-865c-11eb-8e8d-1d4c802c71d1.png">

## Impacted areas of the application
committee profile page

List general components of the application that this PR will affect:
data/views.py
 
## How to test
1) checkout branch
2) point to any api
3) ./manage.py test
pytest
4) test committee profile page (compare with prod)

(1)C00409011
(local) http://127.0.0.1:8000/data/committee/C00409011/
(prod) https://www.fec.gov/data/committee/C00409011/

(2) C00580100 (active committee)should no change
(local) http://127.0.0.1:8000/data/committee/C00580100/
(prod) https://www.fec.gov/data/committee/C00580100/

(3) C00619411 (terminated committee) should no change
(local) http://127.0.0.1:8000/data/committee/C00619411/
(prod) https://www.fec.gov/data/committee/C00619411/

5) test global search, should display committee status in current cycle.
input ex: C00409011, C00580100, C00619411
<img width="300" alt="Screen Shot 2021-03-10 at 11 29 50 PM" src="https://user-images.githubusercontent.com/24395751/111356975-41ddc480-865f-11eb-9e7b-1e70f1c02462.png">


6) test data lending page, should display committee status in current cycle.
https://www.fec.gov/data/
http://127.0.0.1:8000/data/
input ex: C00409011, C00580100, C00619411
<img width="300" alt="Screen Shot 2021-03-10 at 11 29 22 PM" src="https://user-images.githubusercontent.com/24395751/111356394-b2d0ac80-865e-11eb-9c8e-4ca9ce9e14c1.png">

7) this PR also fix a minor local bug(only happen on local) in arc-mur page (happen when without mur_name value).
http://127.0.0.1:8000/data/legal/matter-under-review/4321/
<img width="300" alt="Screen Shot 2021-03-16 at 12 38 15 PM" src="https://user-images.githubusercontent.com/24395751/111356673-f88d7500-865e-11eb-8a27-4b954ce0db62.png">

## Reviewers
one cms-backend, one cms-front-end