### PR TITLE
Stop using JavaScript to hide columns

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -174,8 +174,8 @@ function modalRenderFactory(template, fetch) {
             $row.toggleClass('row-active', true);
             $('body').toggleClass('panel-active', true);
             accessibility.restoreTabindex($modal);
-            var hideColumns = api.columns('.hide-panel');
-            hideColumns.visible(false);
+            // var hideColumns = api.columns('.hide-panel');
+            // hideColumns.visible(false);
 
             // Populate the pdf button if there is one
             if (fetched.pdf_url) {
@@ -189,9 +189,9 @@ function modalRenderFactory(template, fetch) {
 
             // When under $large-screen
             // TODO figure way to share these values with CSS.
-            if ($(document).width() < 980) {
-              api.columns('.hide-panel-tablet').visible(false);
-            }
+            // if ($(document).width() < 980) {
+            //   api.columns('.hide-panel-tablet').visible(false);
+            // }
           });
         }
       }
@@ -215,14 +215,14 @@ function hidePanel(api, $modal) {
   $('body').toggleClass('panel-active', false);
   $modal.attr('aria-hidden', 'true');
 
-  if ($(document).width() > 640) {
-    api.columns('.hide-panel-tablet').visible(true);
-    api.columns('.hide-panel.min-tablet').visible(true);
-  }
+  // if ($(document).width() > 640) {
+  //   api.columns('.hide-panel-tablet').visible(true);
+  //   api.columns('.hide-panel.min-tablet').visible(true);
+  // }
 
-  if ($(document).width() > 980) {
-    api.columns('.hide-panel').visible(true);
-  }
+  // if ($(document).width() > 980) {
+  //   api.columns('.hide-panel').visible(true);
+  // }
 
   accessibility.removeTabindex($modal);
 }


### PR DESCRIPTION
## Summary

- Resolves #4913 


### Required reviewers

- front-end
- UX
- someone else to help check possible weirdness

## Impacted areas of the application

Potentially all datatables

## Screenshots

![image](https://user-images.githubusercontent.com/26720877/160684078-56d24bd1-8b67-4ae0-86fb-ed04abae6dfd.png)

left: initial load;
right: after opening a details panel on the smallest browser width

## Related PRs

None

## How to test

#### How to replicate

- go to a [datatables page](http://127.0.0.1:8000/data/receipts/?data_type=processed&two_year_transaction_period=2022&min_date=01%2F01%2F2021&max_date=12%2F31%2F2022)
- shrink the browser window to the smallest width
- reload the page
- right-click the first Source name listed and Inspect
- see how there are seven `<td>`? That quantity is what we're watching
- back to the main window
- close the filters (they're just in the way)
- click one of the ⊕ in the right column of the table
- see how now there are fewer `<td>`?
- now expanding the browser window won't restore those `<td>` because they no longer exist
- that's what this PR is trying to fix

#### Testing this PR

- pull the branch
- maybe `npm i` but likely not
- `npm run build` (or just `npm run build-js`)
- `./manage.py runserver`
- go to the datatables page linked in 'How to replicate'
- follow the replication steps
- now, expanding the browser window after having opened and closed the ⊕ panel should show the same columns as a wide-layout page load

#### Side effects

- **Does this break anything on other datatables pages?**
- This won't be a fun test.
- We'll need to test opening and close panels on different width on every template.
- Why was `api.columns…visible()` being used at all? Was it just left-over from before the `hide-panel-*` classes were implemented? There's a comment in tables.js: `// TODO figure way to share these values with CSS.`

## Next steps

If approved, remove the commented code from tables.js
