### PR TITLE
Update hybrid pac descriptions on committee filters

### DIFF
--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -150,11 +150,11 @@
         </li>
         <li class="dropdown__item">
           <input id="committee-type-checkbox-V" type="checkbox" name="{{ committee_type }}" value="V">
-          <label class="dropdown__value" for="committee-type-checkbox-V">Hybrid PAC - nonqualified</label>
+          <label class="dropdown__value" for="committee-type-checkbox-V">Hybrid PAC (with Non-Contribution Account) - Nonqualified</label>
         </li>
         <li class="dropdown__item">
           <input id="committee-type-checkbox-W" type="checkbox" name="{{ committee_type }}" value="W">
-          <label class="dropdown__value" for="committee-type-checkbox-W">Hybrid PAC - qualified</label>
+          <label class="dropdown__value" for="committee-type-checkbox-W">Hybrid PAC (with Non-Contribution Account) - Qualified</label>
         </li>
         <li class="dropdown__subhead">Separate segregated funds</li>
         <li class="dropdown__item">

--- a/fec/data/templates/partials/filters/audit-committee-types.jinja
+++ b/fec/data/templates/partials/filters/audit-committee-types.jinja
@@ -84,11 +84,11 @@
           </li>
           <li class="dropdown__item">
             <input id="committee-type-checkbox-V" type="checkbox" name="committee_type" value="V">
-            <label class="dropdown__value" for="committee-type-checkbox-V">Hybrid PAC - nonqualified</label>
+            <label class="dropdown__value" for="committee-type-checkbox-V">Hybrid PAC (with Non-Contribution Account) - Nonqualified</label>
           </li>
           <li class="dropdown__item">
             <input id="committee-type-checkbox-W" type="checkbox" name="committee_type" value="W">
-            <label class="dropdown__value" for="committee-type-checkbox-W">Hybrid PAC - qualified</label>
+            <label class="dropdown__value" for="committee-type-checkbox-W">Hybrid PAC (with Non-Contribution Account) - Qualified</label>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary (required)

Update Hybrid pac descriptions where hardcoded in CMS
Descriptions in `datatables` and `commitee profile pages`  should  be fixed by https://github.com/fecgov/openFEC/issues/5133

- Resolves #5121

- Related OpenFEC issue : https://github.com/fecgov/openFEC/issues/5133

Old hybrid PAC description
 - PAC with Non-Contribution Account - Nonqualified
 - PAC with Non-Contribution Account - Qualified

Updated hybrid PAC description
 - Hybrid PAC (with Non-Contribution Account) - Nonqualified 
 - Hybrid PAC (with Non-Contribution Account) - Qualified

### Required reviewers

one frontend

## Impacted areas of the application

	modified:   data/templates/macros/filters/committee-types.jinja
	modified:   data/templates/partials/filters/audit-committee-types.jinja


## Related PRs

## How to test

- Checkout and  run branch
- Below are the pages using  `committee type filter`  to confirm it shows the new wording for Hybrid pacs.
- All these pages use the same filter template except `audits search` which has its own. 

http://127.0.0.1:8000/data/committees/

http://127.0.0.1:8000/data/committees/pac-party/

http://127.0.0.1:8000/data/receipts/data_type=processed&two_year_transaction_period=2022&min_date=01%2F01%2F2021&max_date=12%2F31%2F2022

http://127.0.0.1:8000/data/receipts/individual-contributions/?two_year_transaction_period=2022&min_date=01%2F01%2F2021&max_date=12%2F31%2F2022

http://127.0.0.1:8000/data/disbursements/?data_type=processed&two_year_transaction_period=2022&min_date=01%2F01%2F2021&max_date=12%2F31%2F2022

http://127.0.0.1:8000/legal-resources/enforcement/audit-search/
