### PR TITLE
Feature/4718 pac snapshot

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -63,6 +63,7 @@
             aria-selected="true">Financial Summary</a>
             {% if committee_type != 'I' %}
             <ul>
+              <li><a href="#committee-snapshot">Committee snapshot</a></li>
               <li><a href="#total-raised">Total raised</a></li>
               <li><a href="#total-spent">Total spent</a></li>
               <li><a href="#cash-summary">Cash summary</a></li>

--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -63,7 +63,7 @@
             aria-selected="true">Financial Summary</a>
             {% if committee_type != 'I' %}
             <ul>
-              <li><a href="#committee-snapshot">Committee snapshot</a></li>
+              {% if FEATURES.pac_snapshot %}<li><a href="#committee-snapshot">Committee snapshot</a></li>{% endif %}
               <li><a href="#total-raised">Total raised</a></li>
               <li><a href="#total-spent">Total spent</a></li>
               <li><a href="#cash-summary">Cash summary</a></li>

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -40,6 +40,10 @@
             border-bottom-style: solid;
             border-bottom-width: 2px 0;
           }
+          #committee-snapshot figcaption {
+            text-align: center;
+          }
+
           #committee-snapshot .donut text {
             font-family: 'karla';
             font-size: 1rem;
@@ -59,47 +63,146 @@
           #committee-snapshot .donut.spending text {
             fill: #35BDBB;
           }
+
+          @media(max-width:648px) {
+            #committee-snapshot figure {
+              display: flex;
+              align-items: center;
+            }
+            #committee-snapshot figure svg {
+              width: 33.3%;
+            }
+            #committee-snapshot figcaption {
+              text-align: left;
+              width: 66.6%;
+            }
+          }
         </style>
         <div class="entity__figure entity__figure--narrow" id="committee-snapshot">
           <div class="heading--section heading--with-action">
             <h3>Committee snapshot</h3>
           </div>
-          <p>Learn more about hybrid PACs like ACTBLUE.</p>
+          {% set coverage_str = totals.coverage_start_date|date ~' to ' ~totals.coverage_end_date|date %}
+
+          {% if totals.individual_contributions_percent %}
+            {% set rec_ind = totals.individual_contributions_percent|round|int %}
+            {% set rec_ind_class = 'raising' %}
+            {% set rec_ind_ring = '0 100' %}
+            {% set rec_ind_l = rec_ind ~'%' %}
+            {% if rec_ind > 100 %}
+            {% set rec_ind_l = '>100%' %}
+            {% set rec_ind_ring = '100 0' %}
+            {% elif rec_ind > 0 and rec_ind < 1 %}
+            {% set rec_ind_l = '<1%' %}
+            {% else %}
+            {% set rec_ind_ring = rec_ind ~ ' ' ~ (100 - rec_ind) %}
+            {% endif %}
+          {% else %}
+            {% set rec_ind_l = '!' %}
+            {% set rec_ind_ring = '0 100' %}
+            {% set rec_ind_class = '' %}
+          {% endif %}
+
+          {% if totals.party_and_other_committee_contributions_percent %}
+            {% set rec_com = totals.party_and_other_committee_contributions_percent|round|int %}
+            {% set rec_com_class = 'raising' %}
+            {% set rec_com_ring = '0 100' %}
+            {% set rec_com_l = rec_com ~'%' %}
+            {% if rec_com > 100 %}
+            {% set rec_com_l = '>100%' %}
+            {% set rec_com_ring = '100 0' %}
+            {% elif rec_com > 0 and rec_com < 1 %}
+            {% set rec_com_l = '<1%' %}
+            {% else %}
+            {% set rec_com_ring = rec_com ~ ' ' ~ (100 - rec_com) %}
+            {% endif %}
+          {% else %}
+            {% set rec_com_l = '!' %}
+            {% set rec_com_ring = '0 100' %}
+            {% set rec_com_class = '' %}
+          {% endif %}
+
+          {% if totals.contributions_ie_and_party_expenditures_made_percent %}
+            {% set dis_com = totals.contributions_ie_and_party_expenditures_made_percent|round|int %}
+            {% set dis_com_class = 'spending' %}
+            {% set dis_com_ring = '0 100' %}
+            {% set dis_com_l = dis_com ~'%' %}
+            {% if dis_com > 100 %}
+            {% set dis_com_l = '>100%' %}
+            {% set dis_com_ring = '100 0' %}
+            {% elif dis_com > 0 and dis_com < 1 %}
+            {% set dis_com_l = '<1%' %}
+            {% else %}
+            {% set dis_com_ring = dis_com ~ ' ' ~ (100 - dis_com) %}
+            {% endif %}
+          {% else %}
+            {% set dis_com_l = '!' %}
+            {% set dis_com_ring = '0 100' %}
+            {% set dis_com_class = '' %}
+          {% endif %}
+
+          {% if totals.operating_expenditures_percent %}
+            {% set dis_oe = totals.operating_expenditures_percent|round|int %}
+            {% set dis_oe_class = 'spending' %}
+            {% set dis_oe_ring = '0 100' %}
+            {% set dis_oe_l = dis_oe ~'%' %}
+            {% if dis_oe > 100 %}
+            {% set dis_oe_l = '>100%' %}
+            {% set dis_oe_ring = '100 0' %}
+            {% elif dis_oe > 0 and dis_oe < 1 %}
+            {% set dis_oe_l = '<1%' %}
+            {% else %}
+            {% set dis_oe_ring = dis_oe ~ ' ' ~ (100 - dis_oe) %}
+            {% endif %}
+          {% else %}
+            {% set dis_oe_l = '!' %}
+            {% set dis_oe_ring = '0 100' %}
+            {% set dis_oe_class = '' %}
+          {% endif %}
+
+
+          <p>Learn more about <span class="term" data-term="hybrid pac" title="Click to define" tabindex="0">hybrid PACs</span> like ACTBLUE.</p>
           <div class="tag__category">
-            <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{totals.coverage_end_date|date}}</div>
+            <div class="tag__item">Coverage dates: {{ coverage_str }}</div>
           </div>
-          <div>Total receipts: $ <div></div>| Total disbursements: $ <div></div>| Cash on hand: $<div></div></div>
+          <div>
+            <div>Total receipts: <strong>{{ totals.fed_receipts|currency }}</strong></div>
+            <div>|</div>
+            <div>Total disbursements: <strong>{{ totals.fed_disbursements|currency }}</strong></div>
+            <div>|</div>
+            <div>Cash on hand: <strong>{{ totals.last_cash_on_hand_end_period|currency }}</strong></div>
+          </div>
           <div class="grid grid--2-wide">
             <div class="grid__item">
               <h4 class="t-centered">Money raised</h4>
               <div class="grid grid--2-wide">
                 <div class="grid__item">
                   <figure>
-                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut raising" role="img" aria-labelledby="snap-raise-ind-t snap-raise-ind-d">
-                      <title id="snap-raise-ind-t">Percent raised from individual conributions during 2019-2020</title>
+                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut {{ rec_ind_class }}" role="img" aria-labelledby="snap-raise-ind-t snap-raise-ind-d">
+                      <title id="snap-raise-ind-t">Percent raised from individual conributions {{ coverage_str }}</title>
                       <desc id="snap-raise-ind-d">98% of money raised came from individual contributions</desc>
                       <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
                       <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
-                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke-width="3" stroke-dasharray="98 2" stroke-dashoffset="25"></circle>
+                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke-width="3" stroke-dasharray="{{ rec_ind_ring }}" stroke-dashoffset="25"></circle>
                       <g class="chart-text">
-                        <text x="50%" y="57%" text-anchor="middle">98%</text>
+                        <text x="50%" y="57%" text-anchor="middle">{{ rec_ind_l }}</text>
                       </g>
                     </svg>
-                    <figcaption class="t-centered">Percent raised in invididual contributions</figcaption>
+                    <figcaption>Percent raised in individual <span class="term" data-term="contribution" title="Click to define" tabindex="0">contributions</span></figcaption>
                   </figure>
                 </div>
                 <div class="grid__item">
                   <figure>
-                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut raising" aria-labelledby="snap-raise-com-t snap-raise-com-d">
-                      <title id="snap-raise-com-t">Percent raised from other federal political committees during 2019-2020</title>
-                      <desc id="snap-raise-com-d">0% of money raised came from other federal political committees during 2019-2020</desc>
+                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut {{ rec_com_class }}" aria-labelledby="snap-raise-com-t snap-raise-com-d">
+                      <title id="snap-raise-com-t">Percent raised from other federal political committees {{ coverage_str }}</title>
+                      <desc id="snap-raise-com-d">0% of money raised came from other federal political committees</desc>
                       <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
                       <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
                       <!-- The stroke-dashoffset should add up to 100, with the first value being the color -->
