### PR TITLE
Upgrade Wagtail from 2.11.7 -> 2.11.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ requests==2.25.1
 urllib3==1.26.4
 slacker==0.8.6
 whitenoise==5.2.0
-wagtail==2.11.7
+wagtail==2.11.8
 Jinja2==2.11.3
 django_jinja==2.7.0
 pillow==8.2.0


### PR DESCRIPTION
## Summary

- Resolves #4723 

Security update to address XSS possibility

### Required reviewers

1 front-end (localhost or test env)
1 content (test env) (need to choose and tag)

## Impacted areas of the application

Wagtail StreamFields, which are all over the place. But, according to the [release notes](https://docs.wagtail.io/en/stable/releases/2.11.8.html), it's only exploitable by those with admin/author privileges, so 🤞🏼 no noticeable changes for us.

## Screenshots

No visual changes

## Related PRs

None

## How to test

- pull the branch
- `pip install -r requirements.txt`
- `./manage.py runserver`
- Being that it's a fix, I don't know if there's a way to test a failure.
- The release notes say the changes would affect `include_block` which we're only doing in `section.html` and `meeting_page.html` so we should check those:
   - meeting pages (make sure content displays correctly)
   - resource pages (ditto) (section.html is used by ResourceBlocks, which are only used by ResourcePages)

