### PR TITLE
Update results display for archive MURs

### DIFF
--- a/fec/legal/templates/partials/legal-search-results-mur.jinja
+++ b/fec/legal/templates/partials/legal-search-results-mur.jinja
@@ -71,7 +71,11 @@
                 {% if mur.mur_type == 'current' %}
                   {{ document.description }}
                 {% else %}
-                  Case documents, part {{ document.document_id }}
+                  {% if mur.get('documents', {}) | length == 1 %}
+                    Case document
+                  {% else %}
+                    Case documents, part {{ document.document_id }}
+                  {% endif %}
                 {% endif %}
                 </a>
               </div>

--- a/fec/legal/templates/partials/legal-search-results-mur.jinja
+++ b/fec/legal/templates/partials/legal-search-results-mur.jinja
@@ -30,9 +30,7 @@
       </div>
       <div class="simple-table__cell no--pad">
         {% if mur.mur_type == 'current' %}
-        <div class="u-margin--bottom  u-padding--top--med u-margin--left"><strong>Election cycle(s):</strong> {{ '; '.join(mur['election_cycles'] | map('string') | sort) }}</div>
-        {% else %}
-          &nbsp;
+        <div class="u-margin--bottom u-padding--top--med u-margin--left"><strong>Election cycle(s):</strong> {{ '; '.join(mur['election_cycles'] | map('string') | sort) }}</div>
         {% endif %}
         {% if mur.mur_type == 'current' %}
         {# Archived MUR subjects are a tree-structure so we don't render them inline #}
@@ -40,31 +38,42 @@
             <strong>Subject(s):</strong> {{ '; '.join(mur['subjects']) }}
           </div>
         {% endif %}
-        <div class="u-margin--bottom u-margin--left">
+        <div class="u-margin--top u-margin--bottom u-margin--left">
+        {% if mur.mur_type == 'current' %}
           <strong>Disposition(s):</strong>
           {# group disposition by disposition names #}
           {% set disposition_dict = dict() %}
           {% for disposition_record in mur.dispositions %}
-             {% set disposition = disposition_record.disposition %}
-             {% if( disposition_dict[disposition] ) %}
+            {% set disposition = disposition_record.disposition %}
+            {% if( disposition_dict[disposition] ) %}
               {# increment the respondents count for existing dispositions #}
               {% do disposition_dict.update({disposition: disposition_dict[disposition] + 1 }) %}
-             {% else %}
-               {# set the count to 1 for new dispositions #}
-               {% do disposition_dict.update({disposition: 1}) %}
-             {% endif %}
+            {% else %}
+              {# set the count to 1 for new dispositions #}
+              {% do disposition_dict.update({disposition: 1}) %}
+            {% endif %}
           {% endfor %}
           {# for each unique disposition, display the count of respondents/records #}
           {% for disposition in disposition_dict %}
             {{ disposition }} ({{ disposition_dict[disposition] }} respondents){% if not loop.last %};&nbsp;{% endif %}
           {% endfor %}
+        {% else %}
+          <strong>Disposition(s):</strong> Not available for archived cases
+        {% endif %}
         </div>
         <div class="legal-search-result__hit u-padding--left--small split__cell">
           {% for document in mur.documents %}
             {% set query_highlight = mur.document_highlights[loop.index0 | string]%}
             {% if(query_highlight) %}
               <div class="post--icon u-padding--top">
-                <span class="icon icon--inline--left i-document"></span><a href="{{document.url}}">{{ document.description }}</a>
+                <span class="icon icon--inline--left i-document"></span>
+                <a href="{{document.url}}">
+                {% if mur.mur_type == 'current' %}
+                  {{ document.description }}
+                {% else %}
+                  Case documents, part {{ document.document_id }}
+                {% endif %}
+                </a>
               </div>
               {# show only first document highlight result #}
               <ul>
@@ -74,7 +83,11 @@
               </ul>
               {# show additional document highlight results, if any #}
               {% if(query_highlight|length > 1) %}
-              <div class="js-accordion u-margin--top" data-content-prefix="additional-result-{{ mur.no }}-{{loop.index0}}">
+              {% if mur.mur_type == 'current' %}
+                <div class="js-accordion u-margin--top" data-content-prefix="additional-result-{{ mur.no }}-{{loop.index0}}">
+              {% else %}
+                <div class="js-accordion u-margin--top u-padding--bottom" data-content-prefix="additional-result-{{ mur.no }}-{{loop.index0}}">
+              {% endif %}
                 <button type="button" class="js-accordion-trigger accordion__button results__button" aria-controls="additional-result-{{ mur.no }}-{{loop.index0}}" aria-expanded="false">
                   {% if(query_highlight|length == 2) %}
                     1 more match
@@ -93,11 +106,13 @@
                   </div>
               </div>
               {% endif %}
-              <ul class="tags u-padding--bottom">
-                <li class="tag__category tag__category--doc">
-                  <div class="tag tag--primary">{{ document.category }}</div>
-                </li>
-              </ul>
+              {% if mur.mur_type == 'current' %}
+                <ul class="tags u-padding--bottom">
+                  <li class="tag__category tag__category--doc">
+                    <div class="tag tag--primary">{{ document.category }}</div>
+                  </li>
+                </ul>
+              {% endif %}
               
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
## Summary

- Resolves #5423 

In MUR results for archive MURs:
- Update language for dispositions to say "Not available for archived cases"
- Change document link text to be "Case documents, part [document_id]"
- Remove document category as it does not exist
- fix up styles to add padding as needed

### Required reviewers

1 UX and 1 front end

## Impacted areas of the application

General components of the application that this PR will affect:

- MUR search results display

## Screenshots

### Archive MUR with only 1 document
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/12799132/196211275-13a04da6-d603-4cd6-a883-f01960c4e577.png">

### Archive MUR with multiple documents
<img width="1455" alt="image" src="https://user-images.githubusercontent.com/12799132/196212207-0810483e-e7ec-4ff5-bb8e-53bebf413666.png">

### Archive MUR results without filters
<img width="1389" alt="image" src="https://user-images.githubusercontent.com/12799132/195430778-fc6dce4c-9e72-4096-9449-8a1039b6907a.png">

## How to test

- Checkout this branch
- `./manage.py runserver`
- Go to MUR search page and look at archive MUR results with keywords and only one document. Ex: http://localhost:8000/data/legal/search/murs/?search=committee&case_respondents=&case_min_open_date=&case_max_open_date=&case_min_close_date=&case_max_close_date=&offset=4000#results-murs
- Go to MUR search page and look at archive MUR results with keywords and multiple documents. Ex: http://localhost:8000/data/legal/search/murs/?search_type=murs&search=american&case_no=1252&case_respondents=&case_min_open_date=&case_max_open_date=&case_min_close_date=&case_max_close_date= 
- Go to MUR search page and look at archive MUR results without filters. Ex: http://localhost:8000/data/legal/search/murs/?case_respondents=&case_min_open_date=&case_max_open_date=&case_min_close_date=&case_max_close_date=&offset=4000#results-murs