-                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F77B42" stroke-width="3" stroke-dasharray="0.1 99.9" stroke-dashoffset="25"></circle>
-                      <text x="50%" y="57%" text-anchor="middle">0%</text>
+                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F77B42" stroke-width="3" stroke-dasharray="{{ rec_com_ring }}" stroke-dashoffset="25"></circle>
+                      <text x="50%" y="57%" text-anchor="middle">{{ rec_com_l }}</text>
                     </svg>
-                    <figcaption class="t-centered">Percent raised in contributions from other federal political committees</figcaption>
+                    <figcaption>Percent raised in contributions from other federal <span class="term" data-term="political committee" title="Click to define" tabindex="0">political committees</span></figcaption>
                   </figure>
                 </div>
               </div>
@@ -109,31 +212,31 @@
               <div class="grid grid--2-wide">
                 <div class="grid__item">
                   <figure>
-                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut spending" role="img" aria-labelledby="snap-spend-com-t snap-spend-com-d">
-                      <title id="snap-spend-com-t">Percent spent on contributions to other federal political committees during 2019-2020</title>
-                      <desc id="snap-spend-com-d">96% of money spent went to other federal political committees during 2019-2020</desc>
+                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut {{ dis_com_class }}" role="img" aria-labelledby="snap-spend-com-t snap-spend-com-d">
+                      <title id="snap-spend-com-t">Percent spent on contributions to other federal political committees {{ coverage_str }}</title>
+                      <desc id="snap-spend-com-d">96% of money spent went to other federal political committees</desc>
                       <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
                       <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
-                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke-width="3" stroke-dasharray="96 4" stroke-dashoffset="25"></circle>
+                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke-width="3" stroke-dasharray="{{ dis_com_ring }}" stroke-dashoffset="25"></circle>
                       <g class="chart-text">
-                        <text x="50%" y="57%" text-anchor="middle">96%</text>
+                        <text x="50%" y="57%" text-anchor="middle">{{ dis_com_l }}</text>
                       </g>
                     </svg>
-                    <figcaption class="t-centered">Percent spent on contributions to other federal committees</figcaption>
+                    <figcaption>Percent spent on contributions to other <span class="term" data-term="national committee" title="Click to define" tabindex="0">federal committees</span></figcaption>
                   </figure>
                 </div>
                 <div class="grid__item">
                   <figure>
-                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut spending" role="img" aria-labelledby="snap-spend-ox-t snap-spend-ox-d">
-                      <title id="snap-spend-ox-t">Percent spent on operating expenditures during 2019-2020</title>
-                      <desc id="snap-spend-ox-d">96% of money spent on operating expenditures during 2019-2020</desc>
+                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut {{ dis_oe_class }}" role="img" aria-labelledby="snap-spend-ox-t snap-spend-ox-d">
+                      <title id="snap-spend-ox-t">Percent spent on operating expenditures {{ coverage_str }}</title>
+                      <desc id="snap-spend-ox-d">96% of money spent on operating expenditures</desc>
                       <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
                       <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
                       <!-- The stroke-dashoffset should add up to 100, with the first value being the color -->
-                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F77B42" stroke-width="3" stroke-dasharray="0.1 99.9" stroke-dashoffset="25"></circle>
-                      <text x="50%" y="57%" text-anchor="middle">&lt;1%</text>
+                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F77B42" stroke-width="3" stroke-dasharray="{{ dis_oe_ring }}" stroke-dashoffset="25"></circle>
+                      <text x="50%" y="57%" text-anchor="middle">{{ dis_oe_l }}</text>
                     </svg>
-                    <figcaption class="t-centered">Percent spent on operating expenditures</figcaption>
+                    <figcaption>Percent spent on <span class="term" data-term="operating expenditures" title="Click to define" tabindex="0">operating expenditures</span></figcaption>
                   </figure>
                 </div>
               </div>

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -40,8 +40,8 @@
             <h3>Committee snapshot</h3>
           </div>
 
-          {% set shared_circle_props = 'cx=21 cy=21 r=15.91549430918954' %}
-          {% set shared_text_props = 'x=50% y=57%' %}
+          {% set shared_circle_props = 'cx="21" cy="21" r="15.91549430918954"' %}
+          {% set shared_text_props = 'x="50%" y="57%"' %}
           {% set coverage_str = totals.coverage_start_date|date ~' to ' ~totals.coverage_end_date|date %}
 
           {% if totals.individual_contributions_percent %}
@@ -156,11 +156,11 @@
                     <svg viewBox="0 0 42 42" class="donut {{ rec_ind_class }}" role="img" aria-labelledby="snap-raise-ind-t snap-raise-ind-d">
                       <title id="snap-raise-ind-t">Percent raised from individual conributions {{ coverage_str }}</title>
                       <desc id="snap-raise-ind-d">98% of money raised came from individual contributions</desc>
-                      <circle class="center" {{ shared_circle_props }}></circle>
-                      <circle class="ring" {{ shared_circle_props }}></circle>
-                      <circle class="segment" {{ shared_circle_props }} stroke-dasharray="{{ rec_ind_ring }}"></circle>
+                      <circle class="center" {{ shared_circle_props|safe }}></circle>
+                      <circle class="ring" {{ shared_circle_props|safe }}></circle>
+                      <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ rec_ind_ring }}"></circle>
                       <g class="chart-text">
-                        <text {{ shared_text_props }}>{{ rec_ind_l }}</text>
+                        <text {{ shared_text_props|safe }}>{{ rec_ind_l }}</text>
                       </g>
                     </svg>
                     <figcaption>Percent raised in individual <span class="term" data-term="contribution" title="Click to define" tabindex="0">contributions</span></figcaption>
@@ -171,11 +171,11 @@
                     <svg viewBox="0 0 42 42" class="donut {{ rec_com_class }}" aria-labelledby="snap-raise-com-t snap-raise-com-d">
                       <title id="snap-raise-com-t">Percent raised from other federal political committees {{ coverage_str }}</title>
                       <desc id="snap-raise-com-d">0% of money raised came from other federal political committees</desc>
-                      <circle class="center" {{ shared_circle_props }}></circle>
-                      <circle class="ring" {{ shared_circle_props }}></circle>
+                      <circle class="center" {{ shared_circle_props|safe }}></circle>
+                      <circle class="ring" {{ shared_circle_props|safe }}></circle>
                       <!-- The stroke-dashoffset should add up to 100, with the first value being the color -->
-                      <circle class="segment" {{ shared_circle_props }} stroke-dasharray="{{ rec_com_ring }}"></circle>
-                      <text {{ shared_text_props }}>{{ rec_com_l }}</text>
+                      <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ rec_com_ring }}"></circle>
+                      <text {{ shared_text_props|safe }}>{{ rec_com_l }}</text>
                     </svg>
                     <figcaption>Percent raised in contributions from other federal <span class="term" data-term="political committee" title="Click to define" tabindex="0">political committees</span></figcaption>
                   </figure>
@@ -190,11 +190,11 @@
                     <svg viewBox="0 0 42 42" class="donut {{ dis_com_class }}" role="img" aria-labelledby="snap-spend-com-t snap-spend-com-d">
                       <title id="snap-spend-com-t">Percent spent on contributions to other federal political committees {{ coverage_str }}</title>
                       <desc id="snap-spend-com-d">96% of money spent went to other federal political committees</desc>
-                      <circle class="center"{{ shared_circle_props }}></circle>
-                      <circle class="ring"{{ shared_circle_props }}></circle>
-                      <circle class="segment" {{ shared_circle_props }} stroke-dasharray="{{ dis_com_ring }}"></circle>
+                      <circle class="center"{{ shared_circle_props|safe }}></circle>
+                      <circle class="ring"{{ shared_circle_props|safe }}></circle>
+                      <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ dis_com_ring }}"></circle>
                       <g class="chart-text">
-                        <text {{ shared_text_props }}>{{ dis_com_l }}</text>
+                        <text {{ shared_text_props|safe }}>{{ dis_com_l }}</text>
                       </g>
                     </svg>
                     <figcaption>Percent spent on contributions to other <span class="term" data-term="national committee" title="Click to define" tabindex="0">federal committees</span></figcaption>
@@ -205,11 +205,11 @@
                     <svg viewBox="0 0 42 42" class="donut {{ dis_oe_class }}" role="img" aria-labelledby="snap-spend-ox-t snap-spend-ox-d">
                       <title id="snap-spend-ox-t">Percent spent on operating expenditures {{ coverage_str }}</title>
                       <desc id="snap-spend-ox-d">96% of money spent on operating expenditures</desc>
-                      <circle class="center" {{ shared_circle_props }}></circle>
-                      <circle class="ring" {{ shared_circle_props }}></circle>
+                      <circle class="center" {{ shared_circle_props|safe }}></circle>
+                      <circle class="ring" {{ shared_circle_props|safe }}></circle>
                       <!-- The stroke-dashoffset should add up to 100, with the first value being the color -->
