### PR TITLE
4568 fix legal resources datatable link

### DIFF
--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -53,7 +53,7 @@
                   </div>
               {% if results["total_" + category] %}
                   <div class="results-info__right">
-                  <span class="results-info__details">1&ndash;{{ results[category + "_returned"] }} of <a href="/data/legal/search/enforcement/?search={{ query }}&search_type={{ category}}"><strong>{{ results["total_" + category] }}</strong> results</a></span>
+                  <span class="results-info__details">1&ndash;{{ results[category + "_returned"] }} of <a href="/data/legal/search/{{ category }}/?search={{ query }}&search_type={{ category}}"><strong>{{ results["total_" + category] }}</strong> results</a></span>
                   </div>
               {% endif %}
               </div>

--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -53,7 +53,7 @@
                   </div>
               {% if results["total_" + category] %}
                   <div class="results-info__right">
-                  <span class="results-info__details">1&ndash;{{ results[category + "_returned"] }} of <a href="/data/legal/search/{{ category }}/?search={{ query }}&search_type={{ category}}"><strong>{{ results["total_" + category] }}</strong> results</a></span>
+                  <span class="results-info__details">1&ndash;{{ results[category + "_returned"] }} of <a href="/data/legal/search/{{ category | replace('_', '-') }}/?search={{ query }}&search_type={{ category}}"><strong>{{ results["total_" + category] }}</strong> results</a></span>
                   </div>
               {% endif %}
               </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #4568 

Fixes the bug using global legal resources search on the legal resources landing page (seen below) by distinguishing the results link based on type by adding the category variable to the results link and adding the underscore replace filter. 

Following the results link below, for any resource type, will take you to MURs. 

![Screen Shot 2021-05-20 at 3 54 35 PM](https://user-images.githubusercontent.com/66386084/119041463-a9c4ca00-b984-11eb-8c2d-d108397c7f39.png)

## Impacted areas of the application

General components of the application that this PR will affect:

-  The global legal resources search datatable on the legal resources landing page


## Screenshots

Before:

![Screen Shot 2021-05-18 at 1 59 22 PM](https://user-images.githubusercontent.com/66386084/118701501-c7a5f980-b7e1-11eb-851e-64b4122f214e.png)


After:
![Screen Shot 2021-05-18 at 2 14 09 PM](https://user-images.githubusercontent.com/66386084/118702839-6f6ff700-b7e3-11eb-8d59-8d5e12e7413d.png)



## How to test

- links to sample pages to test:
http://127.0.0.1:8000/data/legal/search/?search_type=all&search=money
select "877 results"
www.fec.gov/data/legal/search/?search_type=all&search=money
select "877 results" 



Also, thanks to Laura I'm no longer using my forked copy so you don't have to checkout my branch from my copy! 

