### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Update committee profile page financial summary query string for IEs to be q_spender

### DIFF
--- a/fec/data/templates/macros/tables.jinja
+++ b/fec/data/templates/macros/tables.jinja
@@ -31,7 +31,10 @@ case 2: this page comes from data/committee/<committee_id>/:
 The committee_id is a string, the count=9.
 
 case 3: for committe profile page.
-not 'type' object, so use 'link' to check for 'independent-expenditures' and 'party-coordinated-expenditure'
+not 'type' object, so use 'link' to check for 'independent-expenditures' with q_spender in query string
+
+case 4: for committe profile page.
+not 'type' object, so use 'link' to check for 'party-coordinated-expenditure' with committee_id in query string
 #}
 
         {% if item[1]['type'] and committee_id|count < 9 %}
@@ -45,13 +48,15 @@ not 'type' object, so use 'link' to check for 'independent-expenditures' and 'pa
           line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
           </a>
-
         {% elif item[1]['type'] and committee_id|count == 9 %}
           <a href="/data/{{ item[1]['type']['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&line_number={{ item[1]['type'][office_or_committee] }}">
             {{ item[0]|currency }}
           </a>
-
-        {% elif (item[1]['link']=="independent-expenditures" or item[1]['link'] == "party-coordinated-expenditures") and committee_id|count == 9 %}
+        {% elif (item[1]['link']=="independent-expenditures") and committee_id|count == 9 %}
+          <a href="/data/{{ item[1]['link'] }}/?q_spender={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}">
+            {{ item[0]|currency }}
+          </a>
+        {% elif (item[1]['link'] == "party-coordinated-expenditures") and committee_id|count == 9 %}
           <a href="/data/{{ item[1]['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}">
             {{ item[0]|currency }}
           </a>


### PR DESCRIPTION
## Summary

- Resolves #5422 
Fixes link for independent expenditures on financial summary committee profile pages

### Required reviewers

1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Committee profile page financial summary

## Screenshots

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/12799132/195187880-8459b3ac-6417-43e0-9219-82fb97880742.png">

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------

## How to test

- Open any committee profile page with independent expenditures. Ex: http://localhost:8000/data/committee/C00687103/?tab=summary
- Make sure independent expenditures line item has `q_spender` in the link. Party coordinated expenditures should remain the same with `committee_id` in the link.