### PR TITLE
4615-Fix text in disbursements datatable filter

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -481,12 +481,12 @@ line_numbers = {
             ('F3X-26', 'Loan repayments made (Line 26)'),
             ('F3X-27', 'Loans made (Line 27)'),
             ('F3X-28A',
-                'Refunds of Contributions Made to Individuals/Persons Other Than Political Committees (Line 28a)'),
+                'Refunds of contributions made to individuals/persons other than political committees (Line 28a)'),
             ('F3X-28B', 'Refunds of contributions to political party committees (Line 28b)'),
             ('F3X-28C', 'Refunds of contributions to other political committees (Line 28c)'),
             ('F3X-28D', 'Total contributions refunds (Line 28d)'),
             ('F3X-29', 'Other disbursements (Line 29)'),
-            ('F3X-30B', 'Party - Types 3 & 4 Federal Election Activity (FEA) (Line 30(b))'),
+            ('F3X-30B', 'Party - Types 3 & 4 Federal Election Activity (FEA) (Line 30b)'),
         ])
     }
 }


### PR DESCRIPTION
## Summary 

- Resolves #4615 

Making minor updates to formatting for text in disbursements data table filter

### Required reviewers

1-2 reviewers

## Impacted areas of the application

General components of the application that this PR will affect:

-  Disbursements Datatable located: https://www.fec.gov/data/disbursements/?data_type=processed&two_year_transaction_period=2022&min_date=01%2F01%2F2021&max_date=12%2F31%2F2022
- Select Disbursement Details, Made by PACs or party committees


## Screenshots
Before:
![image](https://user-images.githubusercontent.com/66386084/125790978-46f9f5b7-e4fb-49fb-b5d7-06e30d4e3ddc.png)

After:
![image](https://user-images.githubusercontent.com/66386084/125791937-c30999e8-ea3d-4093-a267-75738a6ba365.png)


## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- https://www.fec.gov/data/disbursements/?data_type=processed&two_year_transaction_period=2022&min_date=01%2F01%2F2021&max_date=12%2F31%2F2022
- http://127.0.0.1:8000/data/disbursements/?data_type=processed&two_year_transaction_period=2022&min_date=01%2F01%2F2021&max_date=12%2F31%2F2022
