### PR TITLE
Add dividing lines for AO filters

### DIFF
--- a/fec/fec/static/js/legal/FilterPanel.js
+++ b/fec/fec/static/js/legal/FilterPanel.js
@@ -24,7 +24,7 @@ class FilterPanel extends React.Component {
           {this.props.header}
         </button>
         <div
-          className="accordion__content filters-inner"
+          className="accordion__content"
           id={this.props.id}
           hidden={!this.state.expanded}
         >

--- a/fec/fec/static/js/legal/Filters.js
+++ b/fec/fec/static/js/legal/Filters.js
@@ -17,7 +17,7 @@ function Filters(props) {
 
   return (
     <div>
-      <div className="accordion__content">
+      <div className="filters__inner">
         <TextFilter
           key="ao_no"
           name="ao_no"

--- a/fec/fec/static/js/legal/filters/TextFilter.js
+++ b/fec/fec/static/js/legal/filters/TextFilter.js
@@ -10,53 +10,51 @@ function TextFilter(props) {
   }
 
   return (
-    <div>
-      <div className="filter">
-        <label
-          className="label t-inline-block"
-          htmlFor={props.name + '-filter'}
+    <div className="filter">
+      <label
+        className="label t-inline-block"
+        htmlFor={props.name + '-filter'}
+      >
+        {props.label}
+      </label>
+      {props.TooltipHelp.addTooltip && (
+        <TooltipHelp
+          message={props.TooltipHelp.message}
+          verticalPosition={props.TooltipHelp.verticalPosition}
+          horizontalPosition={props.TooltipHelp.horizontalPosition}
+        />
+      )}
+      <div className="combo combo--search--mini">
+        <input
+          id={props.name + '-filter'}
+          type="text"
+          name={props.name}
+          className="combo__input"
+          value={props.value || ''}
+          onChange={props.handleChange}
+          onKeyDown={handleKeydown}
+        />
+        <button
+          className="combo__button button--search button--standard"
+          onClick={props.getResults}
         >
-          {props.label}
-        </label>
-        {props.TooltipHelp.addTooltip && (
-          <TooltipHelp
-            message={props.TooltipHelp.message}
-            verticalPosition={props.TooltipHelp.verticalPosition}
-            horizontalPosition={props.TooltipHelp.horizontalPosition}
-          />
-        )}
-        <div className="combo combo--search--mini">
-          <input
-            id={props.name + '-filter'}
-            type="text"
-            name={props.name}
-            className="combo__input"
-            value={props.value || ''}
-            onChange={props.handleChange}
-            onKeyDown={handleKeydown}
-          />
-          <button
-            className="combo__button button--search button--standard"
-            onClick={props.getResults}
-          >
-            <span className="u-visually-hidden">Search</span>
-          </button>
-        </div>
-        {props.keywordModal && (
-          <button
-            className="button--keywords"
-            aria-controls="keyword-modal"
-            data-a11y-dialog-show="keyword-modal"
-          >
-            More keyword options
-          </button>
-        )}
-        {props.helpText && (
-          <span className="t-note t-sans search__example">
-            {props.helpText}
-          </span>
-        )}
+          <span className="u-visually-hidden">Search</span>
+        </button>
       </div>
+      {props.keywordModal && (
+        <button
+          className="button--keywords"
+          aria-controls="keyword-modal"
+          data-a11y-dialog-show="keyword-modal"
+        >
+          More keyword options
+        </button>
+      )}
+      {props.helpText && (
+        <span className="t-note t-sans search__example">
+          {props.helpText}
+        </span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary (required)

- Resolves #5211 

Update and clean up DOM HTML elements to add dividing lines to AO filters

### Required reviewers

1 front end and 1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

-  AO filter panel: http://localhost:8000/data/legal/search/advisory-opinions/

## Screenshots

<img width="299" alt="Screen Shot 2022-06-02 at 12 38 49 PM" src="https://user-images.githubusercontent.com/12799132/171681305-f573e386-e59c-42d0-8575-9f891a97ee7b.png">

## How to test

- Checkout this branch
- `npm run build-js`
- `cd fec && ./manage.py runserver`
- Go to the [AO search page](http://localhost:8000/data/legal/search/advisory-opinions/) and check the dividing lines are present in the first set of filters. The accordion content should also retain the dividing lines.
