### PR TITLE
Swap top /data/ sections

### DIFF
--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -19,6 +19,78 @@
 <div class="main container js-accordion accordion--neutral" data-content-prefix="about">
   <section class="content__section">
     <div class="grid--2-wide grid--flex">
+      <div class="grid__item">
+        <h2>Compare candidates</h2>
+        <div id="election-lookup" class="search--election-mini">
+          <div class="usa-width-one-half">
+            <form action="/data/elections" class="content__section">
+              <div class="search-controls__state">
+                <label for="state" class="label">State</label>
+                <select id="state" name="state" aria-label="Select a state">
+                  <option value="">Select state</option>
+                  {% for value, label in constants.states.items() %}
+                  <option value="{{ value }}">{{ label }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="search-controls__district">
+                <label for="District" class="label">District <span class="label__optional">(optional)</span></label>
+                <select id="district" name="district" aria-label="Select a district" class="select--alt">
+                  <option value="">Select district</option>
+                  <option value="S">Senate</option>
+                  <optgroup label="House">
+                    {% for value in range(1, 100) %}
+                    {% with formatted = '{0:02d}'.format(value) %}
+                    <option value="{{ formatted }}">{{ formatted }}</option>
+                    {% endwith %}
+                    {% endfor %}
+                  </optgroup>
+                </select>
+              </div>
+              <div class="search-controls__submit search-controls__no-label">
+                <button type="submit" class="button--search--text button--standard">Search</button>
+              </div>
+            </form>
+          </div>
+          <div class="election-map election-map--small usa-width-one-half"></div>
+        </div>
+      </div>
+      <div class="grid__item example--primary callout-holder">
+        <h2>&nbsp;</h2>
+        <div class="grid grid--2-wide">  
+          <div class="grid__item">
+            <div class="card card--neutral">
+              <a href="/data/raising-bythenumbers" title="Raising: by the numbers">
+                <div class="card__image__container">
+                  <span class="card__icon i-graph-horizontal-ordered"><span class="u-visually-hidden">Icon of a graph</span></span>
+                </div>
+                <div class="card__content">
+                  <h3>Raising &raquo;</h3>
+                  <p>Discover which candidates are raising the most</p>
+                </div>
+              </a>
+            </div>
+          </div>
+          <div class="grid__item">
+            <div class="card card--neutral">
+              <a href="/data/spending-bythenumbers" title="Spending: by the numbers">
+                <div class="card__image__container">
+                  <span class="card__icon i-graph-horizontal-ordered"><span class="u-visually-hidden">Icon of a graph</span></span>
+                </div>
+                <div class="card__content">
+                  <h3>Spending &raquo;</h3>
+                  <p>Discover which candidates are spending the most</p>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="content__section">
+    <div class="grid--2-wide grid--flex">
       <div class="grid__item card t-left-aligned">
         <h2>Look up candidate and <br> committee profiles</h2>
         <div class="content__section">
@@ -159,78 +231,6 @@
             </div>
           </aside>
         </a>
-      </div>
-    </div>
-  </section>
-
-  <section class="content__section">
-    <div class="grid--2-wide grid--flex">
-      <div class="grid__item">
-        <h2>Compare candidates</h2>
-        <div id="election-lookup" class="search--election-mini">
-          <div class="usa-width-one-half">
-            <form action="/data/elections" class="content__section">
-              <div class="search-controls__state">
-                <label for="state" class="label">State</label>
-                <select id="state" name="state" aria-label="Select a state">
-                  <option value="">Select state</option>
-                  {% for value, label in constants.states.items() %}
-                  <option value="{{ value }}">{{ label }}</option>
-                  {% endfor %}
-                </select>
-              </div>
-              <div class="search-controls__district">
-                <label for="District" class="label">District <span class="label__optional">(optional)</span></label>
-                <select id="district" name="district" aria-label="Select a district" class="select--alt">
-                  <option value="">Select district</option>
-                  <option value="S">Senate</option>
-                  <optgroup label="House">
-                    {% for value in range(1, 100) %}
-                    {% with formatted = '{0:02d}'.format(value) %}
-                    <option value="{{ formatted }}">{{ formatted }}</option>
-                    {% endwith %}
-                    {% endfor %}
-                  </optgroup>
-                </select>
-              </div>
-              <div class="search-controls__submit search-controls__no-label">
-                <button type="submit" class="button--search--text button--standard">Search</button>
-              </div>
-            </form>
-          </div>
-          <div class="election-map election-map--small usa-width-one-half"></div>
-        </div>
-      </div>
-      <div class="grid__item example--primary callout-holder">
-        <h2>&nbsp;</h2>
-        <div class="grid grid--2-wide">  
-          <div class="grid__item">
-            <div class="card card--neutral">
-              <a href="/data/raising-bythenumbers" title="Raising: by the numbers">
-                <div class="card__image__container">
-                  <span class="card__icon i-graph-horizontal-ordered"><span class="u-visually-hidden">Icon of a graph</span></span>
-                </div>
-                <div class="card__content">
-                  <h3>Raising &raquo;</h3>
-                  <p>Discover which candidates are raising the most</p>
-                </div>
-              </a>
-            </div>
-          </div>
-          <div class="grid__item">
-            <div class="card card--neutral">
-              <a href="/data/spending-bythenumbers" title="Spending: by the numbers">
-                <div class="card__image__container">
-                  <span class="card__icon i-graph-horizontal-ordered"><span class="u-visually-hidden">Icon of a graph</span></span>
-                </div>
-                <div class="card__content">
-                  <h3>Spending &raquo;</h3>
-                  <p>Discover which candidates are spending the most</p>
-                </div>
-              </a>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   </section>

--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -60,78 +60,6 @@
   </section>
 
   <section class="content__section">
-    <div class="grid--2-wide grid--flex">
-      <div class="grid__item">
-        <h2>Compare candidates</h2>
-        <div id="election-lookup" class="search--election-mini">
-          <div class="usa-width-one-half">
-            <form action="/data/elections" class="content__section">
-              <div class="search-controls__state">
-                <label for="state" class="label">State</label>
-                <select id="state" name="state" aria-label="Select a state">
-                  <option value="">Select state</option>
-                  {% for value, label in constants.states.items() %}
-                  <option value="{{ value }}">{{ label }}</option>
-                  {% endfor %}
-                </select>
-              </div>
-              <div class="search-controls__district">
-                <label for="District" class="label">District <span class="label__optional">(optional)</span></label>
-                <select id="district" name="district" aria-label="Select a district" class="select--alt">
-                  <option value="">Select district</option>
-                  <option value="S">Senate</option>
-                  <optgroup label="House">
-                    {% for value in range(1, 100) %}
-                    {% with formatted = '{0:02d}'.format(value) %}
-                    <option value="{{ formatted }}">{{ formatted }}</option>
-                    {% endwith %}
-                    {% endfor %}
-                  </optgroup>
-                </select>
-              </div>
-              <div class="search-controls__submit search-controls__no-label">
-                <button type="submit" class="button--search--text button--standard">Search</button>
-              </div>
-            </form>
-          </div>
-          <div class="election-map election-map--small usa-width-one-half"></div>
-        </div>
-      </div>
-      <div class="grid__item example--primary callout-holder">
-        <h2>&nbsp;</h2>
-        <div class="grid grid--2-wide">  
-          <div class="grid__item">
-            <div class="card card--neutral">
-              <a href="/data/raising-bythenumbers" title="Raising: by the numbers">
-                <div class="card__image__container">
-                  <span class="card__icon i-graph-horizontal-ordered"><span class="u-visually-hidden">Icon of a graph</span></span>
-                </div>
-                <div class="card__content">
-                  <h3>Raising &raquo;</h3>
-                  <p>Discover which candidates are raising the most</p>
-                </div>
-              </a>
-            </div>
-          </div>
-          <div class="grid__item">
-            <div class="card card--neutral">
-              <a href="/data/spending-bythenumbers" title="Spending: by the numbers">
-                <div class="card__image__container">
-                  <span class="card__icon i-graph-horizontal-ordered"><span class="u-visually-hidden">Icon of a graph</span></span>
-                </div>
-                <div class="card__content">
-                  <h3>Spending &raquo;</h3>
-                  <p>Discover which candidates are spending the most</p>
-                </div>
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section class="content__section">
     <h2>Browse data</h2>
     <div class="grid grid--4-wide">
       <div class="grid__item">
@@ -231,6 +159,78 @@
             </div>
           </aside>
         </a>
+      </div>
+    </div>
+  </section>
+
+  <section class="content__section">
+    <div class="grid--2-wide grid--flex">
+      <div class="grid__item">
+        <h2>Compare candidates</h2>
+        <div id="election-lookup" class="search--election-mini">
+          <div class="usa-width-one-half">
+            <form action="/data/elections" class="content__section">
+              <div class="search-controls__state">
+                <label for="state" class="label">State</label>
+                <select id="state" name="state" aria-label="Select a state">
+                  <option value="">Select state</option>
+                  {% for value, label in constants.states.items() %}
+                  <option value="{{ value }}">{{ label }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="search-controls__district">
+                <label for="District" class="label">District <span class="label__optional">(optional)</span></label>
+                <select id="district" name="district" aria-label="Select a district" class="select--alt">
+                  <option value="">Select district</option>
+                  <option value="S">Senate</option>
+                  <optgroup label="House">
+                    {% for value in range(1, 100) %}
+                    {% with formatted = '{0:02d}'.format(value) %}
+                    <option value="{{ formatted }}">{{ formatted }}</option>
+                    {% endwith %}
+                    {% endfor %}
+                  </optgroup>
+                </select>
+              </div>
+              <div class="search-controls__submit search-controls__no-label">
+                <button type="submit" class="button--search--text button--standard">Search</button>
+              </div>
+            </form>
+          </div>
+          <div class="election-map election-map--small usa-width-one-half"></div>
+        </div>
+      </div>
+      <div class="grid__item example--primary callout-holder">
+        <h2>&nbsp;</h2>
+        <div class="grid grid--2-wide">  
+          <div class="grid__item">
+            <div class="card card--neutral">
+              <a href="/data/raising-bythenumbers" title="Raising: by the numbers">
+                <div class="card__image__container">
+                  <span class="card__icon i-graph-horizontal-ordered"><span class="u-visually-hidden">Icon of a graph</span></span>
+                </div>
+                <div class="card__content">
+                  <h3>Raising &raquo;</h3>
+                  <p>Discover which candidates are raising the most</p>
+                </div>
+              </a>
+            </div>
+          </div>
+          <div class="grid__item">
+            <div class="card card--neutral">
+              <a href="/data/spending-bythenumbers" title="Spending: by the numbers">
+                <div class="card__image__container">
+                  <span class="card__icon i-graph-horizontal-ordered"><span class="u-visually-hidden">Icon of a graph</span></span>
+                </div>
+                <div class="card__content">
+                  <h3>Spending &raquo;</h3>
+                  <p>Discover which candidates are spending the most</p>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

- Resolves #5087

Moving Compare Candidates to the top of /data/

### Required reviewers

One front-end or UX

## Impacted areas of the application

Only the data landing page

## Screenshots

<img width="888" alt="image" src="https://user-images.githubusercontent.com/26720877/160126732-da5b0028-5294-43da-b8da-4076345c2f9f.png">

## Related PRs

None

## How to test

- pull the branch
- ./manage.py runserver
- check the [data landing page (http://127.0.0.1:8000/data/)](http://127.0.0.1:8000/data/)
- make sure "Compare candidates" is first and "Look up candidate and committee profiles" is second
- if it isn't:
  - open Inspector (right-click anywhere on the page, choose Inspect)
  - switch to the Application tab
  - in the left column, choose Storage > Local Storage > http://127.0.0.1:8000
  - under Key, look for `gtmExp:2021_data_landing` and change its value to `0`
  - reload the page (close inspector if you like)
