### PR TITLE
Change 'contributor' to 'source' for Receipts

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -395,7 +395,7 @@ table_columns = OrderedDict([
     ('loans', ['Committee Name', 'Loaner name', 'Incurred date', 'Payment to date', 'Original loan amount']),
     ('debts', ['Committee Name', 'Creditor/Debtor Name', 'Beginning Balance', 'Ending Balance']),
     ('party-coordinated-expenditures', ['Spender', 'Candidate', 'Payee name', 'Expenditure date', 'Amount']),
-    ('receipts', ['Contributor name', 'Recipient', 'Election', 'State', 'Receipt date', 'Amount']),
+    ('receipts', ['Source name', 'Recipient', 'Election', 'State', 'Receipt date', 'Amount']),
     ('reports-presidential',
         ['Committee', 'Report type', 'Version', 'Receipt date', 'Coverage end date', 'Total receipts',
             'Total disbursements']),

--- a/fec/data/templates/partials/browse-data/raising.jinja
+++ b/fec/data/templates/partials/browse-data/raising.jinja
@@ -10,7 +10,7 @@
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/receipts/">All receipts</a></h4>
-          <p>Search candidate and committee receipt data by contributor, amount and date.</p>
+          <p>Search candidate and committee receipt data by source amount and date.</p>
         </div>
       </li>
       <li>

--- a/fec/data/templates/partials/browse-data/raising.jinja
+++ b/fec/data/templates/partials/browse-data/raising.jinja
@@ -10,7 +10,7 @@
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/receipts/">All receipts</a></h4>
-          <p>Search candidate and committee receipt data by source amount and date.</p>
+          <p>Search candidate and committee receipt data by source, amount and date.</p>
         </div>
       </li>
       <li>

--- a/fec/data/templates/partials/receipts-filter.jinja
+++ b/fec/data/templates/partials/receipts-filter.jinja
@@ -20,8 +20,8 @@ Filter receipts
 {% block efiling_filters %}
 <div class="filters__inner">
   {{ typeahead.field('committee_id', 'Recipient name or ID', id_suffix='_raw') }}
-  {{ text.field('contributor_name', 'Contributor name', id_suffix='_raw') }}
-  {{ text.field('contributor_city', 'Contributor city', id_suffix='_raw') }}
+  {{ text.field('contributor_name', 'Source name', id_suffix='_raw') }}
+  {{ text.field('contributor_city', 'Source city', id_suffix='_raw') }}
   {{ states.field('contributor_state', id_suffix='_raw') }}
 </div>
 {% endblock %}
@@ -29,8 +29,8 @@ Filter receipts
 {% block filters %}
 <div class="filters__inner">
   {{ typeahead.field('committee_id', 'Recipient name or ID', helper_text = 'Limit 10 recipient names or IDs') }}
-  <legend class="label u-margin--top">Contributor details</legend>
-  {{ typeahead.field(name = 'contributor_name', title = 'Name or ID', dataset='committees', allow_text=True, minor_label_text = True, helper_text = 'Limit 10 contributor names or IDs') }}
+  <legend class="label u-margin--top">Source details</legend>
+  {{ typeahead.field(name = 'contributor_name', title = 'Name or ID', dataset='committees', allow_text=True, minor_label_text = True, helper_text = 'Limit 10 source names or IDs') }}
   {{ text.field(name = 'contributor_city', title = 'City', minor_label_text = True, helper_text = 'Limit 10 cities') }}
   {{ text.field(name = 'contributor_zip', title = 'ZIP code', attrs = {'maxlength':5}, minor_label_text = True, helper_text = 'Limit 10 ZIP codes') }}
   {{ text.field(name = 'contributor_occupation', title = 'Occupation', minor_label_text = True, helper_text = 'Use the employer field to search by occupation in reports filed before 2003. Limit 10 occupations') }}
@@ -40,10 +40,10 @@ Filter receipts
 <div class="js-accordion accordion--neutral restricted-fields" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Time period</button>
   <div class="accordion__content">
-    {{ years.cycles('two_year_transaction_period', 'Report time period', multi_time_period_label="When searching multiple time periods, choose one or more fields: recipient name or ID, contributor name or ID, city, ZIP code, occupation or employer, or image number.")  }}
+    {{ years.cycles('two_year_transaction_period', 'Report time period', multi_time_period_label="When searching multiple time periods, choose one or more fields: recipient name or ID, source name or ID, city, ZIP code, occupation or employer, or image number.")  }}
     {{ date.field('date', 'Receipt date range' ) }}
   </div>
-  <button type="button" class="js-accordion-trigger accordion__button">More contributor details</button>
+  <button type="button" class="js-accordion-trigger accordion__button">More source details</button>
   <div class="accordion__content">
     {{ states.field('contributor_state') }}
     {% include 'partials/filters/unique-receipts.jinja' %}

--- a/fec/fec/static/js/pages/datatable-receipts.js
+++ b/fec/fec/static/js/pages/datatable-receipts.js
@@ -23,7 +23,7 @@ $(document).ready(function() {
     useExport: true,
     rowCallback: tables.modalRenderRow,
     error400Message:
-      '<p>You&#39;re trying to search across multiple time periods. Filter by recipient name or ID, contributor details, or image number for results.</p>',
+      '<p>You&#39;re trying to search across multiple time periods. Filter by recipient name or ID, source details, or image number for results.</p>',
     callbacks: {
       afterRender: tables.modalRenderFactory(donationTemplate)
     }

--- a/fec/fec/static/js/templates/receipts.hbs
+++ b/fec/fec/static/js/templates/receipts.hbs
@@ -1,5 +1,5 @@
 <div class="panel__row">
-  <h4 class="panel__title">Contributor information</h4>
+  <h4 class="panel__title">Source information</h4>
   <table>
     <tr>
       {{#panelRow "Name"}}

--- a/fec/fec/static/js/templates/receipts.hbs
+++ b/fec/fec/static/js/templates/receipts.hbs
@@ -39,7 +39,7 @@
 </div>
 
 <div class="panel__row">
-  <h4 class="panel__title">Contribution information</h4>
+  <h4 class="panel__title">Receipt information</h4>
   <table>
     {{#panelRow "Amount"}}
       {{{currency contribution_receipt_amount}}}


### PR DESCRIPTION
## Summary (required)

- Resolves #4513
- Change "contributor" to "source" on `data/receipts` :
     - labels, help-text, and warning messages on filter panels(processed and raw)
     - datatable header and flyout panel
     - change `Contributor information` to `Receipts information` on flyout panel
- Change "contributor" to "source"  on Browse data Receipts section

### Required reviewers
one front-end, on UX

## Impacted areas of the application

	modified:   data/constants.py
	modified:   data/templates/partials/browse-data/raising.jinja
	modified:   data/templates/partials/receipts-filter.jinja
	modified:   fec/static/js/pages/datatable-receipts.js
	modified:   fec/static/js/templates/receipts.hbs

## How to test

- checkout `feature/4513-change-contributor-to-source`
- `npm run build-js`
- Please see PR Summary or [issue](https://github.com/fecgov/fec-cms/issues/4513) for places where changes should be made.
- Confirm changes from "contributor" to "source"  where applicable
- Did we miss any places that you can think of?

