### PR TITLE
Update language for audit hearings

### DIFF
--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -44,7 +44,7 @@
     {% elif self.meeting_type == 'E' %}
       <p>The Commission meets regularly in executive sessions to discuss pending enforcement actions, litigation and other matters that, by law, must be kept confidential.</p>
     {% elif self.meeting_type == 'H' %}
-       <p>The Commission considers new regulations, advisory opinions and other public matters at public hearings. Members of the public can attend public hearing in person. Public hearings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.</p>
+       <p>The Commission considers new regulations and other public matters at public hearings. Members of the public can attend public hearings in person. Public hearings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.</p>
     {% endif %}
 
     {% if self.live_video_embed %}


### PR DESCRIPTION
## Summary (required)

#(https://github.com/fecgov/fec-cms/issues/4950)

Replaced audit hearing language with this:
The Commission considers new regulations and other public matters at public hearings. Members of the public can attend public hearings in person. Public hearings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.

## Impacted areas of the application

Meeting pages for audit hearings


Example of audit hearing page and what it should say after this change is at https://www.fec.gov/updates/november-10-2021-audit-hearing/

## How to test

Ensure it says the updated language above.


