### PR TITLE
Activate state election cards on election profile pages

### DIFF
--- a/fec/data/templates/partials/elections/election-profile-cards.jinja
+++ b/fec/data/templates/partials/elections/election-profile-cards.jinja
@@ -24,15 +24,17 @@
         </aside>
     </div>
   {% else %}
-    <div class="grid__item is-disabled">
-      <aside class="card card--horizontal card--neutral-base">
-        <div class="card__image__container">
-          <span class="card__icon i-election"><span class="u-visually-hidden">Icon of elections</span></span>
-        </div>
-        <div class="card__content">
-          All {% if state %} - {{ state|fmt_state_full }} {% endif %}state elections
-        </div>
-      </aside>
+    <div class="grid__item">
+      <a href="/data/elections/?cycle={{ cycle }}&state={{ state }}">
+        <aside class="card card--horizontal card--neutral-base">
+          <div class="card__image__container">
+            <span class="card__icon i-election"><span class="u-visually-hidden">Icon of elections</span></span>
+          </div>
+          <div class="card__content">
+            All {% if state %} - {{ state|fmt_state_full }} {% endif %}state elections
+          </div>
+        </aside>
+      </a>
     </div>
   {% endif %}
   <div class="grid__item is-disabled">

--- a/fec/data/templates/partials/elections/election-profile-cards.jinja
+++ b/fec/data/templates/partials/elections/election-profile-cards.jinja
@@ -22,7 +22,7 @@
             <span class="card__icon i-election"><span class="u-visually-hidden">Icon of elections</span></span>
           </div>
           <div class="card__content">
-            All {% if state %} {{ state|fmt_state_full }} {% endif %}state elections
+            All federal {% if state %} {{ state|fmt_state_full }} {% endif %} elections
           </div>
         </aside>
       </a>
@@ -34,7 +34,7 @@
         <span class="card__icon i-election"><span class="u-visually-hidden">Icon of elections</span></span>
       </div>
       <div class="card__content">
-        All {{ office|title }} elections
+        All federal {{ office|title }} elections
       </div>
     </aside>
   </div>

--- a/fec/data/templates/partials/elections/election-profile-cards.jinja
+++ b/fec/data/templates/partials/elections/election-profile-cards.jinja
@@ -13,25 +13,16 @@
     </a>
   </div>
   {% if office == 'president' %}
