### PR TITLE
Add pac, IE, and auth committees filter tooltips

### DIFF
--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -78,7 +78,13 @@
 {% if display_alt_ie_committees_filter %}
   <div class="filter">
     <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_type">
-      <label class="label t-inline-block" for="committee_type">Independent expenditure committees</label>
+      <label class="label t-inline" for="committee_type">Independent expenditure committees</label>
+      <div class="tooltip__container">
+        <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+        <div role="tooltip" class="tooltip tooltip--under tooltip--left">
+          <p class="tooltip__content">A political committee that makes only independent expenditures that may solicit and accept unlimited contributions from individuals, corporations, labor organizations and other political committees. It may not accept contributions from foreign nationals, federal contractors, national banks or federally chartered corporations. See AO 2010-11. Such committees, popularly known as Super PACs, must register with the Commission and comply with all applicable reporting requirements of the Act.</p>
+        </div>
+      </div>
       <ul class="dropdown__selected">
         <li>
           <input id="committee-type-checkbox-O" type="checkbox" name="{{ committee_type }}" value="O">

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -10,7 +10,7 @@
   display_default_other_committees_filter=True, 
   display_alt_other_committees_filter=False, 
   display_default_ie_committees_filter=True, 
-  display_alt_ie_committees_filter=False
+  display_alt_ie_committees_filter=False)
 %}
 
 {% if display_authorized_committee_filter %}

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -1,11 +1,27 @@
 {% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
 
-{% macro field(committee_type='committee_type', organization_type='organization_type', designation='designation', display_sponsor_candidate_filter=False, display_authorized_committee_filter=True, display_parties_only_filter=False, display_default_other_committees_filter=True, display_alt_other_committees_filter=False, display_default_ie_committees_filter=True, display_alt_ie_committees_filter=False) %}
+{% macro field(
+  committee_type='committee_type', 
+  organization_type='organization_type', 
+  designation='designation', 
+  display_sponsor_candidate_filter=False, 
+  display_authorized_committee_filter=True, 
+  display_parties_only_filter=False, 
+  display_default_other_committees_filter=True, 
+  display_alt_other_committees_filter=False, 
+  display_default_ie_committees_filter=True, 
+  display_alt_ie_committees_filter=False) %}
 
 {% if display_authorized_committee_filter %}
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="hsp-committee_type">
-    <legend class="label" for="committee_type">Authorized committees</legend>
+    <label class="label t-inline-block" for="committee_type">Authorized committees</label>
+    <div class="tooltip__container">
+      <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+      <div role="tooltip" class="tooltip tooltip--under tooltip--left">
+        <p class="tooltip__content">A political committee that has been authorized by a candidate to accept contributions or make expenditures on his or her behalf, or one that accepts contributions or makes expenditures on behalf of a candidate and has not been disavowed by the candidate.</p>
+      </div>
+    </div>
     <ul class="dropdown__selected">
       <li>
         <input id="committee-type-checkbox-P" type="checkbox" name="{{ committee_type }}" value="P">
@@ -27,7 +43,13 @@
 {% if display_default_ie_committees_filter %}
   <div class="filter">
     <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_type">
-      <label class="label t-inline-block" for="committee_type">Independent expenditure committees</label>
+      <label class="label t-inline" for="committee_type">Independent expenditure committees</label>
+      <div class="tooltip__container">
+        <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+        <div role="tooltip" class="tooltip tooltip--under tooltip--left">
+          <p class="tooltip__content">A political committee that makes only independent expenditures that may solicit and accept unlimited contributions from individuals, corporations, labor organizations and other political committees. It may not accept contributions from foreign nationals, federal contractors, national banks or federally chartered corporations. See AO 2010-11. Such committees, popularly known as Super PACs, must register with the Commission and comply with all applicable reporting requirements of the Act.</p>
+        </div>
+      </div>
       <ul class="dropdown__selected">
         <li>
           <input id="committee-type-checkbox-O" type="checkbox" name="{{ committee_type }}" value="O">
@@ -70,6 +92,12 @@
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="organization_type">
     <label class="label t-inline-block" for="committee_type">PACs</label>
+    <div class="tooltip__container">
+      <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+      <div role="tooltip" class="tooltip tooltip--under tooltip--left">
+        <p class="tooltip__content">Popular term for a political committee that is neither a party committee nor an authorized committee of a candidate. PACs directly or indirectly established, administered or financially supported by a corporation or labor organization are called separate segregated funds (SSFs). PACs without such a corporate or labor sponsor are called nonconnected PACs.</p>
+      </div>
+    </div>
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -21,7 +21,7 @@
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
       <div role="tooltip" class="tooltip tooltip--under tooltip--left">
-        <p class="tooltip__content">A political committee that has been authorized by a candidate to accept contributions or make expenditures on his or her behalf, or one that accepts contributions or makes expenditures on behalf of a candidate and has not been disavowed by the candidate.</p>
+        <p class="tooltip__content">A political committee authorized by a candidate to accept contributions or make expenditures on behalf of that candidate. Also known as a campaign committee.</p>
       </div>
     </div>
     {% endif %}
@@ -107,7 +107,7 @@
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
       <div role="tooltip" class="tooltip tooltip--under tooltip--left">
-        <p class="tooltip__content">Popular term for a political committee that is neither a party committee nor an authorized committee of a candidate. PACs directly or indirectly established, administered or financially supported by a corporation or labor organization are called separate segregated funds (SSFs). PACs without such a corporate or labor sponsor are called nonconnected PACs.</p>
+        <p class="tooltip__content">Popular term for a political committee that is neither a candidate’s authorized committee nor a party committee.</p>
       </div>
     </div>
     {% endif %}

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -10,21 +10,19 @@
   display_default_other_committees_filter=True, 
   display_alt_other_committees_filter=False, 
   display_default_ie_committees_filter=True, 
-  display_alt_ie_committees_filter=False,
-  show_tooltip=False) %}
+  display_alt_ie_committees_filter=False
+%}
 
 {% if display_authorized_committee_filter %}
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="hsp-committee_type">
     <label class="label t-inline-block" for="committee_type">Authorized committees</label>
