### PR TITLE
[Don't merge yet] Feature/5243 remove map and zip election search

### DIFF
--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -28,13 +28,13 @@
         <div class="search-controls__either">
           <div class="row">
             <div class="search-controls__zip combo combo--search__medium combo--search--inline">
-              <label for="zip" class="label">Find by ZIP code</label>
-              <input type="text" inputmode="numeric" id="zip" name="zip" class="combo__input">
-              <button class="combo__button button--search button--standard" type="submit">
+              <label for="zip" class="label is-disabled">Find by ZIP code</label>
+              <input type="text" inputmode="numeric" id="zip" name="zip" class="combo__input is-disabled" disabled>
+              <button class="combo__button button--search button--standard is-disabled" type="submit" disabled>
                   <span class="u-visually-hidden">Search</span>
               </button>
 
-              <span class="t-note t-sans search__example">Example: 90210</span>
+              <span class="t-note t-sans search__example">Temporarily unavailable</span>
             </div>
           </div>
         </div>

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -10,7 +10,7 @@
 
 {% block body %}
   {{ header.header(title) }}
-<section class="main election-search" id="election-lookup">
+<section class="main election-search na-map na-zip" id="election-lookup">
   <div class="container">
     <header class="heading--main">
       <h1>Search</h1>
@@ -97,7 +97,9 @@
         </div>
       </div>
       <div class="usa-width-one-half">
-        <div class="election-map"></div>
+        <div class="election-map">
+          <p class="message message--inverse-alt message--info">The election map and ZIP code search are unavailable at this time. Following the 2020 Census, some states may redraw their districts. Some candidates may subsequently amend their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may run in different districts than in the past. The FEC will re-enable the map and ZIP code search once complete information has been made available from each state.</p>
+        </div>
         <div class="t-italic js-map-approx-message">
             <p>District maps on this page are approximate.</p>
         </div>

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -70,12 +70,6 @@
   <div class="container">
     <div class="content__section--extra">
       <div class="usa-width-one-half">
-        <div class="js-accordion accordion--neutral u-padding--bottom" data-content-prefix="2022-redistricting">
-          <button type="button" class="js-accordion-trigger accordion__button" aria-controls="2022-redistricting-content-0" aria-expanded="false">Information about redistricting and the 2020 Decennial Census</button>
-            <div class="accordion__content" id="2022-redistricting-content-0" aria-hidden="true">
-              <p>Following the 2020 Census, some states may redraw their districts. Some candidates may subsequently amend their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may run in different districts than in the past. The FEC will update its map to reflect the new congressional districts and boundaries once information has been made available from each state.</p>
-          </div>
-        </div>
         <div class="heading--section js-results-heading">
           <h2>Results</h2>
         {% if FEATURES.house_senate_overview %}

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -100,7 +100,7 @@
         <div class="election-map">
           <p class="message message--inverse-alt message--info">The election map and ZIP code search are unavailable at this time. Following the 2020 Census, some states may redraw their districts. Some candidates may subsequently amend their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may run in different districts than in the past. The FEC will re-enable the map and ZIP code search once complete information has been made available from each state.</p>
         </div>
-        <div class="t-italic js-map-approx-message">
+        <div class="t-italic js-map-approx-message" aria-hidden="true">
             <p>District maps on this page are approximate.</p>
         </div>
         <div class="message message--info js-map-message" aria-hidden="true">

--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -21,7 +21,7 @@
     <div class="grid--2-wide grid--flex">
       <div class="grid__item">
         <h2>Compare candidates</h2>
-        <div id="election-lookup" class="search--election-mini">
+        <div id="election-lookup" class="search--election-mini na-map na-zip">
           <div class="usa-width-one-half">
             <form action="/data/elections" class="content__section">
               <div class="search-controls__state">
@@ -52,7 +52,10 @@
               </div>
             </form>
           </div>
-          <div class="election-map election-map--small usa-width-one-half"></div>
+          <div class="election-map election-map--small usa-width-one-half">
+            <!-- map would render here -->
+            <p class="message message--inverse-alt message--info">The election map and ZIP code search are unavailable at this time. Following the 2020 Census, some states may redraw their districts. Some candidates may subsequently amend their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may run in different districts than in the past. The FEC will re-enable the map and ZIP code search once complete information has been made available from each state.</p>
+          </div>
         </div>
       </div>
       <div class="grid__item example--primary callout-holder">

--- a/fec/fec/static/js/pages/data-landing.js
+++ b/fec/fec/static/js/pages/data-landing.js
@@ -5,7 +5,9 @@ var lookup = require('../modules/election-lookup');
 var analytics = require('../modules/analytics');
 
 $(document).ready(function() {
-  new lookup.ElectionLookup('#election-lookup', false);
+  // If #election-lookup doesn't also have the na-map class, init it
+  if (document.querySelector('#election-lookup:not(.na-map)'))
+    new lookup.ElectionLookup('#election-lookup', false);
 });
 
 $('.js-ga-event').each(function() {

--- a/fec/fec/static/js/pages/election-lookup.js
+++ b/fec/fec/static/js/pages/election-lookup.js
@@ -4,5 +4,7 @@ var $ = require('jquery');
 var lookup = require('../modules/election-search');
 
 $(document).ready(function() {
-  new lookup.ElectionSearch('#election-lookup', true);
+  // If #election-lookup doesn't also have the na-map class, init it
+  if (document.querySelector('#election-lookup:not(.na-map)'))
+    new lookup.ElectionSearch('#election-lookup', true);
 });

--- a/fec/fec/static/scss/components/_form-styles.scss
+++ b/fec/fec/static/scss/components/_form-styles.scss
@@ -313,8 +313,12 @@
   margin-bottom: u(2rem);
 }
 
-// Disable and active styles for filter fields
+// Let labels use the same is-disabled classes for styles
+label.is-disabled {
+  opacity: .5;
+}
 
+// Disable and active styles for filter fields
 .is-active-filter {
   opacity: 1;
   pointer-events: auto;

--- a/fec/fec/static/scss/components/_maps.scss
+++ b/fec/fec/static/scss/components/_maps.scss
@@ -14,21 +14,28 @@
 // </div>
 //
 
-.election-map {
-  border: 1px solid $gray;
-  height: u(40rem);
+#election-lookup:not(.na-map) {
+  .election-map {
+    border: 1px solid $gray;
+    height: u(40rem);
 
-  svg path {
-    stroke-width: 1px;
+    svg path {
+      stroke-width: 1px;
+    }
+  }
+
+  .election-map--small {
+    height: u(24rem);
+  }
+
+  .election-map--home {
+    height: u(26rem);
   }
 }
-
-.election-map--small {
-  height: u(24rem);
-}
-
-.election-map--home {
-  height: u(26rem);
+#election-lookup.na-map {
+  .election-map--home .message {
+    background-color: #fff !important;
+  }
 }
 
 .choropleths {

--- a/fec/fec/static/scss/components/_search-controls.scss
+++ b/fec/fec/static/scss/components/_search-controls.scss
@@ -287,6 +287,33 @@
       width: 100%;
     }
   }
+  #election-lookup.na-map {
+    .message {
+      @include clearfix();
+      background-size: u(2rem);
+      background-position: u(2rem 2rem);
+      background-color: $gray-lightest;
+      border-color: $gray;
+      border-style: solid;
+      border-width: 0 0 0 3px;
+      margin: u(2rem 0);
+      padding: u(5rem 2rem 2rem 2rem);
+    
+      @include media($med) {
+        background-position: u(2rem 2rem);
+        background-size: u(3rem);
+        min-height: u(8rem);
+        padding: u(2rem 2rem 2rem 6rem);
+      }
+
+      p:last-child {
+        margin-bottom: 0;
+      }
+    }
+    .message--info {
+      @include u-icon-bg($info-circle, $primary);
+    }
+  }
   
   .callout-holder {
     border: none;

--- a/fec/fec/static/scss/components/_search-controls.scss
+++ b/fec/fec/static/scss/components/_search-controls.scss
@@ -287,33 +287,6 @@
       width: 100%;
     }
   }
-  #election-lookup.na-map {
-    .message {
-      @include clearfix();
-      background-size: u(2rem);
-      background-position: u(2rem 2rem);
-      background-color: $gray-lightest;
-      border-color: $gray;
-      border-style: solid;
-      border-width: 0 0 0 3px;
-      margin: u(2rem 0);
-      padding: u(5rem 2rem 2rem 2rem);
-    
-      @include media($med) {
-        background-position: u(2rem 2rem);
-        background-size: u(3rem);
-        min-height: u(8rem);
-        padding: u(2rem 2rem 2rem 6rem);
-      }
-
-      p:last-child {
-        margin-bottom: 0;
-      }
-    }
-    .message--info {
-      @include u-icon-bg($info-circle, $primary);
-    }
-  }
   
   .callout-holder {
     border: none;
@@ -435,5 +408,33 @@
       order: 1;
       width: 66.66%;
     }
