### PR TITLE
Remove spaceless tags to fix spacing bug

### DIFF
--- a/fec/fec/static/scss/components/_glossary.scss
+++ b/fec/fec/static/scss/components/_glossary.scss
@@ -115,11 +115,6 @@
   margin-bottom: u(1rem) !important;
 }
 
-// Correct spacing when term is used after certain tags
-a + .term, i + .term, b + .term, .t-sans + .term  {
-margin-left: .4rem;
-}
-
 @media print {
   .term {
     background-image: none;

--- a/fec/home/templates/home/collection_page.html
+++ b/fec/home/templates/home/collection_page.html
@@ -14,7 +14,6 @@
       but we still have some style rules that rely on it
       so we're adding it back for blocks defined in models.py as RichTextBlock
     {% endcomment %}
-    {% spaceless %}
     {% for block in self.body %}
     <div class="block-{{ block.block_type }}">
       {% if block.block_type == 'paragraph' %}
@@ -24,7 +23,6 @@
       {% endif %}
     </div>
     {% endfor %}
-    {% endspaceless %}
   </div>
   {% if self.sidebar_title %}
   <div class="sidebar-container">
@@ -59,7 +57,7 @@
             class="option">
       <div class="option__content">
         <h2>{{ block.value.title }}</h2>
-        <div class="rich-text">{{ block.value.intro }}</div>
+        {{ block.value.intro }}</div>
         <ul class="{% if block.value.style == 'check' %}list--checks list--checks--secondary{% else %}list--bulleted--alt{% endif %} t-sans">
         {% for item in block.value.items %}
            <li><div class="rich-text">{{ item }}</div></li>

--- a/fec/home/templates/home/contact_page.html
+++ b/fec/home/templates/home/contact_page.html
@@ -21,7 +21,6 @@
     </div>
     <div class="usa-width-two-thirds u-padding--left"">
       <h2>{{ self.services_title }}</h2>
-      {% spaceless %}
       {% for block in self.services %}
       <div class="block-{{ block.block_type }}">
         {% if block.block_type == 'paragraph' %}
@@ -31,7 +30,6 @@
         {% endif %}
       </div>
       {% endfor %}
-      {% endspaceless %}
     </div>
   </div>
 </div>

--- a/fec/home/templates/home/custom_page.html
+++ b/fec/home/templates/home/custom_page.html
@@ -17,7 +17,6 @@
     </header>
     <div class="row">
       <div class="main__content">
-        {% spaceless %}
         {% for block in self.body %}
         <div class="block-{{ block.block_type }}">
           {% if block.block_type == 'paragraph' %}
@@ -27,7 +26,6 @@
           {% endif %}
         </div>
         {% endfor %}
-        {% endspaceless %}
       </div>
       <div class="sidebar-container">
         {% if self.sidebar %}

--- a/fec/home/templates/home/example_page.html
+++ b/fec/home/templates/home/example_page.html
@@ -31,7 +31,6 @@
         but we still have some style rules that rely on it
         so we're adding it back for blocks defined in models.py as RichTextBlock
       {% endcomment %}
-      {% spaceless %}
       {% for block in self.body %}
       <div class="block-{{ block.block_type }}">
         {% if block.block_type == 'paragraph' %}
@@ -41,7 +40,6 @@
         {% endif %}
       </div>
       {% endfor %}
-      {% endspaceless %}
     </div>
     {% if self.related_media %}
     <div class="content__section--ruled content__section">

--- a/fec/home/templates/home/full_width_page.html
+++ b/fec/home/templates/home/full_width_page.html
@@ -20,7 +20,6 @@
       but we still have some style rules that rely on it
       so we're adding it back for blocks defined in models.py as RichTextBlock
     {% endcomment %}
-    {% spaceless %}
     {% for block in self.body %}
     <div class="block-{{ block.block_type }}">
       {% if block.block_type == 'paragraph' %}
@@ -30,7 +29,6 @@
       {% endif %}
     </div>
     {% endfor %}
-    {% endspaceless %}
 
     {% if self.citations %}
       <div id="legal-citations" class="sidebar--secondary t-sans">

--- a/fec/home/templates/home/oig_landing_page.html
+++ b/fec/home/templates/home/oig_landing_page.html
@@ -32,7 +32,6 @@
         but we still have some style rules that rely on it
         so we're adding it back for blocks defined in models.py as RichTextBlock
         {% endcomment %}
-        {% spaceless %}
         {% for block in self.stats_content %}
         <div class="block-{{ block.block_type }}">
         {% if block.block_type == 'paragraph' %}
@@ -42,7 +41,6 @@
         {% endif %}
         </div>
         {% endfor %}
-        {% endspaceless %}
       </div>
       {% else %}
       <div class="grid__item card t-left-aligned placeholder-oig-logo" aria-hidden="true">&nbsp;</div>

--- a/fec/home/templates/home/press_landing_page.html
+++ b/fec/home/templates/home/press_landing_page.html
@@ -33,7 +33,6 @@
       <div id="press-releases" class="option">
         <h2><a href="/updates?update_type=press-release">Press releases</a></h2>
         <div class="content__section">
-          {% spaceless %}
           {% for block in self.release_intro %}
           <div class="block-{{ block.block_type }}">
             {% if block.block_type == 'paragraph' %}
@@ -43,7 +42,6 @@
             {% endif %}
           </div>
           {% endfor %}
-          {% endspaceless %}
           <a class="button button--standard button--go" href="/updates?update_type=press-release">All press releases</a>
         </div>
         <div class="post-feed">
@@ -54,7 +52,6 @@
       <div id="weekly-digest" class="option">
         <h2><a href="/updates?update_type=weekly-digest">Weekly Digests</a></h2>
         <div class="content__section">
-          {% spaceless %}
           {% for block in self.digest_intro %}
           <div class="block-{{ block.block_type }}">
             {% if block.block_type == 'paragraph' %}
@@ -64,7 +61,6 @@
             {% endif %}
           </div>
           {% endfor %}
-          {% endspaceless %}
           <a class="button button--standard button--go" href="/updates?update_type=weekly-digest">All Weekly Digests</a>
         </div>
         <div class="post-feed">


### PR DESCRIPTION
## Summary (required)

- Resolves #4846

### Required reviewers

- Fixes spacing bug ,reported by Wagtail editors, related to adjacent links or other RTE elements that get wrapped in html tags like italic, bold, glossary, links etc.
- Fixed by removing spaceless tag anywhere is was wrapping `rich-text class`
- Reverts earlier changes made to glossary SCSS to ix same bug  which is now fixed with this change
- This bug is caused by the combination of the `Wagtail Draftail rich-text editor` wrapping elements in html tags and `Django spaceless tag` removing whitespace between html tags
Reference: https://github.com/wagtail/wagtail/issues/6710 

## Impacted areas of the application

fec/static/scss/components/_glossary.scss
modified:   home/templates/home/collection_page.html
	modified:   home/templates/home/contact_page.html
	modified:   home/templates/home/custom_page.html
	modified:   home/templates/home/example_page.html
	modified:   home/templates/home/full_width_page.html
	modified:   home/templates/home/oig_landing_page.html
	modified:   home/templates/home/press_landing_page.html

## Screenshots

to come...

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

## How to test

To come...
