### PR TITLE
PAC & party datatable: default election year applied on load and make time period a single select

### DIFF
--- a/fec/data/templates/macros/filters/years.jinja
+++ b/fec/data/templates/macros/filters/years.jinja
@@ -55,7 +55,7 @@
 <div class="filter">
   <fieldset data-name="{{name}}" class="js-filter" data-filter="select" data-required-default="{{constants.DEFAULT_ELECTION_YEAR}}">
     <label class="label" for="{{ name }}">{{ label }}</label>
-    <select id="{{ name }}-select" name="{{ name }}" class="select--full">
+    <select id="{{ name }}-select" name="{{ name }}" class="select--full" data-filter-change="true">
     {% for year in range(constants.END_YEAR, constants.START_YEAR, -2) %}
       <option value="{{ year }}">{{ year | fmt_year_range }}</option>
     {% endfor %}

--- a/fec/data/templates/macros/filters/years.jinja
+++ b/fec/data/templates/macros/filters/years.jinja
@@ -51,6 +51,20 @@
 {% endmacro %}
 
 
+{% macro singleElectionYear(name, label) %}
+<div class="filter">
+  <fieldset data-name="{{name}}" class="js-filter" data-filter="select" data-required-default="{{constants.DEFAULT_ELECTION_YEAR}}">
+    <label class="label" for="{{ name }}">{{ label }}</label>
+    <select id="{{ name }}-select" name="{{ name }}" class="select--full">
+    {% for year in range(constants.END_YEAR, constants.START_YEAR, -2) %}
+      <option value="{{ year }}">{{ year | fmt_year_range }}</option>
+    {% endfor %}
+    </select>
+  </fieldset>
+</div>
+{% endmacro %}
+
+
 {% macro cycleRange(name, label) %}
 <fieldset class="filter" id="{{name}}-field">
   <legend class="label">{{ label }}</legend>

