### PR TITLE
Refine display of details panel in PAC and party datatable

### DIFF
--- a/fec/fec/static/js/templates/pac-party.hbs
+++ b/fec/fec/static/js/templates/pac-party.hbs
@@ -3,11 +3,12 @@ Template for PAC and party committee datatable details panel
 --}}
 
 <div class="panel__row">
-  <h4 class="panel__title">
+  <h4 class="panel__title u-padding--bottom">
     <a href="{{basePath}}/committee/{{committee_id}}">{{committee_name}}</a>
   </h4>
-</div>
-<div class="panel__row">
+  <h4 class="panel__title">
+    Committee information
+  </h4>
   <table>
     {{#panelRow "Committee type"}}
       {{committee_type_full}}
@@ -15,6 +16,14 @@ Template for PAC and party committee datatable details panel
     {{#panelRow "Designation"}}
       {{committee_designation_full}}
     {{/panelRow}}
+    {{!-- TODO: Update the API field names for leadership PAC sponsor when it's ready in the API --}}
+    {{!-- {{#if sponsor_candidate_ids}}
+      {{#panelRow "Leadership PAC sponsor"}}
+        {{#each sponsor_candidate_ids}}
+          <a href="{{ basePath }}/candidate/{{ sponsor_candidate_ids }}/"><span class="leadership_pac_sponsor_name">{{ sponsor_candidate_name }}</span> ({{ sponsor_candidate_ids }})</a>;<br />
+        {{/each}}
+      {{/panelRow}}
+    {{/if}} --}}
     {{#panelRow "Most recent treasurer"}}
     {{!-- TODO: Fill this when available --}}
       {{ TBD }}
@@ -23,19 +32,60 @@ Template for PAC and party committee datatable details panel
     {{!-- TODO: Fill this when available --}}
       {{ TBD }}
     {{/panelRow}}
-    {{#panelRow "Total individual contributions"}}
-      {{{currency individual_contributions}}}
-    {{/panelRow}}
     {{#panelRow "Filing frequency"}}
     {{!-- TODO: Fill this when available --}}
       {{ TBD }}
     {{/panelRow}}
-    {{#panelRow "Coverage end date"}}
-      {{datetime coverage_end_date format="pretty"}}
-    {{/panelRow}}
     {{#panelRow "First filing date"}}
-    {{!-- TODO: Fill this when available --}}
+      {{!-- TODO: Fill this when available --}}
       {{datetime TBD format="pretty"}}
+    {{/panelRow}}
+  </table>
+</div>
+
+<div class="panel__row">
+  <h4 class="panel__title">
+    Financial totals for {{ format_range cycle }}
+  </h4>
+  <table>
+    {{#panelRow "Receipts"}}
+      {{ currency receipts }}
+    {{/panelRow}}
+    <tr>
+      <td class="panel__term">
+        <span>Individual contributions</span>
+        <div class="tooltip__container">
+          <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+          <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
+            {{!-- TODO: Add final tooltip language --}}
+            <p class="tooltip__content">A gift, subscription, loan, advance or deposit of money or anything of value given to influence a federal election; or the payment by any person of compensation for the personal services of another person if those services are rendered without charge to a political committee for any purpose. 11 CFR 100.52(a) and 100.54.</p>
+          </div>
+        </div>
+      </td>
+      <td class="panel__data">
+        {{ currency individual_contributions }}
+      </td>
+    </tr>
+    {{#panelRow "Disbursements"}}
+      {{ currency disbursements }}
+    {{/panelRow}}
+    <tr>
+      <td class="panel__term">
+        Ending cash on hand
+        <div class="tooltip__container">
+          <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+          <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
+            {{!-- TODO: Add final tooltip language --}}
+            <p class="tooltip__content">The total amount of cash on hand that remains after the amount of cash on hand at the beginning of the reporting period is adjusted to add the total receipts for the reporting period and subtract the total disbursements for the reporting period.</p>
+          </div>
+        </div>
+      </td>
+      <td class="panel__data">
+        {{ currency last_cash_on_hand_end_period }}
+      </td>
+    </tr>
+    {{#panelRow "Debts owed by committee"}}
+      {{ currency last_debts_owed_by_committee }}
     {{/panelRow}}
   </table>
 </div>

--- a/fec/fec/static/js/templates/pac-party.hbs
+++ b/fec/fec/static/js/templates/pac-party.hbs
@@ -30,12 +30,23 @@ Template for PAC and party committee datatable details panel
     {{#panelRow "State"}}
       {{ committee_state }}
     {{/panelRow}}
-    {{#panelRow "Filing frequency"}}
-    {{!-- TODO: Update to show the full filing frequency name --}}
-      {{ filing_frequency }}
-    {{/panelRow}}
+    <tr>
+      <td class="panel__term">
+        <span>Filing frequency</span>
+        <div class="tooltip__container">
+          <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+          <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
+            {{!-- TODO: Add final tooltip language --}}
+            <p class="tooltip__content">Filing freqency description goes here.</p>
+          </div>
+        </div>
+      </td>
+      <td class="panel__data">
+        {{ filing_frequency_full }}
+      </td>
+    </tr>
     {{#panelRow "First filing date"}}
-      {{datetime first_file_date format="pretty"}}
+      {{ datetime first_file_date format="pretty" }}
     {{/panelRow}}
   </table>
 </div>
@@ -45,6 +56,9 @@ Template for PAC and party committee datatable details panel
     Financial totals for {{ format_range cycle }}
   </h4>
   <table>
+    {{#panelRow "Coverage end date"}}
+      {{ datetime coverage_end_date format="pretty" }}
+    {{/panelRow}}
     {{#panelRow "Receipts"}}
       {{ currency receipts }}
     {{/panelRow}}

--- a/fec/fec/static/js/templates/pac-party.hbs
+++ b/fec/fec/static/js/templates/pac-party.hbs
@@ -4,7 +4,7 @@ Template for PAC and party committee datatable details panel
 
 <div class="panel__row">
   <h4 class="panel__title u-padding--bottom">
-    <a href="{{basePath}}/committee/{{committee_id}}">{{committee_name}}</a>
+    <a href="{{basePath}}/committee/{{committee_id}}/">{{committee_name}}</a>
   </h4>
   <h4 class="panel__title">
     Committee information
@@ -25,20 +25,17 @@ Template for PAC and party committee datatable details panel
       {{/panelRow}}
     {{/if}} --}}
     {{#panelRow "Most recent treasurer"}}
-    {{!-- TODO: Fill this when available --}}
-      {{ TBD }}
+      {{ treasurer_name }}
     {{/panelRow}}
     {{#panelRow "State"}}
-    {{!-- TODO: Fill this when available --}}
-      {{ TBD }}
+      {{ committee_state }}
     {{/panelRow}}
     {{#panelRow "Filing frequency"}}
-    {{!-- TODO: Fill this when available --}}
-      {{ TBD }}
+    {{!-- TODO: Update to show the full filing frequency name --}}
+      {{ filing_frequency }}
     {{/panelRow}}
     {{#panelRow "First filing date"}}
-      {{!-- TODO: Fill this when available --}}
-      {{datetime TBD format="pretty"}}
+      {{datetime first_file_date format="pretty"}}
     {{/panelRow}}
   </table>
 </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #4688 

Refines filter display to match design mock ups.

**Note:** Leadership PAC sponsor code was added but commented out for now until that can be added to the API. Related issue: https://github.com/fecgov/fec-cms/issues/4690

### Required reviewers

1 UX, 1 front-end, 1 back-end

## Impacted areas of the application

General components of the application that this PR will affect:

-  PAC and party datatable

## Screenshots

![Screen Shot 2021-06-15 at 10 41 58 AM](https://user-images.githubusercontent.com/12799132/122075116-cf988f80-cdc7-11eb-846e-611dc85aecb0.png)


## Related PRs

branch | PR
------ | ------
feature/4651-minimal-pac-party-datatable | [link](https://github.com/fecgov/fec-cms/pull/4653)
feature/4686-single-select-time-period | [link](https://github.com/fecgov/fec-cms/pull/4692)

## How to test

- `npm run build`
- Go to [PAC and party datatable](http://localhost:8000/data/committees/pac-party/)
- Click on a committee details panel button
- Ensure that all fields in the details panel appears as expected per the comp