### PR TITLE
Upgrade cms python-runtime to 3.8.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.7.9-stretch-node-browsers
+      - image: circleci/python:3.8.12-buster-node-browsers
         environment:
           TZ: America/New_York
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ run into problems please
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python (the latest 3.7 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
+    * Python (the latest 3.8 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which
       includes `npm`).
     * PostgreSQL (the latest 11 release).

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.x
+python-3.8.x


### PR DESCRIPTION
## Summary

- Resolves #4894

circle python 3.8.12 docker image is pulled from here: 
https://hub.docker.com/layers/circleci/python/3.8.12-buster-node-browsers/images/sha256-5afc92a6d6144e8115f8c9872526daa7e224d05e51d40cf7be6d5fa59f4b8008?context=explore

Update python version 3.8 in
- circleci/config.yml
- README.md
- runtime.txt

### Required reviewers 2
One backend, one other front or backend

## Related PRs
Last update to 3.7: https://github.com/fecgov/fec-cms/pull/3639

## How to test
- Create and activate a Python 3.8.12 virtual environment ( You may have to install 3.8.12 with  Pyenv first)
- Checkout `feature/4894-upgrade-python-to-3.8`
- run `pytest`
- run `npm run test-single`
- runserver and test datatables, presidential map and few endpoints to make sure data loads OK
-  These changes were tested with a deploy to dev with  no issues on a since-deleted branch. But we could  also  deploy this branch to dev to test new Circle CI image etc. if that gives reviewers more confidence.
