### PR TITLE
Feature/4637 commissioner photos height

### DIFF
--- a/fec/fec/static/scss/components/_icon-headings.scss
+++ b/fec/fec/static/scss/components/_icon-headings.scss
@@ -22,6 +22,7 @@
 
 .icon-heading__image {
   @include span-columns(1);
+  height: auto;
 }
 
 .icon-heading__content {
@@ -41,6 +42,7 @@
 .grid--3-wide {
   .icon-heading__image {
     @include span-columns(3);
+    height: auto;
   }
 
   .icon-heading__content {

--- a/fec/home/templates/home/alert_for_emergency_use_only.html
+++ b/fec/home/templates/home/alert_for_emergency_use_only.html
@@ -184,7 +184,7 @@ This template is for previewing the alert-for-emergency-use-only banner on Wagta
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Vacant Position">
+            <img class="icon-heading__image" src="{% static 'img/headshot--no-photo.jpg' %}" alt="Placeholder no photo">
             <div class="icon-heading__content">
               <div class="t-lead">Vacant seat</div>
               <div class="t-sans"></div>

--- a/fec/home/templates/home/home_page_banner_announcement.html
+++ b/fec/home/templates/home/home_page_banner_announcement.html
@@ -184,7 +184,7 @@ This template is for previewing the home page banner announcement on Wagtail
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Vacant Position">
+            <img class="icon-heading__image" src="{% static 'img/headshot--no-photo.jpg' %}" alt="Placeholder no photo">
             <div class="icon-heading__content">
               <div class="t-lead">Vacant seat</div>
               <div class="t-sans"></div>

--- a/fec/home/templates/partials/commissioner.html
+++ b/fec/home/templates/partials/commissioner.html
@@ -7,7 +7,7 @@
     {% image commissioner.picture original as commissioner_picture %}
     <img class="icon-heading__image" src="{{ commissioner_picture.url }}" alt="Headshot of {{ commissioner.title }}" width="70" height="70">
     {% else %}
-    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of {{ commissioner.title }}" width="70" height="70">
+    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Placeholder no photo of {{ commissioner.title }}" width="70" height="70">
     {% endif %}
     <div class="icon-heading__content">
       <div class="t-lead"><a href="{{ commissioner.url }}">{{ commissioner.title }}</a></div>

--- a/fec/home/templates/partials/current-commissioners.html
+++ b/fec/home/templates/partials/current-commissioners.html
@@ -20,7 +20,7 @@
 {% for vacant in vacant_seats %}
   <div class="grid__item commissioner-height">
   <div class="icon-heading">
-    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of vacant seat" width="160" height="160">
+    <img class="icon-heading__image" src="{% static 'img/headshot--no-photo.jpg' %}" alt="" width="160" height="160">
     <div class="icon-heading__content">
       <div class="t-lead">Vacant seat</div>
     </div>

--- a/fec/home/templates/partials/current-commissioners.html
+++ b/fec/home/templates/partials/current-commissioners.html
@@ -20,7 +20,7 @@
 {% for vacant in vacant_seats %}
   <div class="grid__item commissioner-height">
   <div class="icon-heading">
-    <img class="icon-heading__image" src="{% static 'img/headshot--no-photo.jpg' %}" alt="" width="160" height="160">
+    <img class="icon-heading__image" src="{% static 'img/headshot--no-photo.jpg' %}" alt="Placeholder no photo" width="160" height="160">
     <div class="icon-heading__content">
       <div class="t-lead">Vacant seat</div>
     </div>


### PR DESCRIPTION
## Summary

- Resolves #4637 

Previous work to set default image sizes was fine, except we didn't set a default height for commissioner images. Also, removed the alt tag for we-don't-have-a-photo vacant seats

### Required reviewers

2-3 people

@bmathesonFEC I've tagged you because you reported the issue; feel free to review on dev, or just remove yourself as a reviewer.

## Impacted areas of the application

Photos of commissioners, anywhere the `icon-heading__image` class is used, which, for now, is only for photos of commissioners.

I didn't like the "Headshot of vacant seat" alt tag for the open seats so changed it to blank because why would we verbally tell a tabbing user that we're not showing them a headshot? If I were tabbing and heard "no photo," I'd wonder why they took the time to tell me there wasn't a photo.

## Screenshots

The 'before' images are in the ticket. Here's an 'after':
![image](https://user-images.githubusercontent.com/26720877/118993390-7a499980-b953-11eb-962a-0716b9ae0e0e.png)


## Related PRs

None

## How to test

- pull the branch
- `npm i`
- `npm run build`
- check that commissioner images aren't skewed—they should be circles. (You may need to use Inspector to change image paths to `https://www.fec.gov/resources/cms-content/images/…`)
  - homepage [local](http://127.0.0.1:8000)
  - leadership page [local](http://127.0.0.1:8000/about/leadership-and-structure/)

My localhost doesn't show images so we can check on dev, too.
