### PR TITLE
3979 Calendar tooltip widths

### DIFF
--- a/fec/fec/static/scss/components/_calendar.scss
+++ b/fec/fec/static/scss/components/_calendar.scss
@@ -183,7 +183,7 @@
   }
 
   &::after {
-    @include linear-gradient(90deg, rgba($inverse, 0), $inverse);
+    @include linear-gradient(90deg, rgba($gray-lightest, 0), $gray-lightest);
     content: '';
     display: block;
     position: absolute;

--- a/fec/fec/static/scss/components/_calendar.scss
+++ b/fec/fec/static/scss/components/_calendar.scss
@@ -521,7 +521,6 @@
     padding: u(3px .5rem);
 
     .fc-title {
-      float: left;
       font-weight: bold;
       height: auto;
       line-height: u(2rem);

--- a/fec/fec/static/scss/components/_tooltips.scss
+++ b/fec/fec/static/scss/components/_tooltips.scss
@@ -139,7 +139,6 @@
 
 .tooltip--under {
   $top: u(1.5rem);
-  // width: u(12rem);
   left: u(-14rem);
   top: calc(100% + #{$top});
 

--- a/fec/fec/static/scss/components/_tooltips.scss
+++ b/fec/fec/static/scss/components/_tooltips.scss
@@ -139,7 +139,7 @@
 
 .tooltip--under {
   $top: u(1.5rem);
-  width: u(12rem);
+  // width: u(12rem);
   left: u(-14rem);
   top: calc(100% + #{$top});
 
@@ -259,9 +259,17 @@
     @include clearfix();
     background: $primary;
     color: $inverse;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 
+    .tooltip__title {
+      flex-grow: 2;
+      text-align: left;
+    }
     .button {
       float: right;
+      flex-grow: 0;
     }
   }
 


### PR DESCRIPTION
## Summary

- Resolves #3979 

Polishing the appearance of the calendar tooltip

### Required reviewers

Two

## Impacted areas of the application

Changed the style rules for the calendar tooltip

## Screenshots

(The ticket has a 'before' shot)

Top (with a long title)
![image](https://user-images.githubusercontent.com/26720877/124644660-87b5d700-de60-11eb-80ad-3f474217ddb5.png)

Right
![image](https://user-images.githubusercontent.com/26720877/124644775-9e5c2e00-de60-11eb-926d-486bd781ae8b.png)

Bottom
![image](https://user-images.githubusercontent.com/26720877/124644853-b3d15800-de60-11eb-8de6-2ed2e126e4b1.png)

Left
![image](https://user-images.githubusercontent.com/26720877/124644887-bf248380-de60-11eb-8fc6-fa62c75bfb68.png)


## Related PRs

None

## How to test

- pull the branch
- `npm run build-sass`
- `./manage.py runserver`
- Go to the [calendar](http://127.0.0.1:8000/calendar/)
- Switch to the calendar grid view
- Start clicking events!
  - Higher ones
  - Lower ones
  - Left & right ones
  - Find one with a really long title (or use Inspector to edit one to be really long)
  - Chrome should be fine
  - Double-check Firefox
  - If you can get Safari to load calendar entries, check that (or wait until dev/stg)