### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Remove user testing from sign up from feedback drawer

### DIFF
--- a/fec/fec/static/js/templates/feedback.hbs
+++ b/fec/fec/static/js/templates/feedback.hbs
@@ -11,18 +11,7 @@
     </div>
     <form id="feedback-form" class="container">
       <fieldset>
-        <legend class="feedback__title">Help us improve FEC.gov</legend>
-        <h3 class="t-sans">Test new website features with our design team</h3>
-        <div class="signup__row">
-          <div class="signup__button">
-          <a class="button--cta" href="https://ethn.io/12085">Sign up</a>
-          </div>
-          <div class="signup__note">
-            <p class="t-sans t-note">Sign up for a 30-minute video call to  help us test new website features.</p>
-          </div>
-        </div>
-        <hr />
-        <h3 class="t-sans">Or post public feedback about the FEC.gov website anonymously</h3>
+        <h3 class="t-sans">Post public feedback about the FEC.gov website anonymously</h3>
         <p class="t-sans t-note">How can we improve FEC.gov? Your feedback, browser information and the URL of the page you were viewing at the time of submission will be posted publicly - so don't include sensitive information like your name, contact information or Social Security number.</p>
         <label for="feedback-1" class="label">What were you trying to do on fec.gov, and how can we improve it? <span class="label--help">(required)</span></label>
         <textarea id="feedback-1" name="action"></textarea>

--- a/fec/home/templates/purgecss-homepage/full.html
+++ b/fec/home/templates/purgecss-homepage/full.html
@@ -929,18 +929,7 @@
         </div>
         <form id="feedback-form" class="container">
           <fieldset>
-            <legend class="feedback__title">Help us improve FEC.gov</legend>
-            <h3 class="t-sans">Test new website features with our design team</h3>
-            <div class="signup__row">
-              <div class="signup__button">
-              <a class="button--cta" href="https://ethn.io/12085" tabindex="-1">Sign up</a>
-              </div>
-              <div class="signup__note">
-                <p class="t-sans t-note">Sign up for a 30-minute video call to  help us test new website features.</p>
-              </div>
-            </div>
-            <hr>
-            <h3 class="t-sans">Or post public feedback about the FEC.gov website anonymously</h3>
+            <h3 class="t-sans">Post public feedback about the FEC.gov website anonymously</h3>
             <p class="t-sans t-note">How can we improve FEC.gov? Your feedback, browser information and the URL of the page you were viewing at the time of submission will be posted publicly - so don't include sensitive information like your name, contact information or Social Security number.</p>
             <label for="feedback-1" class="label">What were you trying to do on fec.gov, and how can we improve it? <span class="label--help">(required)</span></label>
             <textarea id="feedback-1" name="action" tabindex="-1"></textarea>

--- a/fec/home/templates/purgecss-homepage/toggled.html
+++ b/fec/home/templates/purgecss-homepage/toggled.html
@@ -67,18 +67,7 @@
         </div>
         <form id="feedback-form" class="container">
           <fieldset>
-            <legend class="feedback__title">Help us improve FEC.gov</legend>
-            <h3 class="t-sans">Test new website features with our design team</h3>
-            <div class="signup__row">
-              <div class="signup__button">
-              <a class="button--cta" href="https://ethn.io/12085" tabindex="-1">Sign up</a>
-              </div>
-              <div class="signup__note">
-                <p class="t-sans t-note">Sign up for a 30-minute video call to  help us test new website features.</p>
-              </div>
-            </div>
-            <hr>
-            <h3 class="t-sans">Or post public feedback about the FEC.gov website anonymously</h3>
+            <h3 class="t-sans">Post public feedback about the FEC.gov website anonymously</h3>
             <p class="t-sans t-note">How can we improve FEC.gov? Your feedback, browser information and the URL of the page you were viewing at the time of submission will be posted publicly - so don't include sensitive information like your name, contact information or Social Security number.</p>
             <label for="feedback-1" class="label">What were you trying to do on fec.gov, and how can we improve it? <span class="label--help">(required)</span></label>
             <textarea id="feedback-1" name="action" tabindex="-1"></textarea>


### PR DESCRIPTION
## Summary (required)

This removes user testing sign ups from the feedback drawer.

### Required reviewers

1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

-  Feedback drawer

## Screenshots

![Screen Shot 2022-02-16 at 11 26 02 AM](https://user-images.githubusercontent.com/12799132/154310400-dbec150b-cbf4-4d9d-9089-e7833b117678.png)

## How to test

- Checkout this branch
- `npm run build`
- `cd fec && ./manage.py runserver`
- Check that the user testing sign up is no longer present in the feedback drawer
