### PR TITLE
Fix disclaimer text

### DIFF
--- a/fec/data/templates/macros/disclaimer.jinja
+++ b/fec/data/templates/macros/disclaimer.jinja
@@ -1,7 +1,7 @@
 {% macro disclaimer(type, id, cycle) %}
   <div class="datatable__note">
     <p class="t-note">These totals are calculated, in part, using free-text input as reported by this committee. Variations in spelling or abbreviation can produce multiple totals for the same category. For the most complete information,
-    {# <a href="{{ url_for(type, committee_id=id, cycle=cycle) }}">access the list of itemized transactions.</a></p> #}
+    <a href="/{{ type }}/?committee_id={{ id }}&two_year_transaction_period={{ cycle }}">access the list of itemized transactions.</a></p>
   </div>
 {% endmacro %}
 {% macro summary() %}

--- a/fec/data/templates/macros/disclaimer.jinja
+++ b/fec/data/templates/macros/disclaimer.jinja
@@ -1,7 +1,7 @@
 {% macro disclaimer(type, id, cycle) %}
   <div class="datatable__note">
     <p class="t-note">These totals are calculated, in part, using free-text input as reported by this committee. Variations in spelling or abbreviation can produce multiple totals for the same category. For the most complete information,
-    <a href="/{{ type }}/?committee_id={{ id }}&two_year_transaction_period={{ cycle }}">access the list of itemized transactions.</a></p>
+    <a href="{{ url('data-landing') }}{{ type }}/?committee_id={{ id }}&two_year_transaction_period={{ cycle }}">access the list of itemized transactions.</a></p>
   </div>
 {% endmacro %}
 {% macro summary() %}

--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -5,7 +5,7 @@ from data import views_datatables
 from fec import settings
 
 urlpatterns = [
-    url(r'^data/$', views.landing),
+    url(r'^data/$', views.landing, name='data-landing'),
     url(r'^data/search/$', views.search),
     url(r'^data/browse-data/$', views.browse_data, name='browse-data'),
     url(r'^data/candidate/(?P<candidate_id>\w+)/$', views.candidate),


### PR DESCRIPTION
## Summary

- Resolves #4657 

Fix the incomplete disclaimer text at the bottom of the committee profile page disbursements datatable.

### Required reviewers

1 front end and 1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

-  Committee profile pages

## Screenshots

![Screen Shot 2021-05-25 at 6 20 58 PM](https://user-images.githubusercontent.com/12799132/119576046-03166a00-bd86-11eb-84a6-feab63fab835.png)

## How to test

- Check out this branch
- ./manage.py runserver
- Go to any committee profile page disbursements section and click on the "Recipient name" tab. Look at the disclaimer text below the table to make sure it's complete and links correctly.