### PR TITLE
Change to modal window for methodology overview

### DIFF
--- a/fec/data/templates/partials/browse-data/raising.jinja
+++ b/fec/data/templates/partials/browse-data/raising.jinja
@@ -26,7 +26,7 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="lobbyist_bundled_contributions">
             <button type="button" class="js-accordion-trigger accordion__button">Download this data as .CSV to use on your own</button>
             <div class="accordion__content">
-              <h6 class="t-no-rules">Lobbyist bundled contributions</h4>
+              <h6 class="t-no-rules">Lobbyist bundled contributions</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                  <ul class="list--flat-bordered u-no-margin">
@@ -45,7 +45,7 @@
             <h3 class="heading__left">Cumulative amount raised by committees</h3>
             <div class="heading__right">
               <ul class="list--buttons">
-                <a href="/data/raising-bythenumbers" class="button button--cta button--go"  data-a11y-dialog-show="raising-modal" data-ga-event="Raising methodology clicked">More raising charts</a>
+                <a href="/data/raising-bythenumbers" class="button button--cta button--go" data-ga-event="More raising charts clicked">More raising charts</a>
               </ul>
             </div>
           </div>
@@ -55,15 +55,18 @@
         </section>
       </li>
       <li>
-        <div class="content__section--ruled-responsive">
-
-            <p class="t-small u-negative--top--margin t-serif"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
-
-          <div class="js-accordion accordion--neutral" data-content-prefix="methodology_raising">
-            <button type="button" class="js-accordion-trigger accordion__button">Methodology</button>
-            <div class="accordion__content">
+        <div class="content__section--ruled-responsive t-serif">
+          <div class="heading--with-action t-small u-negative--top--margin t-serif"><i class="data-disclaimer">Newly filed summary data may not appear for up to 48 hours.</i>
+            <div class="heading__right">
+              <a class="button button--alt js-ga-event" data-a11y-dialog-show="raising-chart-modal" data-ga-event="Raising chart methodology modal clicked" aria-controls="raising-chart-modal">Methodology</a>
+            </div>
+          </div>
+          <div class="js-modal modal" id="raising-chart-modal" aria-hidden="true">
+           <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide></div>
+             <div role="dialog" class="modal__content" aria-labelledby="raising-chart-modal-title">
               <div role="document">
-                <h6 class="t-no-rules">Methodology Overview</h4>
+                <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide title="Close this dialog window"></button>
+                <h2>Methodology Overview</h2>
                 <p class="t-note">This data includes Forms 3, 3P, and 3X.</p>
                 <p><strong>Money raised</strong> includes each of the following:</p>
                 <ul class="list--bulleted">
@@ -84,8 +87,8 @@
                   <li><strong>Form 3X:</strong> <em>line 19</em> - (<em>line 11(b)</em> + <em>line 11(c)</em> + <em>line 15</em> + <em>line 16</em> + <em>line 18(a)</em> + <em>line 26</em> + <em>line 28(d)</em>)</li>
                 </ul>
               </div>
-            </div>
-          </div>
+             </div>
+           </div>
         </div>
       </li>
     </ul>

--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -21,7 +21,7 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="independent-expenditure">
             <button type="button" class="js-accordion-trigger accordion__button">Download this data as .CSV to use on your own</button>
             <div class="accordion__content">
-              <h6 class="t-no-rules">Independent expenditures</h4>
+              <h6 class="t-no-rules">Independent expenditures</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
@@ -55,7 +55,7 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="electioneering-communications">
             <button type="button" class="js-accordion-trigger accordion__button">Download this data as .CSV to use on your own</button>
             <div class="accordion__content">
-              <h6 class="t-no-rules">Electioneering communications</h4>
+              <h6 class="t-no-rules">Electioneering communications</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
@@ -82,7 +82,7 @@
           <div class="js-accordion accordion--neutral" data-content-prefix="communication-costs">
             <button type="button" class="js-accordion-trigger accordion__button">Download this data as .CSV to use on your own</button>
             <div class="accordion__content">
