### PR TITLE
Upgrade ua-parser-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13717,9 +13717,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
-      "version": "0.7.22",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+      "integrity": "sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw=="
     },
     "uglify-js": {
       "version": "3.6.7",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "topojson": "^3.0.2",
     "tough-cookie": "^2.5.0",
     "tunnel-agent": "^0.6.0",
+    "ua-parser-js": "^0.7.24",
     "underscore": "^1.8.3",
     "whatwg-fetch": "^3.5.0"
   },


### PR DESCRIPTION
## Summary

Resolves #4392

Upgrading ua-parser-js to satisfy the vulnerability warning

### Required reviewers

front-end

## Impacted areas of the application

Potentially draft-js and backend editing but likely none. It was a patch-level increase of a dependency of a dependency (draftjs > fbjs > ua). Rather than edit package-lock, we're adding ua-parser-js to package, which gets inherited/deduped for fbjs' `^0.7.18` requirement. (I looked at upgrading `fbjs`, too. 2.0.0 is the only 2.x release)

## Screenshots

None

## Related PRs

None

## How to test

- pull branch
- `npm i`
- `npm run build`
- scan package.json
- check that the warning about ua-parser-js has gone away
- check that site admin/management works as expected


