### PR TITLE
Don't show individual contributions for inaugural organization type committees

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -120,7 +120,9 @@
               {% if committee_type not in ['C', 'E', 'I'] %}
               <ul>
                 <li><a href="#total-receipts">Total receipts</a></li>
+                {% if not is_inaugural %}
                 <li><a href="#individual-contribution-transactions">Individual contribution transactions</a></li>
+                {% endif %}
               </ul>
               {% endif %}
           </li>

--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -39,6 +39,7 @@
       </div>
       </div>
     {% endif %}
+    {% if not is_inaugural %}
     <div class="entity__figure" id="individual-contribution-transactions">
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Individual contributions</h3>
@@ -195,5 +196,6 @@
         </div>
       </div>
     </div>
+    {% endif %}
   </div>
 </section>

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -403,6 +403,9 @@ def get_committee(committee_id, cycle):
     # Check organization types to determine SSF status
     is_ssf = committee.get("organization_type") in ["W", "C", "L", "V", "M", "T"]
 
+    # Check if it's an inaugural organization type
+    is_inaugural = committee.get("organization_type") in ["I"]
+
     # Check committee's status (active, terminated, or administratively terminated)
     is_active = committee.get("is_active")
     filing_frequency = committee.get("filing_frequency")
@@ -549,6 +552,7 @@ def get_committee(committee_id, cycle):
         "cycle": cycle,
         "cycles": cycles,
         "is_SSF": is_ssf,
+        "is_inaugural": is_inaugural,
         "current_committee_status": current_committee_status,
         "cycle_out_of_range": cycle_out_of_range,
         "parent": parent,


### PR DESCRIPTION
## Summary

- Resolves #3390 

For Inaugural organization types, don't show the individual contributions on the committee profile pages.

### Required reviewers

1 front end or 1 back end developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Inaugural committee profile pages

## Screenshots

### Before

<img width="1330" alt="Screen Shot 2021-11-02 at 2 42 42 PM" src="https://user-images.githubusercontent.com/12799132/139925632-1d93207a-f2f9-4e44-839a-59d790ac2f0d.png">

### After

<img width="1316" alt="Screen Shot 2021-11-02 at 2 41 25 PM" src="https://user-images.githubusercontent.com/12799132/139925531-9b8efe7a-6450-4513-ac42-6a46b69e0d7e.png">

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- Checkout this branch
- `cd fec && ./manage.py runserver`
- Go to any inaugural committee page and make sure that the individual contribution section does not show up under the raising tab. Ex: http://localhost:8000/data/committee/C00540005/?tab=raising&cycle=2014, http://localhost:8000/data/committee/C00409011/?tab=raising&cycle=2006
