### PR TITLE
Change the label for the qualified and non-contribution PACs

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -286,8 +286,8 @@ pac_party = OrderedDict([
 pac_party_types = OrderedDict([
     ('N', 'PAC - nonqualified'),
     ('Q', 'PAC - qualified'),
-    ('V', 'PAC with non-contribution account - nonqualified'),
-    ('W', 'PAC with non-contribution account - qualified'),
+    ('V', 'Hybrid PAC - nonqualified'),
+    ('W', 'Hybrid PAC - qualified'),
     ('P', 'Party - nonqualified'),
     ('Y', 'Party - qualified'),
     ('Z', 'National party nonfederal account'),

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -93,11 +93,11 @@
         </li>
         <li class="dropdown__item">
           <input id="committee-type-checkbox-V" type="checkbox" name="{{ committee_type }}" value="V">
-          <label class="dropdown__value" for="committee-type-checkbox-V">PAC with non-contribution account - nonqualified</label>
+          <label class="dropdown__value" for="committee-type-checkbox-V">Hybrid PAC - nonqualified</label>
         </li>
         <li class="dropdown__item">
           <input id="committee-type-checkbox-W" type="checkbox" name="{{ committee_type }}" value="W">
-          <label class="dropdown__value" for="committee-type-checkbox-W">PAC with non-contribution account - qualified</label>
+          <label class="dropdown__value" for="committee-type-checkbox-W">Hybrid PAC - qualified</label>
         </li>
         <li class="dropdown__subhead">Separate segregated funds</li>
         <li class="dropdown__item">

--- a/fec/data/templates/partials/filters/audit-committee-types.jinja
+++ b/fec/data/templates/partials/filters/audit-committee-types.jinja
@@ -84,11 +84,11 @@
           </li>
           <li class="dropdown__item">
             <input id="committee-type-checkbox-V" type="checkbox" name="committee_type" value="V">
-            <label class="dropdown__value" for="committee-type-checkbox-V">PAC with non-contribution account - nonqualified</label>
+            <label class="dropdown__value" for="committee-type-checkbox-V">Hybrid PAC - nonqualified</label>
           </li>
           <li class="dropdown__item">
             <input id="committee-type-checkbox-W" type="checkbox" name="committee_type" value="W">
-            <label class="dropdown__value" for="committee-type-checkbox-W">PAC with non-contribution account - qualified</label>
+            <label class="dropdown__value" for="committee-type-checkbox-W">Hybrid PAC - qualified</label>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary

- Resolves #4878 

Updating the labels for "PAC with non-contribution account" to "Hybrid PAC" (both qualified and non-qualified)

### Required reviewers

1 UX, 1 front-end

## Impacted areas of the application

Datatables for Political action and party committees, Committees, Receipts, Individual contributions, Disbursements, and PAC and party committee reports.

## Screenshots

The value in the table columns is coming from the API, as `committee_type_full`
![image](https://user-images.githubusercontent.com/26720877/135892905-22f64455-86a9-4dd5-91cd-a747ee927131.png)
![image](https://user-images.githubusercontent.com/26720877/135892995-e7ba87dc-efce-4b43-bb81-32f08a137909.png)
![image](https://user-images.githubusercontent.com/26720877/135893059-efcea424-0963-4151-ba48-f345e1a471ae.png)
![image](https://user-images.githubusercontent.com/26720877/135893109-e380846b-1c32-41e8-af85-4eb3ed9a722b.png)
![image](https://user-images.githubusercontent.com/26720877/135893165-60cfcf6b-cdfe-46e5-975a-ce5e5d683f26.png)
![image](https://user-images.githubusercontent.com/26720877/135893214-d266514d-6933-4cbd-840f-70cf5cb79bcf.png)


## Related PRs

None

## How to test

- pull the branch
- `./manage.py runserver`
- Check
   - [Political action and party committees](http://127.0.0.1:8000/data/committees/pac-party/)
   - [Committees](http://127.0.0.1:8000/data/committees/)
   - [Receipts](http://127.0.0.1:8000/data/receipts/)
   - [Individual contributions](http://127.0.0.1:8000/data/receipts/individual-contributions/)
   - [Disbursements](http://127.0.0.1:8000/data/disbursements/)
   - [PAC and party committee reports](http://127.0.0.1:8000/data/reports/pac-party/)