### PR TITLE
Sync string values of environment names for GTM

### DIFF
--- a/fec/data/templates/partials/google-tag-manager-noscript.jinja
+++ b/fec/data/templates/partials/google-tag-manager-noscript.jinja
@@ -3,7 +3,7 @@
   {% set gtm_url_params = 'gtm_auth=EDR0yhH3jo_lEfiev6nbSQ&gtm_preview=env-17&gtm_cookies_win=x' %}
   {% set gtm_container_id = 'GTM-T5HPRLH' %}
 
-  {% if FEC_CMS_ENVIRONMENT == 'DEV' %}
+  {% if FEC_CMS_ENVIRONMENT == 'DEVELOPMENT' %}
     {% set gtm_url_params = 'gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x' %}
 
   {% elif FEC_CMS_ENVIRONMENT == 'FEATURE' %}
@@ -12,7 +12,7 @@
   {% elif FEC_CMS_ENVIRONMENT == 'LOCAL' %}
     {% set gtm_url_params = 'gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x' %}
 
-  {% elif FEC_CMS_ENVIRONMENT == 'STAGE' %}
+  {% elif FEC_CMS_ENVIRONMENT == 'STAGING' %}
     {% set gtm_url_params = 'gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x' %}
 
   {% endif %}

--- a/fec/data/templates/partials/google-tag-manager-script.jinja
+++ b/fec/data/templates/partials/google-tag-manager-script.jinja
@@ -3,7 +3,7 @@
   {% set gtm_url_params = 'gtm_auth=EDR0yhH3jo_lEfiev6nbSQ&gtm_preview=env-17&gtm_cookies_win=x' %}
   {% set gtm_container_id = 'GTM-T5HPRLH' %}
 
-  {% if FEC_CMS_ENVIRONMENT == 'DEV' %}
+  {% if FEC_CMS_ENVIRONMENT == 'DEVELOPMENT' %}
     {% set gtm_url_params = 'gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x' %}
 
   {% elif FEC_CMS_ENVIRONMENT == 'FEATURE' %}
@@ -12,7 +12,7 @@
   {% elif FEC_CMS_ENVIRONMENT == 'LOCAL' %}
     {% set gtm_url_params = 'gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x' %}
 
-  {% elif FEC_CMS_ENVIRONMENT == 'STAGE' %}
+  {% elif FEC_CMS_ENVIRONMENT == 'STAGING' %}
     {% set gtm_url_params = 'gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x' %}
 
   {% endif %}

--- a/fec/fec/templates/partials/google-tag-manager-noscript.html
+++ b/fec/fec/templates/partials/google-tag-manager-noscript.html
@@ -1,5 +1,5 @@
 {# Google Tag Manager noscript tag #}
-{% if settings.FEC_CMS_ENVIRONMENT == 'DEV' %}
+{% if settings.FEC_CMS_ENVIRONMENT == 'DEVELOPMENT' %}
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH&gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     
 {% elif settings.FEC_CMS_ENVIRONMENT == 'FEATURE' %}
@@ -8,7 +8,7 @@
 {% elif settings.FEC_CMS_ENVIRONMENT == 'LOCAL' %}
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH&gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     
-{% elif settings.FEC_CMS_ENVIRONMENT == 'STAGE' %}
+{% elif settings.FEC_CMS_ENVIRONMENT == 'STAGING' %}
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5HPRLH&gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 {% else %}

--- a/fec/fec/templates/partials/google-tag-manager-script.html
+++ b/fec/fec/templates/partials/google-tag-manager-script.html
@@ -1,5 +1,5 @@
 {# Google Tag Manager script tag #}
-{% if settings.FEC_CMS_ENVIRONMENT == 'DEV' %}
+{% if settings.FEC_CMS_ENVIRONMENT == 'DEVELOPMENT' %}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=_vM9qqeervv47SONwk4KRg&gtm_preview=env-19&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
     
 {% elif settings.FEC_CMS_ENVIRONMENT == 'FEATURE' %}
@@ -8,7 +8,7 @@
 {% elif settings.FEC_CMS_ENVIRONMENT == 'LOCAL' %}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=sMyHATF1O8P6Wp9TLbF5sA&gtm_preview=env-21&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
 
-{% elif settings.FEC_CMS_ENVIRONMENT == 'STAGE' %}
+{% elif settings.FEC_CMS_ENVIRONMENT == 'STAGING' %}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=ZYJODko0wNc0p1iWNPgvFw&gtm_preview=env-20&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T5HPRLH');</script>
 
 {% else %}


### PR DESCRIPTION
## Summary

- Resolves 

Not sure if these got out of sync or never were in sync, but GTM is using the Prod (default) settings because the string values for Dev and Stage weren't the same as are being set in base.py

### Required reviewers

1-2

## Impacted areas of the application

Only which version of GTM is being used for Dev and for Stage.

## Screenshots

No visual changes

## Related PRs

None

## How to test

- Will have to test on Dev and Stage.
- Load any page and look at its source.
- Dev should mention `_vM9qqeervv47SONwk4KRg`
- Stage should mention `ZYJODko0wNc0p1iWNPgvFw`
- Neither Dev nor Stage should mention `EDR0yhH3jo_lEfiev6nbSQ`