### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Fix election profile page contributor state datatable

### DIFF
--- a/fec/fec/static/js/modules/column-helpers.js
+++ b/fec/fec/static/js/modules/column-helpers.js
@@ -219,7 +219,7 @@ function sizeColumns(context) {
 
 function stateColumns(results, context) {
   var stateColumn = { data: 'state' };
-  var columns = results.map(function(result) {
+  var columns = results.toArray().map(function(result) {
     return makeCommitteeColumn({ data: result.candidate_id }, context, function(
       data,
       type,

--- a/fec/fec/tests/js/column-helpers.js
+++ b/fec/fec/tests/js/column-helpers.js
@@ -217,9 +217,9 @@ describe('column helpers', function() {
 
   describe('stateColumns', function() {
     it('should build a stateColumns from context and results', function() {
-      var results = columnHelpers.stateColumns(houseResults, context);
+      var results = columnHelpers.stateColumns($(houseResults), context);
       expect(results).to.be.an('array');
-      expect(results.length).to.equal(houseResults.length+1);
+      expect(results.length).to.equal(houseResults.length + 1);
     });
   });
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4625 

The `results` in the stateColumns function is an object type. When `_.map()` was replaced with jquery `.map()`, jquery could not handle it because it was expecting an array for it's function and not just an object. So we needed to transform the results object to an array so that it could be handled in the jquery map.

### Required reviewers

1 front end

## Impacted areas of the application

General components of the application that this PR will affect:

-  Election profile page contributor state datatable

## Screenshots

### Before

![Screen Shot 2021-05-18 at 9 28 40 AM](https://user-images.githubusercontent.com/12799132/118659700-8ef32980-b7bb-11eb-95e3-3b698c5fae2e.png)

### After
![Screen Shot 2021-05-18 at 9 28 51 AM](https://user-images.githubusercontent.com/12799132/118659750-961a3780-b7bb-11eb-9df1-a607871d622e.png)


## Related PRs

branch | PR
------ | ------
feature/remove-underscore-templating | [link](https://github.com/fecgov/fec-cms/pull/4574)

## How to test

- npm run build
- ./manage.py runserver
- Go to any election profile page individual contributions datatable section, ex: http://localhost:8000/data/elections/president/2024/#individual-contributions.
- Click on the contributor state toggle.
- Ensure that there is:
    - [ ] No datatable pop up warning when going to the election profile page
    - [ ] The contributor state datatable is loaded ok

