### PR TITLE
'Candidate state or territory'  label for filings data table

### DIFF
--- a/fec/data/templates/macros/filters/states.jinja
+++ b/fec/data/templates/macros/filters/states.jinja
@@ -1,7 +1,7 @@
 {% macro field(name='name', id_suffix='', type='') %}
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox">
-    <legend class="label" for="state">{{ type }} State or Territory</legend>
+    <legend class="label" for="state">{% if type %}{{ type }} {% endif %}State or Territory</legend>
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>

--- a/fec/data/templates/macros/filters/states.jinja
+++ b/fec/data/templates/macros/filters/states.jinja
@@ -1,7 +1,7 @@
-{% macro field(name='name', id_suffix='') %}
+{% macro field(name='name', id_suffix='', type='') %}
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox">
-    <legend class="label" for="state">State or Territory</legend>
+    <legend class="label" for="state">{{ type }} State or Territory</legend>
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>

--- a/fec/data/templates/partials/filings-filter.jinja
+++ b/fec/data/templates/partials/filings-filter.jinja
@@ -31,7 +31,7 @@ Filter reports
   <div class="accordion__content">
     {{ typeahead.field('committee_id', 'Committee name or ID', '') }}
     {{ typeahead.field('candidate_id', 'Candidate name or ID', '', dataset='candidates') }}
-    {{ states.field('state') }}
+    {{ states.field('state', type='Candidate') }}
     {{ office.checkbox() }}
     {{ parties.checkbox() }}
   </div>


### PR DESCRIPTION
## Summary 

We need to add "Candidate" to "state or territory" label under `Filer` filters on filings data table
Add `type=''` arg to states  macro, set it to  `type='candidate'` for filings data table filters

- Resolves #5180


### Required reviewers

one frontend

## Impacted areas of the application
Affects filings data table, `filer` filters 
	modified:   data/templates/macros/filters/states.jinja
	modified:   data/templates/partials/filings-filter.jinja

## Screenshots
<img width="517" alt="Screen Shot 2022-05-17 at 7 55 27 PM" src="https://user-images.githubusercontent.com/5572856/168930694-9b6f5d8d-fc79-4e3d-91af-3c72f193f3e4.png">



## How to test

- checkout and run branch
- check filing data-table for `CANDIDATE STATE OR TERRITORY` label: http://127.0.0.1:8000/data/filings
- check another page using state macro for filters to make sure it displays as usual:  http://127.0.0.1:8000/data/disbursements/
