### PR TITLE
add political party to filter panel, remove 2 options from IE filters

### DIFF
--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -1,6 +1,6 @@
 {% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
 
-{% macro field(committee_type='committee_type', organization_type='organization_type', designation='designation', display_sponsor_candidate_filter=False, display_authorized_committee_filter=True, display_parties_only_filter=False, display_default_other_committees_filter=True, display_alt_other_committees_filter=False) %}
+{% macro field(committee_type='committee_type', organization_type='organization_type', designation='designation', display_sponsor_candidate_filter=False, display_authorized_committee_filter=True, display_parties_only_filter=False, display_default_other_committees_filter=True, display_alt_other_committees_filter=False, display_default_ie_committees_filter=True, display_alt_ie_committees_filter=False) %}
 
 {% if display_authorized_committee_filter %}
 <div class="filter">
@@ -24,32 +24,48 @@
 </div>
 {% endif %}
 
-<div class="filter">
-  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_type">
-    <label class="label t-inline-block" for="committee_type">Independent expenditure committees</label>
-    <ul class="dropdown__selected">
-      <li>
-        <input id="committee-type-checkbox-O" type="checkbox" name="{{ committee_type }}" value="O">
-        <label class="dropdown__value" for="committee-type-checkbox-O">Super PAC (independent expenditure only)</label>
-      </li>
-    </ul>
-    <div class="dropdown">
-      <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>
-      <div id="ie-dropdown" class="dropdown__panel" aria-hidden="true">
-        <ul class="dropdown__list">
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-U" type="checkbox" name="{{ committee_type }}" value="U">
-            <label class="dropdown__value" for="committee-type-checkbox-U">Single candidate independent expenditure</label>
-          </li>
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-I" type="checkbox" name="{{ committee_type }}" value="I">
-            <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditure filer (not a committee)</label>
-          </li>
-        </ul>
+{% if display_default_ie_committees_filter %}
+  <div class="filter">
+    <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_type">
+      <label class="label t-inline-block" for="committee_type">Independent expenditure committees</label>
+      <ul class="dropdown__selected">
+        <li>
+          <input id="committee-type-checkbox-O" type="checkbox" name="{{ committee_type }}" value="O">
+          <label class="dropdown__value" for="committee-type-checkbox-O">Super PAC (independent expenditure only)</label>
+        </li>
+      </ul>
+      <div class="dropdown">
+        <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>
+        <div id="ie-dropdown" class="dropdown__panel" aria-hidden="true">
+          <ul class="dropdown__list">
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-U" type="checkbox" name="{{ committee_type }}" value="U">
+              <label class="dropdown__value" for="committee-type-checkbox-U">Single candidate independent expenditure</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-I" type="checkbox" name="{{ committee_type }}" value="I">
+              <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditure filer (not a committee)</label>
+            </li>
+          </ul>
+        </div>
       </div>
-    </div>
-  </fieldset>
-</div>
+    </fieldset>
+  </div>
+{% endif %}
+
+{% if display_alt_ie_committees_filter %}
+  <div class="filter">
+    <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_type">
+      <label class="label t-inline-block" for="committee_type">Independent expenditure committees</label>
+      <ul class="dropdown__selected">
+        <li>
+          <input id="committee-type-checkbox-O" type="checkbox" name="{{ committee_type }}" value="O">
+          <label class="dropdown__value" for="committee-type-checkbox-O">Super PAC (independent expenditure only)</label>
+        </li>
+      </ul>
+    </fieldset>
+  </div>
+{% endif %}
 
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="organization_type">

--- a/fec/data/templates/partials/pac-party-filter.jinja
+++ b/fec/data/templates/partials/pac-party-filter.jinja
@@ -16,7 +16,7 @@
   <div class="js-accordion accordion--neutral" data-content-prefix="filter">
     <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
     <div class="accordion__content">
-      {{ committee_type.field(display_sponsor_candidate_filter=True, display_authorized_committee_filter=False, display_parties_only_filter=True, display_default_other_committees_filter=False, display_alt_other_committees_filter=True, designation='committee_designation') }}
+      {{ committee_type.field(display_sponsor_candidate_filter=True, display_authorized_committee_filter=False, display_parties_only_filter=True, display_default_other_committees_filter=False, display_alt_other_committees_filter=True, display_default_ie_committees_filter=False, display_alt_ie_committees_filter=True, designation='committee_designation') }}
       {# TODO: API needs `organization_type` and leadership pac sponsor filter#}
     </div>
     <button type="button" class="js-accordion-trigger accordion__button">Committee details</button>

--- a/fec/fec/static/js/templates/pac-party.hbs
+++ b/fec/fec/static/js/templates/pac-party.hbs
@@ -16,6 +16,11 @@ Template for PAC and party committee datatable details panel
     {{#panelRow "Designation"}}
       {{committee_designation_full}}
     {{/panelRow}}
+    {{#if party_full}}
+      {{#panelRow "Political party"}}
+        {{party_full}}
+      {{/panelRow}}
+    {{/if}}
     {{#if sponsor_candidate_list}}
       {{#panelRow "Leadership PAC sponsor"}}
         {{#each sponsor_candidate_list}}


### PR DESCRIPTION
## Summary

- Resolves #4868 
- Resolves #4873 

Removes 2 IE filter options from committee type accordion. Also inserts political party label within the details panel.

### Required reviewers

1 UX and 1 front-end

## Impacted areas of the application

General components of the application that this PR will affect:

-  PAC & Party datatable: http://localhost:8000/data/committees/pac-party/

## Screenshots

<img width="992" alt="Screen Shot 2021-09-14 at 3 46 21 PM" src="https://user-images.githubusercontent.com/12799132/133324531-1a5ed205-abda-489a-8ac7-8e9666c2ac69.png">
<img width="297" alt="Screen Shot 2021-09-14 at 3 46 01 PM" src="https://user-images.githubusercontent.com/12799132/133324532-9453aac7-6f06-4a9f-b5fa-76f98ef43bb8.png">

## How to test

- checkout this branch
- `npm run build`
- Go to the pac and party datatable: http://localhost:8000/data/committees/pac-party/
- Under the "committee type" accordion, choose one of the filters under "Parties". Check to see if the political party is listed under the details panel, as seen in the screenshot above
- Under the "committee type" accordion, make sure that there is now only one option available under the "INDEPENDENT EXPENDITURE COMMITTEES" filter: "Super PAC (independent expenditure only)"