--- a/fec/data/templates/partials/pac-party-filter.jinja
+++ b/fec/data/templates/partials/pac-party-filter.jinja
@@ -1,0 +1,18 @@
+{% extends 'partials/filters.jinja' %}
+
+{% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
+{% import 'macros/filters/years.jinja' as years %}
+{% import 'macros/filters/text.jinja' as text %}
+{% import 'macros/filters/states.jinja' as states %}
+
+{% block filters %}
+  <div class="filters__inner">
+    {{ typeahead.field('committee_id', 'Committee Name or ID') }}
+    {{ years.singleElectionYear('cycle', 'Time period')  }}
+    {% import 'macros/filters/committee-types.jinja' as committee_type %} {# TODO: Need to adjust macro to remove authorized committee filter #}
+    {{ committee_type.field(display_sponsor_candidate_filter=True) }} {# TODO: Not currently filterable in API #}
+    {{ text.field('treasurer_name', 'Most recent treasurer') }} {# TODO: Not currently in API #}
+    {{ states.field('state') }} {# TODO: Not currently in API #}
+    {# TODO: Add filing frequency accordion when available #}
+  </div>
+{% endblock %}

--- a/fec/data/views_datatables.py
+++ b/fec/data/views_datatables.py
@@ -51,6 +51,18 @@ def committees(request):
     })
 
 
+def pac_party(request):
+
+    return render(request, 'datatable.jinja', {
+        'parent': 'data',
+        'result_type': 'pac_party',
+        'slug': 'pac-party',
+        'title': 'Political action and party committees',
+        'columns': constants.table_columns['pac-party'],
+        'social_image_identifier': 'data',
+    })
+
+
 def communication_costs(request):
     return render(request, 'datatable.jinja', {
         'parent': 'data',

--- a/fec/fec/static/js/modules/filters/select-filter.js
+++ b/fec/fec/static/js/modules/filters/select-filter.js
@@ -10,6 +10,7 @@ function SelectFilter(elm) {
   this.name = this.$input.attr('name');
   this.requiredDefault = this.$elm.data('required-default') || null; // If a default is required
   this.loadedOnce = false;
+  this.$input.on('change', this.handleChange.bind(this));
 
   this.setRequiredDefault();
 }
@@ -33,6 +34,36 @@ SelectFilter.prototype.setValue = function(value) {
   this.$input.find('option[selected]').prop('selected', false);
   this.$input.find('option[value="' + value + '"]').prop('selected', true);
   this.$input.change();
+};
+
+SelectFilter.prototype.handleChange = function(e) {
+  var $input = $(e.target);
+  var value = $input.val();
+  var $optElement = $input.find("option[value='" + value + "']");
+  var loadedOnce = $input.data('loaded-once') || false;
+  var eventName;
+
+  if ($input.data('had-value') && value.length > 0) {
+    eventName = 'filter:renamed';
+  } else if (value.length > 0) {
+    eventName = 'filter:added';
+    $input.data('had-value', true);
+  } else {
+    eventName = 'filter:removed';
+    $input.data('had-value', false);
+  }
+
+  $input.trigger(eventName, [
+    {
+      key: $input.attr('id'),
+      value: this.formatValue($input, $optElement.text()),
+      loadedOnce: loadedOnce,
+      name: this.name,
+      nonremovable: true
+    }
+  ]);
+
+  $input.data('loaded-once', true);
 };
 
 module.exports = { SelectFilter: SelectFilter };

--- a/fec/fec/static/js/modules/filters/select-filter.js
+++ b/fec/fec/static/js/modules/filters/select-filter.js
@@ -40,9 +40,9 @@ SelectFilter.prototype.handleChange = function(e) {
   var $input = $(e.target);
   var value = $input.val();
   var $optElement = $input.find("option[value='" + value + "']");
-  var loadedOnce = $input.data('loaded-once') || false;
   var eventName;
 
+  // Handles change for select box filter tags when data-filter-change="true" is present
   if ($input.data('had-value') && value.length > 0) {
     eventName = 'filter:renamed';
   } else if (value.length > 0) {
@@ -52,18 +52,17 @@ SelectFilter.prototype.handleChange = function(e) {
     eventName = 'filter:removed';
     $input.data('had-value', false);
   }
-
-  $input.trigger(eventName, [
-    {
-      key: $input.attr('id'),
-      value: this.formatValue($input, $optElement.text()),
-      loadedOnce: loadedOnce,
-      name: this.name,
-      nonremovable: true
-    }
-  ]);
-
-  $input.data('loaded-once', true);
+  var fireTrigger = $input.data('filter-change');
+  if (fireTrigger) {
+    $input.trigger(eventName, [
+      {
+        key: $input.attr('id'),
+        value: this.formatValue($input, $optElement.text()),
+        name: this.name,
+        nonremovable: true
+      }
+    ]);
+  }
 };
 
 module.exports = { SelectFilter: SelectFilter };


### PR DESCRIPTION
## Summary (required)

- Resolves #4686 

When PAC & party datatable is loaded, apply the DEFAULT_ELECTION_YEAR, which is 2022. Also made the time period select box single select and non-removable.

### Required reviewers

1 UX, 1 front-end

## Impacted areas of the application

General components of the application that this PR will affect:

-  Single select filter on PAC & party datatable

## Screenshots

![Screen Shot 2021-06-10 at 11 17 03 AM](https://user-images.githubusercontent.com/12799132/121551187-6dade380-c9dd-11eb-9a1d-8d146a500d45.png)

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/4651-minimal-pac-party-datatable | [link](https://github.com/fecgov/fec-cms/pull/4653)

## How to test

- npm run build
- Go to [PAC & party datatable page](http://localhost:8000/data/committees/pac-party/)
   - Ensure that 2022 is what is defaulted on load of that page
   - Ensure that you cannot remove the time period filter
   - Ensure that changing the filter updates the datatable with the selected year
