### PR TITLE
Feature/4177 image element sizes

### DIFF
--- a/fec/fec/static/scss/components/_site-header.scss
+++ b/fec/fec/static/scss/components/_site-header.scss
@@ -220,8 +220,9 @@
 
 .usa-banner-header img {
   float: left;
-  margin: u(.0 .7rem 0 1rem);
-  width: u(2rem);
+  margin: u(.2rem .7rem 0 1rem);
+  width: 16px;
+  height: 11px;
 }
 
 
@@ -447,6 +448,7 @@
 @media (min-width: $large-screen) {
   .homepage-seal {
     width: 160px;
+    height: auto;
     top: u(1rem);
     left: u(3rem);
     display: block;

--- a/fec/fec/templates/500-status.html
+++ b/fec/fec/templates/500-status.html
@@ -33,7 +33,7 @@
     <header class="site-header site-header--homepage">
       <div class="masthead">
         <div class="homepage-seal">
-          <img src="{% static 'img/seal.svg' %}" alt="FEC logo">
+          <img src="{% static 'img/seal.svg' %}" alt="FEC logo" width="160" height="160">
         </div>
         <div class="site-title--print"></div>
         <a title="Home" href="/" class="site-title" rel="home"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -38,7 +38,7 @@
     <header class="site-header site-header--homepage">
       <div class="masthead">
         <div class="homepage-seal">
-          <img src="{% static 'img/seal.svg' %}" alt="FEC logo">
+          <img src="{% static 'img/seal.svg' %}" alt="FEC logo" width="160" height="160">
         </div>
         <div class="site-title--print"></div>
         <a title="Home" href="/" class="site-title" rel="home"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -37,7 +37,7 @@
     <header class="site-header site-header--homepage" role="banner">
       <div class="masthead">
         <div class="homepage-seal">
-          <img src="{% static 'img/seal.svg' %}" alt="FEC logo">
+          <img src="{% static 'img/seal.svg' %}" alt="FEC logo" width="160" height="160">
         </div>
         <div class="site-title--print"></div>
         <a title="Home" href="/" class="site-title" rel="home"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>

--- a/fec/fec/templates/partials/usa-banner.html
+++ b/fec/fec/templates/partials/usa-banner.html
@@ -1,15 +1,13 @@
 <header class="usa-banner">
   <div class="js-accordion accordion--neutral" data-content-prefix="gov-banner">
     <div type="button" class="usa-banner-header js-accordion-trigger accordion__button" aria-controls="gov-banner"><span class="u-visually-hidden">Here's how you know</span>
-
-      <img src="/static/img/us_flag_small.png" class="flag" alt="US flag signifying that this is a United States Federal Government website">
+      <img class="flag" src="/static/img/us_flag_small.png" alt="US flag signifying that this is a United States Federal Government website" width="16" height="11">
       <p class="t-inline-block">An official website of the United States government</p>
       <p class="t-inline-block usa-banner-button">Here's how you know</p>
-
     </div>
     <div class="usa-banner-content usa-grid usa-accordion-content accordion-content" id="gov-banner">
       <div class="usa-banner-guidance-gov usa-width-one-half">
-        <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-dot-gov.svg" alt="Dot gov">
+        <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-dot-gov.svg" alt="Dot gov" width="38" height="38">
         <div class="usa-media_block-body">
           <p>
             <strong>Official websites use .gov</strong>
@@ -19,7 +17,7 @@
         </div>
       </div>
       <div class="usa-banner-guidance-ssl usa-width-one-half">
-        <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-https.svg" alt="SSL">
+        <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-https.svg" alt="SSL" width="38" height="38">
         <div class="usa-media_block-body">
           <p>
             <strong>Secure .gov websites use HTTPS</strong>

--- a/fec/home/templates/partials/commissioner.html
+++ b/fec/home/templates/partials/commissioner.html
@@ -5,9 +5,9 @@
   <div class="icon-heading">
     {% if commissioner.picture %}
     {% image commissioner.picture original as commissioner_picture %}
-    <img class="icon-heading__image" src="{{ commissioner_picture.url }}" alt="Headshot of {{ commissioner.title }}">
+    <img class="icon-heading__image" src="{{ commissioner_picture.url }}" alt="Headshot of {{ commissioner.title }}" width="70" height="70">
     {% else %}
-    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of {{ commissioner.title }}">
+    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of {{ commissioner.title }}" width="70" height="70">
     {% endif %}
     <div class="icon-heading__content">
       <div class="t-lead"><a href="{{ commissioner.url }}">{{ commissioner.title }}</a></div>

--- a/fec/home/templates/partials/current-commissioners.html
+++ b/fec/home/templates/partials/current-commissioners.html
@@ -20,7 +20,7 @@
 {% for vacant in vacant_seats %}
   <div class="grid__item commissioner-height">
   <div class="icon-heading">
-    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of vacant seat">
+    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of vacant seat" width="160" height="160">
     <div class="icon-heading__content">
       <div class="t-lead">Vacant seat</div>
     </div>


### PR DESCRIPTION
## Summary

- Resolves #4177 

Lighthouse dinged us for not having default dimensions set for images, the effect being that the page couldn't draw until—or would have to shift/redraw after—the images were done loading

### Required reviewers

- front-end
- UX generally but specifically for the flag margin change

## Impacted areas of the application

- assigned default `width` & `height` for the few images who didn't have them set (FEC seal, US gov flag, US gov banner icon, commissioner headshots on homepage)
- adjusted css rules to add `height: auto` for those images that have new height attributes
- adjusted the top margin for the US gov flag so it stays centered in the banner

## Screenshots

Flag size and top margin, live and localhost:
![image](https://user-images.githubusercontent.com/26720877/113772964-6293ba00-96f3-11eb-9734-59b785ac4b71.png)


## Related PRs

None

## How to test

- pull the branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- Check the [homepage](http://127.0.0.1:8000)
   - US gov banner flag should look normal
   - Opening the US gov banner, the lock icon should appear unchanged
   - The commission icons at the bottom will likely need to wait for Dev
   - Make sure these images don't look distorted for small, medium, large, extra-large browser widths
   - If you'd like to inspect them, they should have values for `width=""` and `height=""`
- Right-click anywhere on the page, go to Inspect
- In the Inspector window, go to Lighthouse on the far right
   - Make sure Performance and Best Practices are checked
   - Choose Mobile or Desktop
   - Click Generate report
   - Don't minimize the browser and do something else; Lighthouse numbers will not be pretty
   - The "Image elements do not have explicit width and height" warning should NOT exist
