### PR TITLE
[Proof of concept - do not merge] MUR citation filters

### DIFF
--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -1,5 +1,6 @@
 {% extends "layouts/legal-doc-search-results.jinja" %}
 {% import 'macros/legal.jinja' as legal %}
+{% import 'macros/filters/typeahead-filter.jinja' as typeahead %}
 {% set document_type_display_name = 'Closed Matters Under Review' %}
 
 {% block header %}
@@ -15,6 +16,18 @@
       <label class="label" for="case_no">MUR number</label>
       <input id="case_no" name="case_no" type="text" value="{{ case_no }}">
     </div>
+    {# Python API call without suggestions #}
+    <div class="filter">
+      <label class="label" for="case_regulatory_citation">Regulatory citation</label>
+      <input id="case_regulatory_citation" name="case_regulatory_citation" type="text" value="{{ case_regulatory_citation }}">
+    </div>
+    <div class="filter">
+      <label class="label" for="case_regulatory_citation">Regulatory citation</label>
+      <input id="case_regulatory_citation" name="case_regulatory_citation" type="text" value="{{ case_regulatory_citation }}">
+    </div>
+    {# Regulatory and statutory citations hooked up with suggestions, not functioning and only for concept #}
+    {{ typeahead.field(name = 'case_regulatory_citation', title = 'Regulatory citation', dataset='caseRegulatoryCitation') }}
+    {{ typeahead.field(name = 'case_statutory_citation', title = 'Statutory citation', dataset='caseStatutoryCitation') }}
     <div class="filter">
       <label class="label" for="case_respondents">MUR respondents</label>
       <input id="case_respondents" name="case_respondents" type="text" value="{{ case_respondents }}">

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -144,6 +144,8 @@ def legal_doc_search_mur(request):
     case_max_open_date = request.GET.get('case_max_open_date', '')
     case_min_close_date = request.GET.get('case_min_close_date', '')
     case_max_close_date = request.GET.get('case_max_close_date', '')
+    case_statutory_citation = request.GET.get('case_statutory_citation', '')
+    case_regulatory_citation = request.GET.get('case_regulatory_citation', '')
 
     results = api_caller.load_legal_search_results(
         query, 'murs',
@@ -153,7 +155,9 @@ def legal_doc_search_mur(request):
         case_min_open_date=case_min_open_date,
         case_max_open_date=case_max_open_date,
         case_min_close_date=case_min_close_date,
-        case_max_close_date=case_max_close_date
+        case_max_close_date=case_max_close_date,
+        case_statutory_citation=case_statutory_citation,
+        case_regulatory_citation=case_regulatory_citation,
     )
 
     return render(request, 'legal-search-results-murs.jinja', {
@@ -166,6 +170,8 @@ def legal_doc_search_mur(request):
         'case_max_open_date': case_max_open_date,
         'case_min_close_date': case_min_close_date,
         'case_max_close_date': case_max_close_date,
+        'case_statutory_citation': case_statutory_citation,
+        'case_regulatory_citation': case_regulatory_citation,        
         'query': query,
         'social_image_identifier': 'legal',
     })


### PR DESCRIPTION
## Summary

- Related #5260 

As a proof of concept, added 2 different methods for regulatory and statutory citations filters. One with purely python request and one with typehead JS. Eventually typeahead will be replaced with autosuggest. We'll want to do the citation filters using the autosuggest and macros rather than using react.

## Impacted areas of the application

General components of the application that this PR will affect:

-  Anywhere citations filters are being used

## How to test

- You can see the proof of concept on the [MUR search page](http://127.0.0.1:8000/data/legal/search/murs/)