### PR TITLE
Remove redirected transition pages from the global search index

### DIFF
--- a/fec/search/management/data/transition_pages.json
+++ b/fec/search/management/data/transition_pages.json
@@ -1,20 +1,3 @@
 [
-    {
-        "document_id": "transition-29",
-        "title": "Offices of the Federal Election Commission",
-        "path": "http://transition.fec.gov/about/offices/offices.shtml",
-        "created": "04/01/2017",
-        "promote": "false",
-        "description": "Offices of the Federal Election Commission",
-        "language": "en"
-    },
-    {
-        "document_id": "transition-33",
-        "title": "Requests for legal consideration",
-        "path": "http://transition.fec.gov/law/legalconsideration.shtml",
-        "created": "04/01/2017",
-        "promote": "false",
-        "description": "Requests for legal consideration",
-        "language": "en"
-    }
+
 ]

--- a/fec/search/management/instructions.md
+++ b/fec/search/management/instructions.md
@@ -115,7 +115,7 @@ You can add `description`, `tags`, or `promoted` fields.*
 This is done through a curl:
 
 ```
-curl "https://i14y.usa.gov/api/v1/documents/{document_id}" -XDELETE -u main:$DIGITALGOV_DRAWER_KEY_MAIN
+curl "https://i14y.usa.gov/api/v1/documents/{document_id}" -XDELETE -u fec_main:$DIGITALGOV_DRAWER_KEY_MAIN
 
 ```
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4646 

Removed all the remaining transition links from the global search index. Updated docs for drawer name.

### Required reviewers

1 front end and 1 content

## Impacted areas of the application

General components of the application that this PR will affect:

-  Global search

## How to test

- Take a look at the changes and make sure there's no more links left in the `transition_pages.json`
- Look at instructions to make sure the drawer name has been updated correctly
