### PR TITLE
Update spending page for inaugural committees

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -150,10 +150,14 @@
               {% if committee_type != 'I' %}
               <li><a href="#total-disbursements">Total disbursements</a></li>
               {% endif %}
-              {% if committee_type not in ['P', 'H', 'S', 'Z', 'C', 'E', 'D'] %}
+              {% if committee_type not in ['P', 'H', 'S', 'Z', 'C', 'E', 'D'] and not is_inaugural %}
               <li><a href="#independent-expenditures">Independent expenditures</a></li>
               {% endif %}
+              {% if not is_inaugural %}
               <li><a href="#disbursement-transactions">Disbursement transactions</a></li>
+              {% else %}
+              <li><a href="#disbursement-transactions">Refund transactions</a></li>
+              {% endif %}
             </ul>
             {% endif %}
         </li>

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -84,7 +84,7 @@
     </div>
     {% endif %}
 
-    {% if committee_type not in ['P', 'H', 'S', 'Z', 'C', 'E', 'D'] %}
+    {% if committee_type not in ['P', 'H', 'S', 'Z', 'C', 'E', 'D'] and not is_inaugural %}
     <div class="entity__figure row" id="independent-expenditures">
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Independent expenditures</h3>
@@ -221,7 +221,11 @@
   {% else %}
   <div class="entity__figure row" id="disbursement-transactions" >
       <div class="heading--section heading--with-action">
+        {% if not is_inaugural %}
         <h3 class="heading__left">Disbursements</h3>
+        {% else %}
+        <h3 class="heading__left">Refunds</h3>
+        {% endif %}
         <a class="heading__right button--alt button--browse"
             href="/data/disbursements/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}">Filter this data</a>
       </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #5352 

For inaugural committees, remove IE table and change disbursements to refunds

### Required reviewers

1 UX and 1 front-end

## Impacted areas of the application

General components of the application that this PR will affect:

-  Inaugural committee pages

## Screenshots
<img width="1515" alt="Screen Shot 2022-08-17 at 2 33 46 PM" src="https://user-images.githubusercontent.com/12799132/185216599-2dd17de0-7cc7-4970-9f6e-af2ebbe91962.png">

## How to test

- checkout this branch
- `cd fec && ./manage.py runserver`
- Go to an inaugural committee page - Ex: http://127.0.0.1:8000/data/committee/C00540005/?tab=spending
   - Check that the independent expenditure table is not there
   - Check that the "Disbursements" table is now labeled "Refunds"
- Go to any committee that is not an inaugural committee and check to make sure that there are no changes - Ex: http://127.0.0.1:8000/data/candidate/S2KY00012/?tab=spending, http://127.0.0.1:8000/data/committee/C00822940/?tab=spending

