### PR TITLE
remove all references to the FEC_TRANSITION_URL

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -37,7 +37,6 @@ FEC_DIGITALGOV_DRAWER_KEY_MAIN = env.get_credential('DIGITALGOV_DRAWER_KEY_MAIN'
 DIGITALGOV_BASE_API_URL = 'https://i14y.usa.gov/api/v1'
 DIGITALGOV_DRAWER_HANDLE = env.get_credential('DIGITALGOV_DRAWER_HANDLE', '')
 
-FEC_TRANSITION_URL = env.get_credential('FEC_TRANSITION_URL', 'https://transition.fec.gov')
 WEBMANAGER_EMAIL = "webmanager@fec.gov"
 
 ENVIRONMENTS = {
@@ -165,7 +164,6 @@ TEMPLATES = [
                 'FEC_API_KEY_PUBLIC': FEC_API_KEY_PUBLIC,
                 'FEC_API_URL': FEC_API_URL,
                 'WEBMANAGER_EMAIL': WEBMANAGER_EMAIL,
-                'TRANSITION_URL': FEC_TRANSITION_URL,
                 'FEC_CMS_ENVIRONMENT': FEC_CMS_ENVIRONMENT,
                 'FEATURES': FEATURES,
             },

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -154,7 +154,6 @@
       window.API_VERSION = '{{ settings.FEC_API_VERSION }}';
       window.API_KEY_PUBLIC = '{{ settings.FEC_API_KEY_PUBLIC }}';
       window.API_KEY_PUBLIC_CALENDAR = '{{ settings.FEC_API_KEY_PUBLIC_CALENDAR }}';
-      window.TRANSITION_URL = '{{ settings.FEC_TRANSITION_URL }}';
       window.CANONICAL_BASE = '{{ settings.CANONICAL_BASE }}'
     </script>
 

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -151,7 +151,6 @@
       window.API_VERSION = '{{ settings.FEC_API_VERSION }}';
       window.API_KEY_PUBLIC = '{{ settings.FEC_API_KEY_PUBLIC }}';
       window.API_KEY_PUBLIC_CALENDAR = '{{ settings.FEC_API_KEY_PUBLIC_CALENDAR }}';
-      window.TRANSITION_URL = '{{ settings.FEC_TRANSITION_URL }}';
       window.CANONICAL_BASE = '{{ settings.CANONICAL_BASE }}'
     </script>
 

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -21,4 +21,3 @@ applications:
       FEC_APP_URL: "/data"
       FEC_CMS_DEBUG: false
       FEC_CMS_ENVIRONMENT: dev
-      FEC_TRANSITION_URL: https://transition.fec.gov

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -23,4 +23,3 @@ applications:
       FEC_APP_URL: '/data'
       FEC_CMS_ENVIRONMENT: feature
       FEC_CMS_DEBUG: false
-      FEC_TRANSITION_URL: https://transition.fec.gov

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -21,4 +21,3 @@ applications:
       FEC_APP_URL: "/data"
       FEC_CMS_DEBUG: false
       FEC_CMS_ENVIRONMENT: prod
-      FEC_TRANSITION_URL: https://transition.fec.gov

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -21,4 +21,3 @@ applications:
       FEC_APP_URL: '/data'
       FEC_CMS_DEBUG: false
       FEC_CMS_ENVIRONMENT: stage
-      FEC_TRANSITION_URL: https://transition.fec.gov


### PR DESCRIPTION
## Summary (required)

- Resolves #4682 

Removes all references to the FEC_TRANSITION_URL

### Required reviewers

1 frontend

## Impacted areas of the application

General components of the application that this PR will affect:

-  Anywhere the FEC_TRANSITION_URL might have been used

## How to test

- `npm run build` just in case
- `./manage.py runserver`
- Ensure that we are no longer using the `FEC_TRANSITION_URL` in the CMS code.
- View page source and ensure that the `FEC_TRANSITION_URL` is no longer in the page HTML source code.
