### PR TITLE
4827-Add filing frequency and registration date to committee pages

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -24,7 +24,13 @@
     <div class="heading--section">
       <span class="t-data t-bold entity__type">
         {% if current_committee_status == "active" %}
-          <span class="is-active-status">Active</span>
+          <span class="is-active-status">Active
+          {% if committee.filing_frequency == "M" %}
+          - Monthly </span>
+          {% endif %}
+          {% if committee.filing_frequency == "Q" %}
+          - Quarterly </span>
+          {% endif %}
         {% elif current_committee_status == "admin_terminated" %}
           <span class="is-terminated-status">Administratively terminated</span>
         {% else %}
@@ -45,6 +51,9 @@
          {% endif %}
       </span>
       <span class="t-data t-bold entity__type">ID: {{ committee_id }}</span>
+      {% if committee_type not in ['C', 'E', 'I'] %}
+      <span class="t-data t-bold entity__type">Registration Date: {{ format_first_file_date(committee.first_file_date) }}</span>
+      {% endif %}
     </div>
   </header>
 

--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -52,7 +52,7 @@
       </span>
       <span class="t-data t-bold entity__type">ID: {{ committee_id }}</span>
       {% if committee_type not in ['C', 'E', 'I'] %}
-      <span class="t-data t-bold entity__type">Registration Date: {{ format_first_file_date(committee.first_file_date) }}</span>
+      <span class="t-data t-bold entity__type">Registration Date: {{ committee.first_file_date|date_full }}</span>
       {% endif %}
     </div>
   </header>

--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -27,8 +27,7 @@
           <span class="is-active-status">Active
           {% if committee.filing_frequency == "M" %}
           - Monthly </span>
-          {% endif %}
-          {% if committee.filing_frequency == "Q" %}
+          {% else %}
           - Quarterly </span>
           {% endif %}
         {% elif current_committee_status == "admin_terminated" %}
@@ -52,7 +51,7 @@
       </span>
       <span class="t-data t-bold entity__type">ID: {{ committee_id }}</span>
       {% if committee_type not in ['C', 'E', 'I'] %}
-      <span class="t-data t-bold entity__type">Registration Date: {{ committee.first_file_date|date_full }}</span>
+      <span class="t-data t-bold entity__type">Registration date: {{ committee.first_file_date|date_full }}</span>
       {% endif %}
     </div>
   </header>

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -5,8 +5,6 @@ import collections
 
 from data import constants
 
-from django_jinja import library
-
 
 def current_cycle(delayed_start=False):
     """
@@ -296,12 +294,6 @@ def format_date_longform(date):
     "12/31/2019" -> "January 31, 2019"
     """
     return datetime.datetime.strptime(date, '%m/%d/%Y').strftime('%B %d, %Y')
-
-
-@library.global_function
-def format_first_file_date(first_file_date):
-    first_file_date = datetime.datetime.strptime(first_file_date, '%Y-%m-%d')
-    return first_file_date.strftime('%B %-d, %Y')
 
 
 def extend(*dicts):

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -5,6 +5,8 @@ import collections
 
 from data import constants
 
+from django_jinja import library
+
 
 def current_cycle(delayed_start=False):
     """
@@ -294,6 +296,12 @@ def format_date_longform(date):
     "12/31/2019" -> "January 31, 2019"
     """
     return datetime.datetime.strptime(date, '%m/%d/%Y').strftime('%B %d, %Y')
+
+
+@library.global_function
+def format_first_file_date(first_file_date):
+    first_file_date = datetime.datetime.strptime(first_file_date, '%Y-%m-%d')
+    return first_file_date.strftime('%B %-d, %Y')
 
 
 def extend(*dicts):


### PR DESCRIPTION
## Summary 

- Resolves #4827 

Updates committee profile pages to display committee registration date and filing frequency. 

### Required reviewers

1-2 reviewers

## Impacted areas of the application

General components of the application that this PR will affect:

-  Committee profile pages

## Screenshots

Before:
<img width="1118" alt="Screen Shot 2021-08-28 at 10 54 22 AM" src="https://user-images.githubusercontent.com/66386084/131222209-046062d3-bb8f-46ee-a3f0-31adbf6f6d1e.png">
<img width="827" alt="Screen Shot 2021-08-28 at 10 53 51 AM" src="https://user-images.githubusercontent.com/66386084/131222210-dd75937a-8d4d-42f3-9dc3-8860248a5a53.png">

After:
<img width="1101" alt="Screen Shot 2021-08-28 at 10 53 19 AM" src="https://user-images.githubusercontent.com/66386084/131222211-998423b0-40b5-46b3-a2f7-a7d757b1fe84.png">
<img width="812" alt="Screen Shot 2021-08-28 at 10 52 02 AM" src="https://user-images.githubusercontent.com/66386084/131222213-ba491efc-b9c2-4698-876a-1038a095f39f.png">

After screenshots of the committee selected specifically for character length in #4827.
<img width="483" alt="Screen Shot 2021-08-28 at 10 57 10 AM" src="https://user-images.githubusercontent.com/66386084/131222207-4ea0701a-73be-428c-9fca-6a9ed75c8b4e.png">
<img width="1152" alt="Screen Shot 2021-08-28 at 10 56 41 AM" src="https://user-images.githubusercontent.com/66386084/131222208-de5be03c-7282-4f3d-92af-81e07f80be4e.png">


## How to test

Different committee types and lengths of characters for testing: 
- http://127.0.0.1:8000/data/committee/C00489658/
- https://www.fec.gov/data/committee/C00489658/
- http://127.0.0.1:8000/data/committee/C00631481/
- https://www.fec.gov/data/committee/C00631481/
- http://127.0.0.1:8000/data/committee/C00139139/
- https://www.fec.gov/data/committee/C00139139/
- http://127.0.0.1:8000/data/committee/C00153262/
- https://www.fec.gov/data/committee/C00153262/

I kept the leading 0's for days because that is the format used in date_full and for consistency. There was not specification about this in the #4827 discussion. 

I tested different mobile views and I think they are pretty good, but I'd be happy to try and optimize this further if you all think that might be best. Also, I did not refactor/consider refactoring committee type so I left that unchecked and think we should create another ticket for that if needed. 

Thanks in advance for your review!
