### PR TITLE
Bugfix for state maps tooltip display

### DIFF
--- a/fec/fec/static/js/modules/maps.js
+++ b/fec/fec/static/js/modules/maps.js
@@ -158,7 +158,7 @@ function stateTooltips(svg, path, results) {
     .attr('class', 'tooltip tooltip--above tooltip--mouse')
     .style('position', 'absolute')
     .style('pointer-events', 'none')
-    .style('display', 'none');
+    .style('visibility', 'hidden');
   svg
     .selectAll('path')
     .on('mouseover', function(d) {
@@ -167,11 +167,11 @@ function stateTooltips(svg, path, results) {
         name: fips.fipsByCode[d.id].STATE_NAME,
         total: helpers.currency(results[d.id] || 0)
       });
-      tooltip.style('display', 'block').html(html);
+      tooltip.style('visibility', 'visible').html(html);
       moveTooltip(tooltip);
     })
     .on('mouseout', function() {
-      tooltip.style('display', 'none');
+      tooltip.style('visibility', 'hidden');
     })
     .on('mousemove', function() {
       moveTooltip(tooltip);


### PR DESCRIPTION
## Summary (required)

- Resolves #4575

- Change the initial tooltip style from `display: none/block`  to `visibility hidden/visible` to maintain tooltip innerHeight value when a user switches to a new candidate's map via the dropdown on all Election profile page's contributions-by-state maps. (or when choosing "Show two candidates" button)

Related issue: https://github.com/fecgov/fec-cms/issues/2644
Related PR: https://github.com/fecgov/fec-cms/pull/2657

### Required reviewers
One frontend

## Impacted areas of the application

Tooltips on election profile page's contributions-by-state maps.
modified:   fec/static/js/modules/maps.js

## Screenshots
### Before

<img width="744" alt="Screen Shot 2022-01-19 at 1 17 28 AM" src="https://user-images.githubusercontent.com/5572856/150075097-9696a7b9-43a7-4f22-bda2-43d8685ada3f.png">

<hr>

**After** 

<img width="739" alt="Screen Shot 2022-01-19 at 1 18 19 AM" src="https://user-images.githubusercontent.com/5572856/150075246-d4c14924-6642-4bcb-b31a-73c989ba18da.png">


<hr>

## How to test

- Checkout branch and run `npm run build-js`
- View an election profile page and go to Individual contributions section, choose  `Contributor state` button, choose `Map` button
- Select a new candidate from the dropdown and confirm that the tooltips now contains their content
- Check Senate, House and Presidential pages
  Examples : 
     - http://127.0.0.1:8000/data/elections/house/CA/01/2020/
     - http://127.0.0.1:8000/data/elections/senate/CA/2022/
     - http://127.0.0.1:8000/data/elections/president/2020/
-  Also try the "Show two candidates" button (this was broken on the initial view of the second map as well)
 - Make sure this does not adversely effect other maps that use tooltip logic from `maps.js`
  
