### PR TITLE
4932-Remove "celebrity" from examples for individual contribution search 

### DIFF
--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -45,7 +45,7 @@
               <span class="u-visually-hidden">Search</span>
             </button>
           </div>
-          <span class="t-note t-sans search__example">Examples: your name, a celebrity, someone running for office.</span>
+          <span class="t-note t-sans search__example">Examples: the name of someone you want to look up; Jane Doe or "Doe, John"</span>
         </form>
         <div class="example--primary">	
           <h4 class="example__title">Possible uses of this data:</h4>	


### PR DESCRIPTION
## Summary 
- Resolves #4932

Improves our list of examples for the individual contribution search feature (and removes "celebrity.")

### Required reviewers

1 reviewer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Individual contribution search feature

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/66386084/140253969-2373d93c-67e0-4f6a-a857-3b810af8aeed.png)
After:
<img width="494" alt="Screen Shot 2021-11-03 at 11 30 05 PM" src="https://user-images.githubusercontent.com/66386084/140254002-2e4738ec-72f9-49d4-89de-8672c974798d.png">

## How to test
http://127.0.0.1:8000/data/
https://www.fec.gov/data/
