### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] On financial summary, make IE link go to regularly filed processed reports

### DIFF
--- a/fec/data/templates/macros/tables.jinja
+++ b/fec/data/templates/macros/tables.jinja
@@ -53,7 +53,7 @@ not 'type' object, so use 'link' to check for 'party-coordinated-expenditure' wi
             {{ item[0]|currency }}
           </a>
         {% elif (item[1]['link']=="independent-expenditures") and committee_id|count == 9 %}
-          <a href="/data/{{ item[1]['link'] }}/?q_spender={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}">
+          <a href="/data/{{ item[1]['link'] }}/?q_spender={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}&is_notice=false&data_type=processed">
             {{ item[0]|currency }}
           </a>
         {% elif (item[1]['link'] == "party-coordinated-expenditures") and committee_id|count == 9 %}


### PR DESCRIPTION
## Summary (required)

- Resolves #5422 

Make the independent expenditures link on the financial summary page of a committee profile page go to the processed regularly filed reports

### Required reviewers

1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Financial summary IE link

## Screenshots

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/12799132/195366168-15021a5a-d590-496b-a0b3-b4ec8dde4588.png">

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/12799132/195366194-4d7482ed-8c9a-45d7-887f-6927bef40aca.png">


## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
[fix/other_pr](https://github.com/fecgov/fec-cms/pull/5438) | [link](hotfix/fix-IE-link-financial-summary)

## How to test

- Open any committee profile page with independent expenditures. Ex: http://localhost:8000/data/committee/C00687103/?tab=summary
- Make sure independent expenditures line item has `is_notice=false&data_type=processed` in the link. Click on the link.
- Make sure that the IE datatable loads the correct processed datatype with the committee and regularly filed reports
