### PR TITLE
Feature/4172 eliminate render blocking resources

### DIFF
--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -112,6 +112,6 @@ var context = {
   }
 };
 </script>
-<script src="{{ asset_for_js('dataviz-common.js') }}"></script>
-<script src="{{ asset_for_js('election-lookup.js') }}"></script>
+<script defer src="{{ asset_for_js('dataviz-common.js') }}"></script>
+<script defer src="{{ asset_for_js('election-lookup.js') }}"></script>
 {% endblock %}

--- a/fec/data/templates/elections.jinja
+++ b/fec/data/templates/elections.jinja
@@ -62,7 +62,7 @@ var context = {
 };
 
 </script>
-<script src="{{ asset_for_js('dataviz-common.js') }}"></script>
-<script src="{{ asset_for_js('elections.js') }}"></script>
+<script defer src="{{ asset_for_js('dataviz-common.js') }}"></script>
+<script defer src="{{ asset_for_js('elections.js') }}"></script>
 {% endblock %}
 

--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -301,6 +301,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ asset_for_js('dataviz-common.js') }}"></script>
-  <script src="{{ asset_for_js('data-landing.js') }}"></script>
+  <script defer src="{{ asset_for_js('dataviz-common.js') }}"></script>
+  <script defer src="{{ asset_for_js('data-landing.js') }}"></script>
 {% endblock %}

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -4,6 +4,7 @@
 <html lang="en">
   <head>
     {% include 'partials/meta-tags.html' %}
+    <link rel="preload" as="image" href="/static/img/Homepage-hero-image-flag.jpg">
     {% include 'partials/meta-tags-preloads.html' %}
     {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
     {% include 'partials/meta-tags-preconnects.html' %}

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -109,12 +109,11 @@
     document.head.appendChild(pfScriptElem);
   }
 </script>
-<script src="{% asset_for_js 'home.js' %}"></script>
-<script src="{% asset_for_js 'bythenumbers.js' %}"></script>
-<script src="{% asset_for_js 'dataviz-common.js' %}"></script>
-<script src="{% asset_for_js 'election-lookup.js' %}"></script>
+<script defer src="{% asset_for_js 'home.js' %}"></script>
+<script defer src="{% asset_for_js 'bythenumbers.js' %}"></script>
+<!-- <script defer src="{% asset_for_js 'dataviz-common.js' %}"></script> -->
+<script defer src="{% asset_for_js 'election-lookup.js' %}"></script>
 <script>
-  //remove competing/confusing querystrings on homepage
   $(function(){
     cleanURI()
     function cleanURI(){


### PR DESCRIPTION
## Summary

- Resolves #4172 
- deferring script loads to improve our page performance
- preloading the homepage hero image

### Required reviewers

Two front-end and/or UX?

## Impacted areas of the application

Preloading the homepage hero has no downside.

Now we're delaying script loads for a few templates. The most likely complication is that one of the scripts won't have loaded when it was expected, meaning a component isn't activated or isn't ready to when a user thinks it should have been. This could happen the first time a site visitor requests a script after our last deploy (pages that share scripts will use their cached versions) and when there's a slow connection.

The affected templates are for the homepage, elections, election search, and landing.

The pages 

## Screenshots

No visual changes

## Related PRs

None

## How to test

- pull the branch
- `./manage.py runserver` 
- Make sure the interactive parts work: (menus, search, widgets, glossary, etc)
   - [homepage](http://127.0.0.1:8000)
   - election-lookup (homepage and /data/elections/)
   - [elections](http://127.0.0.1:8000/data/elections/)
   - [landing](http://127.0.0.1:8000/data/)
   - Slow the connection speed and try again
- In Inspector, under the Network tab, change "No throttling" to something else and re-check the pages. They'll load more slowly and may not become useable until the last file is loaded and processed. But they should become interactive just like usual (just a little later than we're expecting).

For the homepage, Lighthouse should no longer mention "eliminate render blocking resources"