### PR TITLE
Update disclaimer text for all totals elections datatable

### DIFF
--- a/fec/data/templates/partials/house-senate-overview/election-data.jinja
+++ b/fec/data/templates/partials/house-senate-overview/election-data.jinja
@@ -95,7 +95,7 @@
                   <li><a class="button button--alt js-ga-event" data-a11y-dialog-show="contributions-over-time-modal" data-ga-event="Totals for all elections methodology modal clicked" aria-controls="totals-for-all-elections-modal">Methodology</a></li>
                </ul>
                {% endif %}
-               <p class="u-no-margin"><i class="data-disclaimer">Coverage dates for each two-year period cover January 1 of the first year through December 31 of the second year. Newly filed summary data may not appear for up to 48 hours.</i></p>
+               <p class="u-no-margin"><i class="data-disclaimer">Each two-year period includes financial activity from January 1 of the nonelection year through December 31 of the election year. Newly filed summary data may not appear for up to 48 hours.</i></p>
                </div>
                {% if FEATURES.house_senate_overview_methodology %}
                <div class="js-modal modal" id="contributions-over-time-modal" aria-hidden="true">
@@ -181,7 +181,7 @@
                   <li><a class="button button--alt js-ga-event" data-a11y-dialog-show="totals-for-all-elections-modal" data-ga-event="Totals for all elections methodology modal clicked" aria-controls="totals-for-all-elections-modal">Methodology</a></li>
                </ul>
                {% endif %}
-               <p class="u-no-margin"><i class="data-disclaimer">Coverage dates for each two-year period cover January 1 of the first year through December 31 of the second year. Newly filed summary data may not appear for up to 48 hours.</i></p>
+               <p class="u-no-margin"><i class="data-disclaimer">Each two-year period includes financial activity from January 1 of the nonelection year through December 31 of the election year. Newly filed summary data may not appear for up to 48 hours.</i></p>
                </div>
                {% if FEATURES.house_senate_overview_methodology %}
                <div class="js-modal modal" id="totals-for-all-elections-modal" aria-hidden="true">

--- a/fec/data/templates/partials/house-senate-overview/election-data.jinja
+++ b/fec/data/templates/partials/house-senate-overview/election-data.jinja
@@ -181,7 +181,7 @@
                   <li><a class="button button--alt js-ga-event" data-a11y-dialog-show="totals-for-all-elections-modal" data-ga-event="Totals for all elections methodology modal clicked" aria-controls="totals-for-all-elections-modal">Methodology</a></li>
                </ul>
                {% endif %}
-               <p class="u-no-margin"><i class="data-disclaimer">Some kind of disclaimer text that clarifies something high-level that users need to know right away to put the data in context.</i></p>
+               <p class="u-no-margin"><i class="data-disclaimer">Coverage dates for each two-year period cover January 1 of the first year through December 31 of the second year. Newly filed summary data may not appear for up to 48 hours.</i></p>
                </div>
                {% if FEATURES.house_senate_overview_methodology %}
                <div class="js-modal modal" id="totals-for-all-elections-modal" aria-hidden="true">


### PR DESCRIPTION
## Summary

- Resolves #5232 

Updates disclaimer text for all totals elections datatable

### Required reviewers

1 UX and 1 data expert

## Impacted areas of the application

General components of the application that this PR will affect:

-  All elections totals datatable

## Screenshots

<img width="1192" alt="Screen Shot 2022-05-19 at 11 04 14 AM" src="https://user-images.githubusercontent.com/12799132/169328664-9958cafd-7aa4-4250-a98f-3555e18b0494.png">

## How to test

- checkout this branch
- `cd fec && ./manage.py runserver`
- Go to the datatable: http://localhost:8000/data/elections/house/#totals-for-all-elections 