### PR TITLE
[MERGE WITH GITFLOW] Fix Safari bug with desktop-size menu

### DIFF
--- a/fec/fec/templates/partials/navigation/navigation.html
+++ b/fec/fec/templates/partials/navigation/navigation.html
@@ -2,26 +2,6 @@
  <button class="js-nav-toggle site-nav__button" aria-controls="site-menu">Menu</button>
   <div id="site-menu" class="site-nav__container">
     <ul class="site-nav__panel site-nav__panel--main">
-      <!-- <li class="mobile-search utility-nav__search">
-        <form accept-charset="UTF-8" action="/search" id="search_form" class="combo" method="get" role="search">
-          <input type="hidden" name="type" value="candidates">
-          <input type="hidden" name="type" value="committees">
-          <input type="hidden" name="type" value="site">
-          <label class="u-visually-hidden" for="query">Search</label>
-          <div class="combo combo--search combo--search--mini">
-            <input
-              class="js-site-search combo__input"
-              autocomplete="off"
-              id="query"
-              name="query"
-              type="text"
-              aria-label="Search FEC.gov">
-            <button type="submit" class="button--standard combo__button button--search">
-              <span class="u-visually-hidden">Search</span>
-            </button>
-         </div>
-        </form>
-      </li> -->
       <li><h2 class="site-nav__title u-under-lg-only">Menu</h2></li>
       <li class="site-nav__item u-under-lg-only">
         <a class="site-nav__link" href="/" rel="home">
@@ -29,26 +9,26 @@
         </a>
       </li>
       <li class="site-nav__item" data-submenu="data">
-        <a class="site-nav__link {% if self.content_section == 'data' or parent == 'data' %}is-parent{% endif %}" href="/data/" >
+        <a class="site-nav__link {% if self.content_section == 'data' or parent == 'data' %}is-parent{% endif %}" href="/data/" tabindex="0">
           <span class="site-nav__link__title">
           Campaign finance data</span>
         </a>
         {% include 'partials/navigation/nav-data.html' %}
       </li>
       <li class="site-nav__item site-nav__item--secondary" data-submenu="help">
-        <a href="/help-candidates-and-committees/" class="site-nav__link {% if self.content_section == 'help' %}is-parent{% endif %}">
+        <a href="/help-candidates-and-committees/" class="site-nav__link {% if self.content_section == 'help' %}is-parent{% endif %}" tabindex="0">
           <span class="site-nav__link__title">Help for candidates and committees</span>
         </a>
         {% include 'partials/navigation/nav-help.html' %}
       </li>
       <li class="site-nav__item" data-submenu="legal">
-        <a href="/legal-resources/" class="site-nav__link {% if self.content_section == 'legal' or parent == 'legal' %}is-parent{% endif %}">
+        <a href="/legal-resources/" class="site-nav__link {% if self.content_section == 'legal' or parent == 'legal' %}is-parent{% endif %}" tabindex="0">>
           <span class="site-nav__link__title">Legal resources</span>
         </a>
         {% include 'partials/navigation/nav-legal.html' %}
       </li>
       <li class="site-nav__item site-nav__item--secondary" data-submenu="about">
-        <a href="/about/" class="site-nav__link {% if self.content_section == 'about' %}is-parent{% endif %}">
+        <a href="/about/" class="site-nav__link {% if self.content_section == 'about' %}is-parent{% endif %}" tabindex="0">
           <span class="site-nav__link__title">About</span>
         </a>
         {% include 'partials/navigation/nav-about.html' %}

--- a/fec/fec/templates/partials/navigation/navigation.html
+++ b/fec/fec/templates/partials/navigation/navigation.html
@@ -22,7 +22,7 @@
         {% include 'partials/navigation/nav-help.html' %}
       </li>
       <li class="site-nav__item" data-submenu="legal">
-        <a href="/legal-resources/" class="site-nav__link {% if self.content_section == 'legal' or parent == 'legal' %}is-parent{% endif %}" tabindex="0">>
+        <a href="/legal-resources/" class="site-nav__link {% if self.content_section == 'legal' or parent == 'legal' %}is-parent{% endif %}" tabindex="0">
           <span class="site-nav__link__title">Legal resources</span>
         </a>
         {% include 'partials/navigation/nav-legal.html' %}

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -68,15 +68,22 @@ def web_app_url(path):
 
 @register.filter()
 def highlight_matches(text):
-    """Replaces the highlight markers with span tags for digitalgov search results"""
-    highlighted_text = text.replace('\ue000', '<span class="t-highlight">').replace('\ue001', '</span>')
+    """
+    Replaces the highlight markers with span tags for digitalgov search results.
+    Because format_html uses str.format, remove { and } because they are special characters.
+    """
+    cleaned_text = text.replace("{", "").replace("}", "")
+    highlighted_text = cleaned_text.replace(
+        "\ue000", '<span class="t-highlight">'
+    ).replace("\ue001", "</span>")
+
     return format_html(highlighted_text)
 
 
 @register.filter(name='splitlines')
 def splitlines(value):
     """
-        Returns the value turned into a list.
+    Returns the value turned into a list.
     """
     return value.splitlines()
 

--- a/fec/home/tests/test_filters.py
+++ b/fec/home/tests/test_filters.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+
+from home.templatetags.filters import highlight_matches
+
+
+class TestFilters(TestCase):
+
+    def test_highlight_matches(self):
+        text = '\ue000Highlighted\ue001 results'
+        highlighted_text = highlight_matches(text)
+        self.assertEqual(
+            highlighted_text,
+            '<span class="t-highlight">Highlighted</span> results'
+        )
+
+    def test_highlight_matches_with_brackets(self):
+        """highlight_matches should remove { and } from results"""
+        text = '\ue000Highlighted\ue001 {results}'
+        highlighted_text = highlight_matches(text)
+        self.assertEqual(
+            highlighted_text,
+            '<span class="t-highlight">Highlighted</span> results'
+        )


### PR DESCRIPTION
## Summary (required)

- Resolves #4494]
- Restore `tabindex=0` to desktop menu links to make Mega Menu work in Safari. Those `tabindex` attributed  were removed as part of https://github.com/fecgov/fec-cms/pull/4456 to resolve the Lighthouse flag for `[aria-hidden="true"] elements contain focusable descendants` on `div#site-menu.site-nav__container`. This was fine in other browsers but made the menu inoperable in Safari.
- Also removed residual commented code from same file

According to the documentation for Accessible-Mega Menu [Keyboard Accessibility docs](https://github.com/noahmanger/Accessible-Mega-Menu#keyboard-accessibility), these tabindexes are necessary, however they are not in the source code on the GH repo. 

Followup work: 
- [ ] Further investigate how to maintain operability in Safari and avoid that Aria violation. **I am not sure but Lighthouse  seems to be intermittently reporting the `elements contain focusable descendants` error. Need to verify by having a few different people do a Lighthouse accessibility scan for mobile/desktop**

## Impacted areas of the application

modified:   fec/templates/partials/navigation/navigation.html

## How to test

- checkout and run `hotfix/4494-safari-menu-bug`
- Test mega menu in Safari

____