+  }
+}
+
+#election-lookup.na-map {
+  .message {
+    @include clearfix();
+    background-size: u(2rem);
+    background-position: u(2rem 2rem);
+    background-color: $gray-lightest;
+    border-color: $gray;
+    border-style: solid;
+    border-width: 0 0 0 3px;
+    margin: u(2rem 0);
+    padding: u(5rem 2rem 2rem 2rem);
+  
+    @include media($med) {
+      background-position: u(2rem 2rem);
+      background-size: u(3rem);
+      min-height: u(8rem);
+      padding: u(2rem 2rem 2rem 6rem);
+    }
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
+  .message--info {
+    @include u-icon-bg($info-circle, $primary);
   }
 }

--- a/fec/fec/static/scss/data-landing.scss
+++ b/fec/fec/static/scss/data-landing.scss
@@ -26,3 +26,19 @@
 @import "components/search-controls";
 @import "components/data-landing-callouts";
 
+#election-lookup.na-map {
+  flex-wrap: wrap;
+}
+#election-lookup.na-map > .usa-width-one-half {
+  width: 100% !important;
+  &:first-child {
+    order: initial;
+  }
+  &:last-child {
+    order: initial;
+  }
+}
+#election-lookup.na-map .message {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/fec/home/templates/partials/elections-lookup.html
+++ b/fec/home/templates/partials/elections-lookup.html
@@ -3,10 +3,11 @@
 {% load filters %}
 
 <h2 class="heading--section u-padding--top">Compare candidates in an election</h2>
