### PR TITLE
Update django to minor v3.1.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.1.12
+Django==3.1.13
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/fec-cms/issues/4752

Upgrade django python package to a minor version

### Required reviewers

Atleast one front-end developer approval is required

## How to test
- checkout `feature/4752-upgrade-django`
- run `pip install -r requirements.txt`
- run `snyk test --file=requirements.txt --package-manager=pip`
-  run `npm i` 
- run `npm run build`
- start server run `./manage.py runserver`
- check that the cms app works as expected on local env.
