### PR TITLE
[MERGE WITH GITFLOW] H/S across time chart  -  preserve  office param (H/S)  in totals links 

### DIFF
--- a/fec/fec/static/js/pages/elections-overview.js
+++ b/fec/fec/static/js/pages/elections-overview.js
@@ -117,6 +117,7 @@ AcrossTime.prototype.displayUpdatedData = function(queryResponse) {
 
       // Create object for creating querystring for the link for each value
       let searchFilters = {
+        data_type: 'processed',
         two_year_transaction_period: electionYear,
         recipient_committee_type: context.office_code,
         line_number: lineNumbers[line]


### PR DESCRIPTION
## Summary (required)

Preserve  `recipient_committee_type`  parameter (H or S)  in totals links from H/S overview across time chart by explicitly adding `data_type=processed` to URL querystring. Otherwise it strips it.

Although `data_type=processed` gets automatically added to a link to receipts datatable ( https://fec.gov/data/receipts ) ,  the `recipient_committee_type`  will be removed unless `data_type=processed` is already in link at time of clicking (or pasting into browser url bar). Not sure why (?)

### Required reviewers

one frontend

## Impacted areas of the application

	modified:   fec/static/js/pages/elections-overview.js:

## Related PRs

Related PRs against other branches:

https://github.com/fecgov/fec-cms/pull/5166

## How to test

-  `npm run builld-js`
-  Make sure links from totals on chart include the office parameter (`recipient_committee_type=H/S`) in the resulting datatable
