### PR TITLE
Up-grade under-score

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13835,9 +13835,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "undertaker": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "tough-cookie": "^2.5.0",
     "tunnel-agent": "^0.6.0",
     "ua-parser-js": "^0.7.24",
-    "underscore": "^1.8.3",
+    "underscore": "^1.12.1",
     "whatwg-fetch": "^3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Resolves #4523 

Addressing a vulnerability in underscore

### Required reviewers

- front-end

## Impacted areas of the application

Nearly all of the interactive parts of the site built after '18, though, being a minor and patch upgrade, likely none.

## Screenshots

No visual changes

## Related PRs

None

## How to test

- pull the branch
- `npm i` (no errors)
- `npm run build` (no errors)
- `npm run test-single` (no failures)
- `./manage.py runserver`
- Check the interactive parts of the site to make sure race/district search, site search, and filters/chiclets all still work. A couple places where underscore is used:
   - LegalSearch
   - Tags (legal)
   - analytics
   - calendar
   - column-helpers
   - columns
   - cycle-select
   - download
   - election-form
   - election-map
   - election-search
   - election-utils
   - feedback
   - filters-events
   - fips (maps data)
   - helpers
   - line-chart-committees
   - maps
   - other-spending-totals
   - tables
   - toc
   - typeahead
   - urls
   - filter-base
   - filter-typeahead
   - committee-single
