### PR TITLE
Add methodology feature flag for house & senate overview pages

### DIFF
--- a/fec/data/templates/partials/house-senate-overview/election-data.jinja
+++ b/fec/data/templates/partials/house-senate-overview/election-data.jinja
@@ -90,11 +90,14 @@
 
          <div class="content__section--ruled-responsive u-margin--top t-serif">
             <div class="row">
+               {% if FEATURES.house_senate_overview_methodology %}
                <ul class="list--buttons u-float-right">
                   <li><a class="button button--alt js-ga-event" data-a11y-dialog-show="contributions-over-time-modal" data-ga-event="Totals for all elections methodology modal clicked" aria-controls="totals-for-all-elections-modal">Methodology</a></li>
                </ul>
+               {% endif %}
                <p class="u-no-margin"><i class="data-disclaimer">Coverage dates for each two-year period cover January 1 of the first year through December 31 of the second year. Newly filed summary data may not appear for up to 48 hours.</i></p>
                </div>
+               {% if FEATURES.house_senate_overview_methodology %}
                <div class="js-modal modal" id="contributions-over-time-modal" aria-hidden="true">
                   <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide=""></div>
                   <div role="dialog" class="modal__content" aria-labelledby="contributions-over-time-modal-title">
@@ -126,6 +129,7 @@
                      </div>
                   </div>
                </div>
+               {% endif %}
             </div>
          </div>
       {# 
@@ -172,11 +176,14 @@
          </table>
          <div class="content__section u-margin--top t-serif">
             <div class="row">
+               {% if FEATURES.house_senate_overview_methodology %}
                <ul class="list--buttons u-float-right">
                   <li><a class="button button--alt js-ga-event" data-a11y-dialog-show="totals-for-all-elections-modal" data-ga-event="Totals for all elections methodology modal clicked" aria-controls="totals-for-all-elections-modal">Methodology</a></li>
                </ul>
+               {% endif %}
                <p class="u-no-margin"><i class="data-disclaimer">Some kind of disclaimer text that clarifies something high-level that users need to know right away to put the data in context.</i></p>
                </div>
+               {% if FEATURES.house_senate_overview_methodology %}
                <div class="js-modal modal" id="totals-for-all-elections-modal" aria-hidden="true">
                   <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide=""></div>
                   <div role="dialog" class="modal__content" aria-labelledby="totals-for-all-elections-modal-title">
@@ -188,6 +195,7 @@
                      </div>
                   </div>
                </div>
+               {% endif %}
             </div>
          </div>
       </div>

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -66,6 +66,7 @@ FEATURES = {
     'pac_snapshot': bool(env.get_credential('FEC_FEATURE_PAC_SNAPSHOT', '')),
     'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
     'house_senate_overview': bool(env.get_credential('FEC_FEATURE_HOUSE_SENATE_OVERVIEW', '')),
+    'house_senate_overview_methodology': bool(env.get_credential('FEC_FEATURE_HOUSE_SENATE_OVERVIEW_METHODOLOGY', '')),
 }
 
 # Set feature flags to True for local
@@ -81,6 +82,7 @@ if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:
     FEATURES['pac_snapshot'] = True
     FEATURES['presidential_map'] = True
     FEATURES['house_senate_overview'] = True
+    FEATURES['house_senate_overview_methodology'] = True
 
 # Application definition
 INSTALLED_APPS = (


### PR DESCRIPTION
## Summary

#5232 

Add methodology feature flag for house and senate overview pages.

### Required reviewers

1 front end

## Impacted areas of the application

General components of the application that this PR will affect:

- House overview page methodology: http://localhost:8000/data/elections/house/
- Senate overview page methodology: http://localhost:8000/data/elections/senate/

## How to test

- Checkout this branch
- `cd fec && ./manage.py runserver`
- Comment out line 85 of base.py so that the feature won't turn on for your local:    
 # FEATURES['house_senate_overview_methodology'] = True
- Check the house and senate overview pages and make sure methodology does not appear
   - House overview page methodology: http://localhost:8000/data/elections/house/
   - Senate overview page methodology: http://localhost:8000/data/elections/senate/
- Uncomment line 85 of base.py so that the methodology re-appears again to see if it's working as expected
