### PR TITLE
Filter padding on statute and regulations search

### DIFF
--- a/fec/fec/static/scss/components/_buttons.scss
+++ b/fec/fec/static/scss/components/_buttons.scss
@@ -541,7 +541,7 @@
 .button--keywords {
   border-bottom: 1px dotted $base;
   font-size: u(1.4rem);
-  margin-left: u(1.5rem);
+  margin-left: u(2.5rem);
   padding: 0;
   position: relative;
 

--- a/fec/legal/templates/legal-search-results-regulations.jinja
+++ b/fec/legal/templates/legal-search-results-regulations.jinja
@@ -9,7 +9,9 @@
 {% endblock %}
 
 {% block filters %}
-  {{ legal.keyword_search(result_type, query) }}
+    <div class="filters__inner">
+      {{ legal.keyword_search(result_type, query) }}
+    </div>
 {% endblock %}
 
 {% block results %}

--- a/fec/legal/templates/legal-search-results-statutes.jinja
+++ b/fec/legal/templates/legal-search-results-statutes.jinja
@@ -9,7 +9,9 @@
 {% endblock %}
 
 {% block filters %}
-  {{ legal.keyword_search(result_type, query) }}
+  <div class="filters__inner">
+    {{ legal.keyword_search(result_type, query) }}
+  </div>
 {% endblock %}
 
 {% block results %}


### PR DESCRIPTION
## Summary
- Wrap filters in `filters__inner` on  Statute and Regulations search  to add missing padding, 
- Fix placement of `.button--keywords` button  here and elsewhere in `/legal` and `/data`

- Resolves #4975

### Required reviewers
Only one reviewer required:
Any one of frontend, content or UX

## Impacted areas of the application
	modified:   fec/static/scss/components/_buttons.scss
	modified:   legal/templates/legal-search-results-statutes.jinja
	modified:   legal/templates/legal-search-results-regulations.jinja

## Screenshots

### Statutes filters

![padding](https://user-images.githubusercontent.com/5572856/145668125-675a77f4-ea89-4a3f-be13-d083c4e83d98.png)


<hr>

### More keyword options
### Before:


![padding3](https://user-images.githubusercontent.com/5572856/145668484-3f7bf200-b493-4750-9ee0-289d98626c0f.png)

### After:
![padding4](https://user-images.githubusercontent.com/5572856/145668545-401219ed-a3e3-4820-9849-feffc0b62580.png)



<hr>


## How to test

- Checkout branch and `npm run build-sass`
- See inner padding on `filters` on  http://127.0.0.1:8000/data/legal/search/statutes/
- See `button--keywords` CSS change is  also OK where it is used elsewhere like http://127.0.0.1:8000/data/independent-expenditures/?data_type=efiling&is_notice=true
- Test responsive

