### PR TITLE
Fix admin fines calculator typo

### DIFF
--- a/fec/fec/static/js/modules/calc-admin-fines.js
+++ b/fec/fec/static/js/modules/calc-admin-fines.js
@@ -468,7 +468,7 @@ new Vue({
             type: 'p',
             class: '',
             content:
-              'This calculator is for estimating an adminstrative fine for late or not filed reports.\
+              'This calculator is for estimating an administrative fine for late or not filed reports.\
               If you have not yet filed your report, submit it as soon as\xa0possible.'
           },
           {
@@ -492,7 +492,7 @@ new Vue({
       },
       {
         navLabel: '',
-        title: 'When was the committee’s adminstrative fine\xa0assessed?',
+        title: 'When was the committee’s administrative fine\xa0assessed?',
         autoAdvance: true,
         questions: penaltyAssessedDates,
         viewed: false
@@ -669,7 +669,7 @@ new Vue({
             class: '',
             fieldH: 'How many previous\xa0violations?',
             helpTitle: 'Number of previous violations',
-            help: `<p>The number of previous adminstrative fines assessed at final determination during the current and most recently completed two-year election cycle.</p>
+            help: `<p>The number of previous administrative fines assessed at final determination during the current and most recently completed two-year election cycle.</p>
             <p>Enter "0" if none were assessed.</p>`
           },
           { type: 'clear' },

--- a/fec/fec/static/js/modules/calc-admin-fines.js
+++ b/fec/fec/static/js/modules/calc-admin-fines.js
@@ -748,7 +748,7 @@ new Vue({
           {
             type: 'p',
             content:
-              'This is an estimated administrative fine based on the information you provided and may not refelect the actual fine amount assessed by the Commission. Your committee will be notified if the Commission assesses a fine for a late or non-filed\xa0report.'
+              'This is an estimated administrative fine based on the information you provided and may not reflect the actual fine amount assessed by the Commission. Your committee will be notified if the Commission assesses a fine for a late or non-filed\xa0report.'
           }
         ],
         viewed: false

--- a/fec/fec/static/scss/components/_fec-org-chart.scss
+++ b/fec/fec/static/scss/components/_fec-org-chart.scss
@@ -468,7 +468,7 @@ $orgChart_lineSolidDark: thin solid $orgChart_colorStandard;
       <li>
         <a href="https://transition.fec.gov/about/offices/OGC/DepGC.shtml">
           <span>Gregory R. Baker</span>
-          <span>Deputy General Counsel - Adminstration</span>
+          <span>Deputy General Counsel - Administration</span>
         </a>
       </li>
       <li>


### PR DESCRIPTION
## Summary

- Resolves [no related ticket]

Fixing a repeated typo inside the admin fines calculator.

### Required reviewers

One person (feel free to remove yourself)

## Impacted areas of the application

Only changing "adminstrative" to "administrative" in three places inside the admin fines calculator

## Screenshots

None

## Related PRs

None

## How to test

- Pull the branch
- `npm run build`
- `./manage.py runserver`
- Check the [admin fines calculator](http://127.0.0.1:8000/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine)
   - intro text
   - the "When was the committee's administrative fine assessed?" frame
   - the help text for "Number of previous violations"
