### PR TITLE
Elections page - fix responsive behavior  and show currency columns in mobile

### DIFF
--- a/fec/data/templates/elections.jinja
+++ b/fec/data/templates/elections.jinja
@@ -37,7 +37,7 @@
         </div>
       {% endif %}
     </header>
-    <div>
+    <div class="data-container__wrapper">
       {% include 'partials/elections/sidebar-nav.jinja' %}
       <div class="main__content--right-full">
         {% include 'partials/loading-tab.jinja' %}

--- a/fec/data/templates/partials/elections/about-this-election-tab.jinja
+++ b/fec/data/templates/partials/elections/about-this-election-tab.jinja
@@ -1,7 +1,7 @@
 {% import 'macros/cycle-select.jinja' as select %}
 
 <section id="section-2" role="tabpanel" aria-hidden="true" aria-labelledby="section-2-heading">
-  <div class="container">
+
     <h2 id="section-2-heading">About this election</h2>
     <div class="entity__figure u-no-padding row election-dates">
     </div>
@@ -52,5 +52,5 @@
         {% endif %}
       </div>
     </div>
-  </div>
+
 </section>

--- a/fec/data/templates/partials/elections/election-data-and-compliance-tab.jinja
+++ b/fec/data/templates/partials/elections/election-data-and-compliance-tab.jinja
@@ -23,7 +23,6 @@
 } %}
 
 <section id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
-  <div class='container'>
     <h2 id="section-1-heading">Election data and reporting deadlines</h2>
     {% include 'partials/elections/election-profile-cards.jinja' %}
     {% if state == 'PA' and office == 'house' and cycle == 2018 %}
@@ -319,5 +318,4 @@
         {% endif %}
       </div>
     </div>
-  </div>
 </section>

--- a/fec/fec/static/js/modules/table-columns.js
+++ b/fec/fec/static/js/modules/table-columns.js
@@ -89,11 +89,11 @@ function createElectionColumns(context) {
     },
     {
       data: 'party_full',
-      className: 'all'
+      className: 'min-desktop'
     },
     columns.currencyColumn({
       data: 'total_receipts',
-      className: 'column--number t-mono',
+      className: 'column--number t-mono all',
       orderSequence: ['desc', 'asc']
     }),
     columns.currencyColumn({

--- a/fec/fec/static/js/modules/table-columns.js
+++ b/fec/fec/static/js/modules/table-columns.js
@@ -89,7 +89,7 @@ function createElectionColumns(context) {
     },
     {
       data: 'party_full',
-      className:  'min-desktop'
+      className: 'min-desktop'
     },
     columns.currencyColumn({
       data: 'total_receipts',

--- a/fec/fec/static/js/modules/table-columns.js
+++ b/fec/fec/static/js/modules/table-columns.js
@@ -89,7 +89,7 @@ function createElectionColumns(context) {
     },
     {
       data: 'party_full',
-      className: 'min-tablet-l'
+      className:  'min-desktop'
     },
     columns.currencyColumn({
       data: 'total_receipts',
@@ -127,6 +127,7 @@ function createElectionColumns(context) {
           url: url
         });
       },
+      className: 'min-desktop',
       orderable: false
     }
   ];

--- a/fec/fec/static/js/modules/table-columns.js
+++ b/fec/fec/static/js/modules/table-columns.js
@@ -89,7 +89,7 @@ function createElectionColumns(context) {
     },
     {
       data: 'party_full',
-      className: 'min-desktop'
+      className: 'min-tablet-l'
     },
     columns.currencyColumn({
       data: 'total_receipts',
@@ -98,12 +98,12 @@ function createElectionColumns(context) {
     }),
     columns.currencyColumn({
       data: 'total_disbursements',
-      className: 'column--number t-mono',
+      className: 'column--number t-mono all',
       orderSequence: ['desc', 'asc']
     }),
     columns.barCurrencyColumn({
       data: 'cash_on_hand_end_period',
-      className: 'column--number t-mono'
+      className: 'column--number t-mono all'
     }),
     {
       render: function(data, type, row) {
@@ -127,7 +127,6 @@ function createElectionColumns(context) {
           url: url
         });
       },
-      className: 'all',
       orderable: false
     }
   ];

--- a/fec/fec/static/scss/components/_data-container.scss
+++ b/fec/fec/static/scss/components/_data-container.scss
@@ -162,3 +162,15 @@
     }
   }
 }