-<div class="grid grid--2-wide grid--flex u-padding--top" id="election-lookup">
+<div class="grid grid--2-wide grid--flex u-padding--top na-map na-zip" id="election-lookup">
   <div class="grid__item u-margin--bottom">
     <div class="election-map election-map--home">
-      <!--map renders here -->
+      <!-- map would render here -->
+      <p class="message message--inverse-alt message--info">The election map and ZIP code search are unavailable at this time. Following the 2020 Census, some states may redraw their districts. Some candidates may subsequently amend their registration forms to reflect new district numbers. Candidates are listed using information from their registration forms and may run in different districts than in the past. The FEC will re-enable the map and ZIP code search once complete information has been made available from each state.</p>
     </div>
   </div>
   <div class="grid__item example--primary u-margin--bottom search-controls election-search-home">

--- a/fec/home/templates/partials/elections-lookup.html
+++ b/fec/home/templates/partials/elections-lookup.html
@@ -14,11 +14,12 @@
     <form action="/data/elections">
       <div class="row u-margin--bottom">
         <div class="search-controls__zip">
-          <label for="zip" class="label input__label-home">Find by ZIP code</label>
-          <input type="text" inputmode="numeric" id="zip" name="zip" class="combo__input">
+          <label for="zip" class="label input__label-home is-disabled">Find by ZIP code</label>
+          <input type="text" inputmode="numeric" id="zip" name="zip" class="combo__input is-disabled" disabled>
+          <label for="zip" class="t-note t-sans">Temporarily unavailable</label>
         </div>
         <div class="search-controls__submit search-controls__no-label">
-          <button type="submit" class="button--search--text button--standard">Search</button>
+          <button type="submit" class="button--search--text button--standard is-disabled" disabled>Search</button>
         </div>
       </div>
       <div class="row">

--- a/fec/home/templates/purgecss-homepage/full.html
+++ b/fec/home/templates/purgecss-homepage/full.html
@@ -439,8 +439,9 @@
         <form action="/data/elections">
           <div class="row u-margin--bottom">
             <div class="search-controls__zip">
