### PR TITLE
[WIP] 4568 fix legal resources datatable link

### DIFF
--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -53,7 +53,7 @@
                   </div>
               {% if results["total_" + category] %}
                   <div class="results-info__right">
-                  <span class="results-info__details">1&ndash;{{ results[category + "_returned"] }} of <a href="/data/legal/search/enforcement/?search={{ query }}&search_type={{ category}}"><strong>{{ results["total_" + category] }}</strong> results</a></span>
+                  <span class="results-info__details">1&ndash;{{ results[category + "_returned"] }} of <a href="/data/legal/search/{{ category }}/?search={{ query }}&search_type={{ category}}"><strong>{{ results["total_" + category] }}</strong> results</a></span>
                   </div>
               {% endif %}
               </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #4568 

Fixes the bug using global legal resources search on the legal resources landing page by distinguishing the results link based on type by adding the category variable to the results link. 

### Required reviewers


## Impacted areas of the application
General components of the application that this PR will affect:
- The global legal resources search datatable on the legal resources landing page


## Screenshots




## How to test

Include any information that may be helpful to the reviewer(s).
This might include:
https://github.community/t/checkout-a-branch-from-a-fork/276/2

    links to sample pages to test:
    