-    {% if show_tooltip %}
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
       <div role="tooltip" class="tooltip tooltip--under tooltip--left">
         <p class="tooltip__content">A political committee authorized by a candidate to accept contributions or make expenditures on behalf of that candidate. Also known as a campaign committee.</p>
       </div>
     </div>
-    {% endif %}
     <ul class="dropdown__selected">
       <li>
         <input id="committee-type-checkbox-P" type="checkbox" name="{{ committee_type }}" value="P">
@@ -47,14 +45,12 @@
   <div class="filter">
     <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_type">
       <label class="label t-inline" for="committee_type">Independent expenditure committees</label>
-      {% if show_tooltip %}
       <div class="tooltip__container">
         <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
         <div role="tooltip" class="tooltip tooltip--under tooltip--left">
           <p class="tooltip__content">A political committee that makes only independent expenditures and does not make contributions to candidates, parties or other political committees unless they are also independent expenditure committees. These committees may solicit and accept unlimited contributions from individuals, corporations, labor organizations and others.</p>
         </div>
       </div>
-      {% endif %}
       <ul class="dropdown__selected">
         <li>
           <input id="committee-type-checkbox-O" type="checkbox" name="{{ committee_type }}" value="O">
@@ -103,14 +99,12 @@
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="organization_type">
     <label class="label t-inline-block" for="committee_type">PACs</label>
-    {% if show_tooltip %}
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
       <div role="tooltip" class="tooltip tooltip--under tooltip--left">
         <p class="tooltip__content">Popular term for a political committee that is neither a candidate’s authorized committee nor a party committee.</p>
       </div>
     </div>
-    {% endif %}
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -10,18 +10,21 @@
   display_default_other_committees_filter=True, 
   display_alt_other_committees_filter=False, 
   display_default_ie_committees_filter=True, 
-  display_alt_ie_committees_filter=False) %}
+  display_alt_ie_committees_filter=False,
+  show_tooltip=False) %}
 
 {% if display_authorized_committee_filter %}
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="hsp-committee_type">
     <label class="label t-inline-block" for="committee_type">Authorized committees</label>
+    {% if show_tooltip %}
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
       <div role="tooltip" class="tooltip tooltip--under tooltip--left">
         <p class="tooltip__content">A political committee that has been authorized by a candidate to accept contributions or make expenditures on his or her behalf, or one that accepts contributions or makes expenditures on behalf of a candidate and has not been disavowed by the candidate.</p>
       </div>
     </div>
+    {% endif %}
     <ul class="dropdown__selected">
       <li>
         <input id="committee-type-checkbox-P" type="checkbox" name="{{ committee_type }}" value="P">
@@ -44,12 +47,14 @@
   <div class="filter">
     <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_type">
       <label class="label t-inline" for="committee_type">Independent expenditure committees</label>
+      {% if show_tooltip %}
       <div class="tooltip__container">
         <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
         <div role="tooltip" class="tooltip tooltip--under tooltip--left">
           <p class="tooltip__content">A political committee that makes only independent expenditures that may solicit and accept unlimited contributions from individuals, corporations, labor organizations and other political committees. It may not accept contributions from foreign nationals, federal contractors, national banks or federally chartered corporations. See AO 2010-11. Such committees, popularly known as Super PACs, must register with the Commission and comply with all applicable reporting requirements of the Act.</p>
         </div>
       </div>
+      {% endif %}
       <ul class="dropdown__selected">
         <li>
           <input id="committee-type-checkbox-O" type="checkbox" name="{{ committee_type }}" value="O">
@@ -98,12 +103,14 @@
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="organization_type">
     <label class="label t-inline-block" for="committee_type">PACs</label>
