### PR TITLE
4173 - Set font faces to swap

### DIFF
--- a/fec/fec/static/scss/_fonts.scss
+++ b/fec/fec/static/scss/_fonts.scss
@@ -4,6 +4,7 @@
     url('../fonts/gandhiserif-bold.woff') format('woff');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -12,6 +13,7 @@
     url('../fonts/gandhiserif-bolditalic.woff') format('woff');
   font-weight: bold;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -20,6 +22,7 @@
     url('../fonts/gandhiserif-italic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -28,6 +31,7 @@
     url('../fonts/gandhiserif-regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -36,6 +40,7 @@
     url('../fonts/karla-bold.woff') format('woff');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -44,6 +49,7 @@
     url('../fonts/karla-regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -52,6 +58,7 @@
     url('../fonts/fec-currencymono-bold.woff') format('woff');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -60,6 +67,7 @@
     url('../fonts/fec-currencymono-bolditalic.woff') format('woff');
   font-weight: bold;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -68,6 +76,7 @@
     url('../fonts/fec-currencymono-italic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -76,4 +85,5 @@
     url('../fonts/fec-currencymono-regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }


### PR DESCRIPTION
## Summary

- Resolves #4173 

Optimizing out site, let's let our content swap from default fonts to our requested fonts


### Required reviewers

1-2 people, likely either front-end or ux

## Impacted areas of the application

Ideally, only the fonts on the initial load of any page on the site on a slow connection should be affected. If there's no change, great. This PR will let the content display before fonts have finished loading and will then swap over to use our fonts when they're available.

## Screenshots

No visual changes

## Related PRs

None

## How to test

**Warning**: This branch is based on the latest version of develop, which has the newest Wagtail and Django. Switching to this branch should be fine (but takes a couple extra steps), but switching back to older branches that aren't using the newest Wagtail/Django/etc could be challenging. You may want to make a backup of your current database so you can roll back to that if you need to go back to an older Wagtail/Django.

- pull the branch
- upgrade Wagtail, Django, etc **if you haven't already**. See the warning above
   - in repo root, `pip install -r requirements.txt`
   - in fec/ `./manage.py migrate` (if it says there are none to run, no biggie)
- in repo root, `npm i`, then `npm run build`
- in fec/ `./manage.py runserver` (If you needed/need to migrate, it'll tell you now!)
- open an incognito/private window (Chrome: shift-cmd-n or File > New Incognito Window)
- open the [homepage](http://127.0.0.1:8000/)—or any page, really
- go to Inspector (Chrome: cmd-opt-i)(right-click anywhere on the page and choose Inspect)
- switch to the Network tab (should be blank)
- near the top, check "Disable cache"
- reload the page
- back in inspector, near the top of the list are the fonts (gandhi, karla, fec). Make sure they have a size > 0
- reload the page, watching the text and font faces
- fonts look right? Was there a hiccup? The font faces could have swapped but the page load should not have been held up while waiting for fonts to load (A hiccup is okay as long as the fonts loaded and updated)
- in inspector, go to the Lighthouse tab (usually far right)
- we're going to check Performance for either Desktop or Mobile (you can check others, but this PR is only inside Performance)
- click the Generate report button (if you leave this window/inspector, you may need to run it again)
- is there a line for "Ensure text remains visible during webfont load"? (shouldn't be)
- yay!

