### PR TITLE
Feature/4698 fix purgecss

### DIFF
--- a/fec/fec/static/js/modules/site-nav.js
+++ b/fec/fec/static/js/modules/site-nav.js
@@ -30,7 +30,7 @@ function SiteNav(selector) {
   // Open and close the menu on mobile
   this.$toggle.on('click', this.toggleMenu.bind(this));
 
-  /*matchMedia is used belowto ensure searchbox is appended to correct location when 
+  /*matchMedia is used below to ensure searchbox is appended to correct location when 
   user resizes screen while mobile menu is open */
 
   //Define min-width media query that matches our med('mobile') breakpoint
@@ -82,13 +82,21 @@ SiteNav.prototype.assignAria = function() {
   }
 };
 
-//Append searchbox to correct location uponn user screen resize
+/**
+ * Append searchbox to correct location upon user screen resize
+ * @param {Object} mql
+ * @param {Boolean} mql.matches - true if large; false if less than large
+ */
 SiteNav.prototype.mediaQueryResponse = function(mql) {
   //If large
   if (mql.matches) {
     $('body')
       .find('.utility-nav__search')
       .appendTo('.utility-nav.list--flat');
+
+    // If the nav is open when the window is resized to large,
+    // we need to allow scrolling again
+    document.querySelector('body').style.overflow = 'auto';
   }
   //if mobile
   else {
@@ -115,7 +123,7 @@ SiteNav.prototype.showMenu = function() {
   this.$element.addClass('is-open');
   this.$toggle.addClass('active');
   this.$menu.attr('aria-hidden', false);
-  //append seacrh to mobile menu uponn opening
+  //append search to mobile menu upon opening
   $('.site-nav__panel').prepend(this.$searchbox);
   accessibility.restoreTabindex(this.$menu);
 

--- a/fec/gulpfile.js
+++ b/fec/gulpfile.js
@@ -51,7 +51,14 @@ gulp.task('purgecss', () => {
     .src('./dist/fec/static/css/home-*.css')
     .pipe(
       purgecss({
-        content: ['./home/templates/sample-homepage-for-purgecss.html']
+        content: [
+          './home/templates/purgecss-homepage/navs.html',
+          './home/templates/purgecss-homepage/banners.html',
+          './home/templates/purgecss-homepage/hero.html',
+          './home/templates/purgecss-homepage/comissioners.html',
+          './home/templates/purgecss-homepage/toggled.html',
+          './home/templates/purgecss-homepage/full.html'
+        ]
       })
     )
     .pipe(gulp.dest('./dist/fec/static/css'));

--- a/fec/home/templates/purgecss-homepage/banners.html
+++ b/fec/home/templates/purgecss-homepage/banners.html
@@ -1,0 +1,71 @@
+<html lang="en">
+  <head></head>
+  <body class="template-home-page">
+
+    <a href="#main" class="skip-nav">skip navigation</a>
+    
+    <div class="banner-dev">
+      <p class="t-sans t-small">LOCAL<br>
+      This site is for testing ideas and code. View the most accurate data on the <a href="http://www.fec.gov">live site</a>.
+      </p>
+    </div>
+
+    <div id="ie_warning" style="display: none;">
+      <h2>Your web browser is not supported</h2>
+      <p>You're using Internet Explorer, some features might not work. Please switch to another browser like Chrome, Firefox, or Edge for a better experience.</p>
+    </div>
+
+
+    <header class="usa-banner">
+      <div class="js-accordion accordion--neutral" data-content-prefix="gov-banner">
+        <div type="button" class="usa-banner-header js-accordion-trigger accordion__button" aria-controls="gov-banner" aria-expanded="false"><span class="u-visually-hidden">Here's how you know</span>
+          <img class="flag" src="/static/img/us_flag_small.png" alt="US flag signifying that this is a United States Federal Government website" width="16" height="11">
+          <p class="t-inline-block">An official website of the United States government</p>
+          <p class="t-inline-block usa-banner-button">Here's how you know</p>
+        </div>
+        <div class="usa-banner-content usa-grid usa-accordion-content accordion-content" id="gov-banner" aria-hidden="true" >
+          <div class="usa-banner-guidance-gov usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-dot-gov.svg" alt="Dot gov" width="38" height="38">
+            <div class="usa-media_block-body">
+              <p>
+                <strong>Official websites use .gov</strong>
+                <br>
+                A <strong>.gov</strong> website belongs to an official government organization in the United States.
+              </p>
+            </div>
+          </div>
+          <div class="usa-banner-guidance-ssl usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-https.svg" alt="SSL" width="38" height="38">
+            <div class="usa-media_block-body">
+              <p>
+                <strong>Secure .gov websites use HTTPS</strong>
+                <br>
+                A <strong>lock</strong> ( <svg xmlns="http://www.w3.org/2000/svg" width="10" height="15" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title-default banner-lock-description-default"><title id="banner-lock-title-default">Lock</title><desc id="banner-lock-description-default">A locked padlock</desc><path     ></path></svg> ) or <strong>https://</strong> means you've safely connected to the .gov website. Share sensitive information only on official, secure websites.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+    
+    <main id="main">
+      <section class="slab slab--secondary">
+        <div class="container">
+          <div>
+            <div class="message message--vivid message--mini message--info message--inline u-no-margin-top u-no-margin-bottom">
+              <span class="t-bold">Rulemaking petition now open for public comment: </span> Candidate salaries (REG 2021-01)
+            </div>
+            <a href="https://www.fec.gov/legal-resources/regulations/pending-rulemaking-matters-comment/" class="t-sans">Read Federal Register notice &amp; comment now</a> »
+          </div>
+          <div class="u-margin--top">
+            <div class="message message--vivid message--mini message--info message--inline u-no-margin-top u-no-margin-bottom">
+              <span class="t-bold">FEC-related COVID-19 information: </span> Offices remain closed to visitors
+            </div>
+            <a href="https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf" class="t-sans">Get the latest information on FEC operations</a> »
+            &nbsp; | &nbsp; <a href="https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf" class="t-sans">Workplace safety plan</a> »            
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/fec/home/templates/purgecss-homepage/commissioners.html
+++ b/fec/home/templates/purgecss-homepage/commissioners.html
@@ -1,0 +1,76 @@
+<html lang="en">
+  <head></head>
+  <body class="template-home-page">
+    <main id="main">
+      <section class="slab">
+        <div class="container">
+          <h1>Commissioners</h1>
+          <div class="grid grid--3-wide">
+            <div class="grid__item commissioner-height">
+              <div class="icon-heading">
+                <img class="icon-heading__image" src="/media/images/Broussard_S.original.png" alt="Headshot of Shana M. Broussard" width="70" height="70">
+                <div class="icon-heading__content">
+                  <div class="t-lead"><a href="/about/leadership-and-structure/shana-m-broussard/">Shana M. Broussard</a></div>          
+                  <div class="t-lead t-note">Chair</div>
+                  <div class="t-sans">Democrat</div>
+                  <div class="t-italic"></div>
+                </div>
+              </div>
+            </div>
+            <div class="grid__item commissioner-height">
+              <div class="icon-heading">
+                <img class="icon-heading__image" src="/media/images/Dickerson.original.png" alt="Headshot of Allen Dickerson" width="70" height="70">
+                <div class="icon-heading__content">
+                  <div class="t-lead"><a href="/about/leadership-and-structure/allen-dickerson/">Allen Dickerson</a></div>
+                  <div class="t-lead t-note">Vice Chair</div>
+                  <div class="t-sans">Republican</div>
+                  <div class="t-italic"></div>
+                </div>
+              </div>
+            </div>
+            <div class="grid__item commissioner-height">
+              <div class="icon-heading">
+                <img class="icon-heading__image" src="/media/images/Cooksey.original.png" alt="Headshot of Sean J. Cooksey" width="70" height="70">
+                <div class="icon-heading__content">
+                  <div class="t-lead"><a href="/about/leadership-and-structure/sean-j-cooksey/">Sean J. Cooksey</a></div>
+                  <div class="t-sans">Republican</div>
+                  <div class="t-italic"></div>
+                </div>
+              </div>
+            </div>
+            <div class="grid__item commissioner-height">
+              <div class="icon-heading">
+                <img class="icon-heading__image" src="/media/images/headshot--trainor.original.png" alt="Headshot of James E. &quot;Trey&quot; Trainor III" width="70" height="70">
+                <div class="icon-heading__content">
+                  <div class="t-lead"><a href="/about/leadership-and-structure/james-e-trainor-iii/">James E. "Trey" Trainor III</a></div>
+                  <div class="t-sans">Republican</div>
+                  <div class="t-italic"></div>
+                </div>
+              </div>
+            </div>
+            <div class="grid__item commissioner-height">
+              <div class="icon-heading">
+                <img class="icon-heading__image" src="/media/images/headshot--walther.original.png" alt="Headshot of Steven T. Walther" width="70" height="70">
+                <div class="icon-heading__content">
+                  <div class="t-lead"><a href="/about/leadership-and-structure/steven-t-walther/">Steven T. Walther</a></div>
+                  <div class="t-sans">Independent</div>
+                  <div class="t-italic"></div>
+                </div>
+              </div>
+            </div>
+            <div class="grid__item commissioner-height">
+              <div class="icon-heading">
+                <img class="icon-heading__image" src="/media/images/headshot--weintraub_GmIreiA.original.png" alt="Headshot of Ellen L. Weintraub" width="70" height="70">
+                <div class="icon-heading__content">
+                  <div class="t-lead"><a href="/about/leadership-and-structure/ellen-l-weintraub/">Ellen L. Weintraub</a></div>
+                  <div class="t-sans">Democrat</div>
+                  <div class="t-italic"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/fec/home/templates/purgecss-homepage/full.html
+++ b/fec/home/templates/purgecss-homepage/full.html
@@ -1,62 +1,3 @@
-<!--
-    This file exists for purgecss.
-    
-    WHY
-    We use this sample structure to avoid loading the huge elections_*.css in the homepage.
-    Ideally, purgecss would load something like localhost:8000 but it won't. It will load the various templates,
-    but that doesn't account for the JavaScript-powered pieces.
-    TODO: give the JS-powered components their own css and have purge look at template components?
-    
-    This file won't be served to users so its filesize doesn't really matter—it's only used by purgecss
-    during the build process.
-
-    HOW
-    Rather than include all of elections-*.css for the homepage,
-    home.scss is a direct copy of elections.scss.
-
-    Then the Gulp process purgecss takes home-*.css, looks at this file,
-    removes the unused styles in home-*.css, and re-saves it.
-
-    TO UPDATE
-    To update this file (and the css loaded into the homepage),
-    1. Load the homepage, go into Inspector's Elements tab, and copy the <html> tag.
-       Note: it's important to copy the compiled code and not the source code directly
-       as the source won't have elements that have been changed/added by JavaScript
-    2. Paste the <html> tag in this document.
-    3. Remove everything in the <head>.
-    4. Remove any <script> or <style> tags.
-    5. Remove any text content that is the lowest level of its structure (e.g. remove the text inside a <p> but leave
-       the <p> and leave any elements inside the <p>.
-       Having something like <div></div><div><p><a><i><em></em></i></a></p><p></p></div> is totally fine.)
-    6. Feel free to remove any   rules.
-    7. Add any elements/structures that aren't already here.
-       e.g. dev banner, announcement banners, features that are off but may be activated
-    8. Safe to remove non-unique <li> from lists
-       (as long as we keep a first, a last, an even, an odd, an nth, and we don't lose otherwise-unique descendents)
-
-    Safe to remove:
-        <head>
-        <script>
-        <style>
-         
-        rel=""
-        width=""
-        height=""
-        for=""
-        on*=""
-        repeated elements
-        blank lines
-        line breaks
-        comments
-    
-    Preserve:
-        elements
-        aria*=""
-        class=""
-        id=""
-        name=""
-        role=""
--->
 <html lang="en">
     <head></head>
     
@@ -146,10 +87,46 @@
             </a>
           </li>
           <li class="site-nav__item" data-submenu="data">
-            <a class="site-nav__link" href="#0"   id="mega-menu-1620314819143-1" aria-haspopup="true" aria-controls="mega-menu-1620314819143-2" aria-expanded="false">
+            <a class="site-nav__link" href="#0" id="mega-menu-1620314819143-1" aria-haspopup="true" aria-controls="mega-menu-1620314819143-2" aria-expanded="false">
               <span class="site-nav__link__title">
               Campaign finance data</span>
             </a>
+
+            <div class="mega-container is-open" id="mega-menu-1623176291046-2" role="group" aria-expanded="true" aria-hidden="false" aria-labelledby="mega-menu-1623176291046-1">
+              <div class="mega">
+                <div class="mega__inner">
+                  <div class="row">
+                    <div class="u-padding-left d-sm-none d-md-none col-lg-1">&nbsp;</div>
+                    <div class="u-padding--left col-lg-6">
+                      <ul class="t-sans list--1-2-2-3-columns u-padding--top">
+                        <li class="mega__item"><a href="/data/" class="">All data</a></li>
+                        <li class="mega__item"><a href="/data/browse-data/?tab=raising">Raising</a></li>
+                        <li class="mega__item"><a href="/data/browse-data/?tab=spending">Spending</a></li>
+                        <li class="mega__item"><a href="/data/browse-data/?tab=loans-debts">Loans and debts</a></li>
+                        <li class="mega__item"><a href="/data/browse-data/?tab=filings">Filings and reports</a></li>
+                        <li class="mega__item"><a href="/data/browse-data/?tab=candidates">Candidates</a></li>
+                        <li class="mega__item"><a href="/data/browse-data/?tab=committees">Committees</a></li>
+                        <li class="mega__item"><a href="/data/browse-data/?tab=bulk-data">Bulk data</a></li>
+                        <li class="mega__item"><a href="/data/browse-data/?tab=statistics">Campaign finance statistics</a></li>
+                      </ul>
+                    </div>
+                    <div class="u-padding--left col-lg-4">
+                      <div class="icon-heading icon-heading--person-location-circle">
+                        <p class="t-sans t-small icon-heading__text"><a href="/data/elections/">Find elections. Search by state or ZIP code</a></p>
+                      </div>
+                      <div class="icon-heading icon-heading--individual-contributions-circle">
+                        <p class="t-sans t-small icon-heading__text"> <a href="/data/receipts/individual-contributions/">Look up contributions from specific individuals</a></p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+
+
+
             <div class="mega-container" id="mega-menu-1620314819143-2" role="group" aria-expanded="false" aria-hidden="true" aria-labelledby="mega-menu-1620314819143-1">
       <div class="mega">
         <div class="mega__inner">
@@ -593,9 +570,6 @@
                 <option value="H">House candidates</option>
               </select>
             </div>
-              <noscript>
-                <button type="submit" class="button button--cta">Submit</button>
-              </noscript>
           </form>
           <form action="" method="get">
             <div class="row">
@@ -942,9 +916,6 @@
         </ul>
       </div>
     </div>
-    
-    
-        <input type="hidden" name="csrfmiddlewaretoken" value="LcocbFneYSNzDuh0bhv6goceJc7UW5skEks4Hk9vAxUFKXSAJpetVqzXzVNEwfIX">
     <div>
       <button class="js-feedback feedback__toggle button--cta-secondary" aria-controls="feedback" aria-expanded="false" type="button">Feedback</button>
       <div id="feedback" class="js-feedback-box feedback" aria-hidden="true">

--- a/fec/home/templates/purgecss-homepage/hero.html
+++ b/fec/home/templates/purgecss-homepage/hero.html
@@ -1,0 +1,15 @@
+<html lang="en">
+  <head></head>
+  <body class="template-home-page">
+    <main id="main">
+      <section class="hero hero--home" aria-labelledby="hero-heading">
+        <div class="container">
+          <div class="hero__content">
+            <h2 id="hero-heading">Protecting the integrity of the campaign finance process</h2>
+            <a class="button button--thin-border" href="/about">More about the FEC</a>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/fec/home/templates/purgecss-homepage/navs.html
+++ b/fec/home/templates/purgecss-homepage/navs.html
@@ -95,7 +95,7 @@
           </a>
         </li>
         <li class="site-nav__item" data-submenu="data">
-          <a class="site-nav__link" href="#0" tabindex="-1" id="mega-menu-1623176509332-1" aria-haspopup="true" aria-controls="mega-menu-1623176509332-2" aria-expanded="false" style="">
+          <a class="site-nav__link" href="#0" tabindex="-1" id="mega-menu-1623176509332-1" aria-haspopup="true" aria-controls="mega-menu-1623176509332-2" aria-expanded="false">
             <span class="site-nav__link__title">
             Campaign finance data</span>
           </a>

--- a/fec/home/templates/purgecss-homepage/navs.html
+++ b/fec/home/templates/purgecss-homepage/navs.html
@@ -1,0 +1,356 @@
+<html lang="en">
+    <head></head>
+    
+    <body class="template-home-page" style="overflow: auto;">
+      <div id="ie_warning" style="display: none;">
+        <h2>Your web browser is not supported</h2>
+        <p>You're using Internet Explorer, some features might not work. Please switch to another browser like Chrome, Firefox, or Edge for a better experience.</p>
+      </div>
+      
+      <a href="#main" class="skip-nav">skip navigation</a>
+       
+      
+         
+        <div class="banner-dev">
+          
+          <p class="t-sans t-small">LOCAL<br>
+          This site is for testing ideas and code. View the most accurate data on the <a href="http://www.fec.gov">live site</a>.
+          </p>
+        </div>
+      
+    
+  
+      
+      <header class="usa-banner">
+    <div class="js-accordion accordion--neutral" data-content-prefix="gov-banner">
+      <div type="button" class="usa-banner-header js-accordion-trigger accordion__button" aria-controls="gov-banner" aria-expanded="false"><span class="u-visually-hidden">Here's how you know</span>
+        <img class="flag" src="/static/img/us_flag_small.png" alt="US flag signifying that this is a United States Federal Government website" width="16" height="11">
+        <p class="t-inline-block">An official website of the United States government</p>
+        <p class="t-inline-block usa-banner-button">Here's how you know</p>
+      </div>
+      <div class="usa-banner-content usa-grid usa-accordion-content accordion-content" id="gov-banner" aria-hidden="true" style="display: none;">
+        <div class="usa-banner-guidance-gov usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-dot-gov.svg" alt="Dot gov" width="38" height="38">
+          <div class="usa-media_block-body">
+            <p>
+              <strong>Official websites use .gov</strong>
+              <br>
+              A <strong>.gov</strong> website belongs to an official government organization in the United States.
+            </p>
+          </div>
+        </div>
+        <div class="usa-banner-guidance-ssl usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-https.svg" alt="SSL" width="38" height="38">
+          <div class="usa-media_block-body">
+            <p>
+              <strong>Secure .gov websites use HTTPS</strong>
+              <br>
+              A <strong>lock</strong> ( <svg xmlns="http://www.w3.org/2000/svg" width="10" height="15" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title-default banner-lock-description-default"><title id="banner-lock-title-default">Lock</title><desc id="banner-lock-description-default">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg> ) or <strong>https://</strong> means you've safely connected to the .gov website. Share sensitive information only on official, secure websites.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+  
+      
+      <header class="site-header site-header--homepage" role="banner">
+        <div class="masthead">
+          <div class="homepage-seal">
+            <img src="/static/img/seal.svg" alt="FEC logo" width="160" height="160">
+          </div>
+          <div class="site-title--print"></div>
+          <a title="Home" href="/" class="site-title" rel="home"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
+          <ul class="utility-nav list--flat">
+            <li class="utility-nav__item"><a href="/calendar/">Calendar</a></li>
+            <li class="utility-nav__item">
+              <a class="js-glossary-toggle glossary__toggle">Glossary</a>
+            </li>
+            
+            <li class="utility-nav__search">
+              <form accept-charset="UTF-8" action="/search" class="combo" method="get" role="search">
+                <input type="hidden" name="type" value="candidates" tabindex="-1">
+                <input type="hidden" name="type" value="committees" tabindex="-1">
+                <input type="hidden" name="type" value="site" tabindex="-1">
+                <label class="u-visually-hidden" for="query">Search</label>
+                <div class="combo combo--search">
+                  <span class="twitter-typeahead" style="position: relative; display: block;"><input class="js-site-search combo__input tt-input" autocomplete="off" aria-controls="query_listbox" id="query" name="query" type="text" aria-label="Search FEC.gov" spellcheck="false" dir="auto" aria-activedescendant="" aria-owns="query_listbox" role="combobox" aria-autocomplete="list" style="position: relative; vertical-align: top;" aria-expanded="true" tabindex="-1"><span role="status" aria-live="polite" style="position: absolute; padding: 0px; border: 0px; height: 1px; width: 1px; margin-bottom: -1px; margin-right: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap;">10 results are available, use up and down arrow keys to navigate.</span><pre aria-hidden="true" style="position: absolute; visibility: hidden; white-space: pre; font-family: karla, sans-serif; font-size: 14px; font-style: normal; font-variant: normal; font-weight: 400; word-spacing: 0px; letter-spacing: 0px; text-indent: 0px; text-rendering: auto; text-transform: none;">test</pre><div role="listbox" class="tt-menu" aria-live="polite" style="position: absolute; top: 100%; left: 0px; z-index: 100; display: none;" aria-expanded="false"><div role="presentation" class="tt-dataset tt-dataset-candidate"><span class="tt-suggestion__header">Select a candidate:</span><span class="tt-suggestion tt-selectable"><span class="tt-suggestion__name"><strong class="tt-highlight">TEST</strong>ER, R. JON (S6MT00162)</span><span class="tt-suggestion__office">Senate</span></span><span class="tt-suggestion tt-selectable"><span class="tt-suggestion__name"><strong class="tt-highlight">TEST</strong>ERMAN, KAREN (S4NH00104)</span><span class="tt-suggestion__office">Senate</span></span><span class="tt-suggestion tt-selectable"><span class="tt-suggestion__name"><strong class="tt-highlight">TEST</strong>, FITNESSGRAM PACER ESTEEMED OF SEALAND (P40005837)</span><span class="tt-suggestion__office">President</span></span></div><div role="presentation" class="tt-dataset tt-dataset-committee"><span class="tt-suggestion__header">Select a committee:</span><span class="tt-suggestion__name tt-suggestion tt-selectable">MONTANANS FOR <strong class="tt-highlight">TEST</strong>ER (C00412304)&nbsp;<span class="is-active-status"></span></span><span class="tt-suggestion__name tt-suggestion tt-selectable"><strong class="tt-highlight">TEST</strong>ER VICTORY FUND (C00547679)&nbsp;<span class="is-active-status"></span></span><span class="tt-suggestion__name tt-suggestion tt-selectable">GEORGE E BROWN JR <strong class="tt-highlight">TEST</strong>IMONIAL COMMITTEE (C00139998)&nbsp;<span class="is-terminated-status"></span></span><span class="tt-suggestion__name tt-suggestion tt-selectable">HBG <strong class="tt-highlight">TEST</strong>IMONIAL DINNER COMMITTEE (C00221820)&nbsp;<span class="is-terminated-status"></span></span><span class="tt-suggestion__name tt-suggestion tt-selectable">HEINRICH <strong class="tt-highlight">TEST</strong>ER VICTORY FUND (C00660357)&nbsp;<span class="is-terminated-status"></span></span><span class="tt-suggestion__name tt-suggestion tt-selectable">FORD-<strong class="tt-highlight">TEST</strong>ER 2006 (C00427526)&nbsp;<span class="is-terminated-status"></span></span><span class="tt-suggestion__name tt-suggestion tt-selectable"><strong class="tt-highlight">TEST</strong>ERMAN FOR SENATE (C00549972)&nbsp;<span class="is-terminated-status"></span></span><span class="tt-suggestion__name tt-suggestion tt-selectable"><strong class="tt-highlight">TEST</strong> PAC (C00511055)&nbsp;<span class="is-terminated-status"></span></span><span class="tt-suggestion__name tt-suggestion tt-selectable">DENNIS SERRETTE <strong class="tt-highlight">TEST</strong>IMONIAL DINNER (C00172189)&nbsp;<span class="is-terminated-status"></span></span><span class="tt-suggestion__name tt-suggestion tt-selectable">FRIENDS OF KAREN <strong class="tt-highlight">TEST</strong>ERMAN (C00547828)&nbsp;<span class="is-terminated-status"></span></span></div><div role="presentation" class="tt-dataset tt-dataset-0"><span class="tt-suggestion tt-selectable"><strong>Search individual contributions from:</strong> "<strong class="tt-highlight">test</strong>"</span></div><div role="presentation" class="tt-dataset tt-dataset-1"><span class="tt-suggestion tt-selectable"><strong>Search other pages:</strong> "<strong class="tt-highlight">test</strong>"</span></div></div></span>
+                  <button type="submit" class="button--standard combo__button button--search" tabindex="-1">
+                    <span class="u-visually-hidden">Search</span>
+                  </button>
+                </div>
+              </form>
+            </li>
+          
+          </ul>
+        </div>
+        <nav class="site-nav js-site-nav">
+   <button class="js-nav-toggle site-nav__button" aria-controls="site-menu">Menu</button>
+    <div id="site-menu" class="site-nav__container" aria-label="Site-wide navigation" role="navigation" aria-hidden="true">
+      <ul class="site-nav__panel site-nav__panel--main">
+        <li><h2 class="site-nav__title u-under-lg-only">Menu</h2></li>
+        <li class="site-nav__item u-under-lg-only">
+          <a class="site-nav__link" href="/" rel="home" tabindex="-1">
+            <span class="site-nav__link__title">Home</span>
+          </a>
+        </li>
+        <li class="site-nav__item" data-submenu="data">
+          <a class="site-nav__link" href="#0" tabindex="-1" id="mega-menu-1623176509332-1" aria-haspopup="true" aria-controls="mega-menu-1623176509332-2" aria-expanded="false" style="">
+            <span class="site-nav__link__title">
+            Campaign finance data</span>
+          </a>
+          <div class="mega-container is-open" id="mega-menu-1623176509332-2" role="group" aria-expanded="false" aria-hidden="true" aria-labelledby="mega-menu-1623176509332-1">
+    <div class="mega">
+      <div class="mega__inner">
+        <div class="row">
+          <div class="u-padding-left d-sm-none d-md-none col-lg-1">&nbsp;</div>
+          <div class="u-padding--left col-lg-6">
+            <ul class="t-sans list--1-2-2-3-columns u-padding--top">
+              <li class="mega__item"><a href="/data/" tabindex="-1">All data</a></li>
+              <li class="mega__item"><a href="/data/browse-data/?tab=raising" tabindex="-1">Raising</a></li>
+              <li class="mega__item"><a href="/data/browse-data/?tab=spending" tabindex="-1">Spending</a></li>
+              <li class="mega__item"><a href="/data/browse-data/?tab=loans-debts" tabindex="-1">Loans and debts</a></li>
+              <li class="mega__item"><a href="/data/browse-data/?tab=filings" tabindex="-1">Filings and reports</a></li>
+              <li class="mega__item"><a href="/data/browse-data/?tab=candidates" tabindex="-1">Candidates</a></li>
+              <li class="mega__item"><a href="/data/browse-data/?tab=committees" tabindex="-1">Committees</a></li>
+              <li class="mega__item"><a href="/data/browse-data/?tab=bulk-data" tabindex="-1">Bulk data</a></li>
+              <li class="mega__item"><a href="/data/browse-data/?tab=statistics" tabindex="-1">Campaign finance statistics</a></li>
+            </ul>
+          </div>
+          <div class="u-padding--left col-lg-4">
+            <div class="icon-heading icon-heading--person-location-circle">
+              <p class="t-sans t-small icon-heading__text"><a href="/data/elections/" tabindex="-1">Find elections. Search by state or ZIP code</a></p>
+            </div>
+            <div class="icon-heading icon-heading--individual-contributions-circle">
+              <p class="t-sans t-small icon-heading__text"> <a href="/data/receipts/individual-contributions/" tabindex="-1">Look up contributions from specific individuals</a></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+        </li>
+        <li class="site-nav__item site-nav__item--secondary" data-submenu="help">
+          <a href="#0" class="site-nav__link" tabindex="-1" id="mega-menu-1623176509334-3" aria-haspopup="true" aria-controls="mega-menu-1623176509334-4" aria-expanded="false">
+            <span class="site-nav__link__title">Help for candidates and committees</span>
+          </a>
+          <div class="mega-container" id="mega-menu-1623176509334-4" role="group" aria-expanded="false" aria-hidden="true" aria-labelledby="mega-menu-1623176509334-3">
+    <div class="mega mega--secondary">
+      <div class="mega__inner">
+        <div class="row">
+          <div class="d-sm-none d-md-none col-lg-1">&nbsp;</div>
+          <div class="u-padding--left col-lg-6">
+            <ul class="t-sans list--2-columns u-padding--top">
+              <li class="mega__item"><a href="/help-candidates-and-committees/" tabindex="-1">All compliance resources</a></li>
+              <li class="mega__item"><a href="/help-candidates-and-committees/guides/" tabindex="-1">Guides</a></li>
+              <li class="mega__item"><a href="/help-candidates-and-committees/forms/" tabindex="-1">Forms</a></li>
+              <li class="mega__item"><a href="/help-candidates-and-committees/dates-and-deadlines/" tabindex="-1">Dates and deadlines</a></li>
+              <li class="mega__item"><a href="/help-candidates-and-committees/trainings/" tabindex="-1">Trainings</a></li>
+            </ul>
+          </div>
+          <div class="u-padding--left col-lg-5">
+            <div class="icon-heading icon-heading--checklist-circle">
+              <p class="t-sans t-small icon-heading__text"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/" tabindex="-1">Learn about electronic filing</a></p>
+            </div>
+            <div class="icon-heading icon-heading--question-bubble-circle">
+              <p class="t-sans t-small icon-heading__text"> <a href="/help-candidates-and-committees/question-rad/" tabindex="-1">Find and contact your committee's analyst</a></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+        </li>
+        <li class="site-nav__item" data-submenu="legal">
+          <a href="#0" class="site-nav__link" tabindex="-1" id="mega-menu-1623176509337-5" aria-haspopup="true" aria-controls="mega-menu-1623176509337-6" aria-expanded="false">
+            <span class="site-nav__link__title">Legal resources</span>
+          </a>
+          <div class="mega-container" id="mega-menu-1623176509337-6" role="group" aria-expanded="false" aria-hidden="true" aria-labelledby="mega-menu-1623176509337-5">
+    <div class="mega">
+      <div class="mega__inner">
+        <div class="row">
+          <div class="d-sm-none d-md-none col-lg-1">&nbsp;</div>
+          <div class="u-padding--left col-md-4 col-lg-6">
+            <ul class="t-sans list--1-2-2-2-columns u-padding--top">
+              <li class="mega__item"><a href="/legal-resources/" tabindex="-1">All legal resources</a></li>
+              <li class="mega__item"><a href="/data/legal/advisory-opinions/" tabindex="-1">Advisory opinions</a></li>
+              <li class="mega__item"><a href="/legal-resources/enforcement/" tabindex="-1">Enforcement</a></li>
+              <li class="mega__item"><a href="/data/legal/statutes/" tabindex="-1">Statutes</a></li>
+              <li class="mega__item"><a href="/legal-resources/legislation/" tabindex="-1">Legislation</a></li>
+              <li class="mega__item"><a href="/legal-resources/regulations/" tabindex="-1">Regulations</a></li>
+              <li class="mega__item"><a href="/legal-resources/court-cases/" tabindex="-1">Court cases</a></li>
+              <li class="mega__item"><a href="/legal-resources/policy-other-guidance/" tabindex="-1">Policy and other guidance</a></li>
+            </ul>
+          </div>
+          <div class="u-padding--left col-md-3 col-lg-4">
+            <div class="icon-heading icon-heading--magnifying-glass-circle">
+              <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/" tabindex="-1">Search across all legal resources</a></p>
+            </div>
+            <div class="icon-heading icon-heading--magnifying-glass-circle">
+              <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/policy-and-other-guidance/guidance-documents/" tabindex="-1">Search guidance documents</a></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+        </li>
+        <li class="site-nav__item site-nav__item--secondary" data-submenu="about">
+          <a href="#0" class="site-nav__link" tabindex="-1" id="mega-menu-1623176509339-7" aria-haspopup="true" aria-controls="mega-menu-1623176509339-8" aria-expanded="false">
+            <span class="site-nav__link__title">About</span>
+          </a>
+          <div class="mega-container" id="mega-menu-1623176509339-8" role="group" aria-expanded="false" aria-hidden="true" aria-labelledby="mega-menu-1623176509339-7">
+    <div class="mega mega--secondary">
+      <div class="mega__inner">
+        <div class="row">
+          <div class="u-padding--left d-sm-none d-md-none col-lg-1">&nbsp;</div>
+          <div class="u-padding--left col-lg-10">
+            <ul class="t-sans list--1-2-2-3-columns u-padding--top">
+              <li class="mega__item"><a href="/about/" tabindex="-1">All about the FEC</a></li>
+              <li class="mega__item"><a href="/updates/" tabindex="-1">News and announcements</a></li>
+              <li class="mega__item"><a href="/meetings/" tabindex="-1">Commission meetings</a></li>
+              <li class="mega__item"><a href="/about/mission-and-history/" tabindex="-1">Mission and history</a></li>
+              <li class="mega__item"><a href="/about/leadership-and-structure/" tabindex="-1">Leadership and structure</a></li>
+              <li class="mega__item"><a href="/about/reports-about-fec/" tabindex="-1">Reports about the FEC</a></li>
+              <li class="mega__item"><a href="/about/careers/" tabindex="-1">Careers</a></li>
+              <li class="mega__item"><a href="/about/#working-with-the-fec" tabindex="-1">Working with the FEC</a></li>
+              <li class="mega__item"><a href="/contact/" tabindex="-1">Contact</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+        </li>
+  
+      </ul>
+    </div>
+    <a title="Home" href="/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
+  </nav>
+  
+      </header>
+      
+  
+      
+  
+      <nav class="footer-links">
+    <div class="container">
+  
+      <div class="grid grid--6-wide">
+  
+        <div class="grid__item">
+          <ul>
+            <li>
+              <a href="/about/">About</a>
+            </li>
+            <li>
+              <a href="/about/careers/">Careers</a>
+            </li>
+            <li>
+              <a href="/press/">Press</a>
+            </li>
+            <li>
+              <a href="/contact/">Contact</a>
+            </li>
+          </ul>
+        </div>
+  
+        <div class="grid__item"></div>
+  
+        <div class="grid__item"></div>
+  
+        <div class="grid__item">
+          <ul>
+            <li>
+              <a href="/about/privacy-and-security-policy">Privacy and security policy</a>
+            </li>
+            <li>
+              <a href="/about/plain-language/">Plain language</a>
+            </li>
+            <li>
+              <a href="/about/no-fear-act/">No FEAR Act</a>
+            </li>
+            <li>
+              <a href="/about/reports-about-fec/strategy-budget-and-performance/">Strategy, budget and performance</a>
+            </li>
+          </ul>
+        </div>
+  
+        <div class="grid__item">
+          <ul>
+            <li>
+              <a href="/open/">Open government</a>
+            </li>
+            <li>
+              <a href="https://www.fbi.gov/protectedvoices">Protected Voices</a>
+            </li>
+            <li>
+              <a href="https://www.usa.gov/">USA.gov</a>
+            </li>
+            <li>
+              <a href="/office-inspector-general/">Inspector General</a>
+            </li>
+            <li>
+              <a href="/freedom-information-act/">FOIA</a>
+            </li>
+          </ul>
+        </div>
+  
+        <div class="grid__item">
+          <ul>
+            <li>
+              <a href="https://api.open.fec.gov">OpenFEC API</a>
+            </li>
+            <li>
+              <a href="https://github.com/fecgov/fec">GitHub repository</a>
+            </li>
+            <li>
+              <a href="https://github.com/fecgov/FEC/blob/master/release_notes/release_notes.md">Release notes</a>
+            </li>
+            <li>
+              <a href="https://fecgov.statuspage.io/">FEC.gov status</a>
+            </li>
+          </ul>
+        </div>
+  
+      </div>
+    </div>
+  </nav>
+  
+      <footer class="footer">
+        <div class="container">
+          <div class="seal">
+            <img class="seal__img" width="140" height="140" src="/static/img/seal--inverse.svg" alt="Seal of the Federal Election Commission | United States of America">
+            <p class="address__title">Federal Election Commission</p>
+          </div>
+  
+          <div class="address">
+            <ul class="social-media">
+              <li>
+                <div class="i icon--twitter">
+                  <a href="https://twitter.com/fec"><span class="u-visually-hidden">The FEC's Twitter page</span></a>
+                </div>
+              </li>
+              <li>
+                <div class="i icon--youtube">
+                  <a href="https://www.youtube.com/user/FECTube"><span class="u-visually-hidden">The FEC's YouTube page</span></a>
+                </div>
+              </li>
+            </ul>
+  
+            <p>1050 First Street, NE<br>
+            Washington, DC 20463</p>
+  
+            <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
+              <button class="button--standard button--envelope">Sign up for FECMail</button>
+            </a>
+          </div>
+        </div>
+      </footer>
+  </body>
+  </html>
+    

--- a/fec/home/templates/purgecss-homepage/readme.txt
+++ b/fec/home/templates/purgecss-homepage/readme.txt
@@ -1,0 +1,71 @@
+This directory exists for purgecss.
+
+
+WHY
+We use these sample structure components to avoid loading the huge elections_*.css in the homepage.
+Ideally, purgecss would load something like localhost:8000 but it won't. It will load the various templates,
+but that doesn't account for JavaScript-powered components.
+
+These files won't be served to users so their filesize doesn't really matter—they're only used by purgecss
+during the build process.
+
+
+HOW
+Rather than include all of elections-*.css for the homepage,
+home.scss is a direct copy of elections.scss.
+
+Then the Gulp process purgecss takes home-*.css, looks at these files,
+removes the unused styles from home-*.css, and re-saves it.
+
+
+WHAT
+- full.html is a standard page that also includes everything above
+
+As a fallback:
+- navs.html has everything before #main plus the footer nav, including an open menu and populated search suggestions
+- banners.html is for the red banners on the homepage but also has the skip nav link, IE banner, and dev banner
+- hero.html is for the #hero section
+- commissioners.html is for the section for the commissioners
+- toggled.html file has the components that are common but toggled, like feedback, glossary, and toc
+
+
+
+TO UPDATE
+To update these files (and the css loaded into the homepage),
+1. Load the homepage, go into the inspector's Elements tab, and copy the <html> tag.
+   NOTE: it's important to copy the compiled code and not the source code directly
+   as the source won't have elements that have been changed/added by JavaScript
+2. Paste the <html> tag in full.html. 
+3. Remove the <head> and everything in it (no visible elements there).
+4. Remove any <script> or <style> tags.
+5. Remove any text content that is the lowest level of its structure (e.g. remove the text inside a <p> but leave
+    the <p> and leave any elements inside the <p>.
+    Having something like <div></div><div><p><a><i><em></em></i></a></p><p></p></div> is totally fine.)
+6. Feel free to remove any inline style rules.
+7. Add any elements/structures that aren't already here.
+    e.g. dev banner, announcement banners, features that are off but may be activated
+8. Safe to remove non-unique <li> from lists
+    (as long as we keep a first, a last, an even, an odd, an nth, and we don't lose otherwise-unique descendents)
+
+Safe to remove:
+    <head>
+    <script>
+    <style>
+      
+    rel=""
+    width=""
+    height=""
+    for=""
+    on*=""
+    repeated elements
+    blank lines
+    line breaks
+    comments
+
+Preserve:
+    elements
+    aria*=""
+    class=""
+    id=""
+    name=""
+    role=""

--- a/fec/home/templates/purgecss-homepage/toggled.html
+++ b/fec/home/templates/purgecss-homepage/toggled.html
@@ -58,11 +58,11 @@
       <button class="js-feedback feedback__toggle button--cta-secondary" aria-controls="feedback" aria-expanded="false" type="button">Feedback</button>
       <div id="feedback" class="js-feedback-box feedback" aria-hidden="true">
         <button class="js-feedback button--down feedback__close" tabindex="-1"><span class="u-visually-hidden">Close</span></button>
-        <div class="js-status" aria-hidden="true">
-          <div class="message js-message">
-          </div>
+        <div class="js-status" aria-hidden="false">
+          <div class="message js-message message--error"><h2 class="feedback__title">Input required</h2><p>Please fill out the required field.</p></div>
+          <div class="message js-message message--success"><h2 class="feedback__title">Input required</h2><p>Please fill out the required field.</p></div>
           <ul class="list--buttons">
-            <li><button class="js-reset button--cta-primary feedback__button" type="button" tabindex="-1">Submit another issue</button></li>
+            <li><button class="js-reset button--cta-primary feedback__button" type="button" tabindex="0">Try again</button></li>
           </ul>
         </div>
         <form id="feedback-form" class="container">

--- a/fec/home/templates/purgecss-homepage/toggled.html
+++ b/fec/home/templates/purgecss-homepage/toggled.html
@@ -85,9 +85,21 @@
             <label for="feedback-2" class="label">General website feedback</label>
             <textarea id="feedback-2" name="feedback" tabindex="-1"></textarea>
             <label for="feedback-3" class="label">Tell us about yourself</label>
+            
+            <div>
+              <div class="grecaptcha-badge" data-style="inline" style="">
+                <div class="grecaptcha-logo">
+                  <iframe title="reCAPTCHA" src="" width="256" height="60" role="presentation" name="" frameborder="0" scrolling="no" sandbox=""></iframe>
+                </div>
+                <div class="grecaptcha-error"></div>
+                <textarea id="g-recaptcha-response" name="g-recaptcha-response" class="g-recaptcha-response" style=""></textarea>
+              </div>
+              <iframe style="display: none;"></iframe>
+            </div>
+
             <span class="label--help">I'm a <span class="u-blank-space"></span> interested in <span class="u-blank-space"></span>.</span>
             <textarea id="feedback-3" name="about" tabindex="-1"></textarea>
-            <button class="g-recaptcha button--cta feedback__button u-no-margin" data-sitekey="6Lc0uGwUAAAAALGRGXt3mTteJeb_lbse2frNdWjv" data-callback="submitFeedback" data-badge="inline" tabindex="-1">Post</button>
+            <button class="g-recaptcha button--cta feedback__button u-no-margin" data-sitekey="" data-callback="submitFeedback" data-badge="inline" tabindex="-1">Post</button>
             <p class="t-sans t-note u-margin--top"><a href="https://github.com/FECgov/FEC/issues" tabindex="-1">Review all reported feedback</a>  |  <a href="/contact/" tabindex="-1">Contact the FEC about a specific question</a>  |  <a href="/use-recaptcha/" tabindex="-1">Use of reCAPTCHA</a></p>
           </fieldset>
         </form>

--- a/fec/home/templates/purgecss-homepage/toggled.html
+++ b/fec/home/templates/purgecss-homepage/toggled.html
@@ -1,0 +1,96 @@
+<html lang="en">
+  <head></head>
+    <body class="template-home-page">
+      <main id="main"></main>
+    
+      <div id="glossary" class="glossary" aria-describedby="glossary-result" aria-hidden="true">
+      <button title="Close glossary" class="button button--close--inverse toggle js-glossary-close" tabindex="-1"><span class="u-visually-hidden">Hide glossary</span>
+      </button>
+      <h2>Glossary</h2>
+      <label for="glossary-search" class="label">Search terms</label>
+      <input id="glossary-search" class="glossary__search js-glossary-search" type="search" tabindex="-1">
+      <span class="t-note t-sans search__example">Examples: receipt; Hybrid PAC</span>
+      <div class="glossary__content" id="glossary-result">
+        <ul class="glossary__list js-glossary-list accordion--inverse">
+            <li class="glossary__item">
+                <button class="data-glossary-term glossary__term accordion__button" tabindex="-1" aria-controls="glossary-content-0" aria-expanded="false">Act</button>
+                <div class="glossary__definition accordion__content" id="glossary-content-0" aria-hidden="true" >The Federal Election Campaign Act of 1971, as amended (<a href="https://www.fec.gov/data/legal/statutes/" tabindex="-1">52 U.S.C. §§30101-30146</a>). 11 CFR <a href="https://www.fec.gov/regulations/100-18/CURRENT#100-18" tabindex="-1">100.18</a>. Prior to September 1, 2014, the Act appeared in Title 2 of the U.S. Code. Sometimes abbreviated FECA.</div>
+            </li>
+            <li class="glossary__item">
+                <button class="data-glossary-term glossary__term accordion__button" tabindex="-1" aria-controls="glossary-content-1" aria-expanded="false">Administrative expense</button>
+                <div class="glossary__definition accordion__content" id="glossary-content-1" aria-hidden="true" >For party committees, rent, utilities, office equipment, office supplies, routine building maintenance and other operating costs not attributable to a specific candidate.</div>
+            </li>
+            <li class="glossary__item">
+                <button class="data-glossary-term glossary__term accordion__button" tabindex="-1" aria-controls="glossary-content-2" aria-expanded="false">Administrative termination</button>
+                <div class="glossary__definition accordion__content" id="glossary-content-2" aria-hidden="true">Administrative termination is the action taken by the Commission to terminate the reporting obligations of political committees that appear to be inactive in accordance with 52 U.S.C. <a href="https://www.govinfo.gov/link/uscode/52/30103" tabindex="-1">30103(d)(2)</a> and <a href="https://www.fec.gov/regulations/102-4/CURRENT#102-4" tabindex="-1">11 CFR 102.4</a>. Administrative termination does not relieve a committee of any legal responsibility for the payment of any outstanding debt or obligations.</div>
+            </li>
+            <li class="glossary__item">
+                <button class="data-glossary-term glossary__term accordion__button" tabindex="-1" aria-controls="glossary-content-3" aria-expanded="false">Advance</button>
+                <div class="glossary__definition accordion__content" id="glossary-content-3" aria-hidden="true" >The payment by an individual from his or her personal funds, including a personal credit card, for the costs incurred in providing goods or services to, or obtaining goods or services that are used by or on behalf of, a candidate or a political committee.  See <a href="https://www.fec.gov/regulations/116-5/CURRENT#116-5" tabindex="-1">11 CFR 116.5</a>.</div>
+            </li>
+            <li class="glossary__item">
+                <button class="data-glossary-term glossary__term accordion__button" tabindex="-1" aria-controls="glossary-content-4" aria-expanded="false">Advisory opinion (AO)</button>
+                <div class="glossary__definition accordion__content" id="glossary-content-4" aria-hidden="true">A formal response from the Commission regarding the legality of a specific activity proposed in an advisory opinion request (AOR). 11 CFR Part <a href="https://www.fec.gov/regulations/112" tabindex="-1">112</a>.</div>
+            </li>
+            <li class="glossary__item">
+                <button class="data-glossary-term glossary__term accordion__button" tabindex="-1" aria-controls="glossary-content-5" aria-expanded="false">Affiliated committees</button>
+                <div class="glossary__definition accordion__content" id="glossary-content-5" aria-hidden="true">Committees and organizations that are considered one committee for purposes of the contribution limits. <a href="https://www.fec.gov/regulations/110-3/CURRENT#110-3" tabindex="-1">11 CFR 110.3(a)(1)</a>. Affiliated committees include (1) All committees established or authorized by a candidate as part of his or her campaign for federal or nonfederal office; and (2) All committees established, financed, maintained or controlled by the same person, group or organization. 11 CFR <a href="https://www.fec.gov/regulations/100-5/CURRENT#100-5-g" tabindex="-1">100.5(g)(1) and (2)</a>; <a href="https://www.fec.gov/regulations/110-3/CURRENT#110-3" tabindex="-1">11 CFR 110.3(a)(1)</a>.</div>
+            </li>
+            <li class="glossary__item"><button class="data-glossary-term glossary__term accordion__button" tabindex="-1" aria-controls="glossary-content-6" aria-expanded="false">Agent (of a candidate)</button>
+                <div class="glossary__definition accordion__content" id="glossary-content-6" aria-hidden="true">An agent of a federal candidate or officeholder is any person who has actual authority, either express or implied, to engage in any of the following activities on behalf of the candidate or officeholder: 
+                    <ul class="list-bulleted">
+                        <li>To solicit, receive, direct, transfer or spend funds in connection with any election.</li>
+                        <li>To request or suggest that a communication be created, produced or distributed; </li>
+                        <li>To make or authorize a communication that meets one or more of the “content standards” for coordination;</li>
+                        <li>To request or suggest that any other person create, produce, or distribute any communication;</li>
+                        <li>To be materially involved in decisions regarding the content, intended audience, means, media outlet, timing, frequency, size, prominence or duration of a communication;</li>
+                        <li>To provide material or information to assist another person in the creation, production or distribution of any communication; or</li>
+                        <li>To make or direct a communication that is created, produced or distributed with the use of material or information derived from a substantial discussion about the communication with a different candidate;</li>
+                    </ul>
+                11 CFR <a href="https://www.fec.gov/regulations/109-3/CURRENT#109-3-b" tabindex="-1">109.3(b)</a> and <a href="https://www.fec.gov/regulations/300-2/CURRENT#300-2-b-3" tabindex="-1">300.2(b)(3)</a>.</div>
+            </li>
+        </ul>
+      </div>
+    </div>
+    
+    
+    <div>
+      <button class="js-feedback feedback__toggle button--cta-secondary" aria-controls="feedback" aria-expanded="false" type="button">Feedback</button>
+      <div id="feedback" class="js-feedback-box feedback" aria-hidden="true">
+        <button class="js-feedback button--down feedback__close" tabindex="-1"><span class="u-visually-hidden">Close</span></button>
+        <div class="js-status" aria-hidden="true">
+          <div class="message js-message">
+          </div>
+          <ul class="list--buttons">
+            <li><button class="js-reset button--cta-primary feedback__button" type="button" tabindex="-1">Submit another issue</button></li>
+          </ul>
+        </div>
+        <form id="feedback-form" class="container">
+          <fieldset>
+            <legend class="feedback__title">Help us improve FEC.gov</legend>
+            <h3 class="t-sans">Test new website features with our design team</h3>
+            <div class="signup__row">
+              <div class="signup__button">
+              <a class="button--cta" href="https://ethn.io/12085" tabindex="-1">Sign up</a>
+              </div>
+              <div class="signup__note">
+                <p class="t-sans t-note">Sign up for a 30-minute video call to  help us test new website features.</p>
+              </div>
+            </div>
+            <hr>
+            <h3 class="t-sans">Or post public feedback about the FEC.gov website anonymously</h3>
+            <p class="t-sans t-note">How can we improve FEC.gov? Your feedback, browser information and the URL of the page you were viewing at the time of submission will be posted publicly - so don't include sensitive information like your name, contact information or Social Security number.</p>
+            <label for="feedback-1" class="label">What were you trying to do on fec.gov, and how can we improve it? <span class="label--help">(required)</span></label>
+            <textarea id="feedback-1" name="action" tabindex="-1"></textarea>
+            <label for="feedback-2" class="label">General website feedback</label>
+            <textarea id="feedback-2" name="feedback" tabindex="-1"></textarea>
+            <label for="feedback-3" class="label">Tell us about yourself</label>
+            <span class="label--help">I'm a <span class="u-blank-space"></span> interested in <span class="u-blank-space"></span>.</span>
+            <textarea id="feedback-3" name="about" tabindex="-1"></textarea>
+            <button class="g-recaptcha button--cta feedback__button u-no-margin" data-sitekey="6Lc0uGwUAAAAALGRGXt3mTteJeb_lbse2frNdWjv" data-callback="submitFeedback" data-badge="inline" tabindex="-1">Post</button>
+            <p class="t-sans t-note u-margin--top"><a href="https://github.com/FECgov/FEC/issues" tabindex="-1">Review all reported feedback</a>  |  <a href="/contact/" tabindex="-1">Contact the FEC about a specific question</a>  |  <a href="/use-recaptcha/" tabindex="-1">Use of reCAPTCHA</a></p>
+          </fieldset>
+        </form>
+      </div>
+    </div></body></html>
+    


### PR DESCRIPTION
## Summary

- Resolves #4698 

After adding purgecss, we lost styles for the interactive parts of the homepage—the menu wouldn't open and search suggestions were jumbled

### Required reviewers

2

## Impacted areas of the application

The homepage, mostly the interactive components

## Screenshots

The before shots are in the ticket #4698 . The 'after' should look like Production

## Related PRs

Nah

## How to test

- pull the branch
- `npm i` just in case
- `npm run build-sass`
- check [localhost homepage](http://127.0.0.1:8000) to make sure it looks like Prod
- check the interactive parts, too
   - main nav - wide
   - main nav - small
   - search results (make sure you get committee suggestions to see the active/inactive dots)
   - feedback
   - glossary
   - maps
- `npm run build`
   - check the same components
- let me know if things are ugly or invisible
