### PR TITLE
Add CDC COVID json to site CSP

### DIFF
--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -19,6 +19,7 @@ class AddSecureHeaders(MiddlewareMixin):
                 "*.fec.gov",
                 "*.app.cloud.gov",
                 "https://www.google-analytics.com",
+                "https://www.cdc.gov/coronavirus/2019-ncov/json/cdt-ccl-data.json",
             ],
             "font-src": ["'self'"],
             "frame-src": [


### PR DESCRIPTION
## Summary (required)

- Related #5099

Allows for fetch call to CDC json in order to allow us to retrieve DC COVID burden levels.

### Required reviewers

1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  content security policy connect source

## How to test

- Try doing a JS fetch call for this. You can use the code from the [ticket](https://github.com/fecgov/fec-cms/issues/5099#issuecomment-1255168618) and put that into the snippet to try it out.