### PR TITLE
Update districts based on recent changes

### DIFF
--- a/fec/fec/static/js/data/stateDistricts.json
+++ b/fec/fec/static/js/data/stateDistricts.json
@@ -1,4 +1,8 @@
 {
+  "MT": {
+    "districts": 2,
+    "fullname": "Montana"
+  },
   "TN": {
     "districts": 9,
     "fullname": "Tennessee"
@@ -12,11 +16,11 @@
     "fullname": "Massachusetts"
   },
   "CO": {
-    "districts": 7,
+    "districts": 8,
     "fullname": "Colorado"
   },
   "PA": {
-    "districts": 18,
+    "districts": 17,
     "fullname": "Pennsylvania"
   },
   "SC": {
@@ -48,7 +52,7 @@
     "fullname": "Washington"
   },
   "CA": {
-    "districts": 53,
+    "districts": 52,
     "fullname": "California"
   },
   "OK": {
@@ -76,11 +80,11 @@
     "fullname": "Arizona"
   },
   "TX": {
-    "districts": 36,
+    "districts": 38,
     "fullname": "Texas"
   },
   "NY": {
-    "districts": 27,
+    "districts": 26,
     "fullname": "New York"
   },
   "MN": {
@@ -104,7 +108,7 @@
     "fullname": "Nevada"
   },
   "MI": {
-    "districts": 14,
+    "districts": 13,
     "fullname": "Michigan"
   },
   "AL": {
@@ -124,7 +128,7 @@
     "fullname": "Hawaii"
   },
   "NC": {
-    "districts": 13,
+    "districts": 14,
     "fullname": "North Carolina"
   },
   "NH": {
@@ -148,11 +152,11 @@
     "fullname": "Idaho"
   },
   "OH": {
-    "districts": 16,
+    "districts": 15,
     "fullname": "Ohio"
   },
   "FL": {
-    "districts": 27,
+    "districts": 28,
     "fullname": "Florida"
   },
   "VA": {
@@ -160,15 +164,15 @@
     "fullname": "Virginia"
   },
   "WV": {
-    "districts": 3,
+    "districts": 2,
     "fullname": "West Virginia"
   },
   "IL": {
-    "districts": 18,
+    "districts": 17,
     "fullname": "Illinois"
   },
   "OR": {
-    "districts": 5,
+    "districts": 6,
     "fullname": "Oregon"
   }
 }


### PR DESCRIPTION
## Summary

- Resolves #5204 

Update district dropdown based on this list:

State | 2022 district count | Change
| -- | -- | -- |
California | 52 | -1
Colorado | 8 | +1
Florida | 28 | +1
Illinois | 17 | -1
Michigan | 13 | -1
Montana | 2 | +1
New York | 26 | -1
North Carolina | 14 | +1
Ohio | 15 | -1
Oregon | 6 | +1
Pennsylvania | 17 | -1
Texas | 38 | +2
West Virginia | 2 | -1

### Required reviewers

1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

- [Election search page](http://localhost:8000/data/elections/) district dropdown
- [Data landing page](http://localhost:8000/data/) district dropdown
- [Homepage](http://localhost:8000/) district dropdown

## Screenshots

Pure dropdown changes, no screenshots

## How to test

- Checkout this branch
- `npm run build-js`
- Go to each of these pages and cross check to make sure district dropdown is updated according to the list above:
    - [Election search page](http://localhost:8000/data/elections/) district dropdown
    - [Data landing page](http://localhost:8000/data/) district dropdown
    - [Homepage](http://localhost:8000/) district dropdown