### PR TITLE
Add leadership PAC sponsor info to datatable details panel

### DIFF
--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -126,7 +126,7 @@
         {# For Committee sponsor: #}
         {% if sponsor_candidates %}
         <tr>
-            <td class="figure__label">Committee sponsor:</td>
+            <td class="figure__label">Leadership PAC sponsor:</td>
             <td class="figure__value">
               {% for candidate in sponsor_candidates | reverse %}
               <div class='grid'>

--- a/fec/fec/static/js/templates/committees.hbs
+++ b/fec/fec/static/js/templates/committees.hbs
@@ -26,5 +26,12 @@
         {{organization_type_full}}
       {{/panelRow}}
     {{/if}}
+    {{#if sponsor_candidate_list}}
+      {{#panelRow "Leadership PAC sponsor"}}
+        {{#each sponsor_candidate_list}}
+          <a href="{{basePath}}/candidate/{{ sponsor_candidate_id }}/"><span class="leadership_pac_sponsor_name">{{ sponsor_candidate_name }}</span> ({{ sponsor_candidate_id }})</a>;<br />
+        {{/each}}
+      {{/panelRow}}
+    {{/if}}
   </table>
 </div>

--- a/fec/fec/static/js/templates/committees.hbs
+++ b/fec/fec/static/js/templates/committees.hbs
@@ -29,7 +29,7 @@
     {{#if sponsor_candidate_list}}
       {{#panelRow "Leadership PAC sponsor"}}
         {{#each sponsor_candidate_list}}
-          <a href="{{basePath}}/candidate/{{ sponsor_candidate_id }}/"><span class="leadership_pac_sponsor_name">{{ sponsor_candidate_name }}</span> ({{ sponsor_candidate_id }})</a>;<br />
+          <a href="{{basePath}}/candidate/{{ sponsor_candidate_id }}/"><span class="leadership_pac_sponsor_name">{{ sponsor_candidate_name }}</span> ({{ sponsor_candidate_id }})</a>{{#unless @last}};<br />{{/unless}}
         {{/each}}
       {{/panelRow}}
     {{/if}}


### PR DESCRIPTION
## Summary

- Resolves #4660 

Updated label on about this committee profile page to "Leadership PAC sponsor". Also added the leadership PAC sponsor information to the datatables details panel. 

### Required reviewers

1 UX
1 frontend or 1 backend developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Committee profile pages
- Committees datatable

## Screenshots

![Screen Shot 2021-07-12 at 2 41 17 PM](https://user-images.githubusercontent.com/12799132/125339651-83d1fb00-e31f-11eb-8d83-71d77a1adaa6.png)
![Screen Shot 2021-07-12 at 2 39 28 PM](https://user-images.githubusercontent.com/12799132/125339653-846a9180-e31f-11eb-9adc-759dad0b0d37.png)


## How to test

- check out this branch
- `npm run build`
- Go to the committees datatable and try a leadership PAC search. Example: http://localhost:8000/data/committees/?sponsor_candidate_id=S6CA00584
- Go to the committee profile about this committee section to check the new label for Leadership PAC sponsor. Ex: http://localhost:8000/data/committee/C00629071/?tab=about-committee 