### PR TITLE
4630 Only link to document.file_url if it exists

### DIFF
--- a/fec/home/templates/partials/document.html
+++ b/fec/home/templates/partials/document.html
@@ -16,15 +16,17 @@
         <a class="js-read-more post__read-more" href="{{ document.url }}">Read more</a>
     </div>
   {% else %}
-    {% if document.fec_url and document.extension %}
     <h3>
+      {% if document.file_url %}
       <a href="{{ document.file_url }}">{{ document.title }}</a>
+      {% else %}
+      {{ document.title }}
+      {% endif %}
+      {% if document.extension is not '' %}
       <i class="icon icon--inline--right icon--inline--left i-document"></i>
       <span class="t-sans t-normal">({{ document.extension }}){% if document.size %} | ({{ document.size }}){% endif %}</span>
+      {% endif %}
     </h3>
-    {% else %}
-    <h3>{{ document.title }}</h3>
-    {% endif %}
   {% endif %}
     <div class="post__meta">
       <a class="tag tag--secondary" href="">{{ document.category }}</a>

--- a/fec/home/templates/partials/document.html
+++ b/fec/home/templates/partials/document.html
@@ -16,11 +16,15 @@
         <a class="js-read-more post__read-more" href="{{ document.url }}">Read more</a>
     </div>
   {% else %}
+    {% if document.fec_url and document.extension %}
     <h3>
       <a href="{{ document.file_url }}">{{ document.title }}</a>
       <i class="icon icon--inline--right icon--inline--left i-document"></i>
       <span class="t-sans t-normal">({{ document.extension }}){% if document.size %} | ({{ document.size }}){% endif %}</span>
     </h3>
+    {% else %}
+    <h3>{{ document.title }}</h3>
+    {% endif %}
   {% endif %}
     <div class="post__meta">
       <a class="tag tag--secondary" href="">{{ document.category }}</a>


### PR DESCRIPTION
## Summary

- Resolves #4630 

Since the template crashes if fec_url isn't specified and there's no file at that url, let's not link to the non-file url

### Required reviewers

Just a couple—feel free to edit the list

## Impacted areas of the application

Only the document.html template

## Screenshots

The testing document has no url so isn't a link and doesn't have an icon or file size
![image](https://user-images.githubusercontent.com/26720877/124286412-ead00280-db1c-11eb-91ff-08fd507df1c8.png)


## Related PRs

None

## How to test

- pull the branch
- go to the [list of reports](http://127.0.0.1:8000/about/reports-about-fec/agency-operations/)
- Make a mental note of a report with a link
- Find that report in Wagtail
- Remove its url
- Publish it
- Go back to the list of reports
- The report should still be listed but shouldn't be a link and shouldn't have an icon or a file size listed
- All other reports in the list should be unchanged

Alternatively, make a new report with no url, publish it, and make sure it doesn't get a linked title
