### PR TITLE
2021 district message for Election search

### DIFF
--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -70,7 +70,7 @@
   <div class="container">
     <div class="content__section--extra">
       <div class="usa-width-one-half">
-        <div class="js-accordion accordion--neutral _2022-districts-message u-padding--bottom" data-content-prefix="2022-redistricting">
+        <div class="js-accordion accordion--neutral u-padding--bottom" data-content-prefix="2022-redistricting">
           <button type="button" class="js-accordion-trigger accordion__button" aria-controls="2022-redistricting-content-0" aria-expanded="false">Information about 2021 Census redistricting</button>
             <div class="accordion__content" id="2022-redistricting-content-0" aria-hidden="true">
               <p>Following the 2020 Census, some states may redraw their districts. Some candidates may subsequently amend their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may run in different districts than in the past. The FEC will update its map to reflect the new Congressional districts and boundaries once information has been made available from each state.</p>

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -70,6 +70,12 @@
   <div class="container">
     <div class="content__section--extra">
       <div class="usa-width-one-half">
+        <div class="js-accordion accordion--neutral _2022-districts-message u-padding--bottom" data-content-prefix="2022-redistricting">
+            <button type="button" class="js-accordion-trigger accordion__button" aria-controls="2022-redistricting-content-0" aria-expanded="false">Information about 2021 Census redistricting</button>
+            <div class="accordion__content" id="2022-redistricting-content-0" aria-hidden="true">
+                <p>Following the 2020 Census, some states may redraw their districts. Some candidates may subsequently amend their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may run in different districts than in the past. The FEC will update its map to reflect the new Congressional districts and boundaries once information has been made available from each state.</p>
+            </div>
+          </div>
         <div class="heading--section js-results-heading">
           <h2>Results</h2>
           <span class="heading__subtitle js-results-title"></span>

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -71,11 +71,11 @@
     <div class="content__section--extra">
       <div class="usa-width-one-half">
         <div class="js-accordion accordion--neutral _2022-districts-message u-padding--bottom" data-content-prefix="2022-redistricting">
-            <button type="button" class="js-accordion-trigger accordion__button" aria-controls="2022-redistricting-content-0" aria-expanded="false">Information about 2021 Census redistricting</button>
+          <button type="button" class="js-accordion-trigger accordion__button" aria-controls="2022-redistricting-content-0" aria-expanded="false">Information about 2021 Census redistricting</button>
             <div class="accordion__content" id="2022-redistricting-content-0" aria-hidden="true">
-                <p>Following the 2020 Census, some states may redraw their districts. Some candidates may subsequently amend their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may run in different districts than in the past. The FEC will update its map to reflect the new Congressional districts and boundaries once information has been made available from each state.</p>
-            </div>
+              <p>Following the 2020 Census, some states may redraw their districts. Some candidates may subsequently amend their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may run in different districts than in the past. The FEC will update its map to reflect the new Congressional districts and boundaries once information has been made available from each state.</p>
           </div>
+        </div>
         <div class="heading--section js-results-heading">
           <h2>Results</h2>
           <span class="heading__subtitle js-results-title"></span>

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -193,10 +193,10 @@ ElectionSearch.prototype.search = function(e, opts) {
             .toString()
         );
         analytics.pageView();
-        self.$resultsHeading.show()
+        self.$resultsHeading.show();
       }
     } else if (self.results) {
-      self.$resultsHeading.show()
+      self.$resultsHeading.show();
       // Requested options match saved options; redraw cached results. This
       // ensures that clicking on a state or district will highlight it when
       // the search options don't match the state of the map, e.g. after the
@@ -219,16 +219,6 @@ ElectionSearch.prototype.handlePopState = function() {
   this.$cycle.val(params.cycle || this.$cycle.val());
   this.performSearch(null, { pushState: false });
 };
-
-//Update history upon changes to parameters
-ElectionSearch.prototype.handlePushState = function() {
-  var params = URI.parseQuery(window.location.search);
-  var urlParams = new URLSearchParams(params);
-  var isState = urlParams.get('state');
-  if (isState) {
-    this.$resultsHeading.show()
-  }
-}
 
 //search presidential elections only if no other parameters (zip, state, district) are present
 ElectionSearch.prototype.getPresidentialElections = function() {

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -193,9 +193,10 @@ ElectionSearch.prototype.search = function(e, opts) {
             .toString()
         );
         analytics.pageView();
+        self.$resultsHeading.show()
       }
     } else if (self.results) {
-      self.$resultsHeading.show();
+      self.$resultsHeading.show()
       // Requested options match saved options; redraw cached results. This
       // ensures that clicking on a state or district will highlight it when
       // the search options don't match the state of the map, e.g. after the
@@ -218,6 +219,16 @@ ElectionSearch.prototype.handlePopState = function() {
   this.$cycle.val(params.cycle || this.$cycle.val());
   this.performSearch(null, { pushState: false });
 };
+
+//Update history upon changes to parameters
+ElectionSearch.prototype.handlePushState = function() {
+  var params = URI.parseQuery(window.location.search);
+  var urlParams = new URLSearchParams(params);
+  var isState = urlParams.get('state');
+  if (isState) {
+    this.$resultsHeading.show()
+  }
+}
 
 //search presidential elections only if no other parameters (zip, state, district) are present
 ElectionSearch.prototype.getPresidentialElections = function() {

--- a/fec/fec/static/scss/components/_search-controls.scss
+++ b/fec/fec/static/scss/components/_search-controls.scss
@@ -380,6 +380,10 @@
         margin-top: u(0rem);
       }
     }
+
+    .heading--section {
+      display: none;
+    }
   }
 
   .search--container {


### PR DESCRIPTION
## Summary 
- Add a **persistent** accordion for 2021 redistricting information to Election search page. 
- Fix an existing bug : If you click on the map itself, before choosing any form filters, the "Results" headline does not show up until you choose a form filter.
- Fixes existing bug of the "Results" headline flashing briefly on the page before being hidden when you load page (we may not have noticed this in 2020  because it loaded showing the presidential listing for 2020 by default.)

- Resolves #4570

### Required reviewers
one UX, one frontend

## Impacted areas of the application

modified:   data/templates/election-lookup.jinja
modified:   fec/static/js/modules/election-search.js
modified:   fec/static/scss/components/_search-controls.scss

Related PR:
https://github.com/fecgov/fec-cms/pull/2409

## How to test

- checkout branch `feature/4570-district-update-msg`
- `npm run build`
- Go to http://127.0.0.1:8000/data/elections/
- See the 2021 redistricting accordion
- Test that the "Results" heading shows up if you click on the map itself before choosing any form filters
- Notice that "Results" heading does not flash on screen (as it does on production) when you load page with no params (querystring)

