### PR TITLE
Fix closing th tag

### DIFF
--- a/fec/legal/templates/legal-admin_fine.jinja
+++ b/fec/legal/templates/legal-admin_fine.jinja
@@ -35,24 +35,24 @@
         <table class="usa-width-two-thirds">
           <tbody>
             <tr>
-              <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Report:</p></td>
+              <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Report:</p></th>
               <td><p class="u-margin--bottom t-low-height">{{ admin_fine.report_year }} {{ report_type_full }}</p></td>
             </tr>
             <tr>
-              <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Committee name:</p></td>
+              <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Committee name:</p></th>
               <td><p class="u-margin--bottom t-low-height">{{ admin_fine.name }}</p></td>
             </tr>
             <tr>
-              <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Closing date:</p></td>
+              <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Closing date:</p></th>
               <td><p class="u-margin--bottom t-low-height">{{ admin_fine.final_determination_date | date(fmt='%m/%d/%Y') }}</p></td>
             </tr>
             <tr>
-              <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Assessed civil penalty:</p></td>
+              <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Assessed civil penalty:</p></th>
               <td><p class="u-margin--bottom t-low-height">{{ admin_fine.final_determination_amount | currency or '' }}</p></td>
             </tr>
             {% if admin_fine.final_determination_amount != 0 %}
               <tr>
-                <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Civil penalty due date:</p></td>
+                <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Civil penalty due date:</p></th>
                 <td><p class="u-margin--bottom t-low-height">{{ admin_fine.civil_penalty_due_date | date(fmt='%m/%d/%Y') or 'No date available' }}, {{ admin_fine.civil_penalty_payment_status | replace('Did Not Pay', 'Not paid') | capitalize or 'No status available' }}
                 {% if admin_fine.civil_penalty_payment_status == 'Partially Paid' %} {{ admin_fine.payment_amount | currency or '' }}{% endif %}</p>
                 </td>


### PR DESCRIPTION
## Summary (required)

- Resolves #4763  

Adds closing `<th>` tag that was missed.

### Required reviewers

1 front end

## Impacted areas of the application

General components of the application that this PR will affect:

-  Admin fines canonical page

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/4763-accessible-vertical-tables| [link](https://github.com/fecgov/fec-cms/pull/5236)

## How to test

- Checkout this branch
- Look at an admin fine page such as this one: http://localhost:8000/data/legal/administrative-fine/4262/. Check the Summary section table and see that the `<th scope="row">...</th>` was inserted correctly. 
- You can turn on voiceover on your machine and highlight the header row, it should say that the selected item is a heading.