### PR TITLE
5387- Upgrade images and pin flake8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: cimg/python:3.8-browsers
+      - image: cimg/python:3.8.13-browsers
         environment:
           TZ: America/New_York
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,19 +9,18 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.8.12-buster-node-browsers
+      - image: cimg/python:3.8-browsers
         environment:
           TZ: America/New_York
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test
 
       # PostgreSQL
-      - image: circleci/postgres:11.9
+      - image: cimg/postgres:12.8
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: "trust"
           POSTGRES_DB: cfdm_cms_test
 
-    working_directory: ~/repo
 
     steps:
       - checkout
@@ -32,7 +31,7 @@ jobs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
             sudo apt-get update -qq && sudo apt-get install -y build-essential postgresql-client
-            echo 'export PATH=/usr/lib/postgresql/10.11/bin/:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/lib/postgresql/12.8/bin/:$PATH' >> $BASH_ENV
             echo "en_US.UTF-8 UTF-8" | sudo tee /etc/locale.gen
             sudo locale-gen en_US.UTF-8
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ run into problems please
     * Python (the latest 3.8 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which
       includes `npm`).
-    * PostgreSQL (the latest 11 release).
+    * PostgreSQL (the latest 12 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/).
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/).
-         * Read a [Linux tutorial](https://www.postgresql.org/docs/11/installation.html)
+         * Read a [Linux tutorial](https://www.postgresql.org/docs/12/installation.html)
            (or follow your OS package manager).
 
 2. Set up your Node environment — learn how to do this with 18F’s

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ cg-django-uaa==2.1.3
 coverage==5.5
 pytest==6.2.2
 Faker==0.8.6
+flake8==4.0.1 # pinned as tests are failing with latest major version(5.0.0)
 pytest-django==4.1.0
 pytest-cov==2.11.1
 pytest-flake8==1.0.7


### PR DESCRIPTION
## Summary (required)

- Resolves #5387

This updates the docker images and pins flake8 until we can fix our tests failing in the most recent major version. That ticket is [here. ](https://github.com/fecgov/openFEC/issues/5217)

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  circleci config

## Related PRs
https://github.com/fecgov/openFEC/issues/5217

## How to test

I tried to test run circleci config locally via their CLI tools and wasn't able to run them successfully. I got some errors that they seems to know about and aren't moving forward with right now. I did deploy to dev and everything ran successfully. 
-checkout this branch
-deploy to dev
