### PR TITLE
5339-fix-moment-upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "leaflet-providers": "1.8.0 ",
         "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
-        "moment": "2.29.2",
+        "moment": "2.29.4",
         "numeral": "^1.5.3",
         "perfect-scrollbar": "0.6.2",
         "prop-types": "^15.7.2",
@@ -12884,9 +12884,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -30505,9 +30505,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moo": {
       "version": "0.4.3",


### PR DESCRIPTION
## Summary (required)
This issue has been fixed by my previous PR, but I didn't check in a package-lock.json to source control, so snyk (desktop) still shows the vulnerability. This PR is to fix that mistake. 

- Resolves #5339 
Upgrades moment to 2.29.4 to fix Directory Traversal vulnerability




### Required reviewers

1-2 devs

##Related PRs against other branches:
package library TBD

## How to test
- Run `snyk test` to see the vulnerability on dev
- Pull the branch
- rm -rf node_modules
- npm i
- npm run build 
- Run `snyk test` to ensure the vulnerability is now gone
- pytest
- ./manage.py runserver

