### PR TITLE
Feature/4577 update wccf defaults

### DIFF
--- a/fec/fec/static/js/widgets/aggregate-totals-box.js
+++ b/fec/fec/static/js/widgets/aggregate-totals-box.js
@@ -16,11 +16,7 @@ const isModernBrowser = 'fetch' in window && 'assign' in Object;
 // Includes
 import analytics from '../modules/analytics';
 import { buildUrl } from '../modules/helpers';
-import {
-  defaultElectionYear,
-  electionYearsOptions,
-  officeDefs
-} from './widget-vars';
+import { electionYearsOptions, officeDefs } from './widget-vars';
 
 /**
  * Handles the functionality for the aggregate totals box(es).
@@ -49,7 +45,7 @@ function AggregateTotalsBox() {
   this.basePath_partyTotals = ['candidates', 'totals', 'by_office', 'by_party'];
   this.baseQuery = {
     office: 'P',
-    election_year: defaultElectionYear(),
+    election_year: window.DEFAULT_ELECTION_YEAR,
     is_active_candidate: true,
     per_page: 20,
     sort_null_only: false,

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -3,12 +3,11 @@
 /**
  * @fileoverview Controls all functionality inside the Where Contributions Come From widget
  * in cooperation with data-map
- * @copyright 2019 Federal Election Commission
+ * @copyright 2021 Federal Election Commission
  * @license CC0-1.0
  * @owner  fec.gov
- * @version 1.0
- * TODO: Figure out why Aggregate Totals Box isn't defaulting to data-year and window.ELECTION_YEAR
- * TODO: For v2 or whatever, convert to datatable.net (start with the simpliest implementation; no columns.js, etc.)
+ * @version 1.1
+ * TODO: Figure out why Aggregate Totals Box isn't defaulting to data-year and window.DEFAULT_ELECTION_YEAR
  */
 
 // Editable vars
@@ -23,7 +22,6 @@ const rootPathToIndividualContributions =
 
 import { buildUrl, passiveListener } from '../modules/helpers';
 import typeahead from '../modules/typeahead';
-import { defaultElectionYear } from './widget-vars';
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
 import analytics from '../modules/analytics';
 
