### PR TITLE
add administratively terminated committee status

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -23,8 +23,10 @@
     <h1 class="entity__name content__section--narrow">{{ committee.name }}</h1>
     <div class="heading--section">
       <span class="t-data t-bold entity__type">
-        {% if committee.is_active %}
-          <span class="is-active-status">Active</span>      
+        {% if current_committee_status == "active" %}
+          <span class="is-active-status">Active</span>
+        {% elif current_committee_status == "admin_terminated" %}
+          <span class="is-terminated-status">Administratively terminated</span>
         {% else %}
           <span class="is-terminated-status">Terminated</span>         
         {% endif %}

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -397,6 +397,17 @@ def get_committee(committee_id, cycle):
     # Check organization types to determine SSF status
     is_ssf = committee.get("organization_type") in ["W", "C", "L", "V", "M", "T"]
 
+    # Check committee's status (active, terminated, or administratively terminated)
+    is_active = committee.get("is_active")
+    filing_frequency = committee.get("filing_frequency")
+
+    if is_active:
+        current_committee_status = "active"
+    elif not is_active and filing_frequency == "A":
+        current_committee_status = "admin_terminated"
+    else:
+        current_committee_status = "terminated"
+
     # if cycles_has_activity's options are more than cycles_has_financial's,
     # when clicking back to financial summary/raising/spending,
     # reset cycle=fallback_cycle and timePeriod and.
@@ -448,6 +459,7 @@ def get_committee(committee_id, cycle):
         "cycle": cycle,
         "cycles": cycles,
         "is_SSF": is_ssf,
+        "current_committee_status": current_committee_status,
         "cycle_out_of_range": cycle_out_of_range,
         "parent": parent,
         "result_type": result_type,


### PR DESCRIPTION
## Summary

- Resolves #4465 

Adds administratively terminated to the committee profile page if they were administratively terminated.

### Required reviewers

One designer and one developer

## Impacted areas of the application

General components of the application that this PR will affect:

- Committee profile pages

## Screenshots

### Active
<img width="614" alt="Screen Shot 2021-03-31 at 5 37 22 PM" src="https://user-images.githubusercontent.com/12799132/113214747-e78c5880-9247-11eb-8a67-9b525a7c4b57.png">

### Administratively terminated
<img width="616" alt="Screen Shot 2021-03-31 at 5 36 50 PM" src="https://user-images.githubusercontent.com/12799132/113214771-efe49380-9247-11eb-9841-18a342c83c4d.png">

### Terminated
<img width="522" alt="Screen Shot 2021-03-31 at 5 36 38 PM" src="https://user-images.githubusercontent.com/12799132/113214794-fa069200-9247-11eb-8956-8760c7f619a1.png">


## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/add_active_cmte_indicator | [link](https://github.com/fecgov/fec-cms/pull/3781)

## How to test

- Go to any committee that is active and make sure that the committee status in the header reads "Active". Ex: [http://localhost:8000/data/committee/C00409011/?cycle=2006](http://localhost:8000/data/committee/C00409011/?cycle=2006) 
- Go to any committee that is terminated and make sure that the committee status in the header reads "Terminated". Ex: [http://localhost:8000/data/committee/C00431445/?cycle=2018](http://localhost:8000/data/committee/C00431445/?cycle=2018)
- Go to any committee that is administratively terminated and make sure that the committee status in the header reads "Administratively terminated". Ex: [http://localhost:8000/data/committee/C00409011/?cycle=2018](http://localhost:8000/data/committee/C00409011/?cycle=2018). You can also see this [spreadsheet](https://docs.google.com/spreadsheets/d/1d4z-Feq_cdHNl1QCge_BsFnhCvAUfq9b/edit#gid=1769749457) 🔒 for additional examples of administratively terminated committees.