### PR TITLE
adds tooltip to COH range filter

### DIFF
--- a/fec/data/templates/macros/filters/range.jinja
+++ b/fec/data/templates/macros/filters/range.jinja
@@ -1,6 +1,14 @@
-{% macro amount(name, label) %}
+{% macro amount(name, label, tooltip=False) %}
 <fieldset class="filter" id="{{name}}-field">
-  <legend class="label">{{ label }}</legend>
+  <label class="label t-inline-block">{{ label }}</label>
+  {% if tooltip %}
+    <div class="tooltip__container">
+      <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+      <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
+        <p class="tooltip__content">{{ tooltip }}</p>
+      </div>
+    </div>
+  {% endif %}
   <div class="range range--currency">
     <div class="range__input range__input--min js-filter" data-filter="range">
       <label for="min_{{name}}">From</label>

--- a/fec/data/templates/partials/pac-party-filter.jinja
+++ b/fec/data/templates/partials/pac-party-filter.jinja
@@ -29,7 +29,7 @@
     <div class="accordion__content">
       {{ range.amount('receipts', 'Total receipts') }}
       {{ range.amount('disbursements', 'Total disbursements') }}
-      {{ range.amount('last_cash_on_hand_end_period', 'Ending cash on hand') }}
+      {{ range.amount('last_cash_on_hand_end_period', 'Ending cash on hand', tooltip = 'The total amount of cash on hand that remains after the amount of cash on hand at the beginning of the reporting period is adjusted to add the total receipts for the reporting period and subtract the total disbursements for the reporting period.') }}
       {{ range.amount('last_debts_owed_by_committee', 'Debts owed by committee') }}
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Resolves #4781 

Adds "Ending cash on hand" tooltip to the pac and party filter

### Required reviewers

1 UX & 1 frontend

## Impacted areas of the application

General components of the application that this PR will affect:

-  PAC and party datatable range filter

## Screenshots

![Screen Shot 2021-07-21 at 3 25 46 PM](https://user-images.githubusercontent.com/12799132/126548131-4662ee22-a53e-4419-b329-d7f410e448c8.png)

## How to test

- Checkout this branch
- `./manage.py runserver`
- Go to pac and party datatable page: http://localhost:8000/data/committees/pac-party/?cycle=2022
- Check that the tooltip is present on the ending cash on hand filter with the correct definition from the glossary term