### PR TITLE
Remove debts from Loans and debts page

### DIFF
--- a/fec/data/templates/browse-data.jinja
+++ b/fec/data/templates/browse-data.jinja
@@ -48,7 +48,7 @@
                 tabindex="0"
                 aria-controls="loans-debts"
                 href="#loans-debts"
-                aria-selected="false">Loans and debts</a>
+                aria-selected="false">Loans</a>
             </li>
             <li class="side-nav__item" role="presentation">
               <a

--- a/fec/data/templates/partials/browse-data/loans-debts.jinja
+++ b/fec/data/templates/partials/browse-data/loans-debts.jinja
@@ -1,5 +1,5 @@
 <section class="row" id="loans-debts" aria-hidden="true" role="tabpanel">
-  <h2>Loans and debts</h2>
+  <h2>Loans</h2>
   <h3>Search or browse data</h3>
   <div class="content__section--ruled-responsive t-sans">
     <ul>
@@ -9,20 +9,6 @@
           <h4><a href="/data/loans/">Loans</a></h4>
           <p>Search loans owed by or to committees. Search by committee, loaner’s name, date the loan was incurred, original loan amount and payments made.</p>
         </div>
-      </li>
-      <li>
-        {% if FEATURES.debts %}
-        {# TODO: debts dates #}
-        <i class="icon i-magnifying-glass icon--absolute--left"></i>
-        <div class="content__section--indent-left">
-          <h4><a href="/data/debts/">Debts</h4>
-          <p>Search debts owed by or to committees. Search by committee, creditor’s name, and debt amount.</p>
-        </div>
-        {% else %}
-          <div class="content__section--indent-left">
-            <h4 class="is-disabled">Debts (coming soon)</h4>
-          </div>
-        {% endif %}
       </li>
     </ul>
   </div>

--- a/fec/fec/templates/partials/navigation/nav-data.html
+++ b/fec/fec/templates/partials/navigation/nav-data.html
@@ -8,7 +8,7 @@
             <li class="mega__item"><a href="/data/">All data</a></li>
             <li class="mega__item"><a href="/data/browse-data/?tab=raising">Raising</a></li>
             <li class="mega__item"><a href="/data/browse-data/?tab=spending">Spending</a></li>
-            <li class="mega__item"><a href="/data/browse-data/?tab=loans-debts">Loans and debts</a></li>
+            <li class="mega__item"><a href="/data/browse-data/?tab=loans-debts">Loans</a></li>
             <li class="mega__item"><a href="/data/browse-data/?tab=filings">Filings and reports</a></li>
             <li class="mega__item"><a href="/data/browse-data/?tab=candidates">Candidates</a></li>
             <li class="mega__item"><a href="/data/browse-data/?tab=committees">Committees</a></li>


### PR DESCRIPTION
## Summary (required)

- Resolves #5168 

Removes debts language from the loans and debts page, the main navigation and the browse data left navigation

### Required reviewers

One front-end

## Impacted areas of the application

General components of the application that this PR will affect:

-  Browse data
-  Main navigation

## Screenshots
<img width="1318" alt="Screen Shot 2022-04-19 at 11 56 58 AM" src="https://user-images.githubusercontent.com/31663028/164046499-5c19bc0e-9842-4500-9c96-5ba02e35fd28.png">

## How to test

- The word "debt" does not appear on the browse data section, main navigation