### PR TITLE
Committee designation on committee profile page

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -39,12 +39,12 @@
       <span class="t-data t-bold entity__type">
         {% if is_SSF %}
           {{ committee.organization_type_full }} {{ committee.committee_type_full }}
-          {% if designation %}
+          {% if committee.designation %}
           - {{ committee.designation_full }}
           {% endif %}
         {% else %}
           {{ committee.committee_type_full }}
-            {% if designation %}
+            {% if committee.designation %}
             - {{ committee.designation_full }}
             {% endif %}
          {% endif %}

--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -70,7 +70,7 @@
           </td>
         </tr>
         <tr>
-          {% if designation %}
+          {% if committee.designation %}
             <td class="figure__label">Committee designation:</td>
             <td class="figure__value">{{ committee.designation_full }}</td>
           {% endif %}


### PR DESCRIPTION
## Summary (required)

- Resolves #5238

- Fix syntax to enable human-readable committee designation( `designation_full`)  on the header/about-tab of committee profile pages

- History: Conditionals for designation were added here https://github.com/fecgov/fec-cms/commit/49d8ada9b764fa41972b1a90a77dd0467bf9d472  . (Maybe something in view logic has since changed that broke the logic (?), but I could not find  anything in the history.).


### Required reviewers

one frontend and  @PaulClark2 

## Impacted areas of the application

modified:   data/templates/committees-single.jinja

## Related PR:
https://github.com/fecgov/fec-cms/pull/3162


## Screenshots


<img width="779" alt="Screen Shot 2022-05-20 at 12 25 40 AM" src="https://user-images.githubusercontent.com/5572856/169450804-5862a7bc-9cbe-432d-84d8-0ac4f37cc262.png">


## How to test

- checkout and run branch
- verify that committee designations show in header on committee profile pages (see  [the issue](https://github.com/fecgov/fec-cms/issues/5238) for example pages)

