### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Update additional info and informational message placement in CMS

### DIFF
--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -35,10 +35,7 @@
         {% endspaceless %}
       </div>
     </header>
-    {{ self.info_message }}
-    {% if self.additional_information %}
-       <p class="t-bold">{{ self.additional_information|safe }}</p>
-    {% endif %}
+
     {% if self.meeting_type == 'O' %}
       <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:00am.</p>
       <p>Members of the public can attend any open meeting or hearing in person. Open meetings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.</p>
@@ -47,6 +44,12 @@
     {% elif self.meeting_type == 'H' %}
        <p>The Commission considers new regulations and other public matters at public hearings. Members of the public can attend public hearings in person. Public hearings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.</p>
     {% endif %}
+
+    {% if self.additional_information %}
+      <p class="t-bold">{{ self.additional_information|safe }}</p>
+    {% endif %}
+
+    {{ self.info_message }}
 
     {% if self.live_video_embed %}
     <div class="row">


### PR DESCRIPTION
## Summary

- Resolves #5197 

Move additional info and informational message to below template intro text for open meeting and hearing pages.

### Required reviewers

1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Commission public meeting pages such as open and hearing pages

## Screenshots

<img width="977" alt="Screen Shot 2022-05-05 at 2 29 41 PM" src="https://user-images.githubusercontent.com/12799132/166993560-6f763857-e4f5-41d1-a829-f60e6baec361.png">

## How to test

- Checkout this branch
- `cd fec && ./manage.py runserver`
- Go to a meeting page and add a snippet and additional information
- Make sure that the text shows up like the screenshots above