### PR TITLE
Update MUR search results display

### DIFF
--- a/fec/fec/static/scss/components/_accordions.scss
+++ b/fec/fec/static/scss/components/_accordions.scss
@@ -74,6 +74,15 @@
     border-bottom: 0;
     margin-left: u(3rem);
     padding-bottom: 0;
+    max-width: u(80rem);
+  }
+
+  &.results__content li {
+    padding-bottom: u(2rem);
+
+    &:last-child {
+      padding-bottom: 0;
+    }
   }
 }
 

--- a/fec/fec/static/scss/components/_accordions.scss
+++ b/fec/fec/static/scss/components/_accordions.scss
@@ -56,26 +56,10 @@
   }
 
   &.results__button {
-    background-position: 28% 50%;
+    background-position: 0% 50%;
     margin: u(0 0 0 3rem);
-    padding-left: 0rem;
+    padding-left: 3rem;
     border-bottom: 0;
-  }
-
-  @include media($lg) {
-    &.results__button {
-      background-position: 13% 50%;
-      margin: u(0 0 0 3rem);
-      border-bottom: 0;
-    }
-  }
-
-  @include media($med) {
-    &.results__button {
-      background-position: 10% 50%;
-      margin: u(0 0 0 3rem);
-      border-bottom: 0;
-    }
   }
 }
 
@@ -88,7 +72,7 @@
   &.results__content {
     border-top: 1px solid $base;
     border-bottom: 0;
-    padding-left: u(3rem);
+    margin-left: u(3rem);
     padding-bottom: 0;
   }
 }

--- a/fec/fec/static/scss/components/_accordions.scss
+++ b/fec/fec/static/scss/components/_accordions.scss
@@ -54,6 +54,29 @@
       padding: u(1rem 0rem 1rem 0);
     }
   }
+
+  &.results__button {
+    background-position: 28% 50%;
+    margin: u(0 0 0 3rem);
+    padding-left: 0rem;
+    border-bottom: 0;
+  }
+
+  @include media($lg) {
+    &.results__button {
+      background-position: 13% 50%;
+      margin: u(0 0 0 3rem);
+      border-bottom: 0;
+    }
+  }
+
+  @include media($med) {
+    &.results__button {
+      background-position: 10% 50%;
+      margin: u(0 0 0 3rem);
+      border-bottom: 0;
+    }
+  }
 }
 
 .accordion__content {
@@ -61,6 +84,13 @@
   border-bottom: 1px solid $base;
   padding: u(2rem);
   font-family: $sans-serif;
+
+  &.results__content {
+    border-top: 1px solid $base;
+    border-bottom: 0;
+    padding-left: u(3rem);
+    padding-bottom: 0;
+  }
 }
 
 .accordion__button--spacious {

--- a/fec/fec/static/scss/components/_legal-search.scss
+++ b/fec/fec/static/scss/components/_legal-search.scss
@@ -39,6 +39,10 @@
   em {
     @include t-highlight;
   }
+
+  &.split__cell {
+    border-top: 1px solid $gray-lightest;
+  }
 }
 
 .legal-mur {

--- a/fec/fec/static/scss/components/_legal-search.scss
+++ b/fec/fec/static/scss/components/_legal-search.scss
@@ -35,7 +35,6 @@
 }
 
 .legal-search-result__hit {
-  font-style: italic;
 
   em {
     @include t-highlight;

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -99,6 +99,12 @@ h3 + .simple-table {
         padding: u(1rem);
       }
     }
+
+    &.simple-table--responsive {
+      .no--pad {
+        padding: 0;
+      }
+    }
   }
 }
 
@@ -114,11 +120,6 @@ h3 + .simple-table {
 
   .simple-table__cell {
     padding: 0;
-  }
-
-  .simple-table__cell,
-  .simple-table__header-cell {
-    border-left: none;
   }
 
   @include media($med) {

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -122,6 +122,10 @@ h3 + .simple-table {
     padding: 0;
   }
 
+  .simple-table__cell:nth-child(2) {
+    word-break: break-word;
+  }
+
   @include media($med) {
     & {
       border-collapse: collapse;

--- a/fec/fec/static/scss/components/_tags.scss
+++ b/fec/fec/static/scss/components/_tags.scss
@@ -52,6 +52,10 @@
   margin: u(.5rem 3rem 0 0);
 }
 
+.tag--primary {
+  border-color: $primary;
+}
+
 .tag--secondary {
   border-color: $secondary;
   color: $base;
@@ -90,6 +94,11 @@
       }
     }
   }
+}
+
+.tag__category--doc {
+  padding: 0 0 0 3rem;
+  background: none;
 }
 
 .tag__category--and {

--- a/fec/fec/static/scss/layout/_layout.scss
+++ b/fec/fec/static/scss/layout/_layout.scss
@@ -140,6 +140,10 @@
   padding-top: u(.5rem) !important;
 }
 
