### PR TITLE
4850-Remove political party line in details panel for committees showing null values

### DIFF
--- a/fec/fec/static/js/templates/committees.hbs
+++ b/fec/fec/static/js/templates/committees.hbs
@@ -9,9 +9,11 @@
     {{#panelRow "State"}}
       {{state}}
     {{/panelRow}}
-    {{#panelRow "Political party"}}
-      {{party_full}}
-    {{/panelRow}}
+    {{#if party_full}}
+      {{#panelRow "Political party"}}
+        {{party_full}}
+      {{/panelRow}}
+    {{/if}}
     {{#panelRow "First file date"}}
       {{datetime first_file_date format="pretty"}}
     {{/panelRow}}


### PR DESCRIPTION
## Summary (required)

- Resolves #4850 

Removes political party line in details panel for committees showing null values

### Required reviewers

1-2 reviewers

## Impacted areas of the application

General components of the application that this PR will affect:

-  Committees data-table details panel

## Screenshots

<img width="1138" alt="Screen Shot 2021-10-12 at 11 13 10 PM" src="https://user-images.githubusercontent.com/66386084/137062204-416fd040-ee27-4a6b-a78c-ae91611b3d07.png">

<img width="1138" alt="Screen Shot 2021-10-12 at 11 14 27 PM" src="https://user-images.githubusercontent.com/66386084/137062193-6f938f01-0f0e-4576-b363-24321418299f.png">

## How to test

- http://127.0.0.1:8000/data/committees/
- http://127.0.0.1:8000/data/committees/?q=C00003418
- https://www.fec.gov/data/committees/
- https://www.fec.gov/data/committees/?q=C00003418

Thanks!
