### PR TITLE
Handle null strings for SA/SB aggregates

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -95,7 +95,6 @@ var employerColumns = [
     data: 'employer',
     className: 'all',
     orderable: false,
-    defaultContent: 'NOT REPORTED',
     render: function(data){
       return renderNullStringText(data, 'AN EMPLOYER');
     }
@@ -125,7 +124,6 @@ var occupationColumns = [
     data: 'occupation',
     className: 'all',
     orderable: false,
-    defaultContent: 'NOT REPORTED',
     render: function(data){
       return renderNullStringText(data, 'AN OCCUPATION');
     }

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -82,12 +82,21 @@ var stateColumns = [
   }
 ];
 
+var renderNullStringText = function(data) {
+  if (data == 'NULL') {
+    return data = '(BLANK)';
+  } else {
+    return data;
+  }
+};
+
 var employerColumns = [
   {
     data: 'employer',
     className: 'all',
     orderable: false,
-    defaultContent: 'NOT REPORTED'
+    defaultContent: 'NOT REPORTED',
+    render: renderNullStringText
   },
   {
     data: 'total',
@@ -114,7 +123,8 @@ var occupationColumns = [
     data: 'occupation',
     className: 'all',
     orderable: false,
-    defaultContent: 'NOT REPORTED'
+    defaultContent: 'NOT REPORTED',
+    render: renderNullStringText
   },
   {
     data: 'total',
@@ -140,7 +150,8 @@ var disbursementRecipientColumns = [
   {
     data: 'recipient_name',
     className: 'all',
-    orderable: false
+    orderable: false,
+    render: renderNullStringText
   },
   {
     data: 'recipient_disbursement_percent',

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -82,9 +82,9 @@ var stateColumns = [
   }
 ];
 
-var renderNullStringText = function(data) {
+var renderNullStringText = function(data, columnName) {
   if (data == 'NULL') {
-    return data = '(BLANK)';
+    return data = '(COMMITTEE DID NOT PROVIDE ' + columnName + ')';
   } else {
     return data;
   }
@@ -96,7 +96,9 @@ var employerColumns = [
     className: 'all',
     orderable: false,
     defaultContent: 'NOT REPORTED',
-    render: renderNullStringText
+    render: function(data){
+      return renderNullStringText(data, 'AN EMPLOYER');
+    }
   },
   {
     data: 'total',
@@ -124,7 +126,9 @@ var occupationColumns = [
     className: 'all',
     orderable: false,
     defaultContent: 'NOT REPORTED',
-    render: renderNullStringText
+    render: function(data){
+      return renderNullStringText(data, 'AN OCCUPATION');
+    }
   },
   {
     data: 'total',
@@ -151,7 +155,9 @@ var disbursementRecipientColumns = [
     data: 'recipient_name',
     className: 'all',
     orderable: false,
-    render: renderNullStringText
+    render: function(data){
+      return renderNullStringText(data, 'A RECIPIENT');
+    }
   },
   {
     data: 'recipient_disbursement_percent',


### PR DESCRIPTION
## Summary

- Resolves #5178 

Handle null strings for SA by employer, by occupation, and SB by recipient. I do not see anywhere in the CMS code we are using `/schedules/schedule_a/by_zip/` aggregates. So I did not need to accommodate for that, but we will have to later if we decide to make a feature for this.

### Required reviewers

1 front-end, 1 UX, 1 content specialist

## Impacted areas of the application

General components of the application that this PR will affect:

- Committee profile page individual contributions employer tab (http://localhost:8000/data/committee/C00213512/?tab=raising) 
- Committee profile page individual contributions occupation tab (http://localhost:8000/data/committee/C00000539/?tab=raising)
- Committee profile page disbursements recipient name tab (http://localhost:8000/data/committee/C00103861/?tab=spending)

## Screenshots

### Committee profile page individual contributions employer tab (http://localhost:8000/data/committee/C00213512/?tab=raising) 
<img width="1200" alt="employer" src="https://user-images.githubusercontent.com/12799132/169584759-1e09318d-1054-4790-b9c4-e36c458840f6.png">


### Committee profile page individual contributions occupation tab (http://localhost:8000/data/committee/C00000539/?tab=raising)
<img width="1199" alt="occupation" src="https://user-images.githubusercontent.com/12799132/169584743-225e185d-0548-4520-ba16-ba6b02fe51af.png">


### Committee profile page disbursements recipient name tab (http://localhost:8000/data/committee/C00103861/?tab=spending)
<img width="1200" alt="recipient" src="https://user-images.githubusercontent.com/12799132/169584727-99c3ace1-3859-498d-8bd6-5c0c0e81c729.png">



## How to test

- checkout this branch
- `npm run build`
- `cd fec && ./manage.py runserver`
- Go to each of these examples shown in the screenshots section in this PR. Make sure that `NULL` is now appearing as `(COMMITTEE DID NOT PROVIDE AN [COLUMN_NAME])`. To find more examples, you can go to the #5178 and find other committees that have null.
