### PR TITLE
Legacy support for responsive embeds in Wagtail Draftail RTE

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -251,6 +251,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Wagtail settings
 WAGTAIL_SITE_NAME = "fec"
+WAGTAILEMBEDS_RESPONSIVE_HTML = True
 
 # Custom settings
 from fec import constants # noqa E402

--- a/fec/fec/static/scss/components/_responsive-object.scss
+++ b/fec/fec/static/scss/components/_responsive-object.scss
@@ -1,15 +1,18 @@
-// TODO - remove this? Wagtail 2.8 did away with the responsive-object class
-// TODO - https://docs.wagtail.io/en/stable/releases/2.8.html#responsive-html-for-embeds-no-longer-added-by-default
-.responsive-object {
-	width: 100% !important;
-	height: auto !important;
-	padding: 0 !important;
+//Responsive video embeds for RTE with intrinsic sizing technnique
 
-	iframe {
-		width: 100% !important;
-	}
+.responsive-object { 
+	position: relative; 
+	width: 100% !important; 
+	height: auto !important; 
+
+	iframe, object, embed { 
+		position: absolute; 
+		top: 0; 
+		left: 0; 
+		width: 100%; 
+		height: 100%; 
+	} 
 }
-// TODO - remove this? Wagtail 2.8 did away with the responsive-object class
 
 //TV Ad example:
 


### PR DESCRIPTION
## Summary
Legacy support for Wagtails built-in responsive embeds in Draftail Rich Text Editor

- Resolves comment on Wagtail upgrade issue https://github.com/fecgov/fec-cms/pull/4518/files#r605231989
  --AND -- 
- Resolves #2212

**Note/Possible followup work:** This issue originally stemmed from content teams desire not to have tiny videos on the page and not to have the "black-boxing" on either side of the video when using the embed option. They are now 100% width of the content area. If content team decides this is too big, we can make an adjustment to the CSS and set a max-width on the videos. 

## Impacted areas of the application

modified:   fec/settings/base.py
modified:   fec/static/scss/components/_responsive-object.scss

**General components of the application that this PR will affect:**
Use of th media embed button in the Draftail rich text editor

## Screenshots
### Before: using responsive-object class 
<img width="709" alt="Screen Shot 2021-04-13 at 9 05 54 PM" src="https://user-images.githubusercontent.com/5572856/114642101-4bc80700-9ca1-11eb-87c4-2132c1c26dcf.png">

### Before: With responsive-object using current CSS:
<img width="778" alt="Screen Shot 2021-04-13 at 9 05 30 PM" src="https://user-images.githubusercontent.com/5572856/114642067-3ce15480-9ca1-11eb-975a-189575329eff.png">

### After: With reponsive-object class and new CSS
<img width="892" alt="Screen Shot 2021-04-13 at 9 47 11 PM" src="https://user-images.githubusercontent.com/5572856/114642434-e9233b00-9ca1-11eb-81b6-2301a3cd0496.png">

Relkated PR: https://github.com/fecgov/fec-cms/issues/2141

## How to test
- Checkout `feature/resp-object-for-wagtail-upgrade`
- `npm run-build sass`
- Run this branch based on Robert's instructions here: https://github.com/fecgov/fec-cms/pull/4518 (if you already have the Wagtail upgrade branch and virtual environment running, you should not have to do all the steps)
- Create a page like  CustomPage or  ResourcePage and in the RTE, embed a video with the media embed button
- You could use this URL for example: `https://youtu.be/dvN6SUUD1tw`
- Confirm the video looks like the thrid screenshot above



