### PR TITLE
[Adding to hotfix branch] Fix filter when results have `{` or `}`

### DIFF
--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -68,15 +68,22 @@ def web_app_url(path):
 
 @register.filter()
 def highlight_matches(text):
-    """Replaces the highlight markers with span tags for digitalgov search results"""
-    highlighted_text = text.replace('\ue000', '<span class="t-highlight">').replace('\ue001', '</span>')
+    """
+    Replaces the highlight markers with span tags for digitalgov search results.
+    Because format_html uses str.format, remove { and } because they are special characters.
+    """
+    cleaned_text = text.replace("{", "").replace("}", "")
+    highlighted_text = cleaned_text.replace(
+        "\ue000", '<span class="t-highlight">'
+    ).replace("\ue001", "</span>")
+
     return format_html(highlighted_text)
 
 
 @register.filter(name='splitlines')
 def splitlines(value):
     """
-        Returns the value turned into a list.
+    Returns the value turned into a list.
     """
     return value.splitlines()
 

--- a/fec/home/tests/test_filters.py
+++ b/fec/home/tests/test_filters.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+
+from home.templatetags.filters import highlight_matches
+
+
+class TestFilters(TestCase):
+
+    def test_highlight_matches(self):
+        text = '\ue000Highlighted\ue001 results'
+        highlighted_text = highlight_matches(text)
+        self.assertEqual(
+            highlighted_text,
+            '<span class="t-highlight">Highlighted</span> results'
+        )
+
+    def test_highlight_matches_with_brackets(self):
+        """highlight_matches should remove { and } from results"""
+        text = '\ue000Highlighted\ue001 {results}'
+        highlighted_text = highlight_matches(text)
+        self.assertEqual(
+            highlighted_text,
+            '<span class="t-highlight">Highlighted</span> results'
+        )


### PR DESCRIPTION
## Summary (required)

Resolves #4491: Fix sitewide search when results have characters `{` and/or `}` 

- Because `format_html` uses `str.format`, remove `{` and `}` because they are special characters.
- Add test coverage

## Impacted areas of the application

List general components of the application that this PR will affect:

- Sitewide search
- Policy search


## Related PRs

#4452: Replace `mark_safe `with `format_html`

## How to test

- `export FEC_DIGITALGOV_KEY="<get from dev with cf env cms>"`
- `export SEARCH_GOV_POLICY_GUIDANCE_KEY="<get from dev with cf env cms>"`

**Broken on production** 
https://www.fec.gov/search/?type=candidates&type=committees&type=site&query=Micellaneous+text+submission
https://www.fec.gov/search/?type=candidates&type=committees&type=site&query=field+name+%2318
https://www.fec.gov/search/?query=new+form+2&type=candidates&type=committees&type=site
https://www.fec.gov/search/?type=candidates&type=committees&type=site&query=stalland

**Works on local**
http://localhost:8000/search/?type=candidates&type=committees&type=site&query=Micellaneous+text+submission
http://localhost:8000/search/?type=candidates&type=committees&type=site&query=field+name+%2318
http://localhost:8000/search/?query=new+form+2&type=candidates&type=committees&type=site
http://localhost:8000/search/?type=candidates&type=committees&type=site&query=stalland