### PR TITLE
Add links to H/S overviews on Election search page

### DIFF
--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -82,15 +82,12 @@
         </div>
         <div class="u-padding--top">
          <span class="heading__subtitle">All Elections</span>
-          <p>
-            <span class="icon i-star icon--inline--left"></span><a class="t-bold" href="/data/elections/senate/">All senate elections</a>
-            <br>
-            <span class="icon i-star icon--inline--left"></span><a class="t-bold" href="/data/elections/house/">All house elections</a>
-          </p>
+           <h3  class="u-no-margin"> <span class="icon i-star icon--inline--left"></span><a href="/data/elections/senate/">All senate elections</a></h3>
+           <h3><span class="icon i-star icon--inline--left"></span><a href="/data/elections/house/">All house elections</a></h3>
         </div>
-          <div class="result u-padding--bottom--small">
-            <span class="heading__subtitle js-results-title"></span>
-          </div>
+        <div class="result u-padding--bottom--small">
+          <span class="heading__subtitle js-results-title"></span>
+        </div>
         <div class="results__count">
           <div class="js-accordion accordion--neutral pa-message" data-content-prefix="pa-redistricting">
             <button type="button" class="js-accordion-trigger accordion__button" aria-controls="pa-redistricting-content-0" aria-expanded="false">Information about 2018 Pennsylvania redistricting</button>

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -82,10 +82,10 @@
         </div>
         <div class="u-padding--top">
          <span class="heading__subtitle">All Elections</span>
-           <h3  class="u-no-margin"><span class="icon i-star icon--inline--left"></span><a href="/data/elections/senate/">All senate elections</a></h3>
+           <h3  class="u-no-margin-bottom u-margin--top"><span class="icon i-star icon--inline--left"></span><a href="/data/elections/senate/">All senate elections</a></h3>
            <h3><span class="icon i-star icon--inline--left"></span><a href="/data/elections/house/">All house elections</a></h3>
         </div>
-        <div class="result u-padding--bottom--small">
+        <div class="result u-padding--bottom--small u-negative--bottom--margin">
         {% endif %}
           <span class="heading__subtitle js-results-title"></span>
         </div>

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -78,14 +78,15 @@
         </div>
         <div class="heading--section js-results-heading">
           <h2>Results</h2>
-
+        {% if FEATURES.house_senate_overview %}
         </div>
         <div class="u-padding--top">
          <span class="heading__subtitle">All Elections</span>
-           <h3  class="u-no-margin"> <span class="icon i-star icon--inline--left"></span><a href="/data/elections/senate/">All senate elections</a></h3>
+           <h3  class="u-no-margin"><span class="icon i-star icon--inline--left"></span><a href="/data/elections/senate/">All senate elections</a></h3>
            <h3><span class="icon i-star icon--inline--left"></span><a href="/data/elections/house/">All house elections</a></h3>
         </div>
         <div class="result u-padding--bottom--small">
+        {% endif %}
           <span class="heading__subtitle js-results-title"></span>
         </div>
         <div class="results__count">

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -82,8 +82,8 @@
         </div>
         <div class="u-padding--top">
          <span class="heading__subtitle">All Elections</span>
-           <h3  class="u-no-margin-bottom u-margin--top"><span class="icon i-star icon--inline--left"></span><a href="/data/elections/senate/">All senate elections</a></h3>
-           <h3><span class="icon i-star icon--inline--left"></span><a href="/data/elections/house/">All house elections</a></h3>
+           <h3  class="u-no-margin-bottom u-margin--top"><span class="icon i-star icon--inline--left"></span><a href="/data/elections/senate/">All Senate elections</a></h3>
+           <h3><span class="icon i-star icon--inline--left"></span><a href="/data/elections/house/">All House elections</a></h3>
         </div>
         <div class="result u-padding--bottom--small u-negative--bottom--margin">
         {% endif %}

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -78,8 +78,19 @@
         </div>
         <div class="heading--section js-results-heading">
           <h2>Results</h2>
-          <span class="heading__subtitle js-results-title"></span>
+
         </div>
+        <div class="u-padding--top">
+         <span class="heading__subtitle">All Elections</span>
+          <p>
+            <span class="icon i-star icon--inline--left"></span><a class="t-bold" href="/data/elections/senate/">All senate elections</a>
+            <br>
+            <span class="icon i-star icon--inline--left"></span><a class="t-bold" href="/data/elections/house/">All house elections</a>
+          </p>
+        </div>
+          <div class="result u-padding--bottom--small">
+            <span class="heading__subtitle js-results-title"></span>
+          </div>
         <div class="results__count">
           <div class="js-accordion accordion--neutral pa-message" data-content-prefix="pa-redistricting">
             <button type="button" class="js-accordion-trigger accordion__button" aria-controls="pa-redistricting-content-0" aria-expanded="false">Information about 2018 Pennsylvania redistricting</button>

--- a/fec/fec/static/scss/layout/_layout.scss
+++ b/fec/fec/static/scss/layout/_layout.scss
@@ -185,6 +185,10 @@
 margin-top: u(-1rem);
 }
 
+.u-negative--bottom--margin {
+margin-bottom: u(-1rem) !important;
+}
+
 // horizontal rule
 
 .hr--lighter {


### PR DESCRIPTION
## Summary
- Add  links to H/S overview pages  on election search page
- Feature flag the links with  "house_senate_overview"

- Resolves #5182


### Required reviewers

One  UX required.  Optionally,   one frontend

## Impacted areas of the application

modified:   data/templates/election-lookup.jinja

## Screenshots

<img width="1080" alt="Screen Shot 2022-05-06 at 4 54 02 PM" src="https://user-images.githubusercontent.com/5572856/167215090-e1b58a51-a74a-4d6e-9a92-b338dab5d840.png">



## How to test

- checkout and run branch
- test links on  http://127.0.0.1:8000/data/elections/
- Test feature flag by mimicking prod env on your local:  `export FEC_CMS_ENVIRONMENT=prod`  (new links should not show)
- @JonellaCulmer Don't forget to reset your local env:  `export FEC_CMS_ENVIRONMENT=local`

