### PR TITLE
Adds 2009 FR notice to Guidance search

### DIFF
--- a/fec/search/management/data/sitemap_pdf.xml
+++ b/fec/search/management/data/sitemap_pdf.xml
@@ -45,6 +45,10 @@
 <lastmod>2020-04-13T15:30:00+00:00</lastmod>
 </url>
 <url>
+<loc>https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-11.pdf</loc>
+<lastmod>2021-06-10T08:45:00+00:00</lastmod>
+</url>
+<url>
 <loc>https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-09_EO13892.pdf</loc>
 <lastmod>2020-04-13T15:30:00+00:00</lastmod>
 </url>


### PR DESCRIPTION
Adding https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-11.pdf to the guidance search as of 6/10/2021.

## Summary (required)

- Resolves #4691 
