### PR TITLE
Create PAC and party datatable

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -382,6 +382,7 @@ table_columns = OrderedDict([
     ('candidates-office-senate', ['Name', 'Party', 'State', 'Receipts', 'Disbursements']),
     ('candidates-office-house', ['Name', 'Party', 'State', 'District', 'Receipts', 'Disbursements']),
     ('committees', ['Name', 'Committee ID', 'Treasurer', 'Type', 'Designation', 'First filing date']),
+    ('pac-party', ['Name', 'Type', 'Receipts', 'Disbursements', 'Cash on  hand']),
     ('communication-costs', ['Committee', 'Support/Oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Description', 'Disbursement date', 'Amount']),
     ('electioneering-communications',

--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -382,7 +382,7 @@ table_columns = OrderedDict([
     ('candidates-office-senate', ['Name', 'Party', 'State', 'Receipts', 'Disbursements']),
     ('candidates-office-house', ['Name', 'Party', 'State', 'District', 'Receipts', 'Disbursements']),
     ('committees', ['Name', 'Committee ID', 'Treasurer', 'Type', 'Designation', 'First filing date']),
-    ('pac-party', ['Name', 'Type', 'Receipts', 'Disbursements', 'Cash on  hand']),
+    ('pac-party', ['Name', 'Type', 'Receipts', 'Disbursements', 'Cash on hand']),
     ('communication-costs', ['Committee', 'Support/Oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Description', 'Disbursement date', 'Amount']),
     ('electioneering-communications',

--- a/fec/data/templates/partials/browse-data/committees.jinja
+++ b/fec/data/templates/partials/browse-data/committees.jinja
@@ -33,6 +33,13 @@
         </div>
       </li>
       <li>
+        <i class="icon i-magnifying-glass icon--absolute--left"></i>
+        <div class="content__section--indent-left">
+          <h4><a href="/data/committees/pac-party/">All political action and party committees</a></h4>
+          <p class ="u-margin--bottom">Search for political action and party committees by type, years active, treasurer, sponsor, state or territory, and filing frequency.</p>
+        </div>
+      </li>
+      <li>
         <div class="content__section--indent-left">
           <h4>Leadership PACs and sponsors</h4>
           <div class="js-accordion accordion--neutral" data-content-prefix="pacs">

--- a/fec/data/templates/partials/browse-data/committees.jinja
+++ b/fec/data/templates/partials/browse-data/committees.jinja
@@ -32,13 +32,15 @@
           </div>
         </div>
       </li>
-      <li>
-        <i class="icon i-magnifying-glass icon--absolute--left"></i>
-        <div class="content__section--indent-left">
-          <h4><a href="/data/committees/pac-party/">All political action and party committees</a></h4>
-          <p class ="u-margin--bottom">Search for political action and party committees by type, years active, treasurer, sponsor, state or territory, and filing frequency.</p>
-        </div>
-      </li>
+      {% if FEATURES.pac_party %}
+        <li>
+          <i class="icon i-magnifying-glass icon--absolute--left"></i>
+          <div class="content__section--indent-left">
+            <h4><a href="/data/committees/pac-party/">All political action and party committees</a></h4>
+            <p class ="u-margin--bottom">Search for political action and party committees by type, years active, treasurer, sponsor, state or territory, and filing frequency.</p>
+          </div>
+        </li>
+      {% endif %}
       <li>
         <div class="content__section--indent-left">
           <h4>Leadership PACs and sponsors</h4>

--- a/fec/data/templates/partials/pac-party-filter.jinja
+++ b/fec/data/templates/partials/pac-party-filter.jinja
@@ -1,0 +1,18 @@
+{% extends 'partials/filters.jinja' %}
+
+{% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
+{% import 'macros/filters/years.jinja' as years %}
+{% import 'macros/filters/text.jinja' as text %}
+{% import 'macros/filters/states.jinja' as states %}
+
+{% block filters %}
+  <div class="filters__inner">
+    {{ typeahead.field('committee_id', 'Committee Name or ID') }}
+    {{ years.cycles('cycle', 'Time period')  }}
+    {% import 'macros/filters/committee-types.jinja' as committee_type %} {# TODO: Need to adjust macro to remove authorized committee filter #}
+    {{ committee_type.field(display_sponsor_candidate_filter=True) }} {# TODO: Not currently filterable in API #}
+    {{ text.field('treasurer_name', 'Most recent treasurer') }} {# TODO: Not currently in API #}
+    {{ states.field('state') }} {# TODO: Not currently in API #}
+    {# TODO: Add filing frequency accordion when available #}
+  </div>
+{% endblock %}

--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -50,6 +50,11 @@ urlpatterns = [
     url(r'^widgets/aggregate-totals/$', views.aggregate_totals),
 ]
 
+if settings.FEATURES.get('pac_party'):
+    urlpatterns.append(
+        url(r'^data/committees/pac-party/$', views_datatables.pac_party)
+    )
+
 if settings.FEATURES.get('debts'):
     # Debts section TODO: debts dates
     urlpatterns.append(

--- a/fec/data/views_datatables.py
+++ b/fec/data/views_datatables.py
@@ -51,6 +51,20 @@ def committees(request):
     })
 
 
+def pac_party(request):
+    if len(request.GET) == 0:
+        return redirect('/data/committees/pac-party/?cycle=' + str(constants.DEFAULT_TIME_PERIOD))
+
+    return render(request, 'datatable.jinja', {
+        'parent': 'data',
+        'result_type': 'pac_party',
+        'slug': 'pac-party',
+        'title': 'Political action and party committees',
+        'columns': constants.table_columns['pac-party'],
+        'social_image_identifier': 'data',
+    })
+
+
 def communication_costs(request):
     return render(request, 'datatable.jinja', {
         'parent': 'data',

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -63,6 +63,7 @@ FEATURES = {
     'contributionsbystate': bool(env.get_credential('FEC_FEATURE_CONTRIBUTIONS_BY_STATE', '')),
     'debts': bool(env.get_credential('FEC_FEATURE_DEBTS', '')),  # TODO: debts dates
     'map': bool(env.get_credential('FEC_FEATURE_HOME_MAP', '')),
+    'pac_party': bool(env.get_credential('FEC_FEATURE_PAC_PARTY', '')),
     'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
 }
 
@@ -75,6 +76,7 @@ if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:
     FEATURES['contributionsbystate'] = True
     FEATURES['debts'] = True
     FEATURES['map'] = True
+    FEATURES['pac_party'] = True
     FEATURES['presidential_map'] = True
 
 # Application definition

--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -829,6 +829,41 @@ var debts = [
   modalTriggerColumn
 ];
 
+var pac_party = [
+  {
+    data: 'committee_name',
+    orderable: true,
+    className: 'all',
+    render: function(data, type, row) {
+      if (data) {
+        return columnHelpers.buildEntityLink(
+          data,
+          helpers.buildAppUrl(['committee', row.committee_id])
+        );
+      } else {
+        return '';
+      }
+    }
+  },
+  {
+    data: 'committee_type_full',
+    className: 'all'
+  },
+  currencyColumn({
+    data: 'disbursements',
+    className: 'min-desktop hide-panel column--number t-mono'
+  }),
+  currencyColumn({
+    data: 'receipts',
+    className: 'min-desktop hide-panel column--number t-mono'
+  }),
+  currencyColumn({
+    data: 'last_cash_on_hand_end_period',
+    className: 'min-desktop hide-panel column--number t-mono'
+  }),
+  modalTriggerColumn
+];
+
 var audit = [
   columnHelpers.urlColumn('link_to_report', {
     data: 'committee_name',
@@ -905,5 +940,6 @@ module.exports = {
   reports: reports,
   loans: loans,
   debts: debts,
+  pac_party: pac_party,
   audit: audit
 };

--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -850,11 +850,11 @@ var pac_party = [
     className: 'all'
   },
   currencyColumn({
-    data: 'disbursements',
+    data: 'receipts',
     className: 'min-desktop hide-panel column--number t-mono'
   }),
   currencyColumn({
-    data: 'receipts',
+    data: 'disbursements',
     className: 'min-desktop hide-panel column--number t-mono'
   }),
   currencyColumn({

--- a/fec/fec/static/js/pages/datatable-pac-party.js
+++ b/fec/fec/static/js/pages/datatable-pac-party.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * PAC and party committee datatable page
+ **/
+
+var $ = require('jquery');
+
+var tables = require('../modules/tables');
+var columns = require('../modules/columns');
+
+var pacPartyTemplate = require('../templates/pac-party.hbs');
+
+$(document).ready(function() {
+  var $table = $('#results');
+  new tables.DataTable($table, {
+    autoWidth: false,
+    title: 'Political action and party committees',
+    path: ['totals', 'pac-party'],
+    columns: columns.pac_party,
+    order: [[2, 'desc']],
+    useFilters: true,
+    useExport: true,
+    rowCallback: tables.modalRenderRow,
+    callbacks: {
+      afterRender: tables.modalRenderFactory(pacPartyTemplate)
+    }
+  });
+});

--- a/fec/fec/static/js/templates/pac-party.hbs
+++ b/fec/fec/static/js/templates/pac-party.hbs
@@ -1,0 +1,41 @@
+{{!--
+Template for PAC and party committee datatable details panel
+--}}
+
+<div class="panel__row">
+  <h4 class="panel__title">
+    <a href="{{basePath}}/committee/{{committee_id}}">{{committee_name}}</a>
+  </h4>
+</div>
+<div class="panel__row">
+  <table>
+    {{#panelRow "Committee type"}}
+      {{committee_type_full}}
+    {{/panelRow}}
+    {{#panelRow "Designation"}}
+      {{committee_designation_full}}
+    {{/panelRow}}
+    {{#panelRow "Most recent treasurer"}}
+    {{!-- TODO: Fill this when available --}}
+      {{ TBD }}
+    {{/panelRow}}
+    {{#panelRow "State"}}
+    {{!-- TODO: Fill this when available --}}
+      {{ TBD }}
+    {{/panelRow}}
+    {{#panelRow "Total individual contributions"}}
+      {{{currency individual_contributions}}}
+    {{/panelRow}}
+    {{#panelRow "Filing frequency"}}
+    {{!-- TODO: Fill this when available --}}
+      {{ TBD }}
+    {{/panelRow}}
+    {{#panelRow "Coverage end date"}}
+      {{datetime coverage_end_date format="pretty"}}
+    {{/panelRow}}
+    {{#panelRow "First filing date"}}
+    {{!-- TODO: Fill this when available --}}
+      {{datetime TBD format="pretty"}}
+    {{/panelRow}}
+  </table>
+</div>


### PR DESCRIPTION
## Summary (required)

- Resolves #4651 

Create new PAC and party datatable with committee name/ID and time period filters.

**Note:** This datatable is under a feature flag. There are also filters and fields that were added prior to the API work being done. I've noted the items as `TODO` in the code, so we know where to revisit when that data is in the API.

### Required reviewers

1 UX and 1 front-end

## Impacted areas of the application

General components of the application that this PR will affect:

-  PAC and party datatable

## Screenshots

![Screen Shot 2021-05-24 at 5 45 02 PM](https://user-images.githubusercontent.com/12799132/119411056-ca0fc400-bcb7-11eb-8be2-ce819e4153d9.png)

![Screen Shot 2021-06-03 at 1 28 06 PM](https://user-images.githubusercontent.com/12799132/120686983-8fecb200-c46f-11eb-8ea4-8916b30832df.png)

![Screen Shot 2021-06-03 at 1 25 34 PM](https://user-images.githubusercontent.com/12799132/120686715-4603cc00-c46f-11eb-9d91-86883dbca4f9.png)

## How to test

- `npm run build`
- ./manage.py runserver
- Go to datatable: http://localhost:8000/data/committees/pac-party/. Click on the details panel to see more info.
- Go to committees browse data page to see the link to the datatable: http://localhost:8000/data/browse-data/?tab=committees