### PR TITLE
4923-Committees datatable default sort set to registration date

### DIFF
--- a/fec/fec/static/js/pages/datatable-committees.js
+++ b/fec/fec/static/js/pages/datatable-committees.js
@@ -16,7 +16,7 @@ $(document).ready(function() {
     columns: columns.committees,
     useFilters: true,
     useExport: true,
-    order: [[4, 'desc']],
+    order: [[5, 'desc']],
     rowCallback: tables.modalRenderRow,
     callbacks: {
       afterRender: tables.modalRenderFactory(committeesTemplate)


### PR DESCRIPTION
## Summary 

- Resolves #4923 

Updates default sort to registration date, descending

### Required reviewers

1 reviewer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Committees datatable

## Screenshots
Before:
<img width="1420" alt="Screen Shot 2021-11-07 at 4 24 29 PM" src="https://user-images.githubusercontent.com/66386084/140669791-ed4d089c-d8a5-4063-915c-bc07a427fb40.png">

After:
<img width="1304" alt="C4962EFC-FD73-4D07-90B0-150FF92AB809" src="https://user-images.githubusercontent.com/66386084/140670566-c2d7e9ce-6d4a-4648-a62a-7957d2b3a6f0.png">

## How to test

- https://www.fec.gov/data/committees/
- http://127.0.0.1:8000/data/committees/
