### PR TITLE
[WIP Do Not Merge] N/A cannot be built into URL for filtering Datatables

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -109,7 +109,7 @@ var employerColumns = [
       function(data, type, row) {
         if (row.employer && row.employer !== 'N/A' ) {
           return {
-            contributor_employer:row.employer
+            contributor_employer: row.employer
           };
         } else {
           return null;

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -107,9 +107,9 @@ var employerColumns = [
     render: columnHelpers.buildTotalLink(
       ['receipts', 'individual-contributions'],
       function(data, type, row) {
-        if (row.employer) {
+        if (row.employer && row.employer !== 'N/A' ) {
           return {
-            contributor_employer:row.employer.replace('N/A', 'N-A' )
+            contributor_employer:row.employer
           };
         } else {
           return null;

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -109,7 +109,7 @@ var employerColumns = [
       function(data, type, row) {
         if (row.employer) {
           return {
-            contributor_employer: row.employer
+            contributor_employer:row.employer.replace('N/A', 'N-A' )
           };
         } else {
           return null;


### PR DESCRIPTION
## Summary (required)
- Don't link contribution amount when Employer is `N/A` since a value with a `slash ("/")` cannot be passes to the URL because it is a reserved char for a URL
- Whether we put  `N/A` in a link to filtered datatable or a user puts `N/A` in the employer field on a datatable, the API call will always turn it into `N%2FA`. So while the filter tags and the checkbox select shows `N/A` verbatim, it is always calling `N%2FA`.(Which does not return only contributors who submitted N/A, verbatim) [See screenshots in issue comment](https://github.com/fecgov/fec-cms/issues/5220#issuecomment-1234943781)
- One mitigating factor to any concerns about not linking the amount on the profile page table  is the existence of the "Filter this data" button directly above the table, allowing users to click through to the datatable.

- Resolves #5220

### Required reviewers
one frontend

## Impacted areas of the application

committee-single.js 

## How to test

- npm run build-js
- check http://127.0.0.1:8000/data/committee/C00213512/?tab=raising#total-receipts 
- On `Employer` ,  tab If the  employer is `N/A`, the contribution amount should not be linked


