### PR TITLE
[BEFORE RELEASE]Add style rule for full width tab nav

### DIFF
--- a/fec/fec/static/scss/components/_data-container.scss
+++ b/fec/fec/static/scss/components/_data-container.scss
@@ -167,10 +167,11 @@
 //Responsive behavior for datatables in tab pannels on profile pages (committee, candidate, election)
 @media screen and (max-width: 940px) {
   .data-container__wrapper .main__content--right-full {
-    display: block;
+    display: block
    }
 
   .data-container__wrapper .side-nav-alt {
     display: block;
+    width:auto;
   }
 }


### PR DESCRIPTION
## Summary (required)

In the last PR merged for this, a style rule somehow got reverted and left out of the code. This PR corrects that.

The change makes the tab nav full width when the tab nav stacks above the content

Resolves issue #4656 

Original PR #4754 

### Required reviewers

one front-end --OR-- one UX

## Impacted areas of the application

modified:   fec/static/scss/components/_data-container.scss

## Screenshots

<img width="892" alt="Screen Shot 2021-07-18 at 5 39 32 PM" src="https://user-images.githubusercontent.com/5572856/126082990-06e65d82-5a73-4f21-98cf-8d1eec767833.png">

## Related PRs

Original PR #4754 

## How to test

- checkout and `npm run build`
- See that the tab nav spans the whole screen when the screen is resized and the tab nav stacks above the tabbed content


