### PR TITLE
Add calendar event summary and update styles

### DIFF
--- a/fec/fec/static/js/modules/calendar.js
+++ b/fec/fec/static/js/modules/calendar.js
@@ -176,8 +176,9 @@ Calendar.prototype.success = function(response) {
     var processed = {
       category: event.category,
       location: event.location,
-      title: event.description || 'Event title',
-      summary: event.description || 'Event summary',
+      title: event.summary || 'Event title',
+      summary: event.summary || 'Event summary',
+      description: event.description || 'Event description',
       state: event.state ? event.state.join(', ') : null,
       start: event.start_date ? moment(event.start_date) : null,
       hasStartTime: calendarHelpers.checkStartTime(event),

--- a/fec/fec/static/js/templates/calendar/details.hbs
+++ b/fec/fec/static/js/templates/calendar/details.hbs
@@ -1,4 +1,4 @@
-<div class="tooltip tooltip--under cal-details" id="{{detailsId}}" role="tooltip">
+<div class="tooltip tooltip--under cal-details" id="{{ detailsId }}" role="tooltip">
   <div class="tooltip__heading">
     <span class="tooltip__title">{{ category }}</span>
     <button class="button button--close--inverse js-close" type="button"><span class="u-visually-hidden">Close</span></button>
@@ -6,27 +6,28 @@
   <div class="tooltip__content">
     <span class="cal-details__date">
       {{#if allDay}}
-        {{datetime start format="pretty"}}
+        {{ datetime start format="pretty" }}
       {{else}}
-        {{datetime start format="dateTime"}}
+        {{ datetime start format="dateTime" }}
         {{#if end}}
-          &ndash;{{datetime end format="dateTime"}}
+          &ndash;{{ datetime end format="dateTime" }}
         {{/if}}
       {{/if}}
     </span>
     <span class="cal-details__summary">{{ summary }}</span>
+    <span class="cal-details__description">{{ description }}</span>
     {{#if location }}
       <span class="cal-details__location"><span class="t-bold">Location: </span>{{ location }}</span>
     {{/if}}
     {{#if detailUrl}}
-      <span class="t-block"><a class="t-bold" href="{{detailUrl}}">Learn more</a></span>
+      <span class="t-block"><a class="t-bold" href="{{ detailUrl }}">Learn more</a></span>
     {{/if}}
     <div class="cal-details__add dropdown">
       <button class="button button--alt dropdown__button button--add-calendar">Add to calendar</button>
       <ul class="dropdown__panel" aria-hidden="true">
-        <li class="dropdown__item"><a class="dropdown__value" href="{{download}}">Apple Calendar</a></li>
-        <li class="dropdown__item"><a class="dropdown__value" href="{{google}}" target="_blank" rel="noreferrer">Google Calendar</a></li>
-        <li class="dropdown__item"><a class="dropdown__value" href="{{download}}">Outlook Calendar</a></li>
+        <li class="dropdown__item"><a class="dropdown__value" href="{{ download }}">Apple Calendar</a></li>
+        <li class="dropdown__item"><a class="dropdown__value" href="{{ google }}" target="_blank" rel="noreferrer">Google Calendar</a></li>
+        <li class="dropdown__item"><a class="dropdown__value" href="{{ download }}">Outlook Calendar</a></li>
       </ul>
     </div>
   </div>

--- a/fec/fec/static/js/templates/calendar/events.hbs
+++ b/fec/fec/static/js/templates/calendar/events.hbs
@@ -19,10 +19,11 @@
               &nbsp;
             {{/if}}
           </div>
-          <div class="cal-list__description" id="cal-description-{{@index}}">
-            <p>{{summary}}</p>
+          <div class="cal-list__info" id="cal-info-{{@index}}">
+            <p class="cal-list__summary" id="cal-summary-{{@index}}">{{summary}}</p>
+            <p id="cal-description-{{@index}}"> {{description}}</p>
             {{#if location}}
-              <span class="cal-list__location">&ndash; {{location}}</span>
+              <span class="cal-list__location">Location: {{location}}</span>
             {{/if}}
             {{#if detailUrl}}
               <span class="cal-list__details"><a class="t-bold" href="{{detailUrl}}" aria-describedby="cal-description-{{@index}}">Learn more</a></span>

--- a/fec/fec/static/scss/components/_calendar.scss
+++ b/fec/fec/static/scss/components/_calendar.scss
@@ -296,8 +296,7 @@
 
 .cal-details__date {
   display: block;
-  font-weight: bold;
-  padding-bottom: u(1rem);
+  padding-bottom: u(.5rem);
 }
 
 .cal-details__title {
@@ -308,6 +307,13 @@
 }
 
 .cal-details__summary {
+  display: block;
+  font-weight: bold;
+  line-height: 1.2;
+  padding-bottom: u(1rem);
+}
+
+.cal-details__description {
   display: block;
   line-height: 1.2;
   padding-bottom: u(.5rem);

--- a/fec/fec/static/scss/components/_calendar.scss
+++ b/fec/fec/static/scss/components/_calendar.scss
@@ -455,6 +455,13 @@
   }
 }
 
+.cal-list__summary {
+  display: block;
+  font-weight: bold;
+  line-height: 1.2;
+  margin: 0 0 .5rem 0;
+}
+
 .cal-list__date {
   @include span-columns(4 of 8);
   font-weight: bold;
@@ -465,7 +472,7 @@
   @include omega();
 }
 
-.cal-list__description {
+.cal-list__info {
   @include span-columns(8 of 8);
   padding-top: u(2rem);
 
@@ -641,7 +648,7 @@
     @include span-columns(1 of 10);
   }
 
-  .cal-list__description {
+  .cal-list__info {
     @include span-columns(6 of 10);
     padding-top: 0;
   }


### PR DESCRIPTION
## Summary

- Resolves #4111 

Adds the calendar event summary and updates styles [per the comp](https://github.com/fecgov/fec-cms/issues/4111#issuecomment-880920525)

### Required reviewers

1 UX & 1 frontend

## Impacted areas of the application

General components of the application that this PR will affect:

- Calendar view 

## Screenshots

![Screen Shot 2021-07-21 at 3 05 08 PM](https://user-images.githubusercontent.com/12799132/126545820-4046c01f-d933-4b82-b95e-14585eaca394.png)

![Screen Shot 2021-07-22 at 3 22 09 PM](https://user-images.githubusercontent.com/12799132/126697758-c2586baa-bcaa-4394-86be-d1ddd65ea391.png)


## How to test

- Checkout this branch
- `npm run build`
- Go to the calendar page: http://localhost:8000/calendar/
- See that the correct components are there in the calendar events list view [per the comp](https://github.com/fecgov/fec-cms/issues/4111#issuecomment-880920525)
- Toggle to calendar view ![Screen Shot 2021-07-21 at 3 09 42 PM](https://user-images.githubusercontent.com/12799132/126545909-a72fe0e9-02b5-4a44-b86b-bf5aefbf70e7.png)
- See that the correct components are there in the calendar events calendar view [per the comp](https://github.com/fecgov/fec-cms/issues/4111#issuecomment-880920525)
