### PR TITLE
Add percent disbursement column per recipient name for committee profile page

### DIFF
--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -154,6 +154,7 @@
           >
           <thead>
             <th scope="col">Recipient</th>
+            <th scope="col">Percent of total disbursements</th>
             <th scope="col">Total</th>
           </thead>
         </table>
@@ -258,6 +259,7 @@
           >
           <thead>
             <th scope="col">Recipient</th>
+            <th scope="col">Percent of total disbursements</th>
             <th scope="col">Total</th>
           </thead>
         </table>

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -157,7 +157,7 @@ var disbursementRecipientColumns = [
   {
     data: 'total',
     className: 'all',
-    orderable: false,
+    orderable: true,
     orderSequence: ['desc', 'asc'],
     render: columnHelpers.buildTotalLink(['disbursements'], function(
       data,

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -143,6 +143,18 @@ var disbursementRecipientColumns = [
     orderable: false
   },
   {
+    data: 'recipient_disbursement_percent',
+    className: 'all',
+    orderable: false,
+    render: function ( data ) {
+      if(data) {
+        return data + '%';
+      } else{
+        return 'Could not calculate';
+      }
+    }
+  },
+  {
     data: 'total',
     className: 'all',
     orderable: false,
@@ -549,7 +561,7 @@ $(document).ready(function() {
             }),
             columns: disbursementRecipientColumns,
             callbacks: aggregateCallbacks,
-            order: [[1, 'desc']],
+            order: [[2, 'desc']],
             hideEmptyOpts: {
               dataType: 'disbursements',
               name: context.name,


### PR DESCRIPTION
## Summary (required)

- Resolves #4962 

This adds percent of total disbursements column to the committee profile page.

### Required reviewers

1 UX, 1 front end, 1 back end

## Impacted areas of the application

General components of the application that this PR will affect:

-  Committee profile pages disbursement recipient name tab

## Screenshots

### Percent displaying, committee ID C00727834, cycle 2020
<img width="1020" alt="Screen Shot 2021-12-02 at 10 21 19 AM" src="https://user-images.githubusercontent.com/12799132/144450836-ba990853-0829-4cda-ab42-1812e195878e.png">

### Null state, committee ID C00000364, cycle 1978
<img width="1020" alt="Screen Shot 2021-12-02 at 10 21 45 AM" src="https://user-images.githubusercontent.com/12799132/144450835-b236e99d-6227-4e8c-9584-788550234a2c.png">


## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/4988-add-disbursement-percents | [link](https://github.com/fecgov/openFEC/pull/4992)

## How to test

- checkout this branch
- `npm run build`
- `cd fec && ./manage.py runserver`
- Go to any committee profile page disbursements tab. Ex: http://localhost:8000/data/committee/C00727834/?tab=spending&cycle=2020. Click on the group by "Recipient name" tab within disbursements. Check that the "Percent of total disbursements" column is present. 
- Go to a committee profile page with nulls for the percent. Some examples include: C00000364, C00000372, C00000406, C00000554. Make sure that the "Percent of total disbursements" column has "Could not calculate" for its null state.