+
+
+//Responsive behavior for datatables in tab pannels on profile pages (committee, candidate, election)
+@media screen and (max-width: 940px) {
+  .data-container__wrapper .main__content--right-full {
+    display: block;
+   }
+
+  .data-container__wrapper .side-nav-alt {
+    display: block;
+  }
+}


### PR DESCRIPTION
## Summary 
- Adds priority to show  `Total receipts` , `Total disbursements`,  and `Cash on hand` columns in mobile for the first table `Candidate financial totals` in mobile view, issue:  #4668
- Allows obscured rows to be scrolled/swiped to
- Fixes responsive stacking issue on Election and Candidate profile pages, issue:  #4656
  - Committee profile pages stack the tab nav and above the tables at 940px whereas the Election and Candidate proffile pages were not until the size reached @640p cutting off content.
  
 - Quote from issue 4656 that applies to both issues:
   ```
   The display should stack according to screen size and 
   you should also be able to scroll horizontally for the datatables when there's smaller screens.
   
   ```
  
- [ ] Create followup issue : Per the completion criteria, to address overall usability off Election profile page tables and also to address places on Committee profile pages where the most relevant columns are not show in mobile. 
 
 <hr>
 
 -  Resolves #4668 
 - Also resolves issue #4656
 
<hr>

**Note:** At some  screen/device widths, the browser's and dataTables.responsive.js's  built in responsive logic cannot precisely calculate what width to set columns at without the possibility of some partially obscured columns (These columns will be accessible by scrolling/swiping, changing device orientation, or desktop screen resizing) There are many factors at play that determine the nuance of  how a tables columns are sized and hidden/shown:
  - The browsers native column width calculations
  - jQuery `dataTables.responsive.js` calculations
  - jQuery `dataTables.responsive.js` [responsive opts](https://datatables.net/reference/option/autoWidth) and [utility classe](https://datatables.net/extensions/responsive/classes)s that we add to columns in our js.

<hr>


### Required reviewers
one frontend, one UX

## Impacted areas of the application

modified:   fec/static/js/modules/table-columns.js
modified:   fec/static/scss/components/_data-container.scss
modified:  data/templates/elections.jinja
modified:   data/templates/partials/elections/about-this-election-tab.jinja
modified:   data/templates/partials/elections/election-data-and-compliance-tab.jinja

## Screenshots
(This was also tested on a real iphone)
![Jul-09-2021 01-04-22](https://user-images.githubusercontent.com/5572856/125474607-cbf38da7-8eda-45a9-b85e-38afa7185b71.gif)





## How to test [4668 ](https://github.com/fecgov/fec-cms/issues/4668)

- checkout `feature/4668-fix-show-receipts-on-mobile-elections`
- `npm run build`
- View an election page like http://127.0.0.1:8000/data/elections/senate/WI/2022/
- Switch to responsive view in inspector
- Choose `iphone 5/SE`(the size that the issue requestor was using)  and see for `Candidate financial totals` table, the  `Total receipts` is now visible instead of the `Party` column
- Swipe left to also see 'Total disbursements`  and `Cash on hand` (this was tested live on real  IPhone too)
- Change orientation to landscape to see all three columns.
- Regarding the partially obscured, but accessible columns you may see in other device sizes, please see "**Note**" above.

## How to test [4656](https://github.com/fecgov/fec-cms/issues/4656)
- Resize screen in desktop view to see that the cards on Election and Candidate profile pages  do not get cut off. 
  - Note: There is a slight overlap on the cards that happens at about 1000px (before it stacks at 940px), but I did not think is was worth having the whole thing stack at such a large breakpoint just to accommodate a slight overlap on a card. 940px seems large as it is. 

Should you desire, you can test it on your real iPhone or Surface using this technique: https://github.com/fecgov/fec-cms/wiki/Testing-a-dev-branch-on-iPhone,-Internet-Explorer-Windows,-Android