### PR TITLE
4280 - Update default year

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -4,8 +4,8 @@ import operator
 from data import utils
 
 START_YEAR = 1979
-END_YEAR = 2022
-DEFAULT_TIME_PERIOD = 2020  # Change after the April quarterly report (4/15/21)
+END_YEAR = 2024
+DEFAULT_TIME_PERIOD = 2022  # Change after the April quarterly report (4/15/23)
 DEFAULT_ELECTION_YEAR = 2022  # Change after election day (11/8/22)
 DEFAULT_PRESIDENTIAL_YEAR = 2020
 DISTRICT_MAP_CUTOFF = 2018  # The year we show district maps for on election pages

--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -7,7 +7,7 @@ START_YEAR = 1979
 END_YEAR = 2024
 DEFAULT_TIME_PERIOD = 2022  # Change after the April quarterly report (4/15/23)
 DEFAULT_ELECTION_YEAR = 2022  # Change after election day (11/8/22)
-DEFAULT_PRESIDENTIAL_YEAR = 2020
+DEFAULT_PRESIDENTIAL_YEAR = 2020  # Change after April quarterly after mid-terms (4/15/23)
 DISTRICT_MAP_CUTOFF = 2018  # The year we show district maps for on election pages
 
 states = OrderedDict([


### PR DESCRIPTION
## Summary

- Resolves #4280 

Updating default (non-presidential) election year to 2022.

**NOTE**: also:
- updated `END_YEAR` from 2022 to 2024
- updated the note for `DEFAULT_TIME_PERIOD`
- should we add a note / ticket for when we should change `DEFAULT_PRESIDENTIAL_YEAR`?

### Required reviewers

Two of UX, front-end, back-end

## Impacted areas of the application

Any table/component that looks at the default election years for its data

## Screenshots
Defaults that can be non-presidential
![image](https://user-images.githubusercontent.com/26720877/115428023-fa070b80-a1cf-11eb-9517-784220d989f9.png)

Defaults that have to be presidential:
![image](https://user-images.githubusercontent.com/26720877/115428220-2c186d80-a1d0-11eb-8d14-b6fae867ddf8.png)



## Related PRs
None

## How to test

- pull the branch like normal
- `pip install -r requirements.txt` if needed (likely not)
- `npm i` if needed
- `npm run build`
- `./manage.py runserver`
- Check a handful of pages where we have default dates that should default to 2022. Some I know:
   - [homepage](http://127.0.0.1:8000) (map, raising/spending chart(s))
   - [Raising by the numbers](http://127.0.0.1:8000/data/raising-bythenumbers/) (except the presidential map, which should still be 2020)
   - [Spending by the numbers](http://127.0.0.1:8000/data/spending-bythenumbers/)
   - [Candidates](http://127.0.0.1:8000/data/candidates/)
   - [Candidates for Senate](http://127.0.0.1:8000/data/candidates/senate/)
- Check that presidential defaults are still 2020. Some:
   - [Raising by the numbers](http://127.0.0.1:8000/data/raising-bythenumbers/) (only the map at the bottom)
   - [Candidates for president](http://127.0.0.1:8000/data/candidates/president/)