### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Change sort from `report_type_full` to `report_type_full_original`

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -797,7 +797,7 @@ $(document).ready(function() {
                 request_type: ['-1', '-5', '-6', '-9'],
                 sort: [
                   '-coverage_end_date',
-                  'report_type_full',
+                  'report_type_full_original',
                   '-beginning_image_number'
                 ],
                 sort_hide_null: ['false']


### PR DESCRIPTION
## Summary

Change sort from `report_type_full` to `report_type_full_original` due to recent [API changes](https://github.com/fecgov/openFEC/pull/5239/files)

### Required reviewers

1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Committee profile page regularly filed reports table. Ex: http://localhost:8000/data/committee/C00213512/?tab=filings 

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/5222-change-notification-to-report | [link](https://github.com/fecgov/openFEC/pull/5239)

## How to test

- checkout this branch
- `npm run build-js`
- `./manage.py runserver`
- Go to any committee profile and make sure that the regularly filed reports are returning correctly. Ex: http://localhost:8000/data/committee/C00213512/?tab=filings