-              <label for="zip" class="label input__label-home">Find by ZIP code</label>
-              <input type="text" inputmode="numeric" id="zip" name="zip" class="combo__input">
+              <label for="zip" class="label input__label-home is-disabled">Find by ZIP code</label>
+              <input type="text" inputmode="numeric" id="zip" name="zip" class="combo__input is-disabled" disabled>
+              <label class="t-note t-sans">Temporarily unavailable</label>
             </div>
             <div class="search-controls__submit search-controls__no-label">
               <button type="submit" class="button--search--text button--standard">Search</button>

--- a/fec/home/templates/purgecss-homepage/full.html
+++ b/fec/home/templates/purgecss-homepage/full.html
@@ -393,10 +393,11 @@
     
     
     <h2 class="heading--section u-padding--top">Compare candidates in an election</h2>
-    <div class="grid grid--2-wide grid--flex u-padding--top" id="election-lookup">
+    <div class="grid grid--2-wide grid--flex u-padding--top na-map na-zip" id="election-lookup">
       <div class="grid__item u-margin--bottom">
-        <div class="election-map election-map--home leaflet-container leaflet-touch leaflet-fade-anim leaflet-grab leaflet-touch-drag"   >
+        <div class="election-map election-map--home leaflet-container leaflet-touch leaflet-fade-anim leaflet-grab leaflet-touch-drag" >
           <!--map renders here -->
+          <p class="message message--inverse-alt message--info">The election map and ZIP code search are unavailable at this time. </p>
         <div class="leaflet-pane leaflet-map-pane" >
             <div class="leaflet-pane leaflet-tile-pane">
                 <div class="leaflet-layer ">


### PR DESCRIPTION
## Summary

- Resolves #5243 

Deactivating

### Required reviewers
Feel free to remove yourselves—I tagged everyone

- Front-end for functionality and approach
- UX for functionality and look and feel
- Content for language, especially:
   - I capped ZIP since it's an acronym and AP does
   - Merriam-Webster says 'reenabled' isn't a word so I hyphenated it, but I'm not a fan of the connection that 'enabled' has with 'disabled'
- Content for typos

## Impacted areas of the application

-  Election searches on the homepage, data landing page, and election search page

## Screenshots
Homepage, smallest
![image](https://user-images.githubusercontent.com/26720877/171695673-074e5242-343e-41da-bdf9-c7dced649a2f.png)

Homepage, widest
![image](https://user-images.githubusercontent.com/26720877/171696868-d1a32454-3fff-42ec-aa4f-434fdce72b66.png)

Data landing page, smallest
![image](https://user-images.githubusercontent.com/26720877/171696780-6c62e302-8cdd-4981-b858-4feaac2a0677.png)

Data landing page, widest
![image](https://user-images.githubusercontent.com/26720877/171696944-f4840f54-fc97-46b0-8b44-440dbfae27bd.png)

Election search, smallest, ZIP search
![image](https://user-images.githubusercontent.com/26720877/171696039-b23c0b41-ac77-4202-b78f-4e25fa30438a.png)

Election search, smallest, map/message
![image](https://user-images.githubusercontent.com/26720877/171698221-6ec8723e-0109-4608-8e65-336b60e7da76.png)

Election search, widest
![image](https://user-images.githubusercontent.com/26720877/171698265-ce1e652b-3b2f-4b3a-8c80-77291eb829e4.png)


## How to test

Content, feel free to review these screenshots.
Otherwise,
- pull the branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- Check the [homepage](http://127.0.0.1:8000/) across widths
- Check the [data landing page](http://127.0.0.1:8000/data/) across widths
- Check the [election search page](http://127.0.0.1:8000/data/elections/) across widths
- [Presidential candidate map](http://127.0.0.1:8000/data/candidates/president/presidential-map/) should be unaffected (still fully functional)
- [Raising by the number map](http://127.0.0.1:8000/data/raising-bythenumbers/) should be unaffected (still fully functional)

## Known issues / questions
- I really like don't like the way the widest data landing page looks. Our default grid offers us 100% column, 50%, 33.33%, and 25%—we aren't using 7/12 columns anywhere. @JonellaCulmer?
- **Removing the map has broken the district pull-down filtering**. (i.e. selecting a state would update the map, which would then update choices for districts but now we don't have the map so it can't update, so the districts never get refreshed/filtered). @patphongs is working on a fix.
- Tests aren't failing and it seems like they should be