### PR TITLE
[MERGE WITH GIT FLOW] hotfix/5000 admin fines 2022

### DIFF
--- a/fec/fec/static/js/modules/calc-admin-fines-logic.js
+++ b/fec/fec/static/js/modules/calc-admin-fines-logic.js
@@ -148,7 +148,161 @@ CalcAdminFineLogic.prototype.getTotalAdminFine = function(d) {
  * The yearnumber values here should reflect those in {@see availableDates }
  */
 CalcAdminFineLogic.values = {
-  '2022': [{ maxRD: 5000, late_val: 38, late_multi: 6, lateSens_val: 74, lateSens_multi: 14, nonfiler_val: 373, nonfilerSens_val: 748 },{ maxRD: 10000, late_val: 74, late_multi: 6, lateSens_val: 150, lateSens_multi: 14, nonfiler_val: 448, nonfilerSens_val: 897 },{ maxRD: 25000, late_val: 160, late_multi: 6, lateSens_val: 224, lateSens_multi: 14, nonfiler_val: 748, nonfilerSens_val: 1346 },{ maxRD: 50000, late_val: 317, late_multi: 30, lateSens_val: 478, lateSens_multi: 38, nonfiler_val: 1346, nonfilerSens_val: 2093 },{ maxRD: 75000, late_val: 478, late_multi: 120, lateSens_val: 716, lateSens_multi: 120, nonfiler_val: 4292, nonfilerSens_val: 4768 },{ maxRD: 100000, late_val: 635, late_multi: 160, lateSens_val: 952, lateSens_multi: 160, nonfiler_val: 5563, nonfilerSens_val: 6358 },{ maxRD: 150000, late_val: 952, late_multi: 199, lateSens_val: 1431, lateSens_multi: 199, nonfiler_val: 7154, nonfilerSens_val: 7948 },{ maxRD: 200000, late_val: 1274, late_multi: 238, lateSens_val: 1908, lateSens_multi: 238, nonfiler_val: 8743, nonfilerSens_val: 9537 },{ maxRD: 250000, late_val: 1589, late_multi: 277, lateSens_val: 2385, lateSens_multi: 277, nonfiler_val: 10332, nonfilerSens_val: 11922 },{ maxRD: 350000, late_val: 2385, late_multi: 317, lateSens_val: 3576, lateSens_multi: 317, nonfiler_val: 12717, nonfilerSens_val: 14306 },{ maxRD: 450000, late_val: 3180, late_multi: 317, lateSens_val: 4768, lateSens_multi: 317, nonfiler_val: 14306, nonfilerSens_val: 15897 },{ maxRD: 550000, late_val: 3974, late_multi: 317, lateSens_val: 5961, lateSens_multi: 317, nonfiler_val: 15101, nonfilerSens_val: 17485 },{ maxRD: 650000, late_val: 4768, late_multi: 317, lateSens_val: 7154, lateSens_multi: 317, nonfiler_val: 15897, nonfilerSens_val: 19075 },{ maxRD: 750000, late_val: 5563, late_multi: 317, lateSens_val: 8346, lateSens_multi: 317, nonfiler_val: 16691, nonfilerSens_val: 20665 },{ maxRD: 850000, late_val: 6358, late_multi: 317, lateSens_val: 9537, lateSens_multi: 317, nonfiler_val: 17485, nonfilerSens_val: 22255 },{ maxRD: 950000, late_val: 7154, late_multi: 317, lateSens_val: 10729, lateSens_multi: 317, nonfiler_val: 18280, nonfilerSens_val: 23843 },{ maxRD: Number.MAX_SAFE_INTEGER, late_val: 7948, late_multi: 317, lateSens_val: 11922, lateSens_multi: 317, nonfiler_val: 19075, nonfilerSens_val: 25434 }],
+  '2022': [
+    {
+      maxRD: 5000,
+      late_val: 38,
+      late_multi: 6,
+      lateSens_val: 74,
+      lateSens_multi: 14,
+      nonfiler_val: 373,
+      nonfilerSens_val: 748
+    },
+    {
+      maxRD: 10000,
+      late_val: 74,
+      late_multi: 6,
+      lateSens_val: 150,
+      lateSens_multi: 14,
+      nonfiler_val: 448,
+      nonfilerSens_val: 897
+    },
+    {
+      maxRD: 25000,
+      late_val: 160,
+      late_multi: 6,
+      lateSens_val: 224,
+      lateSens_multi: 14,
+      nonfiler_val: 748,
+      nonfilerSens_val: 1346
+    },
+    {
+      maxRD: 50000,
+      late_val: 317,
+      late_multi: 30,
+      lateSens_val: 478,
+      lateSens_multi: 38,
+      nonfiler_val: 1346,
+      nonfilerSens_val: 2093
+    },
+    {
+      maxRD: 75000,
+      late_val: 478,
+      late_multi: 120,
+      lateSens_val: 716,
+      lateSens_multi: 120,
+      nonfiler_val: 4292,
+      nonfilerSens_val: 4768
+    },
+    {
+      maxRD: 100000,
+      late_val: 635,
+      late_multi: 160,
+      lateSens_val: 952,
+      lateSens_multi: 160,
+      nonfiler_val: 5563,
+      nonfilerSens_val: 6358
+    },
+    {
+      maxRD: 150000,
+      late_val: 952,
+      late_multi: 199,
+      lateSens_val: 1431,
+      lateSens_multi: 199,
+      nonfiler_val: 7154,
+      nonfilerSens_val: 7948
+    },
+    {
+      maxRD: 200000,
+      late_val: 1274,
+      late_multi: 238,
+      lateSens_val: 1908,
+      lateSens_multi: 238,
+      nonfiler_val: 8743,
+      nonfilerSens_val: 9537
+    },
+    {
+      maxRD: 250000,
+      late_val: 1589,
+      late_multi: 277,
+      lateSens_val: 2385,
+      lateSens_multi: 277,
+      nonfiler_val: 10332,
+      nonfilerSens_val: 11922
+    },
+    {
+      maxRD: 350000,
+      late_val: 2385,
+      late_multi: 317,
+      lateSens_val: 3576,
+      lateSens_multi: 317,
+      nonfiler_val: 12717,
+      nonfilerSens_val: 14306
+    },
+    {
+      maxRD: 450000,
+      late_val: 3180,
+      late_multi: 317,
+      lateSens_val: 4768,
+      lateSens_multi: 317,
+      nonfiler_val: 14306,
+      nonfilerSens_val: 15897
+    },
+    {
+      maxRD: 550000,
+      late_val: 3974,
+      late_multi: 317,
+      lateSens_val: 5961,
+      lateSens_multi: 317,
+      nonfiler_val: 15101,
+      nonfilerSens_val: 17485
+    },
+    {
+      maxRD: 650000,
+      late_val: 4768,
+      late_multi: 317,
+      lateSens_val: 7154,
+      lateSens_multi: 317,
+      nonfiler_val: 15897,
+      nonfilerSens_val: 19075
+    },
+    {
+      maxRD: 750000,
+      late_val: 5563,
+      late_multi: 317,
+      lateSens_val: 8346,
+      lateSens_multi: 317,
+      nonfiler_val: 16691,
+      nonfilerSens_val: 20665
+    },
+    {
+      maxRD: 850000,
+      late_val: 6358,
+      late_multi: 317,
+      lateSens_val: 9537,
+      lateSens_multi: 317,
+      nonfiler_val: 17485,
+      nonfilerSens_val: 22255
+    },
+    {
+      maxRD: 950000,
+      late_val: 7154,
+      late_multi: 317,
+      lateSens_val: 10729,
+      lateSens_multi: 317,
+      nonfiler_val: 18280,
+      nonfilerSens_val: 23843
+    },
+    {
+      maxRD: Number.MAX_SAFE_INTEGER,
+      late_val: 7948,
+      late_multi: 317,
+      lateSens_val: 11922,
+      lateSens_multi: 317,
+      nonfiler_val: 19075,
+      nonfilerSens_val: 25434
+    }
+  ],
   '2021': [
     {
       maxRD: 5000,

--- a/fec/fec/static/js/modules/calc-admin-fines-logic.js
+++ b/fec/fec/static/js/modules/calc-admin-fines-logic.js
@@ -16,19 +16,19 @@ const availableDates = [
     summary: 'I haven’t been assessed: using latest fine amounts'
   },
   {
+    value: '2022',
+    label: 'On or after January __b, 2022',
+    summary: 'Assessed on or after January __b, 2022'
+  },
+  {
     value: '2021',
-    label: 'On or after January 11, 2021',
-    summary: 'Assessed on or after January 11, 2021'
+    label: 'January 11, 2021 to January __a, 2022',
+    summary: 'Assessed on or after January 11, 2021 to January __a, 2022'
   },
   {
     value: '2020',
     label: 'August 7, 2020 to January 10, 2021',
     summary: 'Assessed on or after August 7, 2020 to January 10, 2021'
-  },
-  {
-    value: '2019',
-    label: 'January 1, 2019 to August 6, 2020',
-    summary: 'Assessed from January 1, 2019 to August 6, 2020'
   }
 ];
 
@@ -46,7 +46,7 @@ function CalcAdminFineLogic() {
  * @param {String} d.lateOrNonFiler
  * @param {Number} d.numberOfDaysLate
  * @param {Number} d.numberOfPrevViolations
- * @param {String} d.penaltyAssessedDate The id of the date/year of the fine e.g. '2019', '2018', '2017', 'latest'
+ * @param {String} d.penaltyAssessedDate The id of the date/year of the fine e.g. '2022', '2021', '2020', 'latest'
  * @param {Boolean} d.sensitiveReport
  * @param {Number} d.totalReceiptsAndDisbursements
  * @returns {Number, String}
@@ -148,6 +148,7 @@ CalcAdminFineLogic.prototype.getTotalAdminFine = function(d) {
  * The yearnumber values here should reflect those in {@see availableDates }
  */
 CalcAdminFineLogic.values = {
+  '2022': [{ maxRD: 5000, late_val: 38, late_multi: 6, lateSens_val: 74, lateSens_multi: 14, nonfiler_val: 373, nonfilerSens_val: 748 },{ maxRD: 10000, late_val: 74, late_multi: 6, lateSens_val: 150, lateSens_multi: 14, nonfiler_val: 448, nonfilerSens_val: 897 },{ maxRD: 25000, late_val: 160, late_multi: 6, lateSens_val: 224, lateSens_multi: 14, nonfiler_val: 748, nonfilerSens_val: 1346 },{ maxRD: 50000, late_val: 317, late_multi: 30, lateSens_val: 478, lateSens_multi: 38, nonfiler_val: 1346, nonfilerSens_val: 2093 },{ maxRD: 75000, late_val: 478, late_multi: 120, lateSens_val: 716, lateSens_multi: 120, nonfiler_val: 4292, nonfilerSens_val: 4768 },{ maxRD: 100000, late_val: 635, late_multi: 160, lateSens_val: 952, lateSens_multi: 160, nonfiler_val: 5563, nonfilerSens_val: 6358 },{ maxRD: 150000, late_val: 952, late_multi: 199, lateSens_val: 1431, lateSens_multi: 199, nonfiler_val: 7154, nonfilerSens_val: 7948 },{ maxRD: 200000, late_val: 1274, late_multi: 238, lateSens_val: 1908, lateSens_multi: 238, nonfiler_val: 8743, nonfilerSens_val: 9537 },{ maxRD: 250000, late_val: 1589, late_multi: 277, lateSens_val: 2385, lateSens_multi: 277, nonfiler_val: 10332, nonfilerSens_val: 11922 },{ maxRD: 350000, late_val: 2385, late_multi: 317, lateSens_val: 3576, lateSens_multi: 317, nonfiler_val: 12717, nonfilerSens_val: 14306 },{ maxRD: 450000, late_val: 3180, late_multi: 317, lateSens_val: 4768, lateSens_multi: 317, nonfiler_val: 14306, nonfilerSens_val: 15897 },{ maxRD: 550000, late_val: 3974, late_multi: 317, lateSens_val: 5961, lateSens_multi: 317, nonfiler_val: 15101, nonfilerSens_val: 17485 },{ maxRD: 650000, late_val: 4768, late_multi: 317, lateSens_val: 7154, lateSens_multi: 317, nonfiler_val: 15897, nonfilerSens_val: 19075 },{ maxRD: 750000, late_val: 5563, late_multi: 317, lateSens_val: 8346, lateSens_multi: 317, nonfiler_val: 16691, nonfilerSens_val: 20665 },{ maxRD: 850000, late_val: 6358, late_multi: 317, lateSens_val: 9537, lateSens_multi: 317, nonfiler_val: 17485, nonfilerSens_val: 22255 },{ maxRD: 950000, late_val: 7154, late_multi: 317, lateSens_val: 10729, lateSens_multi: 317, nonfiler_val: 18280, nonfilerSens_val: 23843 },{ maxRD: Number.MAX_SAFE_INTEGER, late_val: 7948, late_multi: 317, lateSens_val: 11922, lateSens_multi: 317, nonfiler_val: 19075, nonfilerSens_val: 25434 }],
   '2021': [
     {
       maxRD: 5000,

--- a/fec/fec/static/js/modules/calc-admin-fines-logic.js
+++ b/fec/fec/static/js/modules/calc-admin-fines-logic.js
@@ -17,13 +17,13 @@ const availableDates = [
   },
   {
     value: '2022',
-    label: 'On or after January __b, 2022',
-    summary: 'Assessed on or after January __b, 2022'
+    label: 'On or after December 28, 2021',
+    summary: 'Assessed on or after December 28, 2021'
   },
   {
     value: '2021',
-    label: 'January 11, 2021 to January __a, 2022',
-    summary: 'Assessed on or after January 11, 2021 to January __a, 2022'
+    label: 'January 11, 2021 to December 27, 2021',
+    summary: 'Assessed on or after January 11, 2021 to December 27, 2021'
   },
   {
     value: '2020',

--- a/fec/fec/tests/js/calc-admin-fines.js
+++ b/fec/fec/tests/js/calc-admin-fines.js
@@ -19,31 +19,32 @@ var getTotalAdminFine = CalcLogic.getTotalAdminFine;
  */
 describe('Admin fines calc', function() {
   // Define the tests (see var reference above)
+  // (the 't' value is irrelevant for 'non')
   var tests = [
     { y: 'latest', s: true, c: 0, l: 'late', t: 6, v: 10, e: 0 },
-    { y: '2020', s: false, c: 1, l: 'non', t: 3, v: 10, e: 1214 },
+    { y: '2020', s: false, c: 1, l: 'non', t: 0, v: 10, e: 1214 },
     { y: '2021', s: false, c: 4999.99, l: 'late', t: 1, v: 1, e: 52 },
-    { y: '2020', s: true, c: 5000, l: 'non', t: 3, v: 2, e: 1251 },
-    { y: '2020', s: false, c: 9000, l: 'non', t: 1, v: 0, e: 417 },
-    { y: '2019', s: false, c: 24000, l: 'late', t: 5, v: 3, e: 308 },
-    { y: 'latest', s: true, c: 49000, l: 'late', t: 30, v: 10, e: 5355 },
+    { y: '2020', s: true, c: 5000, l: 'non', t: 0, v: 2, e: 1251 },
+    { y: '2020', s: false, c: 9000, l: 'non', t: 0, v: 0, e: 417 },
+    { y: '2022', s: false, c: 24000, l: 'late', t: 5, v: 3, e: 332 },
+    { y: 'latest', s: true, c: 49000, l: 'late', t: 30, v: 10, e: 5663 },
     { y: '2021', s: false, c: 74000, l: 'late', t: 4, v: 4, e: 1804 },
-    { y: '2019', s: true, c: 99000, l: 'non', t: 50, v: 5, e: 13079 },
-    { y: 'latest', s: true, c: 149000, l: 'late', t: 20, v: 1, e: 6358 },
+    { y: '2019', s: true, c: 99000, l: 'non', t: 0, v: 5, e: 13079 },
+    { y: 'latest', s: true, c: 149000, l: 'non', t: 0, v: 1, e: 9935 },
     { y: '2020', s: true, c: 199000, l: 'late', t: 50, v: 2, e: 19237 },
     { y: '2021', s: true, c: 249000, l: 'late', t: 20, v: 5, e: 16796 },
-    { y: '2021', s: false, c: 349000, l: 'non', t: 2, v: 0, e: 11972 },
-    { y: '2021', s: false, c: 440000, l: 'non', t: 15, v: 0, e: 13468 },
-    { y: 'latest', s: false, c: 549000, l: 'late', t: 10, v: 3, e: 11761 },
-    { y: '2019', s: true, c: 649000, l: 'non', t: 5, v: 5, e: 39240 },
-    { y: '2019', s: true, c: 749000, l: 'non', t: 6, v: 2, e: 28342 },
-    { y: 'latest', s: true, c: 849000, l: 'late', t: 2, v: 3, e: 16754 },
-    { y: '2021', s: true, c: 949000, l: 'non', t: 15, v: 1, e: 28057 },
+    { y: '2021', s: false, c: 349000, l: 'non', t: 0, v: 0, e: 11972 },
+    { y: '2021', s: false, c: 440000, l: 'non', t: 0, v: 0, e: 13468 },
+    { y: 'latest', s: false, c: 549000, l: 'late', t: 10, v: 3, e: 12502 },
+    { y: '2022', s: true, c: 649000, l: 'non', t: 0, v: 5, e: 42918 },
+    { y: '2022', s: true, c: 749000, l: 'non', t: 0, v: 2, e: 30997 },
+    { y: 'latest', s: true, c: 849000, l: 'late', t: 2, v: 3, e: 17799 },
+    { y: '2021', s: true, c: 949000, l: 'non', t: 0, v: 1, e: 28057 },
     { y: '2020', s: false, c: 1000000, l: 'late', t: 2, v: 4, e: 15970 },
-    { y: '2019', s: false, c: 2000000, l: 'late', t: 10, v: 4, e: 20334 },
+    { y: '2022', s: false, c: 2000000, l: 'late', t: 10, v: 4, e: 22236 },
     // Errors:
     {
-      y: 2018,
+      y: 2022,
       s: false,
       c: 65356,
       l: 'late',
@@ -52,7 +53,7 @@ describe('Admin fines calc', function() {
       e: 'ERROR'
     }, // late but with no days late
     {
-      y: 2018,
+      y: 2022,
       s: false,
       c: 65356,
       l: 'TEST',

--- a/tasks.py
+++ b/tasks.py
@@ -77,7 +77,6 @@ DEPLOY_RULES = (
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
-    ('feature', lambda _, branch: branch == 'feature/5000-admin-fines-2022'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -77,6 +77,7 @@ DEPLOY_RULES = (
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/5000-admin-fines-2022'),
 )
 
 


### PR DESCRIPTION
## Summary

- Resolves #5000 

Updated the calculator for the new 2022 totals (and removed 2019)

### Required reviewers

Internal team has already verified functionality, so just one code reviewer

## Impacted areas of the application

The admin fines calculator and its tests.

## Screenshots

The date(s) is the only visible change
![image](https://user-images.githubusercontent.com/26720877/148105178-19ad2e82-68a1-45e7-94ed-c4ccecc289fd.png)


## Related PRs

None

## How to test

Internal team tested it on Feature at /legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine


