### PR TITLE
[WIP] Add leadership PAC sponsor field to the committees datatable

### DIFF
--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -126,7 +126,7 @@
         {# For Committee sponsor: #}
         {% if sponsor_candidates %}
         <tr>
-            <td class="figure__label">Committee sponsor:</td>
+            <td class="figure__label">Leadership PAC sponsor:</td>
             <td class="figure__value">
               {% for candidate in sponsor_candidates | reverse %}
               <div class='grid'>

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -170,6 +170,7 @@ function modalRenderFactory(template, fetch) {
           $.when(fetch(response.results[index])).done(function(fetched) {
             $modal.find('.js-panel-content').html(template(fetched));
             $modal.attr('aria-hidden', 'false');
+            $modal.trigger('show');
             $row.siblings().toggleClass('row-active', false);
             $row.toggleClass('row-active', true);
             $('body').toggleClass('panel-active', true);
@@ -214,6 +215,7 @@ function hidePanel(api, $modal) {
   $('.js-panel-toggle tr').toggleClass('row-active', false);
   $('body').toggleClass('panel-active', false);
   $modal.attr('aria-hidden', 'true');
+  $modal.trigger('hide');
 
   if ($(document).width() > 640) {
     api.columns('.hide-panel-tablet').visible(true);

--- a/fec/fec/static/js/pages/datatable-committees.js
+++ b/fec/fec/static/js/pages/datatable-committees.js
@@ -22,4 +22,24 @@ $(document).ready(function() {
       afterRender: tables.modalRenderFactory(committeesTemplate)
     }
   });
+
+  // Call the /names/candidates/ endpoint to get the leadership PAC sponsor name based on the candidate ID.
+  // Call is only made if the leadership_pac_sponsor_name exists for that row
+  $('#datatable-modal').on('show', function() {
+    var $candidateIds = $(this).find('.leadership_pac_sponsor_name');
+    $candidateIds.each(function() {
+      var $candidateIdSpan = $(this);
+      var candidateIdSpan = $candidateIdSpan[0];
+      var candidateId = candidateIdSpan.innerText;
+      $.getJSON(
+        `${window.API_LOCATION}/v1/names/candidates/?q=${candidateId}&api_key=${window.API_KEY_PUBLIC}`,
+        function(data) {
+          if (data.results.length >= 1) {
+            var record = data.results[0];
+            $candidateIdSpan.html(record.name);
+          }
+        }
+      );
+    });
+  });
 });

--- a/fec/fec/static/js/templates/committees.hbs
+++ b/fec/fec/static/js/templates/committees.hbs
@@ -26,5 +26,12 @@
         {{organization_type_full}}
       {{/panelRow}}
     {{/if}}
+    {{#if sponsor_candidate_ids}}
+      {{#panelRow "Leadership PAC sponsor"}}
+        {{#each sponsor_candidate_ids}}
+          <a href="{{basePath}}/candidate/{{this}}/"><span class="leadership_pac_sponsor_name">{{this}}</span> ({{this}})</a>;<br />
+        {{/each}}
+      {{/panelRow}}
+    {{/if}}
   </table>
 </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #4660 

To do: This will be updated later to using the /committees/ endpoint to get the candidate name rather than calling a separate endpoint.

### Required reviewers

(Include who is required to review prior to merge. For example: One designer and two front end developer reviews are required prior to merge)

## Impacted areas of the application

General components of the application that this PR will affect:

-  

## Screenshots

![Screen Shot 2021-06-01 at 5 29 30 PM](https://user-images.githubusercontent.com/12799132/120392773-f7cfbb00-c2fe-11eb-9dd4-41e459d461c2.png)


## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- 

## System architecture updates (if applicable)

(If this pull request changes our [current system diagram](https://github.com/fecgov/FEC/wiki/2.-FEC-system-diagram), include a description of those changes here and create a new ticket to update the system diagram)
