### PR TITLE
Update Other committees filter label

### DIFF
--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -172,7 +172,7 @@
 {% if display_default_other_committees_filter %}
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="designation">
-    <legend class="label" for="committee_type">Other committees</legend>
+    <legend class="label" for="committee_type">Other committees and filers</legend>
     <ul class="dropdown__selected">
       <li>
         <input id="designation-checkbox-J" type="checkbox" name="{{ designation }}" value="J">


### PR DESCRIPTION
## Summary

- Resolves #4766 

Update the "Other committees" filter label to "Other committees and filers" on the following datatables:

http://localhost:8000/data/committees/
http://localhost:8000/data/disbursements/
http://localhost:8000/data/receipts/
http://localhost:8000/data/receipts/individual-contributions/

### Required reviewers

1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

- Committees datatable: http://localhost:8000/data/committees/
- Disbursements datatable: http://localhost:8000/data/disbursements/
- Receipts datatable: http://localhost:8000/data/receipts/
- Individual contributions datatable: http://localhost:8000/data/receipts/individual-contributions/

## Screenshots

![Screen Shot 2021-08-04 at 3 50 11 PM](https://user-images.githubusercontent.com/12799132/128245643-eb540a18-1b2d-44c1-bebc-b849b3b7cb31.png)

## How to test

- Checkout this branch
- `./manage.py runserver`
- Make sure that the "Other committees and filers" label exists on the following datatables:
   - Committees datatable: http://localhost:8000/data/committees/
   - Disbursements datatable: http://localhost:8000/data/disbursements/
   - Receipts datatable: http://localhost:8000/data/receipts/
   - Individual contributions datatable: http://localhost:8000/data/receipts/individual-contributions/
- Make sure that the "Other committees" label is not changed on the following datatables:
   - PAC and party datatable: http://localhost:8000/data/committees/pac-party/
   - Audits datatable: http://localhost:8000/legal-resources/enforcement/audit-search/