### PR TITLE
Convert _.template to ES6

### DIFF
--- a/fec/fec/static/js/modules/column-helpers.js
+++ b/fec/fec/static/js/modules/column-helpers.js
@@ -11,13 +11,6 @@ var sizeInfo = {
   2000: { limits: [2000, null], label: '$2,000 and over' }
 };
 
-let shouldTrace = true;
-function trace(data, ...args) {
-  // if (data && data.candidate_name)
-  //   shouldTrace = data.candidate_name.indexOf('HERMAN');
-  // if (shouldTrace) console.log(...args);
-}
-
 function getSizeParams(size) {
   var limits = sizeInfo[size].limits;
   var params = {};
@@ -31,7 +24,6 @@ function getSizeParams(size) {
 }
 
 function getColumns(columns, keys) {
-  trace('getColumns(columns, keys): ', columns, keys);
   return keys.map(function(key) {
     return columns[key];
   });
@@ -126,7 +118,6 @@ function buildAggregateUrl(cycle, includeTransactionPeriod, duration = 2) {
 // As well as candidate/committee profile "Individual contributions"
 // by state and by size
 function buildTotalLink(path, getParams) {
-  trace(null, 'buildTotalLink(path, getParams): ', path, getParams);
   return function(data, type, row, meta) {
     data = data || 0;
     var params = getParams(data, type, row, meta);
@@ -172,13 +163,6 @@ function buildTotalLink(path, getParams) {
 
 // Used for election profile page "individual contributions to candidates" charts
 function makeCommitteeColumn(opts, context, factory) {
-  trace(
-    context.election,
-    'makeCommitteeColumn(opts, context, factory): ',
-    opts,
-    context,
-    factory
-  );
   return Object.assign(
     {},
     {
@@ -206,8 +190,6 @@ function makeCommitteeColumn(opts, context, factory) {
     opts
   );
 }
-const partial = (func, ...boundArgs) => (...remainingArgs) =>
-  func(...boundArgs, ...remainingArgs);
 
 function sizeColumns(context) {
   var factory = function(data, type, row, meta, column) {
@@ -236,7 +218,6 @@ function sizeColumns(context) {
 }
 
 function stateColumns(results, context) {
-  trace(context, 'stateColumns(context): ', results, context);
   var stateColumn = { data: 'state' };
   var columns = results.map(function(result) {
     return makeCommitteeColumn({ data: result.candidate_id }, context, function(

--- a/fec/fec/static/js/modules/filters/filter-tags.js
+++ b/fec/fec/static/js/modules/filters/filter-tags.js
@@ -1,39 +1,27 @@
 'use strict';
 
 var $ = require('jquery');
-var _ = require('underscore');
 
-var BODY_TEMPLATE = _.template(
-  '<div>' +
-    '<div class="row">' +
-    '<h3 class="tags__title">Viewing ' +
-    '<span class="js-count" aria-hidden="true"></span> ' +
-    '<span class="js-result-type">filtered {{ resultType }} for:</span>' +
-    '</h3>' +
-    '<button type="button" class="{{ clearResetFiltersClass }} button--unstyled tags__clear" aria-hidden="true">{{ clearResetFiltersLabel }}</button>' +
-    '</div>' +
-    '<ul class="tags">' +
-    '</ul>' +
-    '</div>',
-  { interpolate: /\{\{(.+?)\}\}/g }
-);
+const template_body = value => `
+<div>
+  <div class="row">
+    <h3 class="tags__title">Viewing 
+      <span class="js-count" aria-hidden="true"></span>
+      <span class="js-result-type">filtered ${value.resultType} for:</span>
+    </h3>
+    <button type="button" class="${value.clearResetFiltersClass} button--unstyled tags__clear" aria-hidden="true">${value.clearResetFiltersLabel}</button>
+  </div>
+  <ul class="tags">
+  </ul>
+</div>`;
 
-var TAG_TEMPLATE = _.template(
-  '<div data-id="{{ key }}" data-removable="true" class="tag__item">' +
-    '{{ value }}' +
-    '<button class="button js-close tag__remove">' +
-    '<span class="u-visually-hidden">Remove</span>' +
-    '</button>' +
-    '</div>',
-  { interpolate: /\{\{(.+?)\}\}/g }
-);
+const template_tag = value => `<div data-id="${value.key}" data-removable="true" class="tag__item">${value.value}
+  <button class="button js-close tag__remove"><span class="u-visually-hidden">Remove</span></button>
+</div>`;
 
-var NONREMOVABLE_TAG_TEMPLATE = _.template(
-  '<div data-id="{{ key }}" data-removable="false" data-remove-on-switch="{{ removeOnSwitch }}" class="tag__item">' +
-    '{{ value }}' +
-    '</div>',
-  { interpolate: /\{\{(.+?)\}\}/g }
-);
+const template_nonremoveableTag = value => `<div data-id="${value.key}" data-removable="false" data-remove-on-switch="${value.removeOnSwitch}" class="tag__item">
+    ${value.value}
+</div>`;
 
 /**
  * TagLists are created by modules/tables.js and calendar-page.js
@@ -54,7 +42,7 @@ function TagList(opts) {
       this.opts.tableTitle == 'Individual contributions');
 
   this.$body = $(
-    BODY_TEMPLATE({
+    template_body({
       resultType: this.opts.resultType,
       clearResetFiltersLabel: shouldResetFilters
         ? 'Reset filters'
@@ -97,8 +85,8 @@ function TagList(opts) {
  */
 TagList.prototype.addTag = function(e, opts) {
   var tag = opts.nonremovable
-    ? NONREMOVABLE_TAG_TEMPLATE(opts)
-    : TAG_TEMPLATE(opts);
+    ? template_nonremoveableTag(opts)
+    : template_tag(opts);
   var name = opts.range ? opts.rangeName : opts.name;
   var $tagCategory = this.$list.find('[data-tag-category="' + name + '"]');
   this.removeTag(opts.key, false);
@@ -305,8 +293,8 @@ TagList.prototype.removeTagDom = function(e) {
  */
 TagList.prototype.renameTag = function(e, opts) {
   var tag = opts.nonremovable
-    ? NONREMOVABLE_TAG_TEMPLATE(opts)
-    : TAG_TEMPLATE(opts);
+    ? template_nonremoveableTag(opts)
+    : template_tag(opts);
   var $tag = this.$list.find('[data-id="' + opts.key + '"]');
   if ($tag.length) {
     $tag.replaceWith(tag);

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -43,6 +43,22 @@ var textDataset = {
   }
 };
 
+const template_checkbox = value => `
+  <li>
+    <input 
+      id="${value.id}"
+      name="${value.name}"
+      value="${value.value}"
+      type="checkbox"
+      checked
+    />
+    <label for="${value.id}">${value.label}</label>
+    <button class="dropdown__remove">
+    <span class="u-visually-hidden">Remove</span>
+    </button>
+  </li>
+`;
+
 var FilterTypeahead = function(selector, dataset, allowText) {
   this.$elm = $(selector);
   this.dataset = dataset;
@@ -215,30 +231,13 @@ FilterTypeahead.prototype.disableButton = function() {
     .attr('disabled', false);
 };
 
-FilterTypeahead.prototype.checkboxTemplate = _.template(
-  '<li>' +
-    '<input ' +
-    'id="{{id}}" ' +
-    'name="{{name}}" ' +
-    'value="{{value}}" ' +
-    'type="checkbox" ' +
-    'checked' +
-    '/>' +
-    '<label for="{{id}}">{{label}}</label>' +
-    '<button class="dropdown__remove">' +
-    '<span class="u-visually-hidden">Remove</span>' +
-    '</button>' +
-    '</li>',
-  { interpolate: /\{\{(.+?)\}\}/g }
-);
-
 FilterTypeahead.prototype.appendCheckbox = function(opts) {
   var data = this.formatCheckboxData(opts);
 
   if (this.$elm.find('#' + data.id).length) {
     return;
   }
-  var checkbox = $(this.checkboxTemplate(data));
+  var checkbox = $(template_checkbox(data));
   checkbox.appendTo(this.$selected);
   checkbox.find('input').change();
   this.clearInput();

--- a/fec/fec/static/js/modules/filters/text-filter.js
+++ b/fec/fec/static/js/modules/filters/text-filter.js
@@ -72,22 +72,22 @@ TextFilter.prototype.handleBlur = function() {
   }
 };
 
-TextFilter.prototype.checkboxTemplate = _.template(
-  '<li>' +
-    '<input ' +
-    'id="{{id}}" ' +
-    'name="{{name}}" ' +
-    'value="{{value}}" ' +
-    'type="checkbox" ' +
-    'checked' +
-    '/>' +
-    '<label for="{{id}}">"{{value}}"</label>' +
-    '<button class="dropdown__remove js-remove">' +
-    '<span class="u-visually-hidden">Remove</span>' +
-    '</button>' +
-    '</li>',
-  { interpolate: /\{\{(.+?)\}\}/g }
-);
+const template_checkbox = value => `
+  <li>
+    <input
+      id="${value.id}"
+      name="${value.name}"
+      value="${value.value}"
+      type="checkbox"
+      checked
+    />
+    <label for="${value.id}">"${value.value}"</label>
+    <button class="dropdown__remove js-remove">
+    <span class="u-visually-hidden">Remove</span>
+    </button>
+  </li>
+`;
+
 
 // Remove the event handlers for adding and removing tags
 // So the filter count doesn't count double for the text filter and checkbox
@@ -103,7 +103,7 @@ TextFilter.prototype.appendCheckbox = function(value) {
     name: this.name,
     value: _.escape(value.replace(/["]+/g, ''))
   };
-  var checkbox = $(this.checkboxTemplate(opts));
+  var checkbox = $(template_checkbox(opts));
   checkbox.appendTo(this.checkboxList.$elm);
   checkbox.find('input').change();
   this.$input.val('');

--- a/fec/fec/static/js/modules/maps.js
+++ b/fec/fec/static/js/modules/maps.js
@@ -30,9 +30,10 @@ var colorScale = ['#e2ffff', '#278887'];
 var compactRules = [['B', 9], ['M', 6], ['k', 3], ['', 0]];
 var MAX_MAPS = 2;
 
-_.templateSettings = {
-  interpolate: /\{\{(.+?)\}\}/g
-};
+const template_tooltip = value => `
+  <div class="tooltip__title">${value.name}</div>
+  <div class="tooltip__value">${value.total}</div>
+`;
 
 function chooseRule(value) {
   return _.find(compactRules, function(rule) {
@@ -149,11 +150,6 @@ function stateLegend(svg, scale, quantize, quantiles) {
     });
 }
 
-var tooltipTemplate = _.template(
-  '<div class="tooltip__title">{{ name }}</div>' +
-    '<div class="tooltip__value">{{ total }}</div>'
-);
-
 function stateTooltips(svg, path, results) {
   var tooltip = d3
     .select('body')
@@ -167,7 +163,7 @@ function stateTooltips(svg, path, results) {
     .selectAll('path')
     .on('mouseover', function(d) {
       this.parentNode.appendChild(this);
-      var html = tooltipTemplate({
+      var html = template_tooltip({
         name: fips.fipsByCode[d.id].STATE_NAME,
         total: helpers.currency(results[d.id] || 0)
       });

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -35,7 +35,6 @@ var sizeColumns = [
     className: 'all',
     orderable: false,
     render: function(data) {
-      console.log('committee-single.sizeColumns[0] render (data): ', data);
       return columnHelpers.sizeInfo[data].label;
     }
   },
@@ -48,7 +47,6 @@ var sizeColumns = [
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],
       function(data, type, row) {
-        console.log('committee-single.sizeColumns[1] render (data, type, row): ', data, type, row);
         return columnHelpers.getSizeParams(row.size);
       }
     )
@@ -61,7 +59,6 @@ var stateColumns = [
     width: '50%',
     className: 'all',
     render: function(data, type, row, meta) {
-      console.log('committee-single.stateColumns[0] render (data, type, row, meta): ', data, type, row, meta);
       var span = document.createElement('span');
       span.textContent = data;
       span.setAttribute('data-state', data);
@@ -77,7 +74,6 @@ var stateColumns = [
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],
       function(data, type, row) {
-        console.log('committee-single.stateColumns[1] render (data, type, row): ', data, type, row);
         return {
           contributor_state: row.state
         };
@@ -101,7 +97,6 @@ var employerColumns = [
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],
       function(data, type, row) {
-        console.log('committee-single.employerColumns render (data, type, row): ', data, type, row);
         if (row.employer) {
           return {
             contributor_employer: row.employer
@@ -129,7 +124,6 @@ var occupationColumns = [
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],
       function(data, type, row) {
-        console.log('committee-single.occupationColumns render (data, type, row): ', data, type, row);
         if (row.occupation) {
           return {
             contributor_occupation: row.occupation
@@ -158,7 +152,6 @@ var disbursementRecipientColumns = [
       type,
       row
     ) {
-      console.log('committee-single.disbursementReceiptColumns render (data, type, row): ', data, type, row);
       return {
         recipient_name: row.recipient_name
       };
@@ -172,7 +165,6 @@ var disbursementRecipientIDColumns = [
     className: 'all',
     orderable: false,
     render: function(data, type, row) {
-      console.log('committee-single.disbursementRecipientIDColumn[0] render (data, type, row): ', data, type, row);
       return columnHelpers.buildEntityLink(
         data,
         helpers.buildAppUrl(['committee', row.recipient_id]),
@@ -190,7 +182,6 @@ var disbursementRecipientIDColumns = [
       type,
       row
     ) {
-      console.log('committee-single.disbursementRecipientIDColumn[1] render (data, type, row): ', data, type, row);
       return {
         recipient_name: row.recipient_id
       };
@@ -209,7 +200,6 @@ var expendituresColumns = [
       type,
       row
     ) {
-      console.log('committee-single.expendituresColumns render (data, type, row): ', data, type, row);
       return {
         support_oppose_indicator: row.support_oppose_indicator,
         candidate_id: row.candidate_id
@@ -237,7 +227,6 @@ var electioneeringColumns = [
     render: columnHelpers.buildTotalLink(
       ['electioneering-communications'],
       function(data, type, row) {
-        console.log('committee-single.electioneeringColumns render (data, type, row): ', data, type, row);
         return {
           support_oppose_indicator: row.support_oppose_indicator,
           candidate_id: row.candidate_id
@@ -258,7 +247,6 @@ var communicationCostColumns = [
       type,
       row
     ) {
-      console.log('committee-single.communicationCostColumns render (data, type, row): ', data, type, row);
       return {
         support_oppose_indicator: row.support_oppose_indicator,
         candidate_id: row.candidate_id

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -35,6 +35,7 @@ var sizeColumns = [
     className: 'all',
     orderable: false,
     render: function(data) {
+      console.log('committee-single.sizeColumns[0] render (data): ', data);
       return columnHelpers.sizeInfo[data].label;
     }
   },
@@ -47,6 +48,7 @@ var sizeColumns = [
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],
       function(data, type, row) {
+        console.log('committee-single.sizeColumns[1] render (data, type, row): ', data, type, row);
         return columnHelpers.getSizeParams(row.size);
       }
     )
@@ -59,6 +61,7 @@ var stateColumns = [
     width: '50%',
     className: 'all',
     render: function(data, type, row, meta) {
+      console.log('committee-single.stateColumns[0] render (data, type, row, meta): ', data, type, row, meta);
       var span = document.createElement('span');
       span.textContent = data;
       span.setAttribute('data-state', data);
@@ -74,6 +77,7 @@ var stateColumns = [
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],
       function(data, type, row) {
+        console.log('committee-single.stateColumns[1] render (data, type, row): ', data, type, row);
         return {
           contributor_state: row.state
         };
@@ -97,6 +101,7 @@ var employerColumns = [
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],
       function(data, type, row) {
+        console.log('committee-single.employerColumns render (data, type, row): ', data, type, row);
         if (row.employer) {
           return {
             contributor_employer: row.employer
@@ -124,6 +129,7 @@ var occupationColumns = [
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],
       function(data, type, row) {
+        console.log('committee-single.occupationColumns render (data, type, row): ', data, type, row);
         if (row.occupation) {
           return {
             contributor_occupation: row.occupation
@@ -152,6 +158,7 @@ var disbursementRecipientColumns = [
       type,
       row
     ) {
+      console.log('committee-single.disbursementReceiptColumns render (data, type, row): ', data, type, row);
       return {
         recipient_name: row.recipient_name
       };
@@ -165,6 +172,7 @@ var disbursementRecipientIDColumns = [
     className: 'all',
     orderable: false,
     render: function(data, type, row) {
+      console.log('committee-single.disbursementRecipientIDColumn[0] render (data, type, row): ', data, type, row);
       return columnHelpers.buildEntityLink(
         data,
         helpers.buildAppUrl(['committee', row.recipient_id]),
@@ -182,6 +190,7 @@ var disbursementRecipientIDColumns = [
       type,
       row
     ) {
+      console.log('committee-single.disbursementRecipientIDColumn[1] render (data, type, row): ', data, type, row);
       return {
         recipient_name: row.recipient_id
       };
@@ -200,6 +209,7 @@ var expendituresColumns = [
       type,
       row
     ) {
+      console.log('committee-single.expendituresColumns render (data, type, row): ', data, type, row);
       return {
         support_oppose_indicator: row.support_oppose_indicator,
         candidate_id: row.candidate_id
@@ -227,6 +237,7 @@ var electioneeringColumns = [
     render: columnHelpers.buildTotalLink(
       ['electioneering-communications'],
       function(data, type, row) {
+        console.log('committee-single.electioneeringColumns render (data, type, row): ', data, type, row);
         return {
           support_oppose_indicator: row.support_oppose_indicator,
           candidate_id: row.candidate_id
@@ -247,6 +258,7 @@ var communicationCostColumns = [
       type,
       row
     ) {
+      console.log('committee-single.communicationCostColumns render (data, type, row): ', data, type, row);
       return {
         support_oppose_indicator: row.support_oppose_indicator,
         candidate_id: row.candidate_id

--- a/package-lock.json
+++ b/package-lock.json
@@ -2557,6 +2557,17 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
     "buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
@@ -3607,9 +3618,9 @@
       }
     },
     "datatables.net": {
-      "version": "1.10.23",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.23.tgz",
-      "integrity": "sha512-we3tlNkzpxvgkKKlTxTMXPCt35untVXNg8zUYWpQyC1U5vJc+lT0+Zdc1ztK8d3lh5CfdnuFde2p8n3XwaGl3Q==",
+      "version": "1.10.24",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.24.tgz",
+      "integrity": "sha512-CwXixvOdinvBCLXvcTloDinWiEM7Geaz+GwyjPrZL+MXIGPcLv4Op1bbWn8ErsI1JWMIWC8Cuf1rnDU2RrFV5w==",
       "requires": {
         "jquery": ">=1.7"
       }
@@ -10114,21 +10125,10 @@
         "vm-browserify": "^1.0.1"
       },
       "dependencies": {
-        "buffer": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
-          }
-        },
         "events": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-          "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
           "dev": true
         },
         "punycode": {
@@ -10151,9 +10151,9 @@
           }
         },
         "timers-browserify": {
-          "version": "2.0.11",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-          "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+          "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
           "dev": true,
           "requires": {
             "setimmediate": "^1.0.4"
@@ -13859,9 +13859,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "undertaker": {
       "version": "1.2.1",
@@ -14298,9 +14298,9 @@
       },
       "dependencies": {
         "anymatch": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -14309,9 +14309,9 @@
           }
         },
         "binary-extensions": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-          "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
           "dev": true,
           "optional": true
         },
@@ -14326,15 +14326,15 @@
           }
         },
         "chokidar": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-          "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
           "dev": true,
           "optional": true,
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
+            "fsevents": "~2.3.1",
             "glob-parent": "~5.1.0",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
@@ -14353,9 +14353,9 @@
           }
         },
         "fsevents": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
           "dev": true,
           "optional": true
         },
@@ -14394,9 +14394,9 @@
           },
           "dependencies": {
             "picomatch": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-              "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+              "version": "2.2.3",
+              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+              "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
               "dev": true,
               "optional": true
             }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "tough-cookie": "^2.5.0",
     "tunnel-agent": "^0.6.0",
     "ua-parser-js": "^0.7.24",
-    "underscore": "^1.13.1",
     "whatwg-fetch": "^3.5.0"
   },
   "devDependencies": {
@@ -130,6 +129,7 @@
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
     "stringify": "^5.2.0",
+    "underscore": "^1.13.1",
     "urijs": "^1.19.1",
     "vinyl-buffer": "^1.0.1",
     "vue": "^2.6.11",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "tough-cookie": "^2.5.0",
     "tunnel-agent": "^0.6.0",
     "ua-parser-js": "^0.7.24",
-    "underscore": "^1.9.2",
+    "underscore": "^1.13.1",
     "whatwg-fetch": "^3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Resolves # 

With the recent complications with underscore and templates, let's upgrade our template functionality from underscore and to standard ES6

### Required reviewers

Front-end, 

## Impacted areas of the application

Tags, typeaheads, and their tests, site-wide

## Screenshots

No changes

## Related PRs

None

## How to test

- pull the branch
- `npm i`
- `npm run build-js` (or `npm run build`)
- `npm run test-single`
- check various filters and typeaheads across the site