-              <h6 class="t-no-rules">Communication costs</h4>
+              <h6 class="t-no-rules">Communication costs</h6>
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
@@ -107,7 +107,7 @@
             <h3 class="heading__left">Cumulative amount spent by committees</h3>
             <div class="heading__right">
               <ul class="list--buttons">
-                <a href="/data/spending-bythenumbers/" class="button button--cta button--go"  data-a11y-dialog-show="spending-modal" data-ga-event="Spending methodology clicked">More spending charts</a>
+                <a href="/data/spending-bythenumbers/" class="button button--cta button--go" data-ga-event="More spending charts clicked">More spending charts</a>
               </ul>
             </div>
           </div>
@@ -117,34 +117,39 @@
         </section>
       </li>
       <li>
-        <div class="content__section--ruled-responsive">
-          <p class="t-small u-negative--top--margin t-serif"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
-          <div class="js-accordion accordion--neutral" data-content-prefix="methodology_spending">
-            <button type="button" class="js-accordion-trigger accordion__button">Methodology</button>
-            <div class="accordion__content">
-              <div role="document">
-                <h6 class="t-no-rules">Methodology Overview</h4>
-                <p class="t-note">This data includes Forms 3, 3P, and 3X.</p>
-                <p><strong>Money spent</strong> includes each of the following:</p>
-                <ul class="list--bulleted">
-                  <li><em>Adjusted disbursements</em> for PACs, parties, congressional filers and presidential filers</li>
-                </ul>
-                <p><em>Adjusted disbursements</em> are total disbursements minus the following:</p>
-                <ul class="list--bulleted">
-                  <li>Contribution refunds</li>
-                  <li>Contributions to candidates and other political committees</li>
-                  <li>Loan repayments</li>
-                  <li>Nonfederal share of allocated disbursements</li>
-                  <li>Offsets to expenditures</li>
-                  <li>Other disbursements</li>
-                  <li>Transfers to other authorized committees and affiliated committees</li>
-                </ul>
-                <p>The form-by-form breakdown for adjusted disbursements is:</p>
-                <ul class="list--bulleted">
-                  <li><strong>Form 3:</strong> <em>line 22</em> - (<em>line 18</em> + <em>line 19(c)</em> + <em>line 20(d)</em> + <em>line 21</em>)</li>
-                  <li><strong>Form 3P:</strong> <em>line 30</em> - (<em>line 20(d)</em> + <em>line 24</em> + <em>line 27(c)</em> + <em>line 28(d)</em> + <em>line 29</em>)</li>
-                  <li><strong>Form 3X:</strong> <em>line 31</em> - (<em>line 21(a)(ii)</em> + <em>line 22</em> + <em>line 23</em> + <em>line 26</em> + <em>line 28(d)</em> + <em>line 29</em>)</li>
-                </ul>
+        <div class="content__section--ruled-responsive t-serif">
+          <div class="heading--with-action t-small u-negative--top--margin t-serif"><i class="data-disclaimer">Newly filed summary data may not appear for up to 48 hours.</i>
+            <div class="heading__right">
+               <a class="button button--alt js-ga-event" data-a11y-dialog-show="spending-chart-modal" data-ga-event="Spending chart methodology modal clicked" aria-controls="spending-chart-modal">Methodology</a>
+            </div>
+           </div>
+           <div class="js-modal modal" id="spending-chart-modal" aria-hidden="true">
+             <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide></div>
+             <div role="dialog" class="modal__content" aria-labelledby="spending-chart-modal-title">
+               <div role="document">
+                 <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide title="Close this dialog window"></button>
+                 <h2 class="t-no-rules">Methodology Overview</h2>
+                 <p class="t-note">This data includes Forms 3, 3P, and 3X.</p>
+                 <p><strong>Money spent</strong> includes each of the following:</p>
+                 <ul class="list--bulleted">
+                    <li><em>Adjusted disbursements</em> for PACs, parties, congressional filers and presidential filers</li>
+                 </ul>
+                 <p><em>Adjusted disbursements</em> are total disbursements minus the following:</p>
+                 <ul class="list--bulleted">
+                    <li>Contribution refunds</li>
+                    <li>Contributions to candidates and other political committees</li>
+                    <li>Loan repayments</li>
+                    <li>Nonfederal share of allocated disbursements</li>
+                    <li>Offsets to expenditures</li>
+                    <li>Other disbursements</li>
+                    <li>Transfers to other authorized committees and affiliated committees</li>
+                 </ul>
+                 <p>The form-by-form breakdown for adjusted disbursements is:</p>
+                 <ul class="list--bulleted">
+                    <li><strong>Form 3:</strong> <em>line 22</em> - (<em>line 18</em> + <em>line 19(c)</em> + <em>line 20(d)</em> + <em>line 21</em>)</li>
+                    <li><strong>Form 3P:</strong> <em>line 30</em> - (<em>line 20(d)</em> + <em>line 24</em> + <em>line 27(c)</em> + <em>line 28(d)</em> + <em>line 29</em>)</li>
+                    <li><strong>Form 3X:</strong> <em>line 31</em> - (<em>line 21(a)(ii)</em> + <em>line 22</em> + <em>line 23</em> + <em>line 26</em> + <em>line 28(d)</em> + <em>line 29</em>)</li>
+                 </ul>
               </div>
             </div>
           </div>