-                      <circle class="segment" {{ shared_circle_props }} stroke-dasharray="{{ dis_oe_ring }}"></circle>
-                      <text {{ shared_text_props }}>{{ dis_oe_l }}</text>
+                      <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ dis_oe_ring }}"></circle>
+                      <text {{ shared_text_props|safe }}>{{ dis_oe_l }}</text>
                     </svg>
                     <figcaption>Percent spent on <span class="term" data-term="operating expenditures" title="Click to define" tabindex="0">operating expenditures</span></figcaption>
                   </figure>

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -34,6 +34,7 @@
             {{ missing_transferred.missing_transferred_committee_message(former_committee_name, former_authorized_candidate_name, former_authorized_candidate_id) }}
           </div>
         {% endif %}
+        {% if FEATURES.pac_snapshot %}
         <div class="entity__figure entity__figure--narrow" id="committee-snapshot">
           <div class="heading--section">
             <h3>Committee snapshot</h3>
@@ -243,6 +244,8 @@
             </div>
           </div>
         </div>
+        {# end pac_snapshot (next line) #}
+        {% endif %}
         <div class="entity__figure entity__figure--narrow" id="total-raised">
           <div class="heading--section heading--with-action">
             <h3 class="heading__left">Total raised</h3>

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -133,7 +133,9 @@
             {% endif %}
           {% endif %}
 
+          {% if com_type_glossary && com_type_text %}
           <p>Learn more about <span class="term" data-term="{{ com_type_glossary }}" title="Click to define" tabindex="0">{{ com_type_text }}</span> like {{ committee.name }}.</p>
+          {% endif %}
           <div class="tag__category">
             <div class="tag__item">Coverage dates: {{ coverage_str }}</div>
           </div>

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -44,18 +44,20 @@
           {% set shared_text_props = 'x="50%" y="57%"' %}
           {% set coverage_str = totals.coverage_start_date|date ~' to ' ~totals.coverage_end_date|date %}
 
-          {% if totals.individual_contributions_percent %}
-            {% set rec_ind = totals.individual_contributions_percent|round|int %}
+          {% if totals.individual_contributions_percent or totals.individual_contributions_percent == 0 %}
+            {% set rec_ind = totals.individual_contributions_percent %}
             {% set rec_ind_class = 'raising' %}
             {% set rec_ind_ring = '0 100' %}
-            {% set rec_ind_l = rec_ind ~'%' %}
-            {% if rec_ind > 100 %}
-            {% set rec_ind_l = '>100%' %}
-            {% set rec_ind_ring = '100 0' %}
+            {% set rec_ind_l = rec_ind|round|int ~'%' %}
+            {% if rec_ind == 0 %}
+              {% set rec_ind_l = '0%' %}
+            {% elif rec_ind > 100 %}
+              {% set rec_ind_l = '>100%' %}
+              {% set rec_ind_ring = '100 0' %}
             {% elif rec_ind > 0 and rec_ind < 1 %}
-            {% set rec_ind_l = '<1%' %}
+              {% set rec_ind_l = '<1%' %}
             {% else %}
-            {% set rec_ind_ring = rec_ind ~ ' ' ~ (100 - rec_ind) %}
+              {% set rec_ind_ring = rec_ind|round|int ~ ' ' ~ (100 - rec_ind|round|int) %}
             {% endif %}
           {% else %}
             {% set rec_ind_l = '!' %}
@@ -63,18 +65,20 @@
             {% set rec_ind_class = '' %}
           {% endif %}
 
-          {% if totals.party_and_other_committee_contributions_percent %}
+          {% if totals.party_and_other_committee_contributions_percent or totals.party_and_other_committee_contributions_percent == 0 %}
             {% set rec_com = totals.party_and_other_committee_contributions_percent|round|int %}
             {% set rec_com_class = 'raising' %}
             {% set rec_com_ring = '0 100' %}
             {% set rec_com_l = rec_com ~'%' %}
-            {% if rec_com > 100 %}
-            {% set rec_com_l = '>100%' %}
-            {% set rec_com_ring = '100 0' %}
+            {% if rec_com == 0 %}
+              {% set rec_com_l = '0%' %}
+            {% elif rec_com > 100 %}
+              {% set rec_com = '>100%' %}
+              {% set rec_com_ring = '100 0' %}
             {% elif rec_com > 0 and rec_com < 1 %}
-            {% set rec_com_l = '<1%' %}
+              {% set rec_com_l = '<1%' %}
             {% else %}
-            {% set rec_com_ring = rec_com ~ ' ' ~ (100 - rec_com) %}
+              {% set rec_com_ring = rec_com ~ ' ' ~ (100 - rec_com) %}
             {% endif %}
           {% else %}
             {% set rec_com_l = '!' %}
@@ -82,18 +86,20 @@
             {% set rec_com_class = '' %}
           {% endif %}
 
-          {% if totals.contributions_ie_and_party_expenditures_made_percent %}
+          {% if totals.contributions_ie_and_party_expenditures_made_percent or totals.contributions_ie_and_party_expenditures_made_percent == 0 %}
             {% set dis_com = totals.contributions_ie_and_party_expenditures_made_percent|round|int %}
             {% set dis_com_class = 'spending' %}
             {% set dis_com_ring = '0 100' %}
             {% set dis_com_l = dis_com ~'%' %}
-            {% if dis_com > 100 %}
-            {% set dis_com_l = '>100%' %}
-            {% set dis_com_ring = '100 0' %}
+            {% if dis_com == 0 %}
+              {% set dis_com_l = '0%' %}
+            {% elif dis_com > 100 %}
+              {% set dis_com_l = '>100%' %}
+              {% set dis_com_ring = '100 0' %}
             {% elif dis_com > 0 and dis_com < 1 %}
-            {% set dis_com_l = '<1%' %}
+              {% set dis_com_l = '<1%' %}
             {% else %}
-            {% set dis_com_ring = dis_com ~ ' ' ~ (100 - dis_com) %}
+              {% set dis_com_ring = dis_com ~ ' ' ~ (100 - dis_com) %}
             {% endif %}
           {% else %}
             {% set dis_com_l = '!' %}
@@ -101,18 +107,20 @@
             {% set dis_com_class = '' %}
           {% endif %}
 
-          {% if totals.operating_expenditures_percent %}
+          {% if totals.operating_expenditures_percent or totals.operating_expenditures_percent == 0 %}
             {% set dis_oe = totals.operating_expenditures_percent|round|int %}
             {% set dis_oe_class = 'spending' %}
             {% set dis_oe_ring = '0 100' %}
             {% set dis_oe_l = dis_oe ~'%' %}
-            {% if dis_oe > 100 %}
-            {% set dis_oe_l = '>100%' %}
-            {% set dis_oe_ring = '100 0' %}
+            {% if dis_oe == 0 %}
+              {% set dis_oe_l = '0%' %}
+            {% elif dis_oe > 100 %}
+              {% set dis_oe_l = '>100%' %}
+              {% set dis_oe_ring = '100 0' %}
             {% elif dis_oe > 0 and dis_oe < 1 %}
-            {% set dis_oe_l = '<1%' %}
+              {% set dis_oe_l = '<1%' %}
             {% else %}
-            {% set dis_oe_ring = dis_oe ~ ' ' ~ (100 - dis_oe) %}
+              {% set dis_oe_ring = dis_oe ~ ' ' ~ (100 - dis_oe) %}
             {% endif %}
           {% else %}
             {% set dis_oe_l = '!' %}

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -34,54 +34,13 @@
             {{ missing_transferred.missing_transferred_committee_message(former_committee_name, former_authorized_candidate_name, former_authorized_candidate_id) }}
           </div>
         {% endif %}
-        <style>
-          #committee-snapshot .tag__category {
-            border-bottom-color: #112e51;
-            border-bottom-style: solid;
-            border-bottom-width: 2px 0;
-          }
-          #committee-snapshot figcaption {
-            text-align: center;
-          }
-
-          #committee-snapshot .donut text {
-            font-family: 'karla';
-            font-size: 1rem;
-            font-weight: bold;
-          }
-
-          #committee-snapshot .donut.raising .segment {
-            stroke: #F77B42;
-          }
-          #committee-snapshot .donut.raising text {
-            fill: #F77B42;
-          }
-
-          #committee-snapshot .donut.spending .segment {
-            stroke: #35BDBB;
-          }
-          #committee-snapshot .donut.spending text {
-            fill: #35BDBB;
-          }
-
-          @media(max-width:648px) {
-            #committee-snapshot figure {
-              display: flex;
-              align-items: center;
-            }
-            #committee-snapshot figure svg {
-              width: 33.3%;
-            }
-            #committee-snapshot figcaption {
-              text-align: left;
-              width: 66.6%;
-            }
-          }
-        </style>
         <div class="entity__figure entity__figure--narrow" id="committee-snapshot">