+.u-padding--top--med {
+  padding-top: u(1rem) !important;
+}
+
 .u-padding--bottom {
   padding-bottom: u(2rem);
 }
@@ -150,6 +154,10 @@
 
 .u-padding--left {
   padding-left: u(2rem);
+}
+
+.u-padding--left--small {
+  padding-left: u(1rem);
 }
 
 .u-padding--right {

--- a/fec/legal/templates/partials/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/partials/legal-search-results-adrs.jinja
@@ -19,7 +19,7 @@
             <div class="t-sans u-padding--top">Keyword match:</div>
             <div class="legal-search-result__hit u-padding--left">
               {% for highlight in adr.highlights %}
-                <span class="t-serif">
+                <span class="t-serif t-italic">
                     {{ highlight|safe }} &hellip;
                 </span>
               {% endfor %}

--- a/fec/legal/templates/partials/legal-search-results-afs.jinja
+++ b/fec/legal/templates/partials/legal-search-results-afs.jinja
@@ -20,7 +20,7 @@
             <div class="t-sans u-padding--top">Keyword match:</div>
             <div class="legal-search-result__hit u-padding--left">
               {% for highlight in admin_fine.highlights %}
-                <span class="t-serif">
+                <span class="t-serif t-italic">
                     {{ highlight|safe }} &hellip;
                 </span>
               {% endfor %}

--- a/fec/legal/templates/partials/legal-search-results-mur.jinja
+++ b/fec/legal/templates/partials/legal-search-results-mur.jinja
@@ -1,31 +1,36 @@
 <div class="simple-table simple-table--responsive simple-table--display legal-search-results legal-mur data-container__datatable">
   <div class="simple-table__header">
-    <div class="simple-table__header-cell cell--25">Name</div>
-    <div class="simple-table__header-cell">Matches</div>
+    <div class="simple-table__header-cell cell--10">Case number</div>
+    <div class="simple-table__header-cell cell--15">Case name</div>
+    <div class="simple-table__header-cell">Case details and documents</div>
   </div>
   <div class="simple-table__row-group">
   {% for mur in murs %}
     <div class="simple-table__row legal-search-result">
       <div class="simple-table__cell">
         <div class="t-sans">
-          <a title="{{ mur.name }}" href="/data/legal/matter-under-review/{{ mur.no }}">
-            <span class="t-bold">MUR #{{ mur.no }}</span><br>
-            {{ mur.name|upper }}
-          </a>
+          <span class="t-bold">MUR #{{ mur.no }}</span>
         </div>
         {% if mur.mur_type == 'archived' %}
         <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span>Archived case</div>
         {% endif %}
       </div>
       <div class="simple-table__cell">
-        <div class="u-margin--bottom"><strong>Election cycle(s):</strong> {{ '; '.join(mur['election_cycles'] | map('string') | sort) }}</div>
+        <div class="t-sans">
+          <a title="{{ mur.name }}" href="/data/legal/matter-under-review/{{ mur.no }}">
+            {{ mur.name|upper }}
+          </a>
+        </div>
+      </div>
+      <div class="simple-table__cell no--pad">
+        <div class="u-margin--bottom  u-padding--top--med u-margin--left"><strong>Election cycle(s):</strong> {{ '; '.join(mur['election_cycles'] | map('string') | sort) }}</div>
         {% if mur.mur_type == 'current' %}
         {# Archived MUR subjects are a tree-structure so we don't render them inline #}
-          <div class="u-margin--bottom">
+          <div class="u-margin--bottom u-margin--left">
             <strong>Subject(s):</strong> {{ '; '.join(mur['subjects']) }}
           </div>
         {% endif %}
-        <div class="u-margin--bottom">
+        <div class="u-margin--bottom u-margin--left">
           <strong>Disposition(s):</strong>
           {# group disposition by disposition names #}
           {% set disposition_dict = dict() %}
@@ -44,13 +49,12 @@
             {{ disposition }} ({{ disposition_dict[disposition] }} respondents);&nbsp;
           {% endfor %}
         </div>
-        <div class="legal-search-result__hit">
+        <div class="legal-search-result__hit u-padding--left--small split__cell">
           {% for document in mur.documents %}
             {% set query_highlight = mur.document_highlights[loop.index0 | string]%}
             {% if(query_highlight) %}
-              <div class="post--icon">
-                <span class="icon icon--inline--left i-document"></span>
-                <a href="{{document.url}}">{{ document.description }}</a>
+              <div class="post--icon u-padding--top">
+                <span class="icon icon--inline--left i-document"></span><a href="{{document.url}}">{{ document.description }}</a>
               </div>
               {# show only first document highlight result #}
               <ul>
@@ -60,8 +64,14 @@
               </ul>
               {# show additional document highlight results, if any #}
               {% if(query_highlight|length > 1) %}
-              <div class="js-accordion" data-content-prefix="additional-result-{{ mur.no }}-{{loop.index0}}">
-                <button type="button" class="js-accordion-trigger accordion__button results__button" aria-controls="additional-result-{{ mur.no }}-{{loop.index0}}" aria-expanded="false">{{ query_highlight|length -1 }} more items</button>
+              <div class="js-accordion u-margin--top" data-content-prefix="additional-result-{{ mur.no }}-{{loop.index0}}">
+                <button type="button" class="js-accordion-trigger accordion__button results__button" aria-controls="additional-result-{{ mur.no }}-{{loop.index0}}" aria-expanded="false">
+                  {% if(query_highlight|length == 2) %}
+                    1 more match
+                  {% elif(query_highlight|length > 2)  %}
+                    {{ query_highlight|length -1 }} more matches
+                  {% endif %}
+                </button>
                   <div class="accordion__content results__content" aria-hidden="true">
                       <ul>
                         {% for highlight in query_highlight %}

--- a/fec/legal/templates/partials/legal-search-results-mur.jinja
+++ b/fec/legal/templates/partials/legal-search-results-mur.jinja
@@ -18,20 +18,70 @@
         {% endif %}
       </div>
       <div class="simple-table__cell">
-        <div class="t-serif legal-search-result__hit">
-          &hellip;
-          {% for highlight in mur.highlights %}
-            {{ highlight|safe }} &hellip;
-          {% endfor %}
-        </div>
-        <div><strong>Date opened:</strong> {{ mur.open_date | date('%m/%d/%Y') | default('Unknown', True) }}</div>
-        <div><strong>Date closed:</strong> {{ mur.close_date | date('%m/%d/%Y') | default('Unknown', True) }}</div>
+        <div class="u-margin--bottom"><strong>Election cycle(s):</strong> {{ '; '.join(mur['election_cycles'] | map('string') | sort) }}</div>
         {% if mur.mur_type == 'current' %}
         {# Archived MUR subjects are a tree-structure so we don't render them inline #}
-          <div>
-            <strong>Subject:</strong> {{ '; '.join(mur['subjects']) }}
+          <div class="u-margin--bottom">
+            <strong>Subject(s):</strong> {{ '; '.join(mur['subjects']) }}
           </div>
         {% endif %}
+        <div class="u-margin--bottom">
+          <strong>Disposition(s):</strong>
+          {# group disposition by disposition names #}
+          {% set disposition_dict = dict() %}
+          {% for disposition_record in mur.dispositions %}
+             {% set disposition = disposition_record.disposition %}
+             {% if( disposition_dict[disposition] ) %}
+              {# increment the respondents count for existing dispositions #}
+              {% do disposition_dict.update({disposition: disposition_dict[disposition] + 1 }) %}
+             {% else %}
+               {# set the count to 1 for new dispositions #}
+               {% do disposition_dict.update({disposition: 1}) %}
+             {% endif %}
+          {% endfor %}
+          {# for each unique disposition, display the count of respondents/records #}
+          {% for disposition in disposition_dict %}
+            {{ disposition }} ({{ disposition_dict[disposition] }} respondents);&nbsp;
+          {% endfor %}
+        </div>
+        <div class="legal-search-result__hit">
+          {% for document in mur.documents %}
+            {% set query_highlight = mur.document_highlights[loop.index0 | string]%}
+            {% if(query_highlight) %}
+              <div class="post--icon">
+                <span class="icon icon--inline--left i-document"></span>
+                <a href="{{document.url}}">{{ document.description }}</a>
+              </div>
+              {# show only first document highlight result #}
+              <ul>
+                  <li class="post--icon t-serif t-italic u-padding--top">
+                    &#8230;{{ query_highlight[0] | safe }}&#8230;
+                  </li>
+              </ul>
+              {# show additional document highlight results, if any #}
+              {% if(query_highlight|length > 1) %}
+              <div class="js-accordion" data-content-prefix="additional-result-{{ mur.no }}-{{loop.index0}}">
+                <button type="button" class="js-accordion-trigger accordion__button results__button" aria-controls="additional-result-{{ mur.no }}-{{loop.index0}}" aria-expanded="false">{{ query_highlight|length -1 }} more items</button>
+                  <div class="accordion__content results__content" aria-hidden="true">
+                      <ul>
+                        {% for highlight in query_highlight %}
+                          {% if(loop.index0 != 0) %}
+                            <li class="t-serif t-italic u-padding--bottom">&#8230;{{ highlight | safe }}&#8230;</li>
+                          {% endif %}
+                        {% endfor %}
+                      </ul>
+                  </div>
+              </div>
+              {% endif %}
+              <ul class="tags u-padding--bottom">
+                <li class="tag__category tag__category--doc">
+                  <div class="tag tag--primary">{{ document.category }}</div>
+                </li>
+              </ul>
+              
+            {% endif %}
+          {% endfor %}
+        </div>
       </div>
     </div>
   {% endfor %}

--- a/fec/legal/templates/partials/legal-search-results-mur.jinja
+++ b/fec/legal/templates/partials/legal-search-results-mur.jinja
@@ -46,7 +46,7 @@
           {% endfor %}
           {# for each unique disposition, display the count of respondents/records #}
           {% for disposition in disposition_dict %}
-            {{ disposition }} ({{ disposition_dict[disposition] }} respondents);&nbsp;
+            {{ disposition }} ({{ disposition_dict[disposition] }} respondents){% if not loop.last %};&nbsp;{% endif %}
           {% endfor %}
         </div>
         <div class="legal-search-result__hit u-padding--left--small split__cell">

--- a/fec/legal/templates/partials/legal-search-results-mur.jinja
+++ b/fec/legal/templates/partials/legal-search-results-mur.jinja
@@ -58,7 +58,7 @@
               </div>
               {# show only first document highlight result #}
               <ul>
-                  <li class="post--icon t-serif t-italic u-padding--top">
+                  <li class="post--icon t-serif t-italic u-padding--top--med">
                     &#8230;{{ query_highlight[0] | safe }}&#8230;
                   </li>
               </ul>
@@ -76,7 +76,7 @@
                       <ul>
                         {% for highlight in query_highlight %}
                           {% if(loop.index0 != 0) %}
-                            <li class="t-serif t-italic u-padding--bottom">&#8230;{{ highlight | safe }}&#8230;</li>
+                            <li class="t-serif t-italic">&#8230;{{ highlight | safe }}&#8230;</li>
                           {% endif %}
                         {% endfor %}
                       </ul>

--- a/fec/legal/templates/partials/legal-search-results-mur.jinja
+++ b/fec/legal/templates/partials/legal-search-results-mur.jinja
@@ -10,7 +10,7 @@
         <div class="t-sans">
           <a title="{{ mur.name }}" href="/data/legal/matter-under-review/{{ mur.no }}">
             <span class="t-bold">MUR #{{ mur.no }}</span><br>
-            {{ mur.name }}
+            {{ mur.name|upper }}
           </a>
         </div>
         {% if mur.mur_type == 'archived' %}


### PR DESCRIPTION
## Summary

- Resolves #5255

Update MUR search results display with:
 - election cycle
 - disposition
 - subject
 - document name
 - document links
 - document type
 - removed ellipses
 - force all-caps for committee name

### Required reviewers

1 front-end and 1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

-  MUR search results (http://127.0.0.1:8000/data/legal/search/murs/)

## Screenshots
<img width="1380" alt="Screen Shot 2022-07-07 at 3 42 51 PM" src="https://user-images.githubusercontent.com/12799132/177859055-2b2cda3f-853b-4c2d-8745-74fa7836c78e.png">

## How to test

- Checkout this branch
- `npm run build-sass`
- Go to the MUR search page: http://127.0.0.1:8000/data/legal/search/murs/
- Perform a keyword search. Ex: http://127.0.0.1:8000/data/legal/search/murs/?search_type=murs&search=spending 
- Check to see if the results match what's in the design within this [epic](https://github.com/fecgov/fec-epics/issues/221).

