### PR TITLE
Update IE type name

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -360,7 +360,7 @@ pac_party_types = OrderedDict([
     ('Z', 'National party nonfederal account'),
     ('U', 'Single candidate independent expenditure'),
     ('O', 'Super PAC (independent expenditure only'),
-    ('I', 'Independent expenditor (person or group)')
+    ('I', 'Independent expenditure filer (not a committee)')
 ])
 
 house_senate_types = OrderedDict([


### PR DESCRIPTION
## Summary (required)

- Partially fixes #5035 

This will update the dropdown for the PAC & Party datatable to have IE types listed as "Independent expenditure filer (not a committee)".

The API committees endpoint still lists `committee_type_full` as "Independent expenditor (person or group)". Need to do a separate PR for the API to fix that. Related issue: https://github.com/fecgov/openFEC/issues/5041

### Required reviewers

One content or one UX

## Impacted areas of the application

General components of the application that this PR will affect:

-  PAC & Party datatable

## Screenshots

### Before
![Screen Shot 2022-02-03 at 10 30 42 AM](https://user-images.githubusercontent.com/12799132/152374273-c98a48f8-99aa-4474-8643-4d597e8b8162.png)

### After
![Screen Shot 2022-02-03 at 10 31 28 AM](https://user-images.githubusercontent.com/12799132/152374268-550e99a3-cb0c-48e4-a561-81cf8ad4d6a9.png)


## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

## How to test

Content team, please see screenshots above.

For others:
- Checkout this branch
- `./manage.py runserver`
- Go to the [PAC & party datatable](http://localhost:8000/data/reports/pac-party/?two_year_transaction_period=2022&data_type=processed&min_receipt_date=01%2F01%2F2021&max_receipt_date=02%2F03%2F2022)
- Look at the Committee type dropdown and make sure that it now says "Independent expenditure filer (not a committee)".
