### PR TITLE
Upgrade wagtail to 2.15.4

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -1121,7 +1121,7 @@ class MeetingPage(Page):
         ),
         MultiFieldPanel(
             [
-                FieldPanel('imported_html'),
+                StreamFieldPanel('imported_html'),
             ],
             heading='Imported meeting content',
             classname='collapsible collapsed'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ requests==2.25.1
 urllib3==1.26.7
 slacker==0.8.6
 whitenoise==5.2.0
-wagtail==2.11.9
+wagtail==2.15.4
 Jinja2==3.0.0
 django_jinja==2.7.0
 pillow==9.0.1

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/upgrade-wagtail-to-2.15.4'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/upgrade-wagtail-to-2.15.4'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 


### PR DESCRIPTION
## Summary

Upgrade wagtail to 2.15.4

- Resolves #4807
Also resolves https://github.com/fecgov/fec-cms/issues/5043

**Please check these  upgrade-considerations notes and see if anything needs attention and add to "Items to check" list below.**

- [2.12 Release upgrade-considerations](https://docs.wagtail.org/en/stable/releases/2.12.html#upgrade-considerations)
- [2.13 Release upgrade-considerations](https://docs.wagtail.org/en/stable/releases/2.13.html#upgrade-considerations)
     - [2.13.5 Release upgrade-considerations](https://docs.wagtail.org/en/stable/releases/2.13.5.html#upgrade-considerations)
- [2.14 Release upgrade-considerations](https://docs.wagtail.org/en/stable/releases/2.14.html#upgrade-considerations)
    - [2.14.2 Release upgrade-considerations](https://docs.wagtail.org/en/stable/releases/2.14.2.html#upgrade-considerations) 
- [2.15 Release upgrade-considerations](https://docs.wagtail.org/en/stable/releases/2.15.html#upgrade-considerations)
     - [2.15.2 Release upgrade-considerations](https://docs.wagtail.org/en/stable/releases/2.15.2.html#upgrade-considerations)  **(N/A - related  to Support for SQLite )** 
     
 **Items to check from all upgrade considerations above:**
  -  [Updated handling of non-required StreamFields](https://docs.wagtail.org/en/stable/releases/2.13.html#updated-handling-of-non-required-streamfields)
      - check `models.py` and` blocks.py`
   
  -  Determine how/if we use wagtail search backend or elastic search?
     - [Removed support for Elasticsearch 2](https://docs.wagtail.org/en/stable/releases/2.12.html#removed-support-for-elasticsearch-2) @patphongs Does this effect us?
     - [New database search backend ](https://docs.wagtail.org/en/stable/releases/2.15.html#database-search-backends-replaced) **(I don't think this effects us (?))**

<hr>

**Some new features/changes since 2.11.9**:



- [Easier to change admin color scheme](https://docs.wagtail.org/en/stable/releases/2.12.html#admin-color-themes)
- `stream_data` is now deprecated when  we access streamfields in the Python shell( can use `page.body[0].block_type` or `raw_data`
  https://docs.wagtail.org/en/stable/releases/2.12.html#stream-data-on-streamfield-values-is-deprecated
- [End of Internet Explorer 11 support](https://docs.wagtail.org/en/stable/releases/2.13.html#end-of-internet-explorer-11-support)  **(Just for admin, not live site)**
- [Typed table block](https://docs.wagtail.org/en/stable/releases/2.15.html#typed-table-block)
Would have  to be enabled, not available in admin out of box. Possibly coming soon for https://github.com/fecgov/fec-cms/issues/4258
- [Commenting](https://docs.wagtail.org/en/stable/editor_manual/editing_existing_pages.html#commenting) **(no configuration required )**


###Related issues:
QA ticket: https://github.com/fecgov/fec-cms/issues/5132

### Required reviewers

Two frontend, QA ticket done by content team

## Impacted areas of the application

modified:   ../requirements.txt

## Screenshots

<img width="1365" alt="Screen Shot 2022-04-05 at 1 12 50 PM" src="https://user-images.githubusercontent.com/5572856/161812716-33396ec8-7446-4391-a9cb-9463a4b3bfcd.png">

<hr>


## How to test

This has been pushed to feature for Content team to test: https://fec-feature-cms.app.cloud.gov/:  QA ticket: https://github.com/fecgov/fec-cms/issues/5132

Will be also merged by 04/12 so further testing can take place on dev/stage

Before merging:
- [ ]  Get latest database dump for Wagtail database
- [ ]  Remove feature  deploy task in` tasks. py`  before merging

Test:
- checkout branch and  `pip install -r requirements.txt`
- `cd fec`, `./manage.py migrate`
- test Wagtail admin, creating pages, uploading images, documents
- test editing existing pages
- does anything look awry in the admin ?