### PR TITLE
ARIA roles for children and controls

### DIFF
--- a/fec/fec/static/js/templates/top-entity-row.hbs
+++ b/fec/fec/static/js/templates/top-entity-row.hbs
@@ -1,11 +1,11 @@
 <div role="row" class="simple-table__row js-top-row">
-  <div class="simple-table__cell">{{ rank }} <a href="{{ url }}">{{ name }}</a>
+  <div role="gridcell" class="simple-table__cell">{{ rank }} <a href="{{ url }}">{{ name }}</a>
     {{#if party_code}}
     {{ party_code }}
     {{/if}}
   </div>
-  <div class="simple-table__cell t-right-aligned t-mono">{{ amount }}</div>
-  <div class="simple-table__cell">
+  <div role="gridcell" class="simple-table__cell t-right-aligned t-mono">{{ amount }}</div>
+  <div role="gridcell" class="simple-table__cell">
     <div class="bar-container">
       <div class="value-bar" data-value="{{ value }}" data-party="{{ party }}"></div>
     </div>

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -8,22 +8,13 @@
   <div class="usa-width-two-thirds grid--flex">
     <section id="raising-breakdowns" class="breakdowns-home">
        <div class="js-top-entities" data-office="{{ office }}" data-election-year="{{ election_year }}" data-perpage="3">
-
-       <div class="chart-table chart-table-home simple-table--responsive js-top-table" id="top-table" aria-live="polite" role="grid">
-
+      <div class="chart-table chart-table-home simple-table--responsive js-top-table" id="top-table" aria-live="polite" role="grid">
         <div role="row" class="simple-table__header">
           <div role="columnheader" class="simple-table__header-cell cell--40">Candidate</div>
           <div role="columnheader" class="simple-table__header-cell cell--20 t-right-aligned js-type-label">Total <span>{{ action }}</span></div>
           <div role="columnheader" class="simple-table__header-cell cell--40"></div>
         </div>
-
-        {% for datum in data %}
-        <div role="row" class="js-top-row simple-table__row">
-
-        </div>
-        {% endfor %}
-        </div>
-
+      </div>
       <div class="content__section row u-margin--top">
         <ul class="list--buttons u-float-right">
           <li class="u-padding--top--small"><a class="button button--cta button--go js-browse"  href="/data/raising-bythenumbers/">Browse top <span>raising</span> candidates</a></li>
@@ -37,11 +28,11 @@
       <legend class="label input__label-home t-inline-block">Data type</legend>
       <div class="row">
         <label for="switcher-receipts" class="toggle">
-          <input type="radio" class="js-chart-toggle" value="receipts" id="switcher-receipts" checked name="data_type" data-prefix="raising"  aria-controls="processed-message" tabindex="0">
+          <input type="radio" class="js-chart-toggle" value="receipts" id="switcher-receipts" checked name="data_type" data-prefix="raising"  aria-controls="top-table" tabindex="0">
           <span class="button--alt button-first">Money raised</span>
         </label>
         <label for="switcher-disbursements" class="toggle">
-          <input type="radio" class="js-chart-toggle" value="disbursements" id="switcher-disbursements" name="data_type" data-prefix="spending" aria-controls="processed-message" tabindex="0">
+          <input type="radio" class="js-chart-toggle" value="disbursements" id="switcher-disbursements" name="data_type" data-prefix="spending" aria-controls="top-table" tabindex="0">
           <span class="button--alt button-last">Money spent</span>
         </label>
       </div>


### PR DESCRIPTION
## Summary 
**ARIA error:**
 **Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children**
 
   -  **Fix:** Add `aria-role="gridcell"`  to raising/spending table elements. [Reference](https://www.w3.org/TR/wai-aria-1.1/#gridcell)
    
 **ARIA error:**
 **[aria-*] attributes do not have valid values**
  
   - **Fix:** Change to `aria-controls="top-table` for the tableSwitcher widget on the home page raising/spending chart

**Additional changes:** Remove unnecessary code from raising/spending partial used on home page. 

- Resolves #4184
- Resolves #4185 

Requires one front end reviewer

## Impacted areas of the application

modified:   fec/static/js/templates/top-entity-row.hbs
modified:   home/templates/partials/raising-spending.html

General components of the application that this PR will affect:
home page raising/spending bar charts
bar charts on https://www.fec.gov/data/spending-bythenumbers/
bar charts on https://www.fec.gov/data/raisig-bythenumbers/

## Screenshot:
<img width="302" alt="Screen Shot 2021-04-13 at 2 30 22 PM" src="https://user-images.githubusercontent.com/5572856/114602683-e5bd8e80-9c64-11eb-8eac-43710a9de1a3.png">



## How to test
- checkout  `feature/4184-aria-role-children`
- `npm run build-js`
- Run lighthouse scan with only accessibility checked for the following pages and confirm that the two ARIA accessibility errors listed below are gone
  - home page 
  - http://127.0.0.1:8000/data/raising-bythenumbers/
  - http://127.0.0.1:8000/data/spending-bythenumbers/
- Errors that should be gone:
   - `Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children`
   -  `[aria-*] attributes do not have valid values`
   
 - Confirm that the homepage barcharts work as expected (there was some code cleanup here, just want to make sure)

