### PR TITLE
Landing template for house-senate overview pages

### DIFF
--- a/fec/data/templates/house-senate-overview.jinja
+++ b/fec/data/templates/house-senate-overview.jinja
@@ -1,0 +1,56 @@
+{% extends 'layouts/main.jinja' %}
+{% import 'macros/page-header.jinja' as header %}
+{% if office == 'house' %}
+  {% set crumb = office|title  %}
+{% elif office == 'senate' %}
+  {% set crumb = office|title %}
+{% else %}
+  {% set crumb = office|title %}
+{% endif %}
+
+
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block css %}
+  <link rel="stylesheet" type="text/css" href="{{ asset_for_css('elections.css') }}" />
+{% endblock %}
+{% block body %}
+  {{ header.header(title, crumb) }}
+  <div class="u-padding--left u-padding--right tab-interface">
+    <header class="main">
+      <div class="heading--section">
+        <h1 class="entity__name">
+          {{ office|title }} elections
+        </h1>
+      </div>
+    </header>
+    <div class="data-container__wrapper">
+      {% include 'partials/house-senate-overview/sidebar-nav.jinja' %}
+      {% include 'partials/house-senate-overview/election-data.jinja' %}
+      <div class="main__content--right-full">
+
+      </div>
+    </div>
+  </div>
+{% endblock %}
+{% block scripts %}
+<script>
+var context = {
+  election: {
+    cycle: '{{ cycle }}',
+    election_full: true,
+    duration: '{{ election_duration }}',
+    office: '{{ office }}',
+    state: '{{ state or '' }}',
+    stateFull: '{{ state_full or '' }}',
+    district: '{{ district or '' }}'
+  }
+};
+
+</script>
+<script src="{{ asset_for_js('dataviz-common.js') }}"></script>
+<script src="{{ asset_for_js('elections.js') }}"></script>
+<script src="{{ asset_for_js('committee-single.js') }}"></script>
+{% endblock %}
+

--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -61,6 +61,7 @@
   </div>
 {% endmacro %}
 
+
 {% macro election_cycle_select(cycles, cycle=none, id='') %}
 {% set cycle = cycle | int %}
   <div class="row content__section">
