### PR TITLE
4188 Change maximum-scale to 5

### DIFF
--- a/fec/data/templates/partials/meta-tags.jinja
+++ b/fec/data/templates/partials/meta-tags.jinja
@@ -12,7 +12,7 @@
 ================================================== -->
 <meta name="HandheldFriendly" content="True">
 <meta name="MobileOptimized" content="320">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5">
 
 <!-- Twitter
 ================================================== -->

--- a/fec/fec/templates/partials/meta-tags.html
+++ b/fec/fec/templates/partials/meta-tags.html
@@ -9,7 +9,7 @@
 ================================================== -->
 <meta name="HandheldFriendly" content="True">
 <meta name="MobileOptimized" content="320">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5">
 
 <!-- Twitter
 ================================================== -->


### PR DESCRIPTION
## Summary

- Resolves #4188 

Lighthouse gave us accessibility guidance that our maximum-scale was 1 and should be 5+. So I changed it to 5. This should let mobile users zoom into our pages (up to 5x)

### Required reviewers

A couple who can review front-end usage (not code, but usage).

## Impacted areas of the application

Will affect every page of the site, though likely only for mobile.

## Screenshots

No visible changes, but look at this:
![image](https://user-images.githubusercontent.com/26720877/116882951-0a1ce300-abf3-11eb-9e12-96506cddc607.png)


## Related PRs

None

## How to test

- Pull the branch
- `./manage.py runserver`
- Make sure pages load normally and don't look too zoomed (in or out)

**Will need to check on a mobile device from feature, dev, and/or stage**
Make sure pages:
- load at the right size
- can scale/zoom/unpinch,
- pinch back down to 100% device width (if they go smaller, they should relax back to 100%)
   - [ ] Safari (mobile)
   - [ ] Chrome (mobile)
   - [ ] Firefox (mobile)
   - [ ] Internet (mobile, Android)


