### PR TITLE
Fix internet explorer homepage banner

### DIFF
--- a/fec/data/templates/partials/warnings.jinja
+++ b/fec/data/templates/partials/warnings.jinja
@@ -7,7 +7,7 @@
   </div>
 </noscript>
 
-<div id="ie_warning">
+<div id="ie_warning" style="display: none;">
   <h2>Your web browser is not supported</h2>
   <p>You&apos;re using Internet Explorer, some features might not work. Please switch to another browser like Chrome, Firefox, or Edge for a better experience.</p>
 </div>

--- a/fec/fec/static/scss/components/_site-header.scss
+++ b/fec/fec/static/scss/components/_site-header.scss
@@ -541,7 +541,7 @@
 
 @media screen and (-ms-high-contrast: none) {
   #ie_warning {
-    display:block;
+    display:block !important;
   }
 }
 

--- a/fec/fec/templates/500-status.html
+++ b/fec/fec/templates/500-status.html
@@ -16,7 +16,7 @@
   </head>
 
   <body class="status-mode {% block body_class %}{% endblock %}">
-    <div id="ie_warning">
+    <div id="ie_warning" style="display: none;">
       <h2>Your web browser is not supported</h2>
       <p>You&apos;re using Internet Explorer, some features might not work. Please switch to another browser like Chrome, Firefox, or Edge for a better experience.</p>
     </div>

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -19,7 +19,7 @@
   </head>
 
   <body class="{% block body_class %}{% endblock %}">
-    <div id="ie_warning">
+    <div id="ie_warning" style="display: none;">
       <h2>Your web browser is not supported</h2>
       <p>You&apos;re using Internet Explorer, some features might not work. Please switch to another browser like Chrome, Firefox, or Edge for a better experience.</p>
     </div>

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -19,7 +19,7 @@
   </head>
 
   <body class="{% block body_class %}{% endblock %}">
-    <div id="ie_warning">
+    <div id="ie_warning" style="display: none;">
       <h2>Your web browser is not supported</h2>
       <p>You&apos;re using Internet Explorer, some features might not work. Please switch to another browser like Chrome, Firefox, or Edge for a better experience.</p>
     </div>

--- a/fec/home/templates/sample-homepage-for-purgecss.html
+++ b/fec/home/templates/sample-homepage-for-purgecss.html
@@ -62,9 +62,9 @@
     
       <body class="template-home-page">
         <!-- IE note -->
-        <div>
-          <h2>Your browser is outdated</h2>
-          <p>You&apos;re using an older version of Internet Explorer. Please update or switch to another browser like Chrome, Firefox, or Edge for a better experience. <a target="_blank" href="http://browsehappy.com/" rel="noreferrer">Learn how to update your browser</a>.</p>
+        <div id="ie_warning" style="display: none;">
+          <h2>Your web browser is not supported</h2>
+          <p>You're using Internet Explorer, some features might not work. Please switch to another browser like Chrome, Firefox, or Edge for a better experience.</p>
         </div>
         <!-- /IE note -->
         

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "url": "git+https://github.com/fecgov/fec-cms.git"
   },
   "scripts": {
-    "build": "cd fec && webpack && gulp build-sass && gulp build-widgets-sass",
+    "build": "cd fec && webpack && gulp build-sass && gulp build-widgets-sass && gulp purgecss",
     "build-icons": "cd fec && gulp minify-icons && gulp consolidate-icons",
-    "build-sass": "cd fec && gulp build-sass && gulp build-widgets-sass",
+    "build-sass": "cd fec && gulp build-sass && gulp build-widgets-sass && gulp purgecss",
     "build-widgets-sass": "cd fec && gulp build-widgets-sass",
     "build-homepage-css": "cd fec && gulp purgecss",
     "build-js": "cd fec && webpack",


### PR DESCRIPTION
## Summary (required)

- Resolves #4693 

Add IE warning banner to `home/templates/sample-homepage-for-purgecss.html` purge template and build processes so that we can ensure that these are built and tested correctly.

### Required reviewers

One front end

## Impacted areas of the application

General components of the application that this PR will affect:

-  Homepage

## Related PRs

branch | PR
------ | ------
feature/4648-no-longer-support-IE | [link](https://github.com/fecgov/fec-cms/pull/4649)
feature/4170-remove-unused-css | [link](https://github.com/fecgov/fec-cms/pull/4606)

## How to test

- `npm i`
- `npm run build` and look at homepage to make sure IE banner does not appear unless you are in Internet Explorer.
- `npm run build-production` and look at homepage to make sure IE banner does not appear unless you are in Internet Explorer.
- After this is merged in, let's check on dev in an Internet Explorer browser to make sure it will show up.