### PR TITLE
[MERGE BEFORE RELEASE 09/20/22 ]Combo text/typeahead search for committee field  on filings and reports

### DIFF
--- a/fec/data/templates/partials/filings-filter.jinja
+++ b/fec/data/templates/partials/filings-filter.jinja
@@ -20,7 +20,7 @@ Filter reports
 
 {% block efiling_filters %}
   <div class="filters__inner">
-    {{ typeahead.field('committee_id', 'Committee name or ID', '', id_suffix='_raw') }}
+    {{ typeahead.field('q_filer', 'Committee name or ID', id_suffix='_raw', allow_text=True ) }}
     {{ date.field('receipt_date', 'Receipt date', id_suffix='_raw') }}
   </div>
 {% endblock %}
@@ -29,7 +29,8 @@ Filter reports
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Filer</button>
   <div class="accordion__content">
-    {{ typeahead.field('committee_id', 'Committee name or ID', '') }}
+   
+    {{ typeahead.field('q_filer', 'Committee name or ID', '', allow_text=True) }}
     {{ typeahead.field('candidate_id', 'Candidate name or ID', '', dataset='candidates') }}
     {{ states.field('state', type='Candidate') }}
     {{ office.checkbox() }}

--- a/fec/data/templates/partials/independent-expenditures-filter.jinja
+++ b/fec/data/templates/partials/independent-expenditures-filter.jinja
@@ -51,7 +51,7 @@ Filter independent expenditures
 {% block filters %}
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <div class="filters__inner">
-    {{ typeahead.field('committee_id', 'Spender name or ID', helper_text = 'Limit 10 spender names or IDs') }}
+  {{ typeahead.field('q_spender', 'Spender name or ID', helper_text ='Limit 10 spender names or IDs', allow_text=True) }}
     {{ years.cycles('cycle', 'Years', show_tooltip=False) }}
     {{ reports.type(id_suffix='_processed') }}
     {{ reports.form(id_suffix='_processed') }}

--- a/fec/data/templates/partials/reports-filter.jinja
+++ b/fec/data/templates/partials/reports-filter.jinja
@@ -19,7 +19,7 @@ Filter reports
 
 {% block efiling_filters %}
   <div class="filters__inner">
-    {{ typeahead.field('committee_id', 'Committee name or ID', id_suffix='raw') }}
+    {{ typeahead.field('q_filer', 'Committee name or ID', id_suffix='raw', allow_text=True) }}
     {{ date.field('receipt_date', 'Receipt date', id_suffix='raw') }}
   </div>
 {% endblock %}
@@ -28,8 +28,10 @@ Filter reports
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Filer</button>
   <div class="accordion__content">
-    {{ typeahead.field('committee_id', 'Committee name or ID', '') }}
+
+    {{ typeahead.field('q_filer', 'Committee name or ID', '', allow_text=True) }}
     {% if table_context['form_type'] == 'presidential' %}
+
       {{ typeahead.field('candidate_id', 'Authorizing candidate', dataset='candidates') }}
     {% elif table_context['form_type'] == 'house-senate' %}
       {{ typeahead.field('candidate_id', 'Authorizing candidate', dataset='candidates') }}


### PR DESCRIPTION
## Summary (required)

- Resolves #5248

- Allow text and typeahead search for `committee name or id` fields on filings and reports datatables.
- This is for processed and raw tabs on :
   - [All filings](http://127.0.0.1:8000/data/filings)
   - [Presidential committee reports](http://127.0.0.1:8000/data/reports/presidential/?is_amended=false)
   - [House and Senate committee reports](http://127.0.0.1:8000/data/reports/house-senate)
    -  [PAC and party committee reports](http://127.0.0.1:8000/data/reports/pac-party)
 - For processed only on 
   - [Independent expenditures](http://127.0.0.1:8000/data/independent-expenditures)
   - There is an outstanding issue to resolve raw filings text-search issue, [see spreadsheet](https://docs.google.com/spreadsheets/d/1AkQjXA2XMQfxlRyinSY0uynhf2ZRMh7l_BTWdJgHzXY/edit#gid=0)
   
### Required reviewers
one frontend

## Impacted areas of the application
	modified:   data/templates/partials/filings-filter.jinja
	modified:   data/templates/partials/independent-expenditures-filter.jinja
	modified:   data/templates/partials/reports-filter.jinja

## Related PRs
See [spreadhseet ](https://docs.google.com/spreadsheets/d/1AkQjXA2XMQfxlRyinSY0uynhf2ZRMh7l_BTWdJgHzXY/edit#gid=0)for related PRs

## How to test
Check with Helen to see if you can test this with your local pointed to dev api, or whether you still need to checkout and run [her api branch](https://github.com/fecgov/openFEC/pull/5234) locally and point your CMS's  `FEC_API_URL` to localhost:5000. Also would need to set `SQL_CONN` in this scenario.
- Checkout and run branch
- Test text and/or typeahead searches on `processed` and `raw` tabs for these:
    - http://127.0.0.1:8000/data/filings/?data_type=processed
    - http://127.0.0.1:8000/data/reports/pac-party/
    - http://127.0.0.1:8000/data/reports/presidential/?is_amended=false
    - http://127.0.0.1:8000/data/reports/house-senate
 - Test text and/or typeahead searches on `processed` tab only for this one
    - http://127.0.0.1:8000/data/independent-expenditures/
- Exampe test on  http://127.0.0.1:8000/data/reports/pac-party/:
   - `LATINOS FOR AMERICA FIRST` --and-- `LATINOS FOR THE PRESIDENT` both share the id: `C00685776`. 
   - Use typeahead  dropdown to choose one of those from the list. The table shows both, about 26 results.
   - Use free text search to search for only the string: 'latinos for the president'. Table shows only that named committee, about 13 results.