### PR TITLE
Update spending page for inaugural committees v2

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -148,12 +148,20 @@
             {% else %}
             <ul>
               {% if committee_type != 'I' %}
-              <li><a href="#total-disbursements">Total disbursements</a></li>
+                {% if not is_inaugural %}
+                <li><a href="#total-disbursements">Total disbursements</a></li>
+                {% else %}
+                <li><a href="#total-disbursements">Total refunds</a></li>
+                {% endif %}
               {% endif %}
-              {% if committee_type not in ['P', 'H', 'S', 'Z', 'C', 'E', 'D'] %}
+              {% if committee_type not in ['P', 'H', 'S', 'Z', 'C', 'E', 'D'] and not is_inaugural %}
               <li><a href="#independent-expenditures">Independent expenditures</a></li>
               {% endif %}
+              {% if not is_inaugural %}
               <li><a href="#disbursement-transactions">Disbursement transactions</a></li>
+              {% else %}
+              <li><a href="#disbursement-transactions">Refund transactions</a></li>
+              {% endif %}
             </ul>
             {% endif %}
         </li>

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -18,7 +18,11 @@
     <div id="total-disbursements" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">
+          {% if not is_inaugural %}
           <h3 class="heading__left">Total disbursements</h3>
+          {% else %}
+          <h3 class="heading__left">Total refunds</h3>
+          {% endif %}
           <a class="heading__right button--alt button--browse"
               href="/data/disbursements/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}">Filter all disbursements
           </a>
@@ -26,13 +30,25 @@
         <div class="content__section--narrow">
           <div class="row u-margin-bottom">
             <div class="usa-width-one-half">
+              {% if not is_inaugural %}
               <span class="t-big-data">{{ totals.disbursements|currency }}</span>
+              {% else %}
+              <span class="t-big-data">{{ totals.contribution_refunds|currency }}</span>
+              {% endif %}
             </div>
           </div>
           <div class="row">
+            {% if not is_inaugural %}
             <span class="usa-width-one-half t-block t-sans">spent in total disbursements by this committee from <strong>{{totals.coverage_start_date|date_full}} to {{totals.coverage_end_date|date_full}}.</strong></span>
+            {% else %}
+            <span class="usa-width-one-half t-block t-sans">in total donations refunded by this committee from <strong>{{totals.coverage_start_date|date_full}} to {{totals.coverage_end_date|date_full}}.</strong></span>
+            {% endif %}
             <div class="usa-width-one-half">
+              {% if not is_inaugural %}
               <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of disbursement.</span>
+              {% else %}
+              <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for more.</span>
+              {% endif %}
             </div>
           </div>
         </div>
@@ -84,7 +100,7 @@
     </div>
     {% endif %}
 
-    {% if committee_type not in ['P', 'H', 'S', 'Z', 'C', 'E', 'D'] %}
+    {% if committee_type not in ['P', 'H', 'S', 'Z', 'C', 'E', 'D'] and not is_inaugural %}
     <div class="entity__figure row" id="independent-expenditures">
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">Independent expenditures</h3>
@@ -221,7 +237,11 @@
   {% else %}
   <div class="entity__figure row" id="disbursement-transactions" >
       <div class="heading--section heading--with-action">
+        {% if not is_inaugural %}
         <h3 class="heading__left">Disbursements</h3>
+        {% else %}
+        <h3 class="heading__left">Refunds</h3>
+        {% endif %}
         <a class="heading__right button--alt button--browse"
             href="/data/disbursements/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}">Filter this data</a>
       </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #5352 

For inaugural committees, remove IE table and change disbursements to refunds

### Required reviewers

1 UX and 1 front-end

## Impacted areas of the application

General components of the application that this PR will affect:

-  Inaugural committee pages

## Screenshots
<img width="1515" alt="Screen Shot 2022-08-17 at 2 33 46 PM" src="https://user-images.githubusercontent.com/12799132/185216599-2dd17de0-7cc7-4970-9f6e-af2ebbe91962.png">

## How to test

- checkout this branch
- `cd fec && ./manage.py runserver`
- Go to an inaugural committee page - Ex: http://127.0.0.1:8000/data/committee/C00540005/?tab=spending
   - Check that the independent expenditure table is not there
   - Check that the "Disbursements" table is now labeled "Refunds"
- Go to any committee that is not an inaugural committee and check to make sure that there are no changes - Ex: http://127.0.0.1:8000/data/candidate/S2KY00012/?tab=spending, http://127.0.0.1:8000/data/committee/C00822940/?tab=spending