-          <div class="heading--section heading--with-action">
+          <div class="heading--section">
             <h3>Committee snapshot</h3>
           </div>
+
+          {% set shared_circle_props = 'cx=21 cy=21 r=15.91549430918954' %}
+          {% set shared_text_props = 'x=50% y=57%' %}
           {% set coverage_str = totals.coverage_start_date|date ~' to ' ~totals.coverage_end_date|date %}
 
           {% if totals.individual_contributions_percent %}
@@ -160,17 +119,30 @@
             {% set dis_oe_class = '' %}
           {% endif %}
 
+          {# set the meters' max value to the greater of receipts or disbursements #}
+          {% if totals.fed_receipts and totals.fed_disbursements and totals.last_cash_on_hand_end_period %}
+            {% if totals.fed_receipts >= totals.fed_disbursements %}
+              {% set meters_max = totals.fed_receipts %}
+            {% else %}
+              {% set meters_max = totals.fed_disbursements %}
+            {% endif %}
+            {# but override both if COH is larger for some reason #}
+            {% if totals.last_cash_on_hand_end_period > meters_max %}
+              {% set meters_max = totals.last_cash_on_hand_end_period %}
+            {% endif %}
+          {% endif %}
 
-          <p>Learn more about <span class="term" data-term="hybrid pac" title="Click to define" tabindex="0">hybrid PACs</span> like ACTBLUE.</p>
+          <p>Learn more about <span class="term" data-term="{{ com_type_glossary }}" title="Click to define" tabindex="0">{{ com_type_text }}</span> like {{ committee.name }}.</p>
           <div class="tag__category">
             <div class="tag__item">Coverage dates: {{ coverage_str }}</div>
           </div>
-          <div>
-            <div>Total receipts: <strong>{{ totals.fed_receipts|currency }}</strong></div>
-            <div>|</div>
-            <div>Total disbursements: <strong>{{ totals.fed_disbursements|currency }}</strong></div>
-            <div>|</div>
-            <div>Cash on hand: <strong>{{ totals.last_cash_on_hand_end_period|currency }}</strong></div>
+          <div class="snapshot-summary">
+            <span class="t-data t-bold">Total receipts: <span class="t-normal">{{ totals.fed_receipts|currency }}</span></span>
+            <meter min="0" max="{{ meters_max }}" value="{{ totals.fed_receipts }}" title="US Dollars" data-cat="raising"></meter>
+            <span class="t-data t-bold">Total disbursements: <span class="t-normal">{{ totals.fed_disbursements|currency }}</span></span>
+            <meter min="0" max="{{ meters_max }}" value="{{ totals.fed_disbursements }}" title="US Dollars" data-cat="spending"></meter>
+            <span class="t-data t-bold">Cash on hand: <span class="t-normal">{{ totals.last_cash_on_hand_end_period|currency }}</span></span>
+            <meter min="0" max="{{ meters_max }}" value="{{ totals.last_cash_on_hand_end_period }}" title="US Dollars" data-cat="cash"></meter>
           </div>
           <div class="grid grid--2-wide">
             <div class="grid__item">
@@ -178,14 +150,14 @@
               <div class="grid grid--2-wide">
                 <div class="grid__item">
                   <figure>
-                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut {{ rec_ind_class }}" role="img" aria-labelledby="snap-raise-ind-t snap-raise-ind-d">
+                    <svg viewBox="0 0 42 42" class="donut {{ rec_ind_class }}" role="img" aria-labelledby="snap-raise-ind-t snap-raise-ind-d">
                       <title id="snap-raise-ind-t">Percent raised from individual conributions {{ coverage_str }}</title>
                       <desc id="snap-raise-ind-d">98% of money raised came from individual contributions</desc>
-                      <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
-                      <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
-                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke-width="3" stroke-dasharray="{{ rec_ind_ring }}" stroke-dashoffset="25"></circle>
+                      <circle class="center" {{ shared_circle_props }}></circle>
+                      <circle class="ring" {{ shared_circle_props }}></circle>
+                      <circle class="segment" {{ shared_circle_props }} stroke-dasharray="{{ rec_ind_ring }}"></circle>
                       <g class="chart-text">
-                        <text x="50%" y="57%" text-anchor="middle">{{ rec_ind_l }}</text>
+                        <text {{ shared_text_props }}>{{ rec_ind_l }}</text>
                       </g>
                     </svg>
                     <figcaption>Percent raised in individual <span class="term" data-term="contribution" title="Click to define" tabindex="0">contributions</span></figcaption>
@@ -193,14 +165,14 @@
                 </div>
                 <div class="grid__item">
                   <figure>
-                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut {{ rec_com_class }}" aria-labelledby="snap-raise-com-t snap-raise-com-d">
+                    <svg viewBox="0 0 42 42" class="donut {{ rec_com_class }}" aria-labelledby="snap-raise-com-t snap-raise-com-d">
                       <title id="snap-raise-com-t">Percent raised from other federal political committees {{ coverage_str }}</title>
                       <desc id="snap-raise-com-d">0% of money raised came from other federal political committees</desc>
-                      <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
-                      <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
+                      <circle class="center" {{ shared_circle_props }}></circle>
+                      <circle class="ring" {{ shared_circle_props }}></circle>
                       <!-- The stroke-dashoffset should add up to 100, with the first value being the color -->
-                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F77B42" stroke-width="3" stroke-dasharray="{{ rec_com_ring }}" stroke-dashoffset="25"></circle>
-                      <text x="50%" y="57%" text-anchor="middle">{{ rec_com_l }}</text>
+                      <circle class="segment" {{ shared_circle_props }} stroke-dasharray="{{ rec_com_ring }}"></circle>
+                      <text {{ shared_text_props }}>{{ rec_com_l }}</text>
                     </svg>
                     <figcaption>Percent raised in contributions from other federal <span class="term" data-term="political committee" title="Click to define" tabindex="0">political committees</span></figcaption>
                   </figure>
@@ -212,14 +184,14 @@
               <div class="grid grid--2-wide">
                 <div class="grid__item">
                   <figure>
-                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut {{ dis_com_class }}" role="img" aria-labelledby="snap-spend-com-t snap-spend-com-d">
+                    <svg viewBox="0 0 42 42" class="donut {{ dis_com_class }}" role="img" aria-labelledby="snap-spend-com-t snap-spend-com-d">
                       <title id="snap-spend-com-t">Percent spent on contributions to other federal political committees {{ coverage_str }}</title>
                       <desc id="snap-spend-com-d">96% of money spent went to other federal political committees</desc>
-                      <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
-                      <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
-                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke-width="3" stroke-dasharray="{{ dis_com_ring }}" stroke-dashoffset="25"></circle>
+                      <circle class="center"{{ shared_circle_props }}></circle>
+                      <circle class="ring"{{ shared_circle_props }}></circle>
+                      <circle class="segment" {{ shared_circle_props }} stroke-dasharray="{{ dis_com_ring }}"></circle>
                       <g class="chart-text">
-                        <text x="50%" y="57%" text-anchor="middle">{{ dis_com_l }}</text>
+                        <text {{ shared_text_props }}>{{ dis_com_l }}</text>
                       </g>
                     </svg>
                     <figcaption>Percent spent on contributions to other <span class="term" data-term="national committee" title="Click to define" tabindex="0">federal committees</span></figcaption>
@@ -227,14 +199,14 @@
                 </div>
                 <div class="grid__item">
                   <figure>
-                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut {{ dis_oe_class }}" role="img" aria-labelledby="snap-spend-ox-t snap-spend-ox-d">
+                    <svg viewBox="0 0 42 42" class="donut {{ dis_oe_class }}" role="img" aria-labelledby="snap-spend-ox-t snap-spend-ox-d">
                       <title id="snap-spend-ox-t">Percent spent on operating expenditures {{ coverage_str }}</title>
                       <desc id="snap-spend-ox-d">96% of money spent on operating expenditures</desc>
-                      <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
-                      <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
+                      <circle class="center" {{ shared_circle_props }}></circle>
+                      <circle class="ring" {{ shared_circle_props }}></circle>
                       <!-- The stroke-dashoffset should add up to 100, with the first value being the color -->
-                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F77B42" stroke-width="3" stroke-dasharray="{{ dis_oe_ring }}" stroke-dashoffset="25"></circle>
-                      <text x="50%" y="57%" text-anchor="middle">{{ dis_oe_l }}</text>
+                      <circle class="segment" {{ shared_circle_props }} stroke-dasharray="{{ dis_oe_ring }}"></circle>
+                      <text {{ shared_text_props }}>{{ dis_oe_l }}</text>
                     </svg>
                     <figcaption>Percent spent on <span class="term" data-term="operating expenditures" title="Click to define" tabindex="0">operating expenditures</span></figcaption>
                   </figure>
@@ -242,9 +214,13 @@
               </div>
             </div>
           </div>
-          <div class="heading--with-action">
-            <p class="heading__left t-note">The percentages shown do not represent 100% of this committee's activity. Refer to the tables that follow for a complete breakdown of raising and spending.</p>
-            <button class="heading__right button--alt js-methodology" data-a11y-dialog-show="methodology-committee-snapshot">Methodology</button>
+          <div class="footer-methodology">
+            <p class="t-note">
+              The percentages shown do not represent 100% of this committee's activity. Refer to the tables that follow for a complete breakdown of raising and spending.
+            </p>
+            <div>
+              <button class="button--alt js-methodology" data-a11y-dialog-show="methodology-committee-snapshot">Methodology</button>
+            </div>
           </div>
           <div class="js-modal modal" id="methodology-committee-snapshot" aria-hidden="true">
             <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide=""></div>

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -34,6 +34,136 @@
             {{ missing_transferred.missing_transferred_committee_message(former_committee_name, former_authorized_candidate_name, former_authorized_candidate_id) }}
           </div>
         {% endif %}
+        <style>
+          #committee-snapshot .tag__category {
+            border-bottom-color: #112e51;
+            border-bottom-style: solid;
+            border-bottom-width: 2px 0;
+          }
+          #committee-snapshot .donut text {
+            font-family: 'karla';
+            font-size: 1rem;
+            font-weight: bold;
+          }
+
+          #committee-snapshot .donut.raising .segment {
+            stroke: #F77B42;
+          }
+          #committee-snapshot .donut.raising text {
+            fill: #F77B42;
+          }
+
+          #committee-snapshot .donut.spending .segment {
+            stroke: #35BDBB;
+          }
+          #committee-snapshot .donut.spending text {
+            fill: #35BDBB;
+          }
+        </style>
+        <div class="entity__figure entity__figure--narrow" id="committee-snapshot">
+          <div class="heading--section heading--with-action">
+            <h3>Committee snapshot</h3>
+          </div>
+          <p>Learn more about hybrid PACs like ACTBLUE.</p>
+          <div class="tag__category">
+            <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{totals.coverage_end_date|date}}</div>
+          </div>
+          <div>Total receipts: $ <div></div>| Total disbursements: $ <div></div>| Cash on hand: $<div></div></div>
+          <div class="grid grid--2-wide">
+            <div class="grid__item">
+              <h4 class="t-centered">Money raised</h4>
+              <div class="grid grid--2-wide">
+                <div class="grid__item">
+                  <figure>
+                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut raising" role="img" aria-labelledby="snap-raise-ind-t snap-raise-ind-d">
+                      <title id="snap-raise-ind-t">Percent raised from individual conributions during 2019-2020</title>
+                      <desc id="snap-raise-ind-d">98% of money raised came from individual contributions</desc>
+                      <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
+                      <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
+                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke-width="3" stroke-dasharray="98 2" stroke-dashoffset="25"></circle>
+                      <g class="chart-text">
+                        <text x="50%" y="57%" text-anchor="middle">98%</text>
+                      </g>
+                    </svg>
+                    <figcaption class="t-centered">Percent raised in invididual contributions</figcaption>
+                  </figure>
+                </div>
+                <div class="grid__item">
+                  <figure>
+                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut raising" aria-labelledby="snap-raise-com-t snap-raise-com-d">
+                      <title id="snap-raise-com-t">Percent raised from other federal political committees during 2019-2020</title>
+                      <desc id="snap-raise-com-d">0% of money raised came from other federal political committees during 2019-2020</desc>
+                      <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
+                      <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
+                      <!-- The stroke-dashoffset should add up to 100, with the first value being the color -->
+                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F77B42" stroke-width="3" stroke-dasharray="0.1 99.9" stroke-dashoffset="25"></circle>
+                      <text x="50%" y="57%" text-anchor="middle">0%</text>
+                    </svg>
+                    <figcaption class="t-centered">Percent raised in contributions from other federal political committees</figcaption>
+                  </figure>
+                </div>
+              </div>
+            </div>
+            <div class="grid__item">
+              <h4 class="t-centered">Money spent</h4>
+              <div class="grid grid--2-wide">
+                <div class="grid__item">
+                  <figure>
+                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut spending" role="img" aria-labelledby="snap-spend-com-t snap-spend-com-d">
+                      <title id="snap-spend-com-t">Percent spent on contributions to other federal political committees during 2019-2020</title>
+                      <desc id="snap-spend-com-d">96% of money spent went to other federal political committees during 2019-2020</desc>
+                      <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
+                      <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
+                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke-width="3" stroke-dasharray="96 4" stroke-dashoffset="25"></circle>
+                      <g class="chart-text">
+                        <text x="50%" y="57%" text-anchor="middle">96%</text>
+                      </g>
+                    </svg>
+                    <figcaption class="t-centered">Percent spent on contributions to other federal committees</figcaption>
+                  </figure>
+                </div>
+                <div class="grid__item">
+                  <figure>
+                    <svg width="100%" height="100%" viewBox="0 0 42 42" class="donut spending" role="img" aria-labelledby="snap-spend-ox-t snap-spend-ox-d">
+                      <title id="snap-spend-ox-t">Percent spent on operating expenditures during 2019-2020</title>
+                      <desc id="snap-spend-ox-d">96% of money spent on operating expenditures during 2019-2020</desc>
+                      <circle class="center" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
+                      <circle class="ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F1F1F1" stroke-width="3"></circle>
+                      <!-- The stroke-dashoffset should add up to 100, with the first value being the color -->
+                      <circle class="segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#F77B42" stroke-width="3" stroke-dasharray="0.1 99.9" stroke-dashoffset="25"></circle>
+                      <text x="50%" y="57%" text-anchor="middle">&lt;1%</text>
+                    </svg>
+                    <figcaption class="t-centered">Percent spent on operating expenditures</figcaption>
+                  </figure>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="heading--with-action">
+            <p class="heading__left t-note">The percentages shown do not represent 100% of this committee's activity. Refer to the tables that follow for a complete breakdown of raising and spending.</p>
+            <button class="heading__right button--alt js-methodology" data-a11y-dialog-show="methodology-committee-snapshot">Methodology</button>
+          </div>
+          <div class="js-modal modal" id="methodology-committee-snapshot" aria-hidden="true">
+            <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide=""></div>
+            <div role="dialog" class="modal__content" aria-labelledby="raised-modal-title">
+              <div role="document">
+                <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide="" title="Close this dialog window"></button>
+                <h2 id="raised-modal-title">Methodology</h2>
+                <strong>Receipts</strong>
+                <p>Percentage contributions from individuals</p>
+                <ul><li>Total individual contributions divided by total receipts (Form 3X Line 11(a)(iii) divided by Line 19)</li></ul>
+
+                <p>Contributions from party committees plus contributions from other federal committees divided by total receipts (Form 3X Line 11(b) + Line 11(c) divided by Line 19)</p>
+                <ul><li><strong>The language under the doughnut could be something like, "percent raised from contrbutions from PACS and party committees."</strong></li></ul>
+                <strong>Disbursements</strong>
+                <p>Percentage IEs, federal candidate contributions and party coordinated expenditures</p>
+                <ul><li>Contributions to federal candidates plus independent expenditures plus party coordinated expenditures divided by total disbursements (Form 3X Line 23 + 24 + 25 divided by Line 31)</li></ul>
+                <p>Percentage operating expenditures</p>
+                <ul><li>Total operating expenditures divided by total disbursements (Form 3X Line 21(c) divided by Line 31)</li></ul>
+              </div>
+            </div>
+          </div>
+        </div>
         <div class="entity__figure entity__figure--narrow" id="total-raised">
           <div class="heading--section heading--with-action">
             <h3 class="heading__left">Total raised</h3>

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -133,7 +133,7 @@
             {% endif %}
           {% endif %}
 
