### PR TITLE
Correct glossary terms spacing bug

### DIFF
--- a/fec/fec/static/scss/components/_glossary.scss
+++ b/fec/fec/static/scss/components/_glossary.scss
@@ -87,7 +87,7 @@
   @include u-icon-bg($book, $primary);
   @include transition(background-color, .2s, box-shadow, .2s, color, .2s);
   background-size: .6em;
-  background-position: 100% 50%;
+  background-position: 99% 50%;
   background-color: transparent;
   box-shadow: 0 0 0 4px transparent;
   border-bottom: none;
@@ -113,6 +113,11 @@
 .term--inline {
   display: inline-block;
   margin-bottom: u(1rem) !important;
+}
+
+// Correct spacing when term is used after certain tags
+a + .term, i + .term, b + .term, .t-sans + .term  {
+margin-left: .4rem;
 }
 
 @media print {


### PR DESCRIPTION
## Summary

- Resolves #4727
- Glossary and adjacent `italic, bold, or .t-sans` tags had no space between them 
- The glossary icon was slightly cut off in some paragraphs


### Required reviewers
one content, one frontend



## Impacted areas of the application
modified:   fec/static/scss/components/_glossary.scss


<hr>

## Screenshots
### Before: terms adjacent to `i, b, .t-sans` tags are not separated by a space and glossary icon is cutoff intermittently
<hr>

<img width="1304" alt="Screen Shot 2021-07-02 at 1 40 48 AM copy" src="https://user-images.githubusercontent.com/5572856/124227359-8b500380-dad8-11eb-8517-9b9870629aa9.png">
<hr>

### After
<hr>
<img width="1335" alt="Screen Shot 2021-07-02 at 2 01 01 AM" src="https://user-images.githubusercontent.com/5572856/124228313-0cf46100-dada-11eb-8ac2-2fafdad3d801.png">

<hr>


## How to test

- checkout `fix/4727-glossary-spacing-bug`
- `npm run build-sass`
- Test adding glossary terms and adding italic, bold or sans-serif from the RTE menu to words before the glossary term
One offending page was http://localhost:8000/help-candidates-and-committees/registering-political-party/qualifying-political-party/
