### PR TITLE
[MERGE WITH GIT FLOW] Hotfix/fix candidates datatable

### DIFF
--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -179,7 +179,7 @@ var candidates = [
   { data: 'state', className: 'min-desktop hide-panel column--state' },
   { data: 'district', className: 'min-desktop hide-panel column--small' },
   {
-    data: 'first_f1_date',
+    data: 'first_file_date',
     orderable: true,
     className: 'min-desktop hide-panel column--small'
   },


### PR DESCRIPTION
## Summary (required)

- Resolves #4951

Fix candidates datatable by sorting by `first_file_date` instead of `first_f1_date` (First F1 only applies to committees, not candidates)

### Required reviewers

One developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Candidates datatable

## Screenshots

## Before
<img width="854" alt="Screen Shot 2021-11-03 at 12 53 02 PM" src="https://user-images.githubusercontent.com/31420082/140115269-3aa223a7-ede0-4670-841e-aa991e5c0ff3.png">

## After

<img width="854" alt="Screen Shot 2021-11-03 at 12 53 39 PM" src="https://user-images.githubusercontent.com/31420082/140115345-d84f54bf-707b-4ec2-a5c3-61f3d7cccaaf.png">

## Related PRs

https://github.com/fecgov/fec-cms/pull/4856

## How to test
- Check out this branch
- Rebuild static assets with `npm run watch` or `npm run build`
- Make sure http://localhost:8000/data/candidates/?has_raised_funds=true&is_active_candidate=true loads candidates

