### PR TITLE
Close resourceblock section divs, patch draftail

### DIFF
--- a/fec/fec/static/scss/_fonts.scss
+++ b/fec/fec/static/scss/_fonts.scss
@@ -4,6 +4,7 @@
     url('../fonts/gandhiserif-bold.woff') format('woff');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -12,6 +13,7 @@
     url('../fonts/gandhiserif-bolditalic.woff') format('woff');
   font-weight: bold;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -20,6 +22,7 @@
     url('../fonts/gandhiserif-italic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -28,6 +31,7 @@
     url('../fonts/gandhiserif-regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -36,6 +40,7 @@
     url('../fonts/karla-bold.woff') format('woff');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -44,6 +49,7 @@
     url('../fonts/karla-regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -52,6 +58,7 @@
     url('../fonts/fec-currencymono-bold.woff') format('woff');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -60,6 +67,7 @@
     url('../fonts/fec-currencymono-bolditalic.woff') format('woff');
   font-weight: bold;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -68,6 +76,7 @@
     url('../fonts/fec-currencymono-italic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -76,4 +85,5 @@
     url('../fonts/fec-currencymono-regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }

--- a/fec/home/templates/blocks/section.html
+++ b/fec/home/templates/blocks/section.html
@@ -19,13 +19,15 @@
         {% else %}
         {% include_block content_block with blocks=content_block %}
         {% endif %}
+      </div>
       {% endfor %}
+
+    {# close the div we opened based on whether there's an aside #}
+    </div>
 
   {# add the aside if needed #}
   {% if value.aside %}
       {% include_block value.aside with aside=value.aside %}
   {% endif %}
 
-    {# close the div we opened based on whether there's an aside #}
-    </div>
 </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3992,9 +3992,9 @@
       }
     },
     "draftail": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/draftail/-/draftail-1.4.0.tgz",
-      "integrity": "sha512-flrQcizWnd+ry9N2I0Er/kpS0agSNlJfUtvowh4N2Rqvle2zDyo0IZDunkwNHWUcuqcs8iDnZW3yrKQH6lh/rw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/draftail/-/draftail-1.4.1.tgz",
+      "integrity": "sha512-JaVnNngJmoon31Mb/c/RLHaR00WFjIb80tRx+7a/l0LEtYK6zRbtXUNOGKEPqysTSnXLVb0VmWPkaC/DUPk4ww==",
       "requires": {
         "decorate-component-with-props": "^1.0.2",
         "draft-js-plugins-editor": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "debug": "^3.2.6",
     "dompurify": "^2.2.7",
     "draft-js": "^0.11.7",
-    "draftail": "^1.4.0",
+    "draftail": "^1.4.1",
     "es6-weak-map": "2.0.1",
     "eventemitter2": "0.4.14",
     "fullcalendar": "3.3.1",


### PR DESCRIPTION
## Summary

- Resolves # (none?) Not sure if I should create a ticket for such a small fix when its branch has already been merged

Fixing the section.html template to close one div and close another a little earlier.
There was also a patch released for draftail so bumping that by its patch number.

### Required reviewers

1-2

## Impacted areas of the application

The only changes are inside the section.html template/component that's only used by the ResourceBlock


## Screenshots

broken:
![image](https://user-images.githubusercontent.com/26720877/115079381-17399280-9ecf-11eb-831b-852ef76e3f13.png)

correct:
![image](https://user-images.githubusercontent.com/26720877/115079492-405a2300-9ecf-11eb-9d59-7b03a30885ed.png)


## Related PRs

The previous PR for this upgrade work: https://github.com/fecgov/fec-cms/pull/4518

## How to test

- pull the branch, run the server
- go to [dates and deadlines](http://127.0.0.1:8000/help-candidates-and-committees/dates-and-deadlines/) or other Resource types of pages
- make sure the columns align like they do in Production