@@ -117,7 +115,7 @@ function ContributionsByState() {
     '000', // candidate ID
     'committees',
     'history',
-    2020 // election year / cycle
+    window.DEFAULT_ELECTION_YEAR // election year / cycle
   ];
   // Where to find candidate's coverage dates
   this.basePath_candidateCoverageDatesPath = [
@@ -152,7 +150,7 @@ function ContributionsByState() {
       {
         candidate_id: '',
         count: 0,
-        cycle: 2020,
+        cycle: window.DEFAULT_ELECTION_YEAR,
         state: '',
         state_full: '',
         total: 0
@@ -256,9 +254,9 @@ ContributionsByState.prototype.init = function() {
   // Initialize the various queries
   this.baseCandidateQuery = {}; // Calls for candidate details
   this.baseStatesQuery = {
-    cycle: defaultElectionYear(),
+    cycle: window.DEFAULT_ELECTION_YEAR,
     election_full: true,
-    office: 'P',
+    // office: 'P',
     page: 1,
     per_page: 200,
     sort_hide_null: false,
@@ -382,6 +380,7 @@ ContributionsByState.prototype.loadCandidateDetails = function(cand_id) {
   let instance = this;
 
   this.basePath_candidatePath[1] = cand_id;
+
   window
     .fetch(
       buildUrl(this.basePath_candidatePath, this.baseCandidateQuery),

--- a/fec/fec/static/js/widgets/pres-finance-map-box.js
+++ b/fec/fec/static/js/widgets/pres-finance-map-box.js
@@ -72,7 +72,6 @@ const selector_candidateListDisclaimer = '.js-cand-list-note';
 // Imports, etc
 // const $ = jquery;
 import { buildUrl, passiveListener } from '../modules/helpers';
-// import { defaultElectionYear } from './widget-vars';
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
 import analytics from '../modules/analytics';
 

--- a/fec/fec/static/js/widgets/widget-vars.js
+++ b/fec/fec/static/js/widgets/widget-vars.js
@@ -16,45 +16,6 @@ let officeDefs = {
 };
 
 /**
- * If the constants value of DEFAULT_PRESIDENTIAL_YEAR is set, return that.
- * Otherwise return the next election year with the goal of not displaying data when there is none.
- * If next year is an election year, but today is before 15 April, returns the previous election year.
- * @returns {Number} Four-digit year
- * TODO - May need to expand this to default to midterms when we're away from a presidential year
- */
-let defaultElectionYear = () => {
-  let theYear = 0;
-  let now = new Date();
-  let thisYear = now.getFullYear();
-  if (window.ELECTION_YEAR) theYear = window.ELECTION_YEAR;
-  else if (window.DEFAULT_PRESIDENTIAL_YEAR)
-    theYear = window.DEFAULT_PRESIDENTIAL_YEAR;
-  else theYear = thisYear;
-
-  // If we're looking at the url-provided year,
-  // let's check whether it's a presidential year
-  // If not, we'll use DEFAULT_PRESIDENTIAL_YEAR
-  if (theYear == window.ELECTION_YEAR && theYear % 4 > 0) {
-    return window.DEFAULT_PRESIDENTIAL_YEAR;
-  }
-
-  // If we're using this year,
-  if (theYear == thisYear) {
-    // If the next year is a presidential election year
-    // and today's after April 15
-    // let's use next year
-    if ((theYear + 1) % 4 == 0 && now.getMonth() >= 3 && now.getDate() > 15) {
-      return theYear + 1;
-    } else {
-      // Otherwise, let's find the most recent presidential election
-      return theYear % 4 == 0 ? theYear : theYear + (4 - (theYear % 4));
-    }
-  }
-  // Otherwise we're cool to use theYear
-  return theYear;
-};
-
-/**
  * Calculates the next presidential election year, including this year if applicable
  * @returns {Number} The four-digit year of the next presidential year
  */
@@ -95,11 +56,10 @@ let electionYearsList = (type = 'P') => {
  * @param {String} office - What kind of years? (P are every four years, H and S are two years) {@default: 'P'}
  * @param {String, Number} selectedValue - (optional) Which value should be `selected`?
  * @returns A list of <option> elements
- * TODO - Should we assign a default selectedValue of defaultElectionYear()?
  */
 let electionYearsOptions = (
   office = 'P',
-  selectedValue = window.DEFAULT_PRESIDENTIAL_YEAR
+  selectedValue = window.DEFAULT_ELECTION_YEAR
 ) => {
   let toReturn = '';
   let theList = electionYearsList(office);
@@ -129,7 +89,6 @@ let electionYearsOptions = (
 
 // Make them available for import
 module.exports = {
-  defaultElectionYear,
   electionYearsList,
   electionYearsOptions,
   officeDefs


### PR DESCRIPTION
## Summary

- Resolves #4577 

Updating Where Contributions Come From to use default election year, not just the default presidential election year

### Required reviewers

Two? (feel free to edit the list)

## Impacted areas of the application

The changes cascaded so will affect
- Where contributions come from
- Aggregate totals
- widget-vars.js utils file (first two files were no longer using a function in widget-vars, so removed that now-unused function)
- Presidential map (only removed a commented line so would be _really_ surprised if anything changed here)

## Screenshots

Raising by the numbers, upper
![image](https://user-images.githubusercontent.com/26720877/121423151-f5dcac00-c93d-11eb-9573-66c702004065.png)

Raising by the numbers, WCCF
![image](https://user-images.githubusercontent.com/26720877/121423083-e3627280-c93d-11eb-91fa-b6fd14feeb91.png)


## Related PRs

None

## How to test

- pull the branch
- `npm run build`
- `./manage.py runserver`
- Check the [homepage](http://127.0.0.1:8000) to make sure the chart at the bottom isn't affected
- [Raising by the numbers](http://127.0.0.1:8000/data/raising-bythenumbers/)
   - Raising summary should default to 2022 and Senate candidates
   - Who's raising the most should default to 2022 and Senate candidates
   - Where individual contributions come from should default to 2022 and the highest-raising federal office candidate (currently Warnock, Raphael)
   - All elements' interactivity should be identical to Prod
- [Spending by the numbers](http://127.0.0.1:8000/data/spending-bythenumbers/)
   - Spending summary should default to 2022 and Senate candidates
   - Who's spending the most should default to 2022 and Senate candidates
   - All elements' interactivity should be identical to Prod
- [Presidential map](http://127.0.0.1:8000/data/candidates/president/presidential-map/) should still default to 2020 presidential candidates

