### PR TITLE
5247-Upgrade python and cg-django-uaa

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ jobs:
   build:
     docker:
       # CircleCI maintains a library of pre-built images documented at
-      # https://circleci.com/docs/2.0/circleci-images/
+      # https://circleci.com/developer/images
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: cimg/python:3.8-browsers
+      - image: cimg/python:3.9-browsers
         environment:
           TZ: America/New_York
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ run into problems please
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python (the latest 3.8 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
+    * Python (the latest 3.9 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which
       includes `npm`).
     * PostgreSQL (the latest 12 release).

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7
 gunicorn==19.10.0
-gevent==1.4.0
-greenlet==0.4.16 # pinned 2020-09-22 to fix build problem (parent gevent)
+gevent==21.12.0
 psycopg2==2.8.6
 requests==2.25.1
 urllib3==1.26.7
@@ -38,13 +37,13 @@ beautifulsoup4==4.8.2
 django-storages==1.7.1
 boto3==1.7.21
 
-cg-django-uaa==2.1.3
+cg-django-uaa==2.1.4
 
 # Testing
 coverage==5.5
 pytest==6.2.2
 Faker==0.8.6
 flake8==4.0.1
-pytest-django==4.1.0
+pytest-django==3.10.0
 pytest-cov==2.11.1
 pytest-flake8==1.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ flake8==4.0.1
 pytest-django==3.10.0
 pytest-cov==2.11.1
 pytest-flake8==1.0.7
+setuptools==65.1.1 # Pinned to fix the deploy errors caused by the latest setuptool version 65.3.0

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.x
+python-3.9.x


### PR DESCRIPTION
## Summary (required)

- Resolves #5247 

There's a vulnerability with pyJWT which was pinned in cg-django-uaa. cloud.gov released a new version of cg-django-uaa with [my PR's changes ](https://github.com/cloud-gov/cg-django-uaa/pull/66) 

They release other system updates with the new version that needs python 3.9, so we should upgrade in CMS and API. 

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  wagtail cloud.gov login

## Related PRs

Related PRs against other branches:
API PR- https://github.com/fecgov/openFEC/pull/5233
EREGS PR-https://github.com/fecgov/fec-eregs/pull/710
(pattern, proxy ok)

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- ## How to test
-  pull the branch
- `pyenv virtualenv 3.9.13 test-cms-python`
- `pyenv activate test-cms-python`
- `pip install -r requirements.txt`
- `rm -rf node_modules`
- `npm i` 
- `npm run build`
- `pytest`
- `snyk test --all-projects`
- `cd fec`
- `./manage.py runserver`
- check that the site's working as expected especially the wagtail login page
