### PR TITLE
Minor style guide fix

### DIFF
--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -48,7 +48,7 @@
         <div class="main__content--right">
           <section id="meetings-open-meetings" role="tabpanel" aria-hidden="true" aria-labelledby="open-meetings">
             <h2>Open meetings</h2>
-            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:00am. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
+            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:00 a.m. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
             <div class="filters--horizontal">
               <form action="" id="openmeetings_form" method="get" class="js-form-nav container">
                 <div class="filter">

--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -37,7 +37,7 @@
     </header>
 
     {% if self.meeting_type == 'O' %}
-      <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:00am.</p>
+      <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:00 a.m.</p>
       <p>Members of the public can attend any open meeting or hearing in person. Open meetings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.</p>
     {% elif self.meeting_type == 'E' %}
       <p>The Commission meets regularly in executive sessions to discuss pending enforcement actions, litigation and other matters that, by law, must be kept confidential.</p>


### PR DESCRIPTION
## Summary (required)

- Resolves #5275 

10:00am. as shown in screenshot from an open meeting page should be 10:00 a.m. with a space between 10:00 and a.m., with a.m. having a period after each letter.

### Required reviewers

1 front-end dev

## Impacted areas of the application

General components of the application that this PR will affect: Meeting page template, in the description for open meetings

## Screenshots

(https://user-images.githubusercontent.com/24437369/171252874-7c66f15a-f92c-412e-bca5-70aa6e26c82a.png)