@@ -72,6 +73,81 @@
               value="{{ each }}"
               {% if cycle and cycle <= each and cycle > (each - 2) %}selected{% endif %}
             >{{ each }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+{% endmacro %}
+
+
+{% macro candidate_cycle_select(cycles, cycle=none, id='') %}
+{% set cycle = cycle | int %}
+  <div class="content__section">
+    <div class="cycle-select">
+      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year period</label>
+      <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query" data-election-full="False">
+        {% for each in cycles | sort(reverse=True) %}
+          <option
+              value="{{ each }}"
+              {% if cycle and cycle <= each and cycle > (each - 2) %}selected{% endif %}
+            >{{ each|fmt_year_range }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+{% endmacro %}
+
+
+{# range of two year periods.Select's class is "js-period-select". Unlike class="js-cycle-select", these do not auto-reload page upon change to a new window.locatio with query params. #}
+ {% macro cycle_range_select(cycles, cycle=none, id='') %}
+ {% set cycle = cycle | int %}
+  <div class="row content__section">
+  <label class="label t-inline-block">Two-year period date range</label>
+  <fieldset id="two-year-period-date-range" name="two-year-period-date-range">
+    <div class="range range--date js-date-range">
+      <div class="range__select range__select--min" data-filter="range">
+        <div class="cycle-select">
+          <label for="{{id}}-cycle">Beginning</label>
+          <select id="{{id}}-cycle" class="js-period-select" name="cycle" data-cycle-location="query">
+            {% for each in cycles | sort(reverse=True) %}
+              <option
+                  value="{{ each }}"
+                  {% if cycle and cycle <= each and cycle > (each - 2) %}selected{% endif %}
+                >{{ each|fmt_year_range }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div class="range__hyphen">-</div>
+      <div class="range__select range__select--max" data-filter="range">
+        <div class="cycle-select">
+          <label for="{{id}}-cycle">Ending</label>
+          <select id="{{id}}-cycle" class="js-period-select" name="cycle" data-cycle-location="query">
+            {% for each in cycles | sort(reverse=True) %}
+              <option
+                  value="{{ each }}"
+                  {% if cycle and cycle <= each and cycle > (each - 2) %}selected{% endif %}
+                >{{ each|fmt_year_range }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+  </div>
+{% endmacro %}
+
+{% macro two_year_select(cycles, cycle=none, id='') %}
+{% set cycle = cycle | int %}
+  <div class="content__section">
+    <div class="cycle-select">
+      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year period</label>
+      <select id="{{id}}-cycle" class="js-period-select" name="cycle" data-cycle-location="query" data-election-full="False">
+        {% for each in cycles | sort(reverse=True) %}
+          <option
+              value="{{ each }}"
+              {% if cycle and cycle <= each and cycle > (each - 2) %}selected{% endif %}
+            >{{ each|fmt_year_range }}</option>
         {% endfor %}
       </select>
     </div>

--- a/fec/data/templates/partials/house-senate-overview/election-data.jinja
+++ b/fec/data/templates/partials/house-senate-overview/election-data.jinja
@@ -1,0 +1,166 @@
+{% import 'macros/null.jinja' as null %}
+{% import 'macros/disclaimer.jinja' as disclaimer %}
+{% import 'macros/cycle-select.jinja' as select %}
+
+{# NEW BELOW #}
+{% import 'macros/filters/date.jinja' as date %}
+{% import 'macros/filters/range.jinja' as range %}
+{% import 'macros/filters/years.jinja' as years %}
+{% import 'macros/filters/election-filter.jinja' as election %}
+{% import "macros/widgets.jinja" as widgets %}
+
+<!-- TODO: if we end up using these patterns, move styles to `components/_cycle-select.scss` or wherever appropriate -->
+<style>
+.range__select {
+    width: auto;
+    display: inline-block;
+}
+.range__select .cycle-select select {
+    width: auto;
+}
+</style>
+
+
+<section id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
+
+
+  <!-- TODO : The design mockup does not have this `h2#section-1-heading`, but it matches the tablist title pattern used for other pages and removing it breaks alignment. If we do keep it, the h2's below should probably become h3's.  However they look like h2's on mockup  -->
+  <h2 id="section-1-heading">{{ office | title }} election data</h2>
+
+  <!-- TODO: For narrower rows, add class: "entity__figure--narrow" -->
+  <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
+    <div id="election-summary" class="entity__figure row"> 
+      <h2 class="heading__left">{{ office | title }} election summary</h2>
+      <p class="t-sans t-bold t-low-height">Comparing total money spent by party. Also comparing total money spent in <span class="term" data-term="independent expenditure" title="Click to define" tabindex="0">independent expenditures</span> by support and opposition.</p>
+  
+
+        <!-- TODO: We might not use these macros at all for the selects, but here if they help -->
+        {{ select.two_year_select(cycles, cycle, id="cycle-4") }}
+
+      <div class="content__section--ruled-responsive t-serif">
+          <div class="heading--with-action t-small u-negative--top--margin t-serif"><i class="data-disclaimer">Some kind of disclaimer text that clarifies something high-level that users need to know right away to put the data in context.</i>
+            <div class="heading__right">
+              <a class="button button--alt js-ga-event" data-a11y-dialog-show="election-summary-modal" data-ga-event="Election summary methodology modal clicked" aria-controls="election-summary-modal">Methodology</a>
+            </div>
+          </div>
+          <div class="js-modal modal" id="election-summary-modal" aria-hidden="true">
+           <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide=""></div>
+             <div role="dialog" class="modal__content" aria-labelledby="election-summary-modal-title">
+              <div role="document">
+                <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide="" title="Close this dialog window"></button>
+                <h2>Methodology Overview</h2>
+                <p class="t-note"></p>
+                <p></p>
+              </div>
+             </div>
+           </div>
+        </div>
+    </div>
+
+    <!-- TODO: For narrower rows, add class: "entity__figure--narrow" -->
+    <div id="contributions-over-time" class="entity__figure row"> 
+      <h2 class="heading__left">{{ office | title }} candidate contributions over time</h2>
+      <p class="t-sans t-bold t-low-height">Comparing current candidate <span class="term" data-term="contribution" title="Click to define" tabindex="0">contributions</span> to contributions received in previous two-year periods. </p>
+        
+        <!-- TODO: We might not use these macros at all for the selects, but here if they help -->
+        {{ select.cycle_range_select(cycles, cycle=cycle, id='')}}
+
+      <div class="content__section--ruled-responsive t-serif">
+          <div class="heading--with-action t-small u-negative--top--margin t-serif"><i class="data-disclaimer">Some kind of disclaimer text that clarifies something high-level that users need to know right away to put the data in context.</i>
+            <div class="heading__right">
+              <a class="button button--alt js-ga-event" data-a11y-dialog-show="contributions-over-time-modal" data-ga-event="Contributions over time methodology modal clicked" aria-controls="contributions-over-time-modal">Methodology</a>
+            </div>
+          </div>
+          <div class="js-modal modal" id="contributions-over-time-modal" aria-hidden="true">
+           <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide=""></div>
+             <div role="dialog" class="modal__content" aria-labelledby="contributions-over-time-modal-title">
+              <div role="document">
+                <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide="" title="Close this dialog window"></button>
+                <h2>Methodology Overview</h2>
+                <p class="t-note"></p>
+                <p></p>
+              </div>
+             </div>
+           </div>
+        </div>
+    </div>
+    
+    <!-- TODO: For narrower rows, add class: "entity__figure--narrow" -->
+    <div id="money-raised-accross-elections" class="entity__figure row">
+      <h2 class="heading__left">Money raised accross {{ office | title }} elections</h2>
+      <p class="t-sans t-bold t-low-height">Compare the money raised in all {{ office | title }} elections by state </p>
+
+      <!-- TODO: We might not use these macros at all for the selects, but here if they help -->
+      {{ select.two_year_select(cycles, cycle, id="cycle-4") }}
+      
+      <div class="content__section--ruled-responsive t-serif">
+          <div class="heading--with-action t-small u-negative--top--margin t-serif"><i class="data-disclaimer">Some kind of disclaimer text that clarifies something high-level that users need to know right away to put the data in context.</i>
+            <div class="heading__right">
+              <a class="button button--alt js-ga-event" data-a11y-dialog-show="money-raised-accross-elections-modal" data-ga-event="Money raised accross elections methodology modal clicked" aria-controls="money-raised-accross-elections-modal">Methodology</a>
+            </div>
+          </div>
+          <div class="js-modal modal" id="money-raised-accross-elections-modal" aria-hidden="true">
+           <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide=""></div>
+             <div role="dialog" class="modal__content" aria-labelledby="money-raised-accross-elections-modal-title">
+              <div role="document">
+                <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide="" title="Close this dialog window"></button>
+                <h2>Methodology Overview</h2>
+                <p class="t-note"></p>
+                <p></p>
+              </div>
+             </div>
+           </div>
+        </div>
+      </div>
+ 
+      <!-- TODO: For narrower rows, add class: "entity__figure--narrow" -->
+      <div id="totals-for-all-elections" class="entity__figure row">
+      <h2 class="heading__left">Totals for all {{ office | title }} elections</h2>
+      <p class="t-sans t-bold t-low-height">Compare the money raised, spent, cash on hand and debts by {{ office | title }} election</p>
+
+
+       <!-- TODO: We might not use these macros at all for the selects, but here if they help -->
+       {{ select.two_year_select(cycles, cycle, id="cycle-4") }}
+
+
+      <!-- TODO: Just a placehholder table for example of similar datatable elsewhere,
+           see artials/elections/election-data-and-compliance-tab.jinja -->
+      <div id="candidate-financial-totals" class="entity__figure row">
+
+        <table
+          class="data-table data-table--heading-borders scrollX"
+          data-type="candidate-financial-totals">
+          <thead>
+            <th role="col">Total receipts</th>
+            <th role="col">Total disbursements</th>
+            <th role="col">Cash on hand</th>
+          </thead>
+        </table>
+        <div class="datatable__note">
+          <p class="t-note" style="margin-bottom: 1em">
+            This table only shows candidates who have registered and filed a financial report. Information in this table may not include the most recently submitted filings.
+          </p>
+        </div> 
+      </div>
+
+      <div class="content__section--ruled-responsive t-serif">
+          <div class="heading--with-action t-small u-negative--top--margin t-serif"><i class="data-disclaimer">Some kind of disclaimer text that clarifies something high-level that users need to know right away to put the data in context.</i>
+            <div class="heading__right">
+              <a class="button button--alt js-ga-event" data-a11y-dialog-show="totals-for-all-elections-modal" data-ga-event="Totals for all elections methodology modal clicked" aria-controls="totals-for-all-elections-modal">Methodology</a>
+            </div>
+          </div>
+          <div class="js-modal modal" id="totals-for-all-elections-modal" aria-hidden="true">
+           <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide=""></div>
+             <div role="dialog" class="modal__content" aria-labelledby="totals-for-all-elections-modal-title">
+              <div role="document">
+                <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide="" title="Close this dialog window"></button>
+                <h2>Methodology Overview</h2>
+                <p class="t-note"></p>
+                <p></p>
+              </div>
+             </div>
+           </div>
+        </div>
+    </div>
+  </div>
+</section>

--- a/fec/data/templates/partials/house-senate-overview/sidebar-nav.jinja
+++ b/fec/data/templates/partials/house-senate-overview/sidebar-nav.jinja
@@ -1,0 +1,22 @@
+  <nav class="sidebar side-nav-alt">
+    <ul class="tablist" role="tablist" data-name="tab">
+      <li class="side-nav__item" role="presentation">
+        <a
+          class="side-nav__link"
+          role="tab"
+          data-name="election-data"
+          tabindex="0"
+          aria-controls="panel1"
+          href="#section-1"
+        >
+          {{ office|title }} election data
+        </a>
+        <ul>
+            <li><a href="#election-summary">{{ office | title }} election summary</a></li>
+            <li><a href="#contributions-over-time">{{ office | title }} candidate contributions over time</a></li>
+            <li><a href="#money-raised-accross-elections">Money raised accross {{ office | title }} elections</a></li>
+            <li><a href="#totals-for-all-elections">Totals for all {{ office | title }} elections</a></li>
+        </ul>
+      </li>
+    </ul>
+  </nav>

--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -18,6 +18,8 @@ urlpatterns = [
     url(r'^data/elections/$', views.elections_lookup),
     url(r'^data/raising-bythenumbers/$', views.raising),
     url(r'^data/spending-bythenumbers/$', views.spending),
+    url(r'^data/house-senate-overview/$', views.house_senate_overview),
+    url(r'^data/house-senate-overview/(?P<office>\w+)/$', views.house_senate_overview, name=''),
 
     # Feedback Tool
     url(r'^data/issue/reaction/$', views.reactionFeedback),

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -816,6 +816,42 @@ def elections(request, office, cycle, state=None, district=None):
     )
 
 
+def house_senate_overview(request, office='senate'):
+    # cycle = int(cycle)
+    # office = request.GET.get("office", "S")
+    cycle = constants.DEFAULT_ELECTION_YEAR
+    max_cycle = utils.current_cycle() + 4
+    cycles = utils.get_cycles(max_cycle)
+
+    # if office.lower() == "president":
+    #     cycles = [each for each in cycles if each % 4 == 0]
+    # elif office.lower() == "senate":
+    #     cycles = api_caller.get_all_senate_cycles(state)
+
+    if office.lower() not in ["president", "senate", "house"]:
+        raise Http404()
+    # if (state is not None) and (state and state.upper() not in constants.states):
+    #    raise Http404()
+
+    return render(
+        request,
+        "house-senate-overview.jinja",
+        {
+            "office": office,
+            "office_code": office[0],
+            "parent": "data",
+            "cycle": cycle,
+            # "election_duration": election_duration,
+            "cycles": cycles,
+            # "state": state,
+            # "state_full": constants.states[state.upper()] if state else None,
+            # "district": district,
+            # "title": utils.election_title(cycle, office, state, district),
+            "social_image_identifier": "data",
+        },
+    )
+
+
 def raising(request):
     office = request.GET.get("office", "S")
 


### PR DESCRIPTION
## Summary
- Landing template for house-senate overview pages based on current profile pages (main template snd partials) 
- Starting point for the view in `views.py`
- entries in `urls.py`
- Two new select  macros that  we may or may not actually use for these, but, at a minimum, helps as placeholders
- TODO comments for code and patters yet to be determinned
- **Please note:** This initial template departs slightly from mockup as it was done using existing patterns but we can certainly make changes wherever necessary

Mockup: https://github.com/fecgov/fec-epics/issues/213

- Resolves #5019

### Required reviewers
One frontend, one UX

## Impacted areas of the application

General components of the application that this PR will affect:

	new file:   data/templates/house-senate-overview.jinja
	modified:   data/templates/macros/cycle-select.jinja
	new file:   data/templates/partials/house-senate-overview/election-data.jinja
	new file:   data/templates/partials/house-senate-overview/sidebar-nav.jinja
	modified:  data/urls.py
	modified:  data/views.py

## Screenshots

<img width="1320" alt="Screen Shot 2022-01-28 at 11 06 59 AM" src="https://user-images.githubusercontent.com/5572856/151582584-41fe47c7-abcd-454b-a7c0-93a8fd142ef2.png">
<hr>

### Or narrower content areas

<img width="1484" alt="Screen Shot 2022-01-28 at 10 58 14 AM" src="https://user-images.githubusercontent.com/5572856/151580158-ccd10ed6-3235-4b51-8ba2-9359b2ac65cd.png">


## How to test
- Checkout and run branch
- Test page with /house, /senate added to end of url (defaults to senate)
    -  http://127.0.0.1:8000/data/house-senate-overview/
- Please comment on things we need to change and/or flesh out more
Mockup: https://github.com/fecgov/fec-epics/issues/213

