### PR TITLE
Upgrade python runtime to 3.8.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.7.9-stretch-node-browsers
+      - image: circleci/python:3.8.12-buster-node-browsers
         environment:
           TZ: America/New_York
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ run into problems please
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python (the latest 3.7 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
+    * Python (the latest 3.8 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which
       includes `npm`).
     * PostgreSQL (the latest 11 release).

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ urllib3==1.26.7
 slacker==0.8.6
 whitenoise==5.2.0
 wagtail==2.11.8
-Jinja2==2.11.3
+Jinja2==3.0.0
 django_jinja==2.7.0
 pillow==8.3.2
 CacheControl==0.11.5

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.x
+python-3.8.x

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/4894-upgrade-python-to-3.8'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )


### PR DESCRIPTION
## Summary (required)

- Resolves #4894

Upgrade Jinja2  to resolve issue while installing the requirements. (https://github.com/pallets/jinja/issues/1585)
Update python version 3.8 in
- circleci/config.yml
- README.md
- runtime.txt

### Required reviewers 2
One backend, one other front or backend

## Related PRs

## How to test
This branch deployed successfully to dev : https://app.circleci.com/pipelines/github/fecgov/fec-cms/1739/workflows/8380c899-4cd3-436c-bd66-d0364a3c95a3/jobs/5033
- Create and activate a Python 3.8.12 virtual environment ( You may have to install 3.8.12 with  Pyenv first)
- Checkout `feature/4894-upgrade-python-to-3.8`
- run `pip install -r requirements.txt`
- run `pytest`
- run `npm run test-single`
-  runserver and test datatables, presidential map and few endpoints to make sure data loads OK

DO NOT MERGE IF `tasks.py` IS STILL INCLUDED  IN FILES CHANGED