-          {% if com_type_glossary && com_type_text %}
+          {% if com_type_glossary and com_type_text %}
           <p>Learn more about <span class="term" data-term="{{ com_type_glossary }}" title="Click to define" tabindex="0">{{ com_type_text }}</span> like {{ committee.name }}.</p>
           {% endif %}
           <div class="tag__category">

--- a/fec/data/templates/partials/committee/financial-summary.jinja
+++ b/fec/data/templates/partials/committee/financial-summary.jinja
@@ -148,80 +148,90 @@
             <div class="tag__item">Coverage dates: {{ coverage_str }}</div>
           </div>
           <div class="snapshot-summary">
-            <span class="t-data t-bold">Total receipts: <span class="t-normal">{{ totals.fed_receipts|currency }}</span></span>
+            <span class="t-data t-bold">Total receipts: <span class="t-normal">{{ totals.fed_receipts|currency_rounded }}</span></span>
             <meter min="0" max="{{ meters_max }}" value="{{ totals.fed_receipts }}" title="US Dollars" data-cat="raising"></meter>
-            <span class="t-data t-bold">Total disbursements: <span class="t-normal">{{ totals.fed_disbursements|currency }}</span></span>
+            <span class="t-data t-bold">Total disbursements: <span class="t-normal">{{ totals.fed_disbursements|currency_rounded }}</span></span>
             <meter min="0" max="{{ meters_max }}" value="{{ totals.fed_disbursements }}" title="US Dollars" data-cat="spending"></meter>