--- a/fec/data/templates/partials/widgets/contributions-by-state.jinja
+++ b/fec/data/templates/partials/widgets/contributions-by-state.jinja
@@ -71,7 +71,7 @@
     <div class="js-modal modal" id="fec-contribs-by-state-modal" aria-hidden="true">
         <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide=""></div>
         <div role="dialog" class="modal__content" aria-labelledby="raised-modal-title">
-            <div role="document">
+            <div role="document" class=t-serif>
                 <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide="" title="Close this dialog window"></button>
                 <h2 id="raised-modal-title">Methodology Overview</h2>
                 <p>The state totals have been calculated by summing itemized individual contributions disclosed on Lines 11(a)(i) and 12 of Form 3 (for congressional candidates) and Lines 17(a)(i) and 18 of Form 3P (for presidential candidates) for each state or region.</p>

--- a/fec/fec/static/scss/components/_headings.scss
+++ b/fec/fec/static/scss/components/_headings.scss
@@ -80,6 +80,11 @@
     line-height: u(3.4rem); // Setting explicit value to height of the action button for vertical alignment
   }
 
+  .data-disclaimer {
+    display: inline-block;
+    margin-bottom: u(1rem);
+  }
+
   @include media($med) {
     .heading__left {
       float: left;


### PR DESCRIPTION
## Summary (required)

- Resolves #4937

-  Change  from accordion to modal popup for methodology overviews on browse data raising and spending tabs
-  Switch font to Ghandi on Raising by the numbers methodology overview
-  Fix some ga-events tags that were conflicting or incorrect
-  Fix some mismatched h6 tags on browse data raising and spending tabs

### Required reviewers: One UX, One frontend

## Impacted areas of the application

	modified:   data/templates/partials/browse-data/raising.jinja
	modified:   data/templates/partials/browse-data/spending.jinja
	modified:   data/templates/partials/widgets/contributions-by-state.jinja
	modified:   fec/static/scss/components/_headings.scss

## How to test
- checkout branch and `npm run build-sass`
-  Test methodology buttons on:
    - http://127.0.0.1:8000/data/browse-data/?tab=raising
    - http://127.0.0.1:8000/data/browse-data/?tab=spending
 - See that font is `Ghandi` on the methodology modal under the map on http://127.0.0.1:8000/data/raising-bythenumbers/  

