### PR TITLE
Modify PAC/Party datatable

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -382,7 +382,7 @@ table_columns = OrderedDict([
     ('candidates-office-senate', ['Name', 'Party', 'State', 'Receipts', 'Disbursements']),
     ('candidates-office-house', ['Name', 'Party', 'State', 'District', 'Receipts', 'Disbursements']),
     ('committees', ['Name', 'Committee ID', 'Treasurer', 'Type', 'Designation', 'First filing date']),
-    ('pac-party', ['Name', 'Type', 'Receipts', 'Disbursements', 'Cash on hand']),
+    ('pac-party', ['Name', 'Type', 'Receipts', 'Disbursements', 'Ending cash on hand']),
     ('communication-costs', ['Committee', 'Support/Oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Description', 'Disbursement date', 'Amount']),
     ('electioneering-communications',

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -26,13 +26,7 @@
 
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_type">
-    <label class="label t-inline" for="committee_type">Independent expenditure committees</label>
-    <div class="tooltip__container">
-      <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
-      <div id="ie-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-        <p class="tooltip__content">TOOLTIP</p>
-      </div>
-    </div>
+    <label class="label t-inline-block" for="committee_type">Independent expenditure committees</label>
     <ul class="dropdown__selected">
       <li>
         <input id="committee-type-checkbox-O" type="checkbox" name="{{ committee_type }}" value="O">
@@ -60,12 +54,6 @@
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="organization_type">
     <label class="label t-inline-block" for="committee_type">PACs</label>
-    <div class="tooltip__container">
-      <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
-      <div id="pacs-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-        <p class="tooltip__content">TOOLTIP</p>
-      </div>
-    </div>
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>
@@ -134,12 +122,6 @@
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="designation_parties">
     <label class="label t-inline-block" for="committee_type">Parties</label>
-    <div class="tooltip__container">
-      <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
-      <div id="parties-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-        <p class="tooltip__content">TOOLTIP</p>
-      </div>
-    </div>
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>

--- a/fec/data/templates/macros/filters/filing-frequency.jinja
+++ b/fec/data/templates/macros/filters/filing-frequency.jinja
@@ -2,12 +2,6 @@
   <div class="filter">
     <fieldset class="js-filter" data-filter="checkbox">
       <label class="label t-inline-block" for="filing-frequency">Filing frequency</label>
-      <div class="tooltip__container">
-        <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
-        <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-          <p class="tooltip__content">TOOLTIP</p>
-        </div>
-      </div>
       <ul>
         <li>
           <input id="filing-frequency-quarterly" name={{ name }} type="checkbox" value="Q">

--- a/fec/data/templates/partials/pac-party-filter.jinja
+++ b/fec/data/templates/partials/pac-party-filter.jinja
@@ -29,7 +29,7 @@
     <div class="accordion__content">
       {{ range.amount('receipts', 'Total receipts') }}
       {{ range.amount('disbursements', 'Total disbursements') }}
-      {{ range.amount('last_cash_on_hand_end_period', 'Cash on hand') }}
+      {{ range.amount('last_cash_on_hand_end_period', 'Ending cash on hand') }}
       {{ range.amount('last_debts_owed_by_committee', 'Debts owed by committee') }}
     </div>
   </div>

--- a/fec/fec/static/js/templates/pac-party.hbs
+++ b/fec/fec/static/js/templates/pac-party.hbs
@@ -16,35 +16,22 @@ Template for PAC and party committee datatable details panel
     {{#panelRow "Designation"}}
       {{committee_designation_full}}
     {{/panelRow}}
-    {{!-- TODO: Update the API field names for leadership PAC sponsor when it's ready in the API --}}
-    {{!-- {{#if sponsor_candidate_ids}}
+    {{#if sponsor_candidate_list}}
       {{#panelRow "Leadership PAC sponsor"}}
-        {{#each sponsor_candidate_ids}}
-          <a href="{{ basePath }}/candidate/{{ sponsor_candidate_ids }}/"><span class="leadership_pac_sponsor_name">{{ sponsor_candidate_name }}</span> ({{ sponsor_candidate_ids }})</a>;<br />
+        {{#each sponsor_candidate_list}}
+          <a href="{{basePath}}/candidate/{{ sponsor_candidate_id }}/"><span class="leadership_pac_sponsor_name">{{ sponsor_candidate_name }}</span> ({{ sponsor_candidate_id }})</a>{{#unless @last}};<br />{{/unless}}
         {{/each}}
       {{/panelRow}}
-    {{/if}} --}}
+    {{/if}}
     {{#panelRow "Most recent treasurer"}}
       {{ treasurer_name }}
     {{/panelRow}}
     {{#panelRow "State"}}
       {{ committee_state }}
     {{/panelRow}}
-    <tr>
-      <td class="panel__term">
-        <span>Filing frequency</span>
-        <div class="tooltip__container">
-          <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
-          <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-            {{!-- TODO: Add final tooltip language --}}
-            <p class="tooltip__content">Filing freqency description goes here.</p>
-          </div>
-        </div>
-      </td>
-      <td class="panel__data">
-        {{ filing_frequency_full }}
-      </td>
-    </tr>
+    {{#panelRow "Filing frequency"}}
+      {{ filing_frequency_full }}
+    {{/panelRow}}
     {{#panelRow "First filing date"}}
       {{ datetime first_file_date format="pretty" }}
     {{/panelRow}}
@@ -62,21 +49,9 @@ Template for PAC and party committee datatable details panel
     {{#panelRow "Receipts"}}
       {{ currency receipts }}
     {{/panelRow}}
-    <tr>
-      <td class="panel__term">
-        <span>Individual contributions</span>
-        <div class="tooltip__container">
-          <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
-          <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-            {{!-- TODO: Add final tooltip language --}}
-            <p class="tooltip__content">A gift, subscription, loan, advance or deposit of money or anything of value given to influence a federal election; or the payment by any person of compensation for the personal services of another person if those services are rendered without charge to a political committee for any purpose. 11 CFR 100.52(a) and 100.54.</p>
-          </div>
-        </div>
-      </td>
-      <td class="panel__data">
-        {{ currency individual_contributions }}
-      </td>
-    </tr>
+    {{#panelRow "Individual contributions"}}
+      {{ currency individual_contributions }}
+    {{/panelRow}}
     {{#panelRow "Disbursements"}}
       {{ currency disbursements }}
     {{/panelRow}}
@@ -86,7 +61,6 @@ Template for PAC and party committee datatable details panel
         <div class="tooltip__container">
           <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
           <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-            {{!-- TODO: Add final tooltip language --}}
             <p class="tooltip__content">The total amount of cash on hand that remains after the amount of cash on hand at the beginning of the reporting period is adjusted to add the total receipts for the reporting period and subtract the total disbursements for the reporting period.</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #4690 
- Resolves #4769  

What's included:

- Removes tooltips for PAC & party datatable as well as committees datatable for IE, Party, PACs, and filing frequency in filters and details panel
- Removes tooltips for IE and PACs from the committees datatable
- Retains tooltip for Ending cash on hand in details panel
- Adds leadership PAC sponsor field to the details panel

### Required reviewers

1 front end & 1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

- PAC & party datatable http://localhost:8000/data/committees/pac-party/
- Committees datatable http://localhost:8000/data/committees/

## Screenshots

![Screen Shot 2021-07-20 at 11 58 44 AM](https://user-images.githubusercontent.com/12799132/126356779-ebca1ff2-45e0-4d07-8f1c-aacf7687c3e1.png)

## How to test

- Checkout this branch
- `cd fec && ./manage.py runserver`
- `npm run build`
- Go to PAC & party datatable: http://localhost:8000/data/committees/pac-party/
     - Ensure tooltips are removed from details panel except for Ending cash on hand
     - Ensure tooltips are removed from the filter panel
     - Ensure that leadership PAC sponsor label has been added to the details panel. It will only show up given certain parameters, so try this link: http://localhost:8000/data/committees/pac-party/?cycle=2020&sponsor_candidate_id=S6CA00584
- Go to the committees datatable: http://localhost:8000/data/committees/
     - Ensure that there are no tooltips for the committee types accordion
