### PR TITLE
Fix mobile view of browse data sections

### DIFF
--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -2,7 +2,7 @@
   <h2>Candidates</h2>
   <p>Search candidate data, including money raised, money spent, cash on hand and debt.</p>
   <h3>Search or browse data</h3>
-  <div class="content__section--ruled t-sans">
+  <div class="content__section--ruled-responsive t-sans">
     <ul>
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>

--- a/fec/data/templates/partials/browse-data/committees.jinja
+++ b/fec/data/templates/partials/browse-data/committees.jinja
@@ -2,7 +2,7 @@
   <h2>Committees</h2>
   <p>The term <span class="term" data-term="political committee">committee</span> encompasses several different political groups that receive and spend money in federal elections.</p>
   <h3>Search or browse data</h3>
-  <div class="content__section--ruled t-sans">
+  <div class="content__section--ruled-responsive t-sans">
     <ul>
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
@@ -121,7 +121,7 @@
       </li>
     </ul>
   </div>
-  <div class="content__section--ruled">
+  <div class="content__section--ruled-responsive">
     <h3>PACronyms</h3>
     <p>"PACronyms" refers to acronyms, abbreviations, initials and common names of federal political action committees (PACs). The Public Records Office can provide assistance in finding information about a specific PAC, including the PAC's PACronym.</p>
   </div>

--- a/fec/data/templates/partials/browse-data/external.jinja
+++ b/fec/data/templates/partials/browse-data/external.jinja
@@ -1,7 +1,7 @@
 <section id="external" class="row" aria-hidden="true" role="tabpanel">
   <h2>External sources</h2>
   <p>Certain information is reported to the FEC, but more information is reported to other governmental agencies.</p>
-  <div class="content__section--ruled t-sans">
+  <div class="content__section--ruled-responsive t-sans">
     <ul>
       <li>
         <i class="icon i-share icon--absolute--left"></i>

--- a/fec/data/templates/partials/browse-data/filings-reports.jinja
+++ b/fec/data/templates/partials/browse-data/filings-reports.jinja
@@ -11,7 +11,7 @@
     </div>
   </div>
   <h3 class="u-padding--top">Search or browse data</h3>
-  <div class="content__section--ruled t-sans">
+  <div class="content__section--ruled-responsive t-sans">
     <ul>
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>

--- a/fec/data/templates/partials/browse-data/loans-debts.jinja
+++ b/fec/data/templates/partials/browse-data/loans-debts.jinja
@@ -1,7 +1,7 @@
 <section class="row" id="loans-debts" aria-hidden="true" role="tabpanel">
   <h2>Loans and debts</h2>
   <h3>Search or browse data</h3>
-  <div class="content__section--ruled t-sans">
+  <div class="content__section--ruled-responsive t-sans">
     <ul>
       <li>
         <i class="icon i-magnifying-glass icon--absolute--left"></i>

--- a/fec/data/templates/partials/browse-data/raising.jinja
+++ b/fec/data/templates/partials/browse-data/raising.jinja
@@ -55,7 +55,7 @@
         </section>
       </li>
       <li>
-        <div class="content__section--ruled">
+        <div class="content__section--ruled-responsive">
 
             <p class="t-small u-negative--top--margin t-serif"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
 

--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -117,7 +117,7 @@
         </section>
       </li>
       <li>
-        <div class="content__section--ruled">
+        <div class="content__section--ruled-responsive">
           <p class="t-small u-negative--top--margin t-serif"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
           <div class="js-accordion accordion--neutral" data-content-prefix="methodology_spending">
             <button type="button" class="js-accordion-trigger accordion__button">Methodology</button>


### PR DESCRIPTION
## Summary

- Resolves #4704 

Add responsive classes to browse data content sections. This fixes the overflow of those sections in mobile view.

### Required reviewers

1 front end and 1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

-  Browse data pages

## Screenshots

### Before
![Image from iOS](https://user-images.githubusercontent.com/12799132/121431895-0003a800-c948-11eb-982e-ac1f61ca0be3.png)

### After
<img width="307" alt="Screen Shot 2021-06-09 at 5 28 30 PM" src="https://user-images.githubusercontent.com/12799132/121432004-2590b180-c948-11eb-8453-b646ebae4267.png">


## How to test

- Use the browser inspector tool
- Click on the device toolbar button (second button from the left in the inspector tools
<img width="32" alt="Screen Shot 2021-06-09 at 5 35 24 PM" src="https://user-images.githubusercontent.com/12799132/121432808-2249f580-c949-11eb-8803-64d87ba1af5e.png">)
- Go to the [browse data pages](http://localhost:8000/data/browse-data/?tab=raising) and click on each tab to make sure the responsive layout looks right