### PR TITLE
Feature/4610 fix read-more links

### DIFF
--- a/fec/fec/static/js/init.js
+++ b/fec/fec/static/js/init.js
@@ -109,12 +109,12 @@ $(document).ready(function() {
   // Move the read more links to be inline with the snippet from the post
   $('.js-post-content').each(function() {
     var $p = $(this).find('p:first-of-type');
-    $p.nextAll().remove()
     var $link = $(this).find('.js-read-more');
     if ($p.text() !== 'PDF') {
       $p.append($link);
     } else {
       $link.remove();
     }
+    $p.nextAll().remove()
   });
 });

--- a/fec/fec/static/js/init.js
+++ b/fec/fec/static/js/init.js
@@ -109,6 +109,7 @@ $(document).ready(function() {
   // Move the read more links to be inline with the snippet from the post
   $('.js-post-content').each(function() {
     var $p = $(this).find('p:first-of-type');
+    $p.nextAll().remove()
     var $link = $(this).find('.js-read-more');
     if ($p.text() !== 'PDF') {
       $p.append($link);


### PR DESCRIPTION
## Summary

- Resolves #4610

- Remove any content that comes after the read more link

### Required reviewers
one content reviewer

## Impacted areas of the application

modified:   fec/static/js/init.js


## How to test
**Content team:**
This is deployed to feature https://fec-feature-proxy.app.cloud.gov/updates/
-  Confirm that there is no content after the Read more links on https://fec-feature-proxy.app.cloud.gov/updates/ 
(To see broken behavior, see screenshots in issue or view on production, Pages 1 and 2 of /updates have example of the issue on prod)


**Developers:**
- checkout `feature/4610-fix-read-more-links`
- `npm run build-js`
-  Confirm that there is no content after the Read more links on http://127.0.0.1:8000/updates/ 
(To see broken behavior, see screenshots in issue or view on production)
