### PR TITLE
Resource page title for browser tag

### DIFF
--- a/fec/home/templates/home/resource_page.html
+++ b/fec/home/templates/home/resource_page.html
@@ -1,7 +1,6 @@
 {% extends "long_page.html" %}
 {% load wagtailcore_tags %}
 {% load static %}
-{% block title %}{{ self.title }}{% endblock %}
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
 
 {% block breadcrumbs %}

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/4797-resource-page-title-display'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/4797-resource-page-title-display'),
 )
 
 


### PR DESCRIPTION
## Summary

- Resolves #4797

Remove {% block_title %} from resource page so it uses the block from `base.py`-- its "grandparent" template (long_page.html` is its parent)

### Required reviewers
@djgarr 

## Impacted areas of the application
modified:   home/templates/home/resource_page.html

## How to test
A copy of this branch is deployed to feature space for testing:  https://fec-feature-cms.app.cloud.gov/

- checkout and run branch
- confirm that the value in the promote tab > `Title tag` field shows in browser tab with existing or newly published `Resource Pages`
- Please double check that any places where a title is rendered  (like the title in Wagtail page explorer or other places you can think of) are not affected.

**Note:** This branch is combined with https://github.com/fecgov/fec-cms/pull/5304 for testing on feature space, so no deploy task to remove before merge