+    {% if show_tooltip %}
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
       <div role="tooltip" class="tooltip tooltip--under tooltip--left">
         <p class="tooltip__content">Popular term for a political committee that is neither a party committee nor an authorized committee of a candidate. PACs directly or indirectly established, administered or financially supported by a corporation or labor organization are called separate segregated funds (SSFs). PACs without such a corporate or labor sponsor are called nonconnected PACs.</p>
       </div>
     </div>
+    {% endif %}
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -51,7 +51,7 @@
       <div class="tooltip__container">
         <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
         <div role="tooltip" class="tooltip tooltip--under tooltip--left">
-          <p class="tooltip__content">A political committee that makes only independent expenditures that may solicit and accept unlimited contributions from individuals, corporations, labor organizations and other political committees. It may not accept contributions from foreign nationals, federal contractors, national banks or federally chartered corporations. See AO 2010-11. Such committees, popularly known as Super PACs, must register with the Commission and comply with all applicable reporting requirements of the Act.</p>
+          <p class="tooltip__content">A political committee that makes only independent expenditures and does not make contributions to candidates, parties or other political committees unless they are also independent expenditure committees. These committees may solicit and accept unlimited contributions from individuals, corporations, labor organizations and others.</p>
         </div>
       </div>
       {% endif %}
@@ -87,7 +87,7 @@
       <div class="tooltip__container">
         <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
         <div role="tooltip" class="tooltip tooltip--under tooltip--left">
-          <p class="tooltip__content">A political committee that makes only independent expenditures that may solicit and accept unlimited contributions from individuals, corporations, labor organizations and other political committees. It may not accept contributions from foreign nationals, federal contractors, national banks or federally chartered corporations. See AO 2010-11. Such committees, popularly known as Super PACs, must register with the Commission and comply with all applicable reporting requirements of the Act.</p>
+          <p class="tooltip__content">A political committee that makes only independent expenditures and does not make contributions to candidates, parties or other political committees unless they are also independent expenditure committees. These committees may solicit and accept unlimited contributions from individuals, corporations, labor organizations and others.</p>
         </div>
       </div>
       <ul class="dropdown__selected">

--- a/fec/data/templates/partials/committees-filter.jinja
+++ b/fec/data/templates/partials/committees-filter.jinja
@@ -23,7 +23,7 @@
   <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
   <div class="accordion__content">
     {% import 'macros/filters/committee-types.jinja' as committee_type %}
-    {{ committee_type.field(display_sponsor_candidate_filter=True, show_tooltip=True) }}
+    {{ committee_type.field(display_sponsor_candidate_filter=True) }}
   </div>
 </div>
 {% endblock %}

--- a/fec/data/templates/partials/committees-filter.jinja
+++ b/fec/data/templates/partials/committees-filter.jinja
@@ -23,7 +23,7 @@
   <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
   <div class="accordion__content">
     {% import 'macros/filters/committee-types.jinja' as committee_type %}
-    {{ committee_type.field(display_sponsor_candidate_filter=True) }}
+    {{ committee_type.field(display_sponsor_candidate_filter=True, show_tooltip=True) }}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary (required)

- Resolves #4963 

Added the tooltips to "authorized committees", "independent expenditure committees", and "PACs" filter labels.

### Required reviewers

1 front end, 1 UX, and 1 content

## Screenshots

<img width="298" alt="Screen Shot 2021-11-29 at 11 50 19 AM" src="https://user-images.githubusercontent.com/12799132/143909409-295f329f-03b8-4081-adb6-1b3b2776578d.png">

### Tooltip text

<img width="333" alt="Screen Shot 2021-12-06 at 4 40 57 PM" src="https://user-images.githubusercontent.com/12799132/144927261-93eddae5-c684-4777-a51f-91c98a7cf76e.png">
<img width="392" alt="Screen Shot 2021-12-06 at 4 40 50 PM" src="https://user-images.githubusercontent.com/12799132/144927263-643bcd5d-ad65-418a-ad9f-c0b1ea267a8c.png">
<img width="483" alt="Screen Shot 2021-12-06 at 4 40 40 PM" src="https://user-images.githubusercontent.com/12799132/144927264-3e1017e9-691e-4152-bf14-8dd4cacc164b.png">
## How to test

### Content team
Please see screenshots to check definitions

### Front end and UX, follow these instructions:
- Checkout this branch
- `cd fec && ./manage.py runserver`
- check that the tooltips are present with the correct definitions for "authorized committees", "independent expenditure committees", and "PACs" filter labels on the following datatables:
     - [Committees datatable](http://localhost:8000/data/committees/)
     - [Political action and party committees datatable](http://localhost:8000/data/committees/pac-party/)
     - [Receipts datatable](http://localhost:8000/data/receipts/)
     - [Individual contributions datatable](http://localhost:8000/data/receipts/individual-contributions/)