### PR TITLE
[BEFORE  02/22/22 RELEASE ] Upgrade Jinja to 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ urllib3==1.26.7
 slacker==0.8.6
 whitenoise==5.2.0
 wagtail==2.11.8
-Jinja2==2.11.3
+Jinja2==3.0.0
 django_jinja==2.7.0
 pillow==8.3.2
 CacheControl==0.11.5


### PR DESCRIPTION
## Summary (required)

Noticed this morning that CMS deploy’s are failing due to  Jinja2 dependency package MarkupSafe.
Jinja2 is now pulling MarkupSafe 2.1.0 as of Feb 17, 2022 which will break all CMS deploys to DEV, STAGE, FEATURE and PRODUCTON spaces.
Here is the DEV build that broke:
https://app.circleci.com/pipelines/github/fecgov/fec-cms/1732/workflows/cb5f52e6-7e18-433c-be3b-277e92cb38c8/jobs/5024
We need to upgrade Jinja2 to v3.0.0 which then pulls MarkupSafe-2.1.0 and push this change to our [cms-release-pr](https://github.com/fecgov/fec-cms/pull/5068)

With Jinja2 2.11.1 we get this error for pytest:
packages/jinja2/filters.py", line 13, in <module>
   ```
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/Users/jcarroll/.pyenv/versions/3.8.12/envs/CMS-3812/lib/python3.8/site-packages/markupsafe/__init__.py)
   
   ```
 Errors are resolved after upgrading Jinja to 3.0.0 

### Required reviewers
1 frontend

## Impacted areas of the application

requirements.txt


## How to test

- checkout and run branch
- run pytest
- check datatables, and other pages  that use Jinja