-            <span class="t-data t-bold">Cash on hand: <span class="t-normal">{{ totals.last_cash_on_hand_end_period|currency }}</span></span>
+            <span class="t-data t-bold">Cash on hand: <span class="t-normal">{{ totals.last_cash_on_hand_end_period|currency_rounded }}</span></span>
             <meter min="0" max="{{ meters_max }}" value="{{ totals.last_cash_on_hand_end_period }}" title="US Dollars" data-cat="cash"></meter>
           </div>
-          <div class="grid grid--2-wide">
-            <div class="grid__item">
-              <h4 class="t-centered">Money raised</h4>
-              <div class="grid grid--2-wide">
-                <div class="grid__item">
-                  <figure>
-                    <svg viewBox="0 0 42 42" class="donut {{ rec_ind_class }}" role="img" aria-labelledby="snap-raise-ind-t snap-raise-ind-d">
-                      <title id="snap-raise-ind-t">Percent raised from individual conributions {{ coverage_str }}</title>
-                      <desc id="snap-raise-ind-d">98% of money raised came from individual contributions</desc>
-                      <circle class="center" {{ shared_circle_props|safe }}></circle>
-                      <circle class="ring" {{ shared_circle_props|safe }}></circle>
-                      <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ rec_ind_ring }}"></circle>
-                      <g class="chart-text">
-                        <text {{ shared_text_props|safe }}>{{ rec_ind_l }}</text>
-                      </g>
-                    </svg>
-                    <figcaption>Percent raised in individual <span class="term" data-term="contribution" title="Click to define" tabindex="0">contributions</span></figcaption>
-                  </figure>
-                </div>
-                <div class="grid__item">
-                  <figure>
-                    <svg viewBox="0 0 42 42" class="donut {{ rec_com_class }}" aria-labelledby="snap-raise-com-t snap-raise-com-d">
-                      <title id="snap-raise-com-t">Percent raised from other federal political committees {{ coverage_str }}</title>
-                      <desc id="snap-raise-com-d">0% of money raised came from other federal political committees</desc>
-                      <circle class="center" {{ shared_circle_props|safe }}></circle>
-                      <circle class="ring" {{ shared_circle_props|safe }}></circle>
-                      <!-- The stroke-dashoffset should add up to 100, with the first value being the color -->
-                      <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ rec_com_ring }}"></circle>
-                      <text {{ shared_text_props|safe }}>{{ rec_com_l }}</text>
-                    </svg>
-                    <figcaption>Percent raised in contributions from other federal <span class="term" data-term="political committee" title="Click to define" tabindex="0">political committees</span></figcaption>
-                  </figure>
-                </div>
+          <div class="donuts-all">
+            <div class="donuts-pair">
+              <h4 class="donuts-head t-centered">Money raised</h4>
+              <div class="donut-cell">
+                <figure>
+                  <svg viewBox="0 0 42 42" class="donut {{ rec_ind_class }}" role="img" aria-labelledby="snap-raise-ind-t snap-raise-ind-d">
+                    <title id="snap-raise-ind-t">Percent raised from individual contributions {{ coverage_str }}</title>
+                    <desc id="snap-raise-ind-d">{% if rec_ind_l != '!' %}{{ rec_ind_l }} of money raised came from individual contributions{% endif %}</desc>
+                    <circle class="center" {{ shared_circle_props|safe }}></circle>
+                    <circle class="ring" {{ shared_circle_props|safe }}></circle>
+                    <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ rec_ind_ring }}"></circle>
+                    <g class="chart-text">
+                      <text {{ shared_text_props|safe }}>{{ rec_ind_l }}</text>
+                    </g>
+                  </svg>
+                  <figcaption>
+                    {% if rec_ind_class == '' %}Could not calculate a percent based on available data
+                    {% else %}Percent raised in individual <span class="term" data-term="contribution" title="Click to define" tabindex="0">contributions</span>
+                    {% endif %}
+                  </figcaption>
+                </figure>
+              </div>
+              <div class="donut-cell">
+                <figure>
+                  <svg viewBox="0 0 42 42" class="donut {{ rec_com_class }}" aria-labelledby="snap-raise-com-t snap-raise-com-d">
+                    <title id="snap-raise-com-t">Percent raised from other federal political committees {{ coverage_str }}</title>
+                    <desc id="snap-raise-com-d">{% if rec_com_l != '!' %}{{ rec_com_l }} of money raised came from other federal political committees{% endif %}</desc>
+                    <circle class="center" {{ shared_circle_props|safe }}></circle>
+                    <circle class="ring" {{ shared_circle_props|safe }}></circle>
+                    <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ rec_com_ring }}"></circle>
+                    <text {{ shared_text_props|safe }}>{{ rec_com_l }}</text>
+                  </svg>
+                  <figcaption>
+                    {%- if rec_com_class == '' %}Could not calculate a percent based on available data
+                    {%- else %}Percent raised in contributions from other federal <span class="term" data-term="political committee" title="Click to define" tabindex="0">political committees</span>
+                    {%- endif -%}
+                  </figcaption>
+                </figure>
               </div>
             </div>
-            <div class="grid__item">
-              <h4 class="t-centered">Money spent</h4>
-              <div class="grid grid--2-wide">
-                <div class="grid__item">
-                  <figure>
-                    <svg viewBox="0 0 42 42" class="donut {{ dis_com_class }}" role="img" aria-labelledby="snap-spend-com-t snap-spend-com-d">
-                      <title id="snap-spend-com-t">Percent spent on contributions to other federal political committees {{ coverage_str }}</title>
-                      <desc id="snap-spend-com-d">96% of money spent went to other federal political committees</desc>
-                      <circle class="center"{{ shared_circle_props|safe }}></circle>
-                      <circle class="ring"{{ shared_circle_props|safe }}></circle>
-                      <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ dis_com_ring }}"></circle>
-                      <g class="chart-text">
-                        <text {{ shared_text_props|safe }}>{{ dis_com_l }}</text>
-                      </g>
-                    </svg>
-                    <figcaption>Percent spent on contributions to other <span class="term" data-term="national committee" title="Click to define" tabindex="0">federal committees</span></figcaption>
-                  </figure>
-                </div>
-                <div class="grid__item">
-                  <figure>
-                    <svg viewBox="0 0 42 42" class="donut {{ dis_oe_class }}" role="img" aria-labelledby="snap-spend-ox-t snap-spend-ox-d">
-                      <title id="snap-spend-ox-t">Percent spent on operating expenditures {{ coverage_str }}</title>
-                      <desc id="snap-spend-ox-d">96% of money spent on operating expenditures</desc>
-                      <circle class="center" {{ shared_circle_props|safe }}></circle>
-                      <circle class="ring" {{ shared_circle_props|safe }}></circle>
-                      <!-- The stroke-dashoffset should add up to 100, with the first value being the color -->
-                      <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ dis_oe_ring }}"></circle>
-                      <text {{ shared_text_props|safe }}>{{ dis_oe_l }}</text>
-                    </svg>
-                    <figcaption>Percent spent on <span class="term" data-term="operating expenditures" title="Click to define" tabindex="0">operating expenditures</span></figcaption>
-                  </figure>
-                </div>
+            <div class="donuts-pair">
+              <h4 class="donuts-head t-centered">Money spent</h4>
+              <div class="donut-cell">
+                <figure>
+                  <svg viewBox="0 0 42 42" class="donut {{ dis_com_class }}" role="img" aria-labelledby="snap-spend-com-t snap-spend-com-d">
+                    <title id="snap-spend-com-t">Percent spent on contributions to other federal political committees {{ coverage_str }}</title>
+                    <desc id="snap-spend-com-d">{% if dis_com_l != '!' %}{{ dis_com_l }} of money spent went to other federal political committees{% endif %}</desc>
+                    <circle class="center"{{ shared_circle_props|safe }}></circle>
+                    <circle class="ring"{{ shared_circle_props|safe }}></circle>
+                    <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ dis_com_ring }}"></circle>
+                    <g class="chart-text">
+                      <text {{ shared_text_props|safe }}>{{ dis_com_l }}</text>
+                    </g>
+                  </svg>
+                  <figcaption>
+                    {% if dis_com_class == '' %}Could not calculate a percent based on available data
+                    {% else %}Percent spent on contributions to other <span class="term" data-term="national committee" title="Click to define" tabindex="0">federal committees</span>
+                    {% endif %}
+                  </figcaption>
+                </figure>
+              </div>
+              <div class="donut-cell">
+                <figure>
+                  <svg viewBox="0 0 42 42" class="donut {{ dis_oe_class }}" role="img" aria-labelledby="snap-spend-ox-t snap-spend-ox-d">
+                    <title id="snap-spend-ox-t">Percent spent on operating expenditures {{ coverage_str }}</title>
+                    <desc id="snap-spend-ox-d">{% if dis_oe_l != '!' %}{{ dis_oe_l }} of money spent on operating expenditures{% endif %}</desc>
+                    <circle class="center" {{ shared_circle_props|safe }}></circle>
+                    <circle class="ring" {{ shared_circle_props|safe }}></circle>
+                    <circle class="segment" {{ shared_circle_props|safe }} stroke-dasharray="{{ dis_oe_ring }}"></circle>
+                    <text {{ shared_text_props|safe }}>{{ dis_oe_l }}</text>
+                  </svg>
+                  <figcaption>
+                    {% if dis_oe_class == '' %}Could not calculate a percent based on available data
+                    {% else %}Percent spent on <span class="term" data-term="operating expenditures" title="Click to define" tabindex="0">operating expenditures</span>
+                    {% endif %}
+                  </figcaption>
+                </figure>
               </div>
             </div>
           </div>

