### PR TITLE
Fix references to first file date/registration date

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -381,7 +381,7 @@ table_columns = OrderedDict([
     ('candidates-office-president', ['Name', 'Party', 'Receipts', 'Disbursements']),
     ('candidates-office-senate', ['Name', 'Party', 'State', 'Receipts', 'Disbursements']),
     ('candidates-office-house', ['Name', 'Party', 'State', 'District', 'Receipts', 'Disbursements']),
-    ('committees', ['Name', 'Committee ID', 'Treasurer', 'Type', 'Designation', 'First filing date']),
+    ('committees', ['Name', 'Committee ID', 'Treasurer', 'Type', 'Designation', 'Registration date']),
     ('pac-party', ['Name', 'Type', 'Receipts', 'Disbursements', 'Ending cash on hand']),
     ('communication-costs', ['Committee', 'Support/Oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Description', 'Disbursement date', 'Amount']),

--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -51,7 +51,7 @@
       </span>
       <span class="t-data t-bold entity__type">ID: {{ committee_id }}</span>
       {% if committee_type not in ['C', 'E', 'I'] %}
-      <span class="t-data t-bold entity__type">Registration date: {{ committee.first_file_date|date_full }}</span>
+      <span class="t-data t-bold entity__type">Registration date: {{ committee.first_f1_date|date_full }}</span>
       {% endif %}
     </div>
   </header>

--- a/fec/data/templates/partials/committees-filter.jinja
+++ b/fec/data/templates/partials/committees-filter.jinja
@@ -18,7 +18,7 @@
     {{ text.field('treasurer_name', 'Most recent treasurer') }}
     {{ parties.checkbox() }}
     {{ states.field('state') }}
-    {{ date.field('first_file_date', 'Date first filed statement of organization', '') }}
+    {{ date.field('first_f1_date', 'Registration date', '') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
   <div class="accordion__content">

--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -179,7 +179,7 @@ var candidates = [
   { data: 'state', className: 'min-desktop hide-panel column--state' },
   { data: 'district', className: 'min-desktop hide-panel column--small' },
   {
-    data: 'first_file_date',
+    data: 'first_f1_date',
     orderable: true,
     className: 'min-desktop hide-panel column--small'
   },
@@ -229,7 +229,7 @@ var committees = [
   { data: 'committee_type_full', className: 'min-tablet hide-panel' },
   { data: 'designation_full', className: 'min-tablet hide-panel' },
   {
-    data: 'first_file_date',
+    data: 'first_f1_date',
     orderable: true,
     className: 'min-desktop hide-panel column--small'
   },

--- a/fec/fec/static/js/templates/committees.hbs
+++ b/fec/fec/static/js/templates/committees.hbs
@@ -14,8 +14,8 @@
         {{party_full}}
       {{/panelRow}}
     {{/if}}
-    {{#panelRow "First file date"}}
-      {{datetime first_file_date format="pretty"}}
+    {{#panelRow "Registration date"}}
+      {{datetime first_f1_date format="pretty"}}
     {{/panelRow}}
     {{#panelRow "Designation"}}
       {{designation_full}}

--- a/fec/fec/static/js/templates/pac-party.hbs
+++ b/fec/fec/static/js/templates/pac-party.hbs
@@ -37,8 +37,8 @@ Template for PAC and party committee datatable details panel
     {{#panelRow "Filing frequency"}}
       {{ filing_frequency_full }}
     {{/panelRow}}
-    {{#panelRow "First filing date"}}
-      {{ datetime first_file_date format="pretty" }}
+    {{#panelRow "Registration date"}}
+      {{ datetime first_f1_date format="pretty" }}
     {{/panelRow}}
   </table>
 </div>


### PR DESCRIPTION
## Summary (required)

Resolves #4843
Resolves #4879 

Many places in the application are displaying/searching the first file date for the first form 1 date (labeled "registration date" on the committee profile page). The first file date is _almost_ always but not always the same date as the first Form 1 date. This PR updates the front-end to always use first Form 1 date for committees and label it "registration date".

**Committees datatable**
- Update filters to search first Form 1 instead of first file date for first form 1 filter
- Rename filter "Registration date"
- Rename column "Registration date" and show first F1 date

**Committee profile page**
- Display first form 1 date under registration date

**PAC/Party datatable**
- Modify flyout panel to show first form 1 date

### Required reviewers

@JonellaCulmer and one front-end developer, please

## Impacted areas of the application

General components of the application that this PR will affect:

-  Committees data table
- PAC/Party datatable
- Committee profile page

## Screenshots

## Committees datatable

### Before
<img width="1425" alt="Screen Shot 2021-08-31 at 10 07 53 AM" src="https://user-images.githubusercontent.com/31420082/131517841-03042c70-3a42-4e57-b9b5-bf7947c88eee.png">

### After
<img width="1426" alt="Screen Shot 2021-08-31 at 10 08 54 AM" src="https://user-images.githubusercontent.com/31420082/131517788-043314b2-d0ca-4e77-bccc-29a36bb6ef64.png">

## Committee profile page

### Before
<img width="575" alt="Screen Shot 2021-10-18 at 11 51 23 AM" src="https://user-images.githubusercontent.com/31420082/137766054-62c33f0f-8850-4b89-bc12-c2098bdac61e.png">

### After
<img width="575" alt="Screen Shot 2021-10-18 at 11 51 48 AM" src="https://user-images.githubusercontent.com/31420082/137766047-e54b1e14-6973-4c19-ad45-7697fe724148.png">

## PAC/Party datatable

### Before
<img width="1368" alt="Screen Shot 2021-10-18 at 12 05 31 PM" src="https://user-images.githubusercontent.com/31420082/137768138-c6da3972-e881-41ea-a803-f02070dba102.png">

### After
<img width="1359" alt="Screen Shot 2021-10-18 at 12 00 49 PM" src="https://user-images.githubusercontent.com/31420082/137768177-525c4fe4-a4c5-4d82-8421-9f27060eef0f.png">
## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- Checkout this branch
- Rebuild static assets with `npm run watch` or `npm run build`

**Committees datatable**
- Go to http://localhost:8000/data/committees/?q=C00010603 
- Note that first F1 is now labelled `Registration date`
- Verify that the column correctly shows `1976-07-29`
- Click on the flyout button, verify that it correctly shows `Registration date  July 29, 1976`
- Do a search for this registration date: http://localhost:8000/data/committees/?min_first_f1_date=07%2F29%2F1976&max_first_f1_date=07%2F29%2F1976
- Verify DNC committee appears (C00010603)
- Verify filter is labeled `REGISTRATION DATE`
(Check out production https://www.fec.gov/data/committees/?q=C00010603 for a comparison)

**Committee profile page**
- Click through to the DNC profile page from the data table
- Verify that the page correctly shows `REGISTRATION DATE: JULY 29, 1976`
(check out production for a comparison https://www.fec.gov/data/committee/C00010603/)

**PAC/Party datatable**
- Go to http://localhost:8000/data/committees/pac-party/?committee_id=C00010603&cycle=2022
- Click on the flyout panel and see that it correctly shows `Registration date July 29, 1976`
- (check out production for a comparison https://www.fec.gov/data/committees/pac-party/?committee_id=C00010603&cycle=2022)




