### PR TITLE
[MERGE WITH GITFLOW - HOTFIX] Downgrade underscore to 1.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13859,9 +13859,9 @@
       }
     },
     "underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
     },
     "undertaker": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "tough-cookie": "^2.5.0",
     "tunnel-agent": "^0.6.0",
     "ua-parser-js": "^0.7.24",
-    "underscore": "^1.12.1",
+    "underscore": "^1.9.2",
     "whatwg-fetch": "^3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Resolves #4572 

underscore 1.12.1 is breaking [some datatables](http://127.0.0.1:8000/data/committee/C00703975/?tab=filings&cycle=2020)

### Required reviewers

A couple

## Impacted areas of the application

Downgrading underscore—should take all underscore-related functionality back to previously-working version


## Screenshots

Broken on left, working on the right
![image](https://user-images.githubusercontent.com/26720877/116282894-4e266880-a759-11eb-8762-5b7ad98b877a.png)


## Related PRs

None

## How to test

- pull branch
- `npm i`
- `npm run build-js`
- Test!