--- a/fec/data/templatetags/filters.py
+++ b/fec/data/templatetags/filters.py
@@ -21,6 +21,17 @@ def currency(num, grouping=True):
     return None
 
 
+@library.filter
+def currency_rounded(num, grouping=True):
+    # set locale for currency filter
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+    to_return = None
+    if isinstance(num, (int, float)):
+        to_return = locale.currency(round(num), grouping=grouping)
+        return to_return[:-3]
+    return to_return
+
+
 def ensure_date(value):
     if isinstance(value, (datetime.date, datetime.datetime)):
         return value

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -456,11 +456,91 @@ def get_committee(committee_id, cycle):
                 sponsor_candidate["related_cycle"] = cycle if election_years else None
                 sponsor_candidates.append(sponsor_candidate)
 
+    # Human-friendly text and glossary links for the front-end
+    com_org_type = committee.get('organization_type')
+    com_com_type = committee.get('committee_type')
+    com_desig = committee.get('designation')
+    # The big "can't be" tests for the others
+    if com_org_type == 'C':
+        com_type_text = 'corporate'
+        com_type_glossary = 'Corporation'
+    elif com_org_type == 'W':
+        com_type_text = 'corporations without capital stock'
+        com_type_glossary = ''
+    elif com_org_type == 'L':
+        com_type_text = 'labor organization'
+        com_type_glossary = 'Labor organization'
+    elif com_org_type == 'M':
+        com_type_text = 'membership organization'
+        com_type_glossary = 'Membership organization'
+    elif com_org_type == 'T':
+        com_type_text = 'trade association'
+        com_type_glossary = 'Trade association'
+    elif com_org_type == 'V':
+        com_type_text = 'cooperatives'
+        com_type_glossary = ''
+    elif com_org_type == 'D':
+        com_type_text = 'leadership PACs'
+        com_type_glossary = ''
+    elif com_com_type == 'H':
+        com_type_text = '=====NO LINE IN SPREADSHEET====='
+        com_type_glossary = ''
+    elif com_com_type == 'S':
+        com_type_text = '=====NO LINE IN SPREADSHEET====='
+        com_type_glossary = ''
+    elif com_com_type == 'P':
+        com_type_text = '=====NO LINE IN SPREADSHEET====='
+        com_type_glossary = ''
+    elif com_desig == 'B':
+        com_type_text = 'lobbyist-registrant PACs'
+        com_type_glossary = 'Lobbyist/Registrant PAC'
+    elif com_desig == 'D':
+        com_type_text = 'leadership PACs'
+        com_type_glossary = 'Leadership PAC'
+    elif com_desig == 'J':
+        com_type_text = 'joint fundraising committees'
+        com_type_glossary = 'Joint fundraising committee'
+    elif com_desig == 'A':
+        com_type_text = '=====NO LINE IN SPREADSHEET====='
+        com_type_glossary = ''
+    elif com_desig == 'P':
+        com_type_text = '=====NO LINE IN SPREADSHEET====='
+        com_type_glossary = ''
+    elif com_com_type == 'O':
+        com_type_text = 'super PACs'
+        com_type_glossary = 'Super PAC'
+    elif com_com_type == 'W':
+        com_type_text = 'hybrid PACs'
+        com_type_glossary = 'Hybrid PAC'
+    elif com_com_type == 'V':
+        com_type_text = 'hybrid PACs'
+        com_type_glossary = 'Hybrid PAC'
+    elif com_com_type == 'N':
+        com_type_text = 'political action committees'
+        com_type_glossary = 'Political Action Committee (PAC)'
+    elif com_com_type == 'Q':
+        com_type_text = 'political action committees'
+        com_type_glossary = 'Political Action Committee (PAC)'
+    elif com_com_type == 'U':
+        com_type_text = '=====TBD====='
+        com_type_glossary = ''
+    elif com_com_type == 'I':
+        com_type_text = '=====TBD====='
+        com_type_glossary = ''
+    elif com_com_type == 'Y':
+        com_type_text = 'party committees'
+        com_type_glossary = 'Party committee'
+    elif com_com_type == 'X':
+        com_type_text = 'party committees'
+        com_type_glossary = 'Party committee'
+
     template_variables = {
         "candidates": candidates,
         "committee": committee,
         "committee_id": committee_id,
         "committee_type": committee["committee_type"],
+        "com_type_text": com_type_text,
+        "com_type_glossary": com_type_glossary,
         "context_vars": context_vars,
         "cycle": cycle,
         "cycles": cycles,
@@ -559,6 +639,10 @@ def committee(request, committee_id):
 
     cycle = request.GET.get("cycle", None)
     committee = get_committee(committee_id, cycle)
+
+    com_type_text = ''
+    com_type_glossary = ''
+
     return render(request, "committees-single.jinja", committee)
 
 

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -460,7 +460,7 @@ def get_committee(committee_id, cycle):
     com_org_type = committee.get('organization_type')
     com_com_type = committee.get('committee_type')
     com_desig = committee.get('designation')
-    # The big "can't be" tests for the others
+    # The big "can't be" tests for organization_types
     if com_org_type == 'C':
         com_type_text = 'corporate'
         com_type_glossary = 'Corporation'
@@ -479,9 +479,7 @@ def get_committee(committee_id, cycle):
     elif com_org_type == 'V':
         com_type_text = 'cooperatives'
         com_type_glossary = ''
-    elif com_org_type == 'D':
-        com_type_text = 'leadership PACs'
-        com_type_glossary = ''
+    # The three biggies which are also 'not' rules for committee_type
     elif com_com_type == 'H':
         com_type_text = '[H committee_type]'
         com_type_glossary = ''
@@ -491,12 +489,14 @@ def get_committee(committee_id, cycle):
     elif com_com_type == 'P':
         com_type_text = '[P committee_type]'
         com_type_glossary = ''
+    # regular designation with no other rules
     elif com_desig == 'B':
         com_type_text = 'lobbyist-registrant PACs'
         com_type_glossary = 'Lobbyist/Registrant PAC'
     elif com_desig == 'D':
         com_type_text = 'leadership PACs'
         com_type_glossary = 'Leadership PAC'
+    # 'not' rules for designation
     elif com_desig == 'J':
         com_type_text = 'joint fundraising committees'
         com_type_glossary = 'Joint fundraising committee'
@@ -506,6 +506,7 @@ def get_committee(committee_id, cycle):
     elif com_desig == 'P':
         com_type_text = '[P designation]'
         com_type_glossary = ''
+    # all the others that were restricted by the 'not' rules above
     elif com_com_type == 'O':
         com_type_text = 'super PACs'
         com_type_glossary = 'Super PAC'

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -483,13 +483,13 @@ def get_committee(committee_id, cycle):
         com_type_text = 'leadership PACs'
         com_type_glossary = ''
     elif com_com_type == 'H':
-        com_type_text = '=====NO LINE IN SPREADSHEET====='
+        com_type_text = '[H committee_type]'
         com_type_glossary = ''
     elif com_com_type == 'S':
-        com_type_text = '=====NO LINE IN SPREADSHEET====='
+        com_type_text = '[S committee_type]'
         com_type_glossary = ''
     elif com_com_type == 'P':
-        com_type_text = '=====NO LINE IN SPREADSHEET====='
+        com_type_text = '[P committee_type]'
         com_type_glossary = ''
     elif com_desig == 'B':
         com_type_text = 'lobbyist-registrant PACs'
@@ -501,10 +501,10 @@ def get_committee(committee_id, cycle):
         com_type_text = 'joint fundraising committees'
         com_type_glossary = 'Joint fundraising committee'
     elif com_desig == 'A':
-        com_type_text = '=====NO LINE IN SPREADSHEET====='
+        com_type_text = '[A designation]'
         com_type_glossary = ''
     elif com_desig == 'P':
-        com_type_text = '=====NO LINE IN SPREADSHEET====='
+        com_type_text = '[P designation]'
         com_type_glossary = ''
     elif com_com_type == 'O':
         com_type_text = 'super PACs'
@@ -522,10 +522,10 @@ def get_committee(committee_id, cycle):
         com_type_text = 'political action committees'
         com_type_glossary = 'Political Action Committee (PAC)'
     elif com_com_type == 'U':
-        com_type_text = '=====TBD====='
+        com_type_text = '[U committee_type]'
         com_type_glossary = ''
     elif com_com_type == 'I':
-        com_type_text = '=====TBD====='
+        com_type_text = '[I committee_type]'
         com_type_glossary = ''
     elif com_com_type == 'Y':
         com_type_text = 'party committees'
@@ -639,9 +639,6 @@ def committee(request, committee_id):
 
     cycle = request.GET.get("cycle", None)
     committee = get_committee(committee_id, cycle)
-
-    com_type_text = ''
-    com_type_glossary = ''
 
     return render(request, "committees-single.jinja", committee)
 

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -64,6 +64,7 @@ FEATURES = {
     'debts': bool(env.get_credential('FEC_FEATURE_DEBTS', '')),  # TODO: debts dates
     'map': bool(env.get_credential('FEC_FEATURE_HOME_MAP', '')),
     'pac_party': bool(env.get_credential('FEC_FEATURE_PAC_PARTY', '')),
+    'pac_snapshot': bool(env.get_credential('FEC_FEATURE_PAC_SNAPSHOT', '')),
     'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
 }
 
@@ -77,6 +78,7 @@ if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:
     FEATURES['debts'] = True
     FEATURES['map'] = True
     FEATURES['pac_party'] = True
+    FEATURES['pac_snapshot'] = True
     FEATURES['presidential_map'] = True
 
 # Application definition

--- a/fec/fec/static/scss/components/_committee-snapshot.scss
+++ b/fec/fec/static/scss/components/_committee-snapshot.scss
@@ -1,0 +1,168 @@
+#committee-snapshot {
+//   .tag__category {
+//     border-bottom-color: #112e51;
+//     border-bottom-style: solid;
+//     border-bottom-width: 2px 0;
+//   }
+  .footer-methodology {
+    border-top: 1px solid;
+    padding-top: 1em;
+
+    @include media($med) {
+      display: flex;
+    }
+    p {
+      margin-bottom: 1em;
+      
+      @include media($med) {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  .snapshot-summary {
+    padding-top: 1rem;
+
+    .divider {
+      display: none;
+
+      @include media($med) {
+        display: initial;
+      }
+    }
+    span {
+      white-space: nowrap;
+
+      @include media($med) {
+        &:not(:last-of-type) {
+          border-right: 1px solid;
+          margin-right: 1em;
+          padding-right: 1em;
+        }
+      } 
+    }
+    > span {
+      display: block;
+
+      @include media($med) {
+        display: initial;
+      }
+    }
+
+    meter {
+      margin-left: 0;
+      background: transparent;
+      height: 1.5em;
+      width: 100%;
+
+      @include media($med) {
+        display: none;
+      }
+
+      &::-webkit-meter-bar {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+      }
+      &::-moz-meter-bar {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+      }
+      &::-webkit-meter-optimum-value {
+        background: $gray-dark;
+        border-radius: 0;
+      }
+      &:-moz-meter-optimum::-moz-meter-bar {
+        background: $gray-dark;
+        border-radius: 0;
+      }
+      &[data-cat='raising'] {
+        &::-webkit-meter-optimum-value {
+          background: $orange;
+        }
+        &:-moz-meter-optimum::-moz-meter-bar {
+          background: $orange;
+        }
+      }
+      &[data-cat='spending'] {
+        &::-webkit-meter-optimum-value {
+          background: $aqua;
+          transition: all 1s;
+        }
+        &:-moz-meter-optimum::-moz-meter-bar {
+          background: $aqua;
+          transition: all 1s;
+        }
+      }
+    }
+  }
+
+  figure {
+    display: flex;
+    align-items: center;
+
+    @include media($med) {
+      display: initial;
+      align-items: unset;
+    }
+  }
+
+  figcaption {
+    text-align: left;
+    width: 66.6%;
+
+    @include media($med) {
+      text-align: center;
+      width: initial;
+    }
+  }
+
+  .donut {
+    width: 33%;
+    height: 100%;
+
+    @include media($med) {
+      width: 100%
+    }
+
+    .center {
+      fill: $inverse
+    }
+    .ring {
+      fill: transparent;
+      stroke: $gray-light;
+      stroke-width: 3;
+    }
+    .segment {
+      fill: transparent;
+      stroke-dashoffset: 25;
+      stroke-width: 3;
+    }
+    text {
+      fill: $gray-light;
+      font-family: $sans-serif;
+      font-size: 1rem;
+      font-weight: bold;
+      text-anchor: middle;
+    }
+
+    &.raising {
+      .segment {
+        stroke: $orange;
+      }
+      text {
+        fill: $orange;
+      }
+    }
+
+    &.spending {
+      .segment {
+        stroke: $aqua;
+      }
+      text {
+        fill: $aqua;
+      }
+    }
+  }
+}

--- a/fec/fec/static/scss/components/_committee-snapshot.scss
+++ b/fec/fec/static/scss/components/_committee-snapshot.scss
@@ -21,6 +21,11 @@
   }
 
   .snapshot-summary {
+    border-bottom: 1px solid $gray-light;
+    border-top: 1px solid $federal-blue;
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+    padding-bottom: 1rem;
     padding-top: 1rem;
 
     .divider {
@@ -36,10 +41,10 @@
       @include media($med) {
         &:not(:last-of-type) {
           border-right: 1px solid;
-          margin-right: 1em;
-          padding-right: 1em;
-        }
-      } 
+          margin-right: 10px;
+          padding-right: 10px;
+        } 
+      }
     }
     > span {
       display: block;
@@ -109,12 +114,60 @@
   }
 
   figcaption {
+    font-family: $sans-serif;
+    line-height: 1.25em;
     text-align: left;
     width: 66.6%;
-
+    
     @include media($med) {
+      margin-bottom: 1em;
+      padding: 0 1em;
       text-align: center;
       width: initial;
+    }
+  }
+
+  .donuts-all {
+    margin-bottom: 1rem;
+
+    .donuts-head {
+      margin-bottom: 0;
+    }
+
+    @include media($med) {
+      display: flex;
+      position: relative;
+
+      .donuts-pair {
+        position: relative;
+        width: 50%;
+
+        .donuts-head {
+          width: 100%;
+          margin-bottom: 1rem;
+        }
+        .donut-cell {
+          float: left;
+          margin-left: 0;
+          margin-right: 0;
+          width: 50%;
+          
+          &:first-child {
+            border-right: 1px solid $gray-light;
+          }
+        }
+      }
+
+      &:after {
+        content: "";
+        display: block;
+        position: absolute;
+        background: $gray-light;
+        height: 90%;
+        width: 1px;
+        top: 5%;
+        left: 50%;
+      }
     }
   }
 

--- a/fec/fec/static/scss/components/_entity-header.scss
+++ b/fec/fec/static/scss/components/_entity-header.scss
@@ -141,8 +141,12 @@
   @include u-bg--neutral();
 
   .entity__info,
-  .entity__type  {
+  .entity__type {
     border-color: $primary;
+    
+    &:last-of-type {
+      border-right: none;
+    }
   }
 }
 

--- a/fec/fec/static/scss/entity.scss
+++ b/fec/fec/static/scss/entity.scss
@@ -1,3 +1,4 @@
+/* Used inside candidate-single and committee-single */
 @import "base";
 
 @import "common";
@@ -12,3 +13,4 @@
 @import "components/table-styles";
 @import "components/results-info";
 @import "components/callouts";
+@import "components/committee-snapshot";


### PR DESCRIPTION
## Summary

- Resolves #4718 

Building the PAC snapshot

### Required reviewers

UX, front-end (x2?), back-end to check the Python (I don't love this proposal)

## Impacted areas of the application

Adds the snapshot to the committees-single template, adds a couple new variables to get_committee in views.py

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## Related PRs

None

## How to test

- pull branch
- `npm run build`
- `./manage.py runserver`
- Check a ton of committee pages, sure to check different types (There have been several discussions and spreadsheets for good examples)

## Known issues
- I don't love this approach of determining the text to display for the glossary links
- There are still some glossary links that need guidance