### PR TITLE
Fix feedback box errors on full width template

### DIFF
--- a/fec/fec/static/js/pages/reporting-dates-tables.js
+++ b/fec/fec/static/js/pages/reporting-dates-tables.js
@@ -73,7 +73,7 @@ const header_notes_modal_partial = `<div tabindex="-1" class="modal__overlay" da
 </div>`;
 
 function ReportingDates() {
-  
+
   //Declare globals (scoped to this function) to get past linter error/tests. For header_notes and footnotes objects declared in CMS field, CSS.escape, Set()
   /* global header_notes, footnotes */
   this.dates_table = document.getElementsByClassName('election-dates-table')[0];
@@ -83,9 +83,9 @@ function ReportingDates() {
   for a page witout an  `.election-dates-table` on it, we don't want to run this logic to avoid undefined errors, hence the
   conditional statement below `if (this.dates_table)`.
 
-  TODO: Make this script be included via a wagtail field ala CustomPage's 1conditional_js1  field. And make that
+  TODO: Make this script be included via a wagtail field ala CustomPage's `conditional_js`  field. And make that
   fieldd a reusable block instead of specific to the CustomPage. Could define it at top of models.py (like streamfactory)
-  or in blocks.py. I think the former makes sense. Aftter this, move BASE_PATH declaration to template.
+  or in blocks.py. I think the former makes sense.
   */
 
   //only run this logic if the page has an `.election-dates-table` onn it

--- a/fec/fec/static/js/pages/reporting-dates-tables.js
+++ b/fec/fec/static/js/pages/reporting-dates-tables.js
@@ -76,68 +76,85 @@ function ReportingDates() {
   //Declare globals (scoped to this function) to get past linter error/tests. For header_notes and footnotes objects declared in CMS field, CSS.escape, Set()
   /* global header_notes, footnotes */
   this.dates_table = document.getElementsByClassName('election-dates-table')[0];
+
+  /*
+  Currenly a referencce to this script is hardcoded onto FullWidth template. If an editor chooses to uae that template
+  for a page witout an  `.election-dates-table` on it, we don't want to run this logic to avoid undefined errors, hence the
+  conditional statement below `if (this.dates_table)`.
+
+  TODO: Make this script be included via a wagtail field ala CustomPage's 1conditional_js1  field. And make that
+  fieldd a reusable block instead of specific to the CustomPage. Could define it at top of models.py (like streamfactory)
+  or in blocks.py. I think the former makes sense.
+  */
+
+  //only run this logic if the page has an `.election-dates-table` onn it
+  if (this.dates_table) {
   //get all acnhor links in TDs)
-  this.anchors = this.dates_table.querySelectorAll('td a[href^=\'#\']');
+    this.anchors = this.dates_table.querySelectorAll('td a[href^=\'#\']');
 
-  //disable default jump behavior for anchor links(#) but keep links for accessibility
-  for (const anchor of this.anchors) {
-    anchor.addEventListener('click', e => {
-      e.preventDefault();
-    });
-  }
+    //disable default jump behavior for anchor links(#) but keep links for accessibility
+    for (const anchor of this.anchors) {
+      anchor.addEventListener('click', e => {
+        e.preventDefault();
+      });
+    }
 
-  this.buildStaticElements();
+    this.buildStaticElements();
 
-  this.addFootnotes();
+    this.addFootnotes();
 
-  this.stripeByState();
+    this.stripeByState();
 
-  //Define media query
-  const mql = window.matchMedia('screen and (max-width: 650px)');
+    //Define media query
+    const mql = window.matchMedia('screen and (max-width: 650px)');
 
-  // call listener function explicitly at run time
-  this.mediaQueryResponse(mql);
+    // call listener function explicitly at run time
+    this.mediaQueryResponse(mql);
 
-  // attach listener function to listen in on state changes
-  mql.addListener(this.mediaQueryResponse);
+    // attach listener function to listen in on state changes
+    mql.addListener(this.mediaQueryResponse);
 
-  //show footnotes on click of a link that wraps the superscripts in cells
-  for (const anchor of this.anchors) {
-    anchor.addEventListener('click', this.showFootnotes.bind(this));
-  }
+    //show footnotes on click of a link that wraps the superscripts in cells
+    for (const anchor of this.anchors) {
+      anchor.addEventListener('click', this.showFootnotes.bind(this));
+    }
 
-  //handle changes on states dropdown
-  this.states = document.getElementById('states');
-  this.states.addEventListener('change', this.handleStateChange.bind(this));
+    //handle changes on states dropdown
+    this.states = document.getElementById('states');
+    this.states.addEventListener('change', this.handleStateChange.bind(this));
 
-  //Define nexUntil() function for use in ShowFootnotes()
-  this.nextUntil = function(elem, selector, filter) {
-    // Setup siblings array
-    const siblings = [];
-
-    // Get the next sibling element
-    elem = elem.nextElementSibling;
-
-    // As long as a sibling exists
-    while (elem) {
-      // If we've reached our match, bail
-      if (elem.matches(selector)) break;
-
-      // If filtering by a selector, check if the sibling matches
-      if (filter && !elem.matches(filter)) {
-        elem = elem.nextElementSibling;
-        continue;
-      }
-
-      // Otherwise, push it to the siblings array
-      siblings.push(elem);
+    //Define nexUntil() function for use in ShowFootnotes()
+    this.nextUntil = function(elem, selector, filter) {
+      // Setup siblings array
+      const siblings = [];
 
       // Get the next sibling element
       elem = elem.nextElementSibling;
-    }
 
-    return siblings;
-  };
+      // As long as a sibling exists
+      while (elem) {
+        // If we've reached our match, bail
+        if (elem.matches(selector)) break;
+
+        // If filtering by a selector, check if the sibling matches
+        if (filter && !elem.matches(filter)) {
+          elem = elem.nextElementSibling;
+          continue;
+        }
+
+        // Otherwise, push it to the siblings array
+        siblings.push(elem);
+
+        // Get the next sibling element
+        elem = elem.nextElementSibling;
+      }
+
+      return siblings;
+    };
+  }
+
+  //Set basepath to /data to override base.html's setting it to '/',  so feedback can submmit properly
+  window.BASE_PATH = '/data';
 }
 
 //create and insert states-dropdown, static footnote/header-notes-list , and dialog

--- a/fec/fec/static/js/pages/reporting-dates-tables.js
+++ b/fec/fec/static/js/pages/reporting-dates-tables.js
@@ -73,6 +73,7 @@ const header_notes_modal_partial = `<div tabindex="-1" class="modal__overlay" da
 </div>`;
 
 function ReportingDates() {
+  
   //Declare globals (scoped to this function) to get past linter error/tests. For header_notes and footnotes objects declared in CMS field, CSS.escape, Set()
   /* global header_notes, footnotes */
   this.dates_table = document.getElementsByClassName('election-dates-table')[0];
@@ -84,7 +85,7 @@ function ReportingDates() {
 
   TODO: Make this script be included via a wagtail field ala CustomPage's 1conditional_js1  field. And make that
   fieldd a reusable block instead of specific to the CustomPage. Could define it at top of models.py (like streamfactory)
-  or in blocks.py. I think the former makes sense.
+  or in blocks.py. I think the former makes sense. Aftter this, move BASE_PATH declaration to template.
   */
 
   //only run this logic if the page has an `.election-dates-table` onn it
@@ -153,8 +154,6 @@ function ReportingDates() {
     };
   }
 
-  //Set basepath to /data to override base.html's setting it to '/',  so feedback can submmit properly
-  window.BASE_PATH = '/data';
 }
 
 //create and insert states-dropdown, static footnote/header-notes-list , and dialog

--- a/fec/home/templates/home/full_width_page.html
+++ b/fec/home/templates/home/full_width_page.html
@@ -55,7 +55,7 @@
 {% endblock %}
 
 {% block extra_js %}
-
+  <script> window.BASE_PATH = '/data' </script>
   <script type="text/javascript" src="{% asset_for_js 'data-init.js' %}"></script>
   <script type="text/javascript" src="{% asset_for_js 'reporting-dates-tables.js' %}"></script>
 {% endblock %}

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'feature/5124-feedback-box-errors-FullWidth-template'),
+    ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/5124-feedback-box-errors-FullWidth-template'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )


### PR DESCRIPTION
## Summary 

- Resolves #5124

Fixes issue  with Feedback box failing to  submit   on pages using `full_width_page.html`. It was submitting to `/issue` instead of `data/issue` 
- Set BASE_PATH  to  `'/data'` in extra JS section of `full_width_page` template to override the BASE_PATH setting of `'/'` that gets set by the  parent template,   `base.html`.  
- Also put in a conditional statement in `reporting-dates-tables.js` so if an editor uses the full_width_page for something that does not have  a `.election_dates_table ` , it will not throw JS error which will potentially block feedback JS or other JS on the page . (followup ticket to be created to only include the JS in pages when its needed)

- [x] Create  followup issue based on comment in `reporting-dates-tables.js` @ line 86
Issue created: https://github.com/fecgov/fec-cms/issues/5153

### Required reviewers

one frontend

## Impacted areas of the application
Any page using full_width_page.html template

modified:   fec/static/js/pages/reporting-dates-tables.js
modified:   home/templates/home/full_width_page.html


<hr>

## Screenshot of successful submission

<img width="926" alt="Screen Shot 2022-03-31 at 9 44 07 PM" src="https://user-images.githubusercontent.com/5572856/161178782-e20b83a3-8917-43c8-a4fd-f76da6e90689.png">

<hr>

## How to test
This branch was pushed to dev and the feedback submitted correctly (hence the screenshot above). If will likely have been overwritten by the time you review but I believe we can just rebuild [that PR in Circle](https://app.circleci.com/pipelines/github/fecgov/fec-cms/1809/workflows/f84f3eca-1e90-4891-bfd3-885f6d05110d)  if you  want to test this page:  
https://dev.fec.gov/help-candidates-and-committees/dates-and-deadlines/2020-reporting-dates/congressional-pre-election-reporting-dates-2020/
(Don't forget to close any submitted test issues in FEC repo.)

- [x] Remove dev deploy task in` tasks. py`  before merging
- checkout branch
-  `npm run build-js`
-  Test submitting feedback on  reporting dates pages below that use` full_width_template`
-  **It IS working if:** you a get 500 error locally and the URL  in console is `http://localhost:8000/data/issue/ `
-  **It  IS NOT working if:** you  get a CSP error and the URL in console  is `http://issue/`.

Local Pages to test (must use localhost,  not 127...):

   - [localhost:8000//help-candidates-and-committees/dates-and-deadlines/2020-reporting-dates/congressional-pre-election-reporting-dates-2020/](http://localhost:8000/help-candidates-and-committees/dates-and-deadlines/2020-reporting-dates/congressional-pre-election-reporting-dates-2020/)

   - [http://localhost:8000/help-candidates-and-committees/dates-and-deadlines/2022-reporting-dates/electioneering-communications-periods-congressional-primaries-2022/](http://localhost:8000/help-candidates-and-committees/dates-and-deadlines/2022-reporting-dates/electioneering-communications-periods-congressional-primaries-2022/)
    
 
