### PR TITLE
fix receipts page 400 bad request

### DIFF
--- a/fec/fec/static/js/pages/datatable-receipts.js
+++ b/fec/fec/static/js/pages/datatable-receipts.js
@@ -16,7 +16,12 @@ $(document).ready(function() {
     title: 'Receipts',
     path: ['schedules', 'schedule_a'],
     columns: columns.receipts,
-    query: { sort_nulls_last: false },
+    query: {
+      sort_nulls_last: false,
+      two_year_transaction_period: window.DEFAULT_ELECTION_YEAR,
+      min_date: '01/01/' + (Number(window.DEFAULT_ELECTION_YEAR) - 1),
+      max_date: '12/31/' + window.DEFAULT_ELECTION_YEAR
+    },
     paginator: tables.SeekPaginator,
     order: [[4, 'desc']],
     useFilters: true,


### PR DESCRIPTION
## Summary (required)
When you go to All receipts page, open browser inspect, the page will throw a 400 bad request error every time. This may not affect sched-a performance, but it will generate many 400 error in Kibana logs.
ex url:
https://www.fec.gov/data/receipts/?data_type=processed&two_year_transaction_period=2022&min_date=01%2F01%2F2021&max_date=12%2F31%2F2022

- Resolves #4525 
add some required parameter to datatable-receiptes.js when call api `schedules/schedule_a`


## Screenshots
<img width="550" alt="1_before" src="https://user-images.githubusercontent.com/24395751/113195142-e9e2b880-922f-11eb-93c7-e45390866895.png">


<img width="550" alt="2_after" src="https://user-images.githubusercontent.com/24395751/113195175-f36c2080-922f-11eb-9fba-0bad141697f8.png">


### Required reviewers
one front end developer

## Impacted areas of the application
All receipts page

