### PR TITLE
4562 SNYK - Upgrade Wagtail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ requests==2.25.1
 urllib3==1.26.4
 slacker==0.8.6
 whitenoise==5.2.0
-wagtail==2.11.6
+wagtail==2.11.7
 Jinja2==2.11.3
 django_jinja==2.7.0
 pillow==8.2.0


### PR DESCRIPTION
## Summary

- Resolves #4562 

Upgrading Wagtail from 2.11.6 to 2.11.7 to address a [security concern](https://snyk.io/vuln/SNYK-PYTHON-WAGTAIL-1252240). [Release notes](https://docs.wagtail.io/en/stable/releases/2.11.7.html) say the .6 > .7 is only to fix this vulnerability.

The updated code is in the admin section and now forces that URLs use a valid protocol (e.g., `http://`, `https://`, `ftp://`)

### Required reviewers

Two (feel free to adjust the list)

## Impacted areas of the application

Maybe all of Wagtail, but likely nothing

## Screenshots

No visual changes

## Related PRs

None

## How to test

- pull the branch
- `pip install -r requirements.txt`
- `npm i` and `npm run build` just in case
- `./manage.py runserver`
- Make sure [localhost](http://127.0.0.1:8000) works as expected
- Make sure the admin tools work as expected, particularly saving rich text fields with URLs and URL fields