### PR TITLE
Fix unable view 2020 filings

### DIFF
--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -507,6 +507,34 @@ class TestCommittee(TestCase):
         assert template_variables["report_type"] == "pac-party"
         assert template_variables["reports"] == self.STOCK_REPORTS
 
+    def test_fallback_cycle(
+        self,
+        load_committee_history_mock,
+        load_cycle_data_mock,
+        load_reports_and_totals_mock,
+        load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
+    ):
+        cycle = 2020
+
+        test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
+        load_committee_history_mock.return_value = (test_committee, [], cycle)
+        # cycle_out_of_range, last_cycle_has_financial, cycles
+        load_cycle_data_mock.return_value = (True, 2018, [2018])
+        load_reports_and_totals_mock.return_value = (
+            self.STOCK_REPORTS,
+            self.STOCK_TOTALS,
+        )
+        load_endpoint_results_mock.return_value = mock.MagicMock()
+        load_committee_statement_of_organization_mock.return_value = {
+            "receipt_date": "2019-11-30T00:00:00"
+        }
+        template_variables = views.get_committee("C001", cycle)
+
+        # JS and Python cycle should equal fallback cycle
+        assert template_variables["context_vars"]["cycle"] == 2018
+        assert template_variables["cycle"] == 2018
+
 
 @mock.patch.object(api_caller, "load_endpoint_results")
 @mock.patch.object(api_caller, "load_first_row_data")

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -390,6 +390,12 @@ def get_committee(committee_id, cycle):
 
     cycle_out_of_range, fallback_cycle, cycles = load_cycle_data(committee, cycle)
 
+    # (fec-cms #4366) at the beginning of every new 2-year period,
+    # before we receive the Q1 reports, passed parameter 'cycle' is not in
+    # `cycles_has_activity` yet. cycle_out_of_range = true.
+    # we set cycle = fallback_cycle
+    cycle = fallback_cycle if cycle_out_of_range else cycle
+
     reports, totals = load_reports_and_totals(
         committee_id, cycle, cycle_out_of_range, fallback_cycle
     )

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -706,8 +706,8 @@ $(document).ready(function() {
         break;
       case 'raw-filings':
         var min_date = $table.attr('data-min-date');
-        // Always use table cycle for filings
-        cycle = $table.attr('data-cycle');
+        // For raw-filings, use previous cycle if provided
+        cycle = context.cycle || $table.attr('data-cycle');
         opts = _.extend(
           {
             columns: rawFilingsColumns,
@@ -731,8 +731,8 @@ $(document).ready(function() {
         tables.DataTable.defer($table, opts);
         break;
       case 'filings-reports':
-        // Always use table cycle for filings
-        cycle = $table.attr('data-cycle');
+        // For filings-reports, use previous cycle if provided
+        cycle = context.cycle || $table.attr('data-cycle');
         opts = _.extend(
           {
             columns: filingsReportsColumns,
@@ -786,8 +786,8 @@ $(document).ready(function() {
         tables.DataTable.defer($table, opts);
         break;
       case 'filings-notices':
-        // Always use table cycle for filings
-        cycle = $table.attr('data-cycle');
+        // For filings-notices, use previous cycle if provided
+        cycle = context.cycle || $table.attr('data-cycle');
         opts = _.extend(
           {
             columns: filingsColumns,
@@ -822,8 +822,8 @@ $(document).ready(function() {
         tables.DataTable.defer($table, opts);
         break;
       case 'filings-statements':
-        // Always use table cycle for filings
-        cycle = $table.attr('data-cycle');
+        // For filings-statements, use previous cycle if provided
+        cycle = context.cycle || $table.attr('data-cycle');
         opts = _.extend(
           {
             columns: filingsColumns,
@@ -855,8 +855,8 @@ $(document).ready(function() {
         tables.DataTable.defer($table, opts);
         break;
       case 'filings-other':
-        // Always use table cycle for filings
-        cycle = $table.attr('data-cycle');
+        // For filings-other, use previous cycle if provided
+        cycle = context.cycle || $table.attr('data-cycle');
         opts = _.extend(
           {
             columns: filingsColumns,


### PR DESCRIPTION
## Summary (required)
Customers should be able to view all reports and statements before 4/15.
When passed cycle is out of cycles_has_activity array, set cycle = last_cycle_has_activity

- Resolves #4366 
- Ref ticket: add test coverage [https://github.com/fecgov/fec-cms/issues/4488](https://github.com/fecgov/fec-cms/issues/4488)

### Required reviewers
one cms front-end developer
one cms back-end developer

## Impacted areas of the application
committee profile page

## How to test
* checkout branch
* point to any api
* run `npm run build`
* run `./manage.py test` and `npm run test-single`
* compare local test urls with production, make sure you can display the `Filings` data locally.
example urls:

1)https://www.fec.gov/data/committee/C00728238/?cycle=2022&tab=filings
http://127.0.0.1:8000/data/committee/C00728238/?cycle=2022&tab=filings

2)https://www.fec.gov/data/committee/C00703124/?cycle=2022&tab=filings
http://127.0.0.1:8000/data/committee/C00703124/?cycle=2022&tab=filings

3)https://www.fec.gov/data/committee/C00698282/?cycle=2022&tab=filings
http://127.0.0.1:8000/data/committee/C00698282/?cycle=2022&tab=filings


* Test other scenarios, make sure local and production the same.

case 1) no cycle parameter passed, default cycle=(last_cycle_has_financial or last_cycle_has_activity)
https://www.fec.gov/data/committee/C00409011/
http://127.0.0.1:8000/data/committee/C00409011/

https://www.fec.gov/data/committee/C00708040/
http://127.0.0.1:8000/data/committee/C00708040/

case 2) passed a cycle is one of cycles_has_financial
https://www.fec.gov/data/committee/C00409011/?cycle=2006
http://127.0.0.1:8000/data/committee/C00409011/?cycle=2006

case 3) passed cycle is in one of cycles_has_activity
https://www.fec.gov/data/committee/C00409011/?cycle=2018
http://127.0.0.1:8000/data/committee/C00409011/?cycle=2018

case 4) passed cycle is out of fec_cycles
`page not found` 
https://www.fec.gov/data/committee/C00409011/?cycle=2028
http://127.0.0.1:8000/data/committee/C00409011/?cycle=2028