-    <div class="grid__item is-disabled" style="display: none;">
-        <aside class="card card--horizontal card--neutral-base">
-          <div class="card__image__container">
-            <span class="card__icon i-election"><span class="u-visually-hidden">Icon of elections</span></span>
-          </div>
-          <div class="card__content">
-            All {% if state %} - {{ state|fmt_state_full }} {% endif %}state elections
-          </div>
-        </aside>
-    </div>
+    {# Don't display state election card for presidential election profile page #}
   {% else %}
     <div class="grid__item">
       <a href="/data/elections/?cycle={{ cycle }}&state={{ state }}">
-        <aside class="card card--horizontal card--neutral-base">
+        <aside class="card card--horizontal card--primary">
           <div class="card__image__container">
             <span class="card__icon i-election"><span class="u-visually-hidden">Icon of elections</span></span>
           </div>
           <div class="card__content">
-            All {% if state %} - {{ state|fmt_state_full }} {% endif %}state elections
+            All {% if state %} {{ state|fmt_state_full }} {% endif %}state elections
           </div>
         </aside>
       </a>

--- a/fec/data/templates/partials/elections/election-profile-cards.jinja
+++ b/fec/data/templates/partials/elections/election-profile-cards.jinja
@@ -1,42 +1,46 @@
 <div class="entity__figure entity__figure--narrow u-no-padding row">
-<div class="grid grid--3-wide">
-  <div class="grid__item">
-    <a href="/help-candidates-and-committees/dates-and-deadlines/">
-      <aside class="card card--horizontal card--primary">
-        <div class="card__image__container">
-          <span class="card__icon i-checklist-2"><span class="u-visually-hidden">Icon of dates and deadlines</span></span>
-        </div>
-        <div class="card__content">
-          Dates and deadlines
-        </div>
-      </aside>
-    </a>
-  </div>
-  {% if office == 'president' %}
-    {# Don't display state election card for presidential election profile page #}
-  {% else %}
+  <div class="grid grid--3-wide">
     <div class="grid__item">
-      <a href="/data/elections/?cycle={{ cycle }}&state={{ state }}">
+      <a href="/help-candidates-and-committees/dates-and-deadlines/">
         <aside class="card card--horizontal card--primary">
           <div class="card__image__container">
-            <span class="card__icon i-election"><span class="u-visually-hidden">Icon of elections</span></span>
+            <span class="card__icon i-checklist-2"><span class="u-visually-hidden">Icon of dates and deadlines</span></span>
           </div>
           <div class="card__content">
-            All federal {% if state %} {{ state|fmt_state_full }} {% endif %} elections
+            Dates and deadlines
           </div>
         </aside>
       </a>
     </div>
-  {% endif %}
-  <div class="grid__item is-disabled">
-    <aside class="card card--horizontal card--neutral-base">
-      <div class="card__image__container">
-        <span class="card__icon i-election"><span class="u-visually-hidden">Icon of elections</span></span>
+    {% if office == 'president' %}
+      {# Don't display state election card for presidential election profile page #}
+    {% else %}
+      <div class="grid__item">
+        <a href="/data/elections/?cycle={{ cycle }}&state={{ state }}">
+          <aside class="card card--horizontal card--primary">
+            <div class="card__image__container">
+              <span class="card__icon i-election"><span class="u-visually-hidden">Icon of elections</span></span>
+            </div>
+            <div class="card__content">
+              All federal {% if state %} {{ state|fmt_state_full }} {% endif %} elections
+            </div>
+          </aside>
+        </a>
       </div>
-      <div class="card__content">
-        All federal {{ office|title }} elections
+    {% endif %}
+    {% if office == 'president' %}
+      {# Don't display the office election card for the presidential election profile page #}
+    {% else %}
+      <div class="grid__item is-disabled">
+        <aside class="card card--horizontal card--neutral-base">
+          <div class="card__image__container">
+            <span class="card__icon i-election"><span class="u-visually-hidden">Icon of elections</span></span>
+          </div>
+          <div class="card__content">
+              All federal {{ office|title }} elections
+          </div>
+        </aside>
       </div>
-    </aside>
+    {% endif %}
   </div>
-</div>
 </div>

--- a/fec/fec/static/scss/components/_cards.scss
+++ b/fec/fec/static/scss/components/_cards.scss
@@ -359,6 +359,10 @@
       @include u-icon-bg($person-location, $primary-contrast);
     }
 
+    &.i-election {
+      @include u-icon-bg($election, $primary-contrast);
+    }
+
     &.i-individual-contributions {
       @include u-icon-bg($individual-contributions, $primary-contrast);
     }

--- a/fec/fec/static/scss/components/_cards.scss
+++ b/fec/fec/static/scss/components/_cards.scss
@@ -32,7 +32,6 @@
   .card__icon {
     &.i-election {
       @include u-icon-bg($election, $primary);
-      background-size: 65%;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Resolves #4654 

Activate state election cards and links them on the election profile pages

### Required reviewers

1 front end and 1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

-  Senate and house election profile pages

## Screenshots

### Presidential election profile page
![Screen Shot 2021-05-27 at 9 57 12 AM](https://user-images.githubusercontent.com/12799132/119839155-f69f2800-bed1-11eb-9a71-6586445537ae.png)

### Senate election profile page
![Screen Shot 2021-05-27 at 9 56 16 AM](https://user-images.githubusercontent.com/12799132/119839158-f69f2800-bed1-11eb-9c51-7ff11ecd9737.png)

### House election profile page
![Screen Shot 2021-05-27 at 9 56 43 AM](https://user-images.githubusercontent.com/12799132/119839156-f69f2800-bed1-11eb-938b-bf48115ae581.png)


## How to test

- checkout this branch
- `./manage.py runserver`
- Go to each type of office (President, Senate, and House) election profile page. Ex: http://localhost:8000/data/elections/president/2020/, http://localhost:8000/data/elections/senate/CA/2022/, http://localhost:8000/data/elections/house/CA/01/2022/, 
- Check that the:
    - [ ] Has the correct election cards displayed up at the top
    - [ ] Election card at the top is active and 
    - [ ] Links back to the correct state and year search on the election search page