### PR TITLE
4845-Fix filter label on filings and reports data-tables

### DIFF
--- a/fec/data/templates/partials/filings-filter.jinja
+++ b/fec/data/templates/partials/filings-filter.jinja
@@ -44,7 +44,7 @@ Filter reports
 
   <button type="button" class="js-accordion-trigger accordion__button">Filing information</button>
   <div class="accordion__content">
-    {{ version_status.version(id_suffix='_processed', checkbox_label='Version') }}
+    {{ version_status.version(id_suffix='_processed', checkbox_label='Current Version') }}
     {{ version_status.status(id_suffix='_processed') }}
     {% include 'partials/filters/form-type.jinja' %}
     {{ text.field('beginning_image_number', 'Beginning image number')}}

--- a/fec/data/templates/partials/reports-filter.jinja
+++ b/fec/data/templates/partials/reports-filter.jinja
@@ -51,7 +51,7 @@ Filter reports
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Version</button>
   <div class="accordion__content">
-    {{ version_status.version(id_suffix='_processed', checkbox_label='Version') }}
+    {{ version_status.version(id_suffix='_processed', checkbox_label='Current Version') }}
     {{ version_status.status(id_suffix='_processed') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Totals</button>


### PR DESCRIPTION
## Summary (required)

- Resolves #4845 

 Changes the checkbox filter on the Filings and Reports data-tables to say "Current version"

### Required reviewers

1-2 reviewers

## Impacted areas of the application

General components of the application that this PR will affect:

-  Filings and Reports data-tables

## Screenshots
Before:
<img width="1073" alt="Screen Shot 2021-10-01 at 12 11 09 PM" src="https://user-images.githubusercontent.com/66386084/135654777-0036b511-d054-4d3a-ac6a-1ef00e005481.png">
<img width="1009" alt="Screen Shot 2021-10-01 at 12 12 37 PM" src="https://user-images.githubusercontent.com/66386084/135654797-fc201f0f-312b-42c4-b939-673336f556ce.png">


After:
<img width="1124" alt="Screen Shot 2021-10-01 at 12 14 03 PM" src="https://user-images.githubusercontent.com/66386084/135654694-991f0f35-3e36-4391-919f-2ee67b3ca06e.png">
<img width="942" alt="Screen Shot 2021-10-01 at 12 18 31 PM" src="https://user-images.githubusercontent.com/66386084/135654478-4c35c406-8f3d-4079-871f-1f857169b090.png">

## How to test
http://www.fec.gov/data/filings/?data_type=processed
http://127.0.0.1:8000/data/filings/?data_type=processed
https://www.fec.gov/data/reports/presidential/?is_amended=false&data_type=processed
http://127.0.0.1:8000/data/reports/presidential/?is_amended=false&data_type=processed