### PR TITLE
[BEFORE RELEASE 09-07-21] Fix EC committee page server errors

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -534,6 +534,9 @@ def get_committee(committee_id, cycle):
     elif com_com_type == 'X':
         com_type_text = 'party committees'
         com_type_glossary = 'Party committee'
+    else:
+        com_type_text = ''
+        com_type_glossary = ''
 
     template_variables = {
         "candidates": candidates,


### PR DESCRIPTION
## Summary 
Fix Electioneering communication committee pages server errors:
https://www.fec.gov/data/committee/C30001101/

 - Add a an else statement to the com_type conditionals on data/views.py to stop server errors for committee pages of `committee type 'E'` (and any others that might have their com/org types listed) 

- Resolves #issue_number
   (reported in Slack by @prstoetzer / @djgarr)

- [ ] Followup: Before enabling the comm snapshot feature flag, add conditional for `com type "E"` to the snapshot glossary link logic in `data/views.py`, Are there any other com/org types we missed?

### Required reviewers

one frontend

## Impacted areas of the application
modified: data/views.py

## Related PRs
https://github.com/fecgov/fec-cms/pull/4767

## How to test

- checkout and run branch
- see that http://127.0.0.1:8000/data/committee/C30001101/ loads without 500 error
- see that others on committee pages linked from the EC datatable page load without server error: http://127.0.0.1:8000/data/electioneering-communications/

