### PR TITLE
Shareable accurate datatable links

### DIFF
--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -13,9 +13,29 @@
   display_alt_ie_committees_filter=False)
 %}
 
+{# On this filter, the  differring `name` attriutes inside of fieldsets would confuse the filterSet logic that expects all the `name `attributes of children of a fieldset to match its `data-name`. The two comments below explain how we solve this  #}
+
+{# Start with three empty hidden fieldsets with `data-name` of the three needed variables to satisfy filterSet logic. #}
+<div class="filter u-visually-hidden">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="{{ organization_type }}" >
+  </fieldset>
+</div>
+
+<div class="filter u-visually-hidden">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="{{ committee_type }}" >
+  </fieldset>
+</div>
+
+<div class="filter u-visually-hidden">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="{{ designation }}" >
+  </fieldset>
+</div>
+
+{# Give the rest of the fieldsets a unique descriptive `data-name` for grouping purpooses but not a `data-name` that resolves to a variable to avoid confusing the filterSet logic. The JS function, checkFromQuery, will handle finding and checking any checkbox filters in a querystring passed on-load.  
+
 {% if display_authorized_committee_filter %}
 <div class="filter">
-  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="hsp-committee_type">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="hsp_committee_types">
     <label class="label t-inline-block" for="committee_type">Authorized committees</label>
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
@@ -43,7 +63,7 @@
 
 {% if display_default_ie_committees_filter %}
   <div class="filter">
-    <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_type">
+    <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="ie_committee_types">
       <label class="label t-inline" for="committee_type">Independent expenditure committees</label>
       <div class="tooltip__container">
         <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
@@ -78,7 +98,7 @@
 
 {% if display_alt_ie_committees_filter %}
   <div class="filter">
-    <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_type">
+    <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="alt_ie_committee_types">
       <label class="label t-inline" for="committee_type">Independent expenditure committees</label>
       <div class="tooltip__container">
         <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
@@ -96,8 +116,10 @@
   </div>
 {% endif %}
 
+
+
 <div class="filter">
-  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="organization_type">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="committee_organization_types">
     <label class="label t-inline-block" for="committee_type">PACs</label>
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
@@ -136,27 +158,27 @@
         </li>
         <li class="dropdown__subhead">Separate segregated funds</li>
         <li class="dropdown__item">
-          <input id="org-type-checkbox-C" name={{ organization_type }} type="checkbox" value="C">
+          <input id="org-type-checkbox-C" name="{{ organization_type }}" type="checkbox" value="C">
           <label class="dropdown__value" for="org-type-checkbox-C">Corporation</label>
         </li>
         <li class="dropdown__item">
-          <input id="org-type-checkbox-L" name={{ organization_type }} type="checkbox" value="L">
+          <input id="org-type-checkbox-L" name="{{ organization_type }}" type="checkbox" value="L">
           <label class="dropdown__value" for="org-type-checkbox-L">Labor organization</label>
         </li>
         <li class="dropdown__item">
-          <input id="org-type-checkbox-M" name={{ organization_type }} type="checkbox" value="M">
+          <input id="org-type-checkbox-M" name="{{ organization_type }}"  type="checkbox" value="M">
           <label class="dropdown__value" for="org-type-checkbox-M">Membership organization</label>
         </li>
         <li class="dropdown__item">
-          <input id="org-type-checkbox-T" name={{ organization_type }} type="checkbox" value="T">
+          <input id="org-type-checkbox-T" name="{{ organization_type }}"  type="checkbox" value="T">
           <label class="dropdown__value" for="org-type-checkbox-T">Trade association</label>
         </li>
         <li class="dropdown__item">
-          <input id="org-type-checkbox-V" name={{ organization_type }} type="checkbox" value="V">
+          <input id="org-type-checkbox-V" name="{{ organization_type }}"  type="checkbox" value="V">
           <label class="dropdown__value" for="org-type-checkbox-V">Cooperative</label>
         </li>
         <li class="dropdown__item">
-          <input id="org-type-checkbox-W" name={{ organization_type }} type="checkbox" value="W">
+          <input id="org-type-checkbox-W" name="{{ organization_type }}"  type="checkbox" value="W">
           <label class="dropdown__value" for="org-type-checkbox-W">Corporation without capital stock</label>
         </li>
       </ul>
@@ -198,7 +220,7 @@
 
 {% if display_alt_other_committees_filter %}
 <div class="filter">
-  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="designation">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="alt_other_committees">
     <legend class="label" for="committee_type">Other committees</legend>
     <ul class="dropdown__selected">
       <li>
@@ -222,7 +244,7 @@
 
 {% if display_default_other_committees_filter %}
 <div class="filter">
-  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="designation">
+  <fieldset class="js-dropdown js-filter" data-filter="checkbox" data-name="other_committees">
     <legend class="label" for="committee_type">Other committees and filers</legend>
     <ul class="dropdown__selected">
       <li>

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -13,7 +13,7 @@
   display_alt_ie_committees_filter=False)
 %}
 
-{# On this filter, the  differring `name` attriutes inside of fieldsets would confuse the filterSet logic that expects all the `name `attributes of children of a fieldset to match its `data-name`. The two comments below explain how we solve this  #}
+{# On this filter, the  differring `name` attriutes inside of fieldsets would confuse the filterSet.js logic that expects all the `name `attributes of children of a fieldset to match its `data-name`. The two comments below explain how we solve this  #}
 
 {# Start with three empty hidden fieldsets with `data-name` of the three needed variables to satisfy filterSet logic. #}
 <div class="filter u-visually-hidden">
@@ -31,7 +31,7 @@
   </fieldset>
 </div>
 
-{# Give the rest of the fieldsets a unique descriptive `data-name` for grouping purpooses but not a `data-name` that resolves to a variable to avoid confusing the filterSet logic. The JS function, checkFromQuery, will handle finding and checking any checkbox filters in a querystring passed on-load.  
+{# Give the rest of the fieldsets a unique descriptive `data-name` for grouping purpooses but not a `data-name` that resolves to a variable to avoid confusing the filterSet.js logic. The JS function, checkFromQuery(), will handle finding and checking any checkbox filters in a querystring passed on-load. #} 
 
 {% if display_authorized_committee_filter %}
 <div class="filter">

--- a/fec/data/templates/partials/filters/audit-committee-types.jinja
+++ b/fec/data/templates/partials/filters/audit-committee-types.jinja
@@ -97,7 +97,7 @@
 </div>
 
 <div class="filter">
-  <fieldset class="js-dropdown js-filter" data-name="designation" data-filter="checkbox">
+  <fieldset class="js-dropdown js-filter" data-name="committee_designation" data-filter="checkbox">
     <legend class="label" for="committee_type">Other committees</legend>
     <ul class="dropdown__selected">
       <li>

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -509,6 +509,85 @@ DataTable.prototype.initTable = function() {
   }
 };
 
+// Get the full querystring on-load
+DataTable.prototype.getVars = function () {
+
+  var initialParams = window.location.search;
+  return initialParams.toString();
+};
+
+// Parse a querystring's parameters and return an object
+DataTable.prototype.parseParams = function(querystring){
+    // Parse query string
+    const params = new URLSearchParams(querystring);
+    const obj = {};
+    // Iterate over all keys
+    for (const key of params.keys()) {
+        if (params.getAll(key).length > 1) {
+         obj[key] = params.getAll(key);
+        } else {
+            obj[key] = params.get(key);
+        }
+     }
+    return obj;
+};
+
+// Activate checkbox filter fields that filterSet.js cannot find to activate (see commitee_types.jinja)
+DataTable.prototype.checkFromQuery = function(){
+    // Create a variable representing the querysring key/vals as an object
+    var queryFields = this.parseParams(this.getVars());
+    // Create an array to hold checkbox html elements
+      var queryBoxes = [];
+    // Iterate the key/vals of queryFields
+    $.each(queryFields, function(key, val){
+      // Create a variable for matching checkbox
+      let queryBox;
+      // Handle val as array
+      if ($.isArray(val)){
+          // iterate the val array
+          val.forEach(i => {
+            // Find matching checkboxes
+            queryBox = $(`input:checkbox[name="${key}"][value="${i}"]`);
+            // Push matching checkboxes to the  array
+            queryBoxes.push(queryBox);
+          });
+        }
+        // Handle singular val
+        else {
+          // find matching checkbox
+          queryBox = $(`input:checkbox[name="${key}"][value="${val}"]`);
+          // Push matching checkbox to the array
+          queryBoxes.push(queryBox);
+         }
+      });
+
+    // Put 0-secopnd, set-timeout on receipts/disbursements datatales so checkoxes are availale to check...
+    // ...after the two folter panels are loaded
+    if ('data_type' in queryFields){
+    setTimeout(function() {
+      // Iterate the array of matching checkboxes(queryBoxes), check them and fire change()
+      for (let box of queryBoxes) {
+        if (!($(box).is(':checked'))) {
+              $(box).prop('checked', true).change();
+        }
+       }
+      }, 0);
+
+     // No Set-timrouot needed on pages without two filter panels...
+     // ... Also it causes a noticeable intermittent lag in populating table on these pages
+     } else {
+      // Iterate the array of matching checkboxes(queryBoxes), check them and fire change()
+      for (let box of queryBoxes) {
+        if (!($(box).is(':checked'))) {
+              $(box).prop('checked', true).change();
+        }
+       }
+      }
+
+  // Remove the loading label GIF on the filter panel
+  $('button.is-loading, label.is-loading').removeClass('is-loading');
+};
+
 DataTable.prototype.initFilters = function() {
   // Set `this.filterSet` before instantiating the nested `DataTable` so that
   // filters are available on fetching initial data
@@ -524,6 +603,10 @@ DataTable.prototype.initFilters = function() {
     this.$widgets.find('.js-filter-tags').prepend(tagList.$body);
     this.filterPanel = new FilterPanel();
     this.filterSet = this.filterPanel.filterSet;
+
+    // Activate checkbox filters missed by above logic (specifically committee checkbox filters)
+    this.checkFromQuery();
+
     $(window).on('popstate', this.handlePopState.bind(this));
   }
 };

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -516,7 +516,7 @@ DataTable.prototype.getVars = function () {
   return initialParams.toString();
 };
 
-// Parse a querystring's parameters and return an object
+// Parse querystring's parameters and return an object
 DataTable.prototype.parseParams = function(querystring){
     // Parse query string
     const params = new URLSearchParams(querystring);
@@ -561,11 +561,12 @@ DataTable.prototype.checkFromQuery = function(){
          }
       });
 
-    // Put 0-secopnd, set-timeout on receipts/disbursements datatales so checkoxes are availale to check...
-    // ...after the two folter panels are loaded
+    // Put 0-second, set-timeout on receipts/disbursements datatables so checkoxes are availale to check...
+    // ...after the two filter panels are loaded
     if ('data_type' in queryFields){
     setTimeout(function() {
-      // Iterate the array of matching checkboxes(queryBoxes), check them and fire change()
+      // Iterate the array of matching checkboxes(queryBoxes), check them and fire change()...
+      // ...if they are not already checked
       for (let box of queryBoxes) {
         if (!($(box).is(':checked'))) {
               $(box).prop('checked', true).change();
@@ -573,10 +574,11 @@ DataTable.prototype.checkFromQuery = function(){
        }
       }, 0);
 
-     // No Set-timrouot needed on pages without two filter panels...
-     // ... Also it causes a noticeable intermittent lag in populating table on these pages
+     // No Set-timeout needed on datatables without two filter panels...
+     // ... Also it causes a noticeable intermittent time-lag while populating table on these pages
      } else {
-      // Iterate the array of matching checkboxes(queryBoxes), check them and fire change()
+      // Iterate the array of matching checkboxes(queryBoxes), check them and fire change()...
+      // ...if they are not already checked
       for (let box of queryBoxes) {
         if (!($(box).is(':checked'))) {
               $(box).prop('checked', true).change();

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/4010-shareable-datatable-links'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/4010-shareable-datatable-links'),
 )
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4010
- Research issue: https://github.com/fecgov/fec-cms/issues/4316
- **Related user-submitted issues:**
https://github.com/fecgov/FEC/issues/10195
https://github.com/fecgov/FEC/issues/10194


This PR  addresses **two existing issues** with some data tables that are causing inconsistencies between the URL querystring parameters  and the state of the filters panel  and taglist buttons.(active filters). Below is each issue and its fix.

1. **Issue:** Certain checkbox filters  (in a checkbox dropdown widget) are not added to the URL querystring parameters when  chosen, or do not remove from the querystring when manually removed via the filter panel or taglist buttons. 

   **Fix**: Use the correct macro variable in `committee_types.jinja` for `data-name` attributes of fieldsets to ensure the Jinja tag resolves to the correct values for the specific datatable it is on. There should be at least one fieldset  on the page for each of the three `data-name` variables. (designation, committee_type, and organization_type)
2. **Issue:** Having checkboxes with differing `name` attributes inside a fieldset of a certain `data-name` confuses existing logic that  compares all filters in the filter  panel against the filters  indicated by querystring parameters. It expects  a fieldsets `data-name` and all of its childrens' `name` attributes to be  the same.
   - This  causes some filters to be stripped from the URL and sometimes not be included in the filtered API call for data. 
   - Another symptom of this is that if there are two checkboxes with the same letter value, having  one in  a querystring can sometimes automatically activate (or replace) the other. 
 
   **Fix:** Upon page load, programmatically activate all checkbox filters indicated in the querystring parameters (if they are not already activated  by existing logic).
     Also add three hidden empty fieldsets to `committee-types.jinja` with  `data-names` of the three needed variables: `(( designation }}`, `{{ committee_type }}` and `{{ organization_type }}`. Then name the other fieldsets with a descriptive data-name for grouping purposes, but not with one of the variable names or a  Jinja tag that resolves to one of the variables. 

This will ensure that the URL  matches the state of the filter panel and vice versa allowing datatable URLs to remain accurate when shared, bookmarked or refreshed.


### Required reviewers

One frontend, one backend. Optional: one content/UX
## Impacted areas of the application

These fixes are specifically for the `committee-type filters`  where we have checkbox filters who's `name` attribute is different than its parent fieldset's `data-name` attribute. The changes allow us to maintain this unique structure without confusing the existing logic that  expects them to match.

modified:   data/templates/macros/filters/committee-types.jinja
modified:   fec/static/js/modules/tables.js

## Related PR
https://github.com/fecgov/fec-cms/pull/5078

## How to test
This branch is deployed to feature space, see pages below listed  under "linked to feature"
- checkout branch and  `npm run build-js`
- Test  adding `Lobbyist/Registrant PAC` as a filter on http://127.0.0.1:8000/data/committees/pac-party/  (or on  [feature](https://fec-feature-cms.app.cloud.gov/data/committees/pac-party/))
   -  Does it get  added to the URL  as `committee_designation=B` ?
    - Does removing this via the filter panel or taglist buttons  also remove it from the URL?
- Test copy/pasting a URL with several query parameters into a browser (Please see list of important pages to test below)
    - Does it preserve the URL you pasted in ?
    -  Also make sure it did not add any parameters that were not in your original URL
    -  Are the filters in the  URL activated in the filter  panel and taglist?
    - Can  you remove parameters  from the URL using the filter  panel and taglist?
    - Are the filter counts correct ?
- Copy/paste this prod URL into a browser `https://www.fec.gov/data/committees/pac-party/?cycle=2020&organization_type=V`
    - Notice how it adds  `committee_type=V` to the URL after the page loads even though is was not in original URL?
    - Make sure this does not happen on feature or your local  ([local link](http://127.0.0.1:8000/data/committees/pac-party/?cycle=2020&organization_type=V), [feature link](https://fec-feature-cms.app.cloud.gov/data/committees/pac-party/?cycle=2020&organization_type=V))
 - Pages important to test  are any pages that use `committee-type filters`:
 
   Linked to local:
    - [/data/committees/pac-party](http://127.0.0.1:8000/data/committees/pac-party/)
    - [ /data/committees/](http://127.0.0.1:8000/data/committees/)
    - [ /data/disbursements](http://127.0.0.1:8000/data/disbursements/)
    - [/data/receipts](http://127.0.0.1:8000/data/receipts/)
    - [/data/receipts/individual-contributions](http://127.0.0.1:8000/data/receipts/individual-contributions/)
    
    Linked to feature:
    - [/data/committees/pac-party](https://fec-feature-cms.app.cloud.gov/data/committees/pac-party/)
    - [ /data/committees/](https://fec-feature-cms.app.cloud.gov/data/committees/)
    - [ /data/disbursements](https://fec-feature-cms.app.cloud.gov/data/disbursements/)
    - [/data/receipts](https://fec-feature-cms.app.cloud.gov/data/receipts/)
    - [/data/receipts/individual-contributions](https://fec-feature-cms.app.cloud.gov/data/receipts/individual-contributions/)

- Try  to break it
- Another test we  should do is to compare  the data returned from using [OpenFEC](https://api.open.fec.gov/) against  results from datatables to ensure the data is indeed filtered according to what  the URL and filter panel/tags indicate.
- I am not sure if this would be useful for testing or not, but there is also a [spreadsheet](https://docs.google.com/spreadsheets/d/1L2aviYhGmiUudYet6gXF4OzV-cy2AUUEWdmqJsVmwrI/edit#gid=0) from the research issue that documents which filters were problematic 

- [x] Don't merge before reverting  `tasks.py`  to remove feature deploy directive