### PR TITLE
Add a tooltip to the individual contributions field on PAC and party datatable side panel

### DIFF
--- a/fec/fec/static/js/templates/pac-party.hbs
+++ b/fec/fec/static/js/templates/pac-party.hbs
@@ -40,9 +40,6 @@ Template for PAC and party committee datatable details panel
     {{#panelRow "Registration date"}}
       {{ datetime first_f1_date format="pretty" }}
     {{/panelRow}}
-    {{#panelRow "Designation"}}
-      {{committee_designation_full}}
-    {{/panelRow}}
     {{#if (eq committee_designation_full "Joint fundraising committee") }}
     {{#panelRow "Joint fundraising participants"}}
       <a href="{{basePath}}/committee/{{committee_id}}/?tab=about-committee">Full list of current participants</a>
@@ -62,9 +59,20 @@ Template for PAC and party committee datatable details panel
     {{#panelRow "Receipts"}}
       {{ currency receipts }}
     {{/panelRow}}
-    {{#panelRow "Individual contributions"}}
-      {{ currency individual_contributions }}
-    {{/panelRow}}
+    <tr>
+      <td class="panel__term">
+        Individual contributions
+        <div class="tooltip__container">
+          <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+          <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
+            <p class="tooltip__content">Individual contributions include itemized and unitemized contributions from the Form 3X Detailed Summary page line 11(a)(iii).</p>
+          </div>
+        </div>
+      </td>
+      <td class="panel__data">
+        {{ currency individual_contributions }}
+      </td>
+    </tr>
     {{#panelRow "Disbursements"}}
       {{ currency disbursements }}
     {{/panelRow}}


### PR DESCRIPTION
## Summary 
add a tooltip to the PAC and party datatable side panel that clarifies which types of contributions are included in the "individual contributions" dollar figure

- Resolves #4876 

- Tooltip added to the `individual contributions` field on the PAC and party datatable side panel 
- Removed redundant `Designation` field from the PAC and party datatable side panel 

### Required reviewers

1-2 developers 

## Impacted areas of the application

PAC and party datatable side panel 

## Screenshots

Before (In production):
<img width="1432" alt="Screen Shot 2022-10-24 at 7 53 44 AM" src="https://user-images.githubusercontent.com/11650355/197519739-6c905a02-1d3c-4ad4-9383-4e410cf207c2.png">


After:
<img width="1427" alt="Screen Shot 2022-10-24 at 7 56 07 AM" src="https://user-images.githubusercontent.com/11650355/197520224-09f637c7-2b60-49b5-a78a-c5a985ab7570.png">


## How to test
- checkout feature branch: `git checkout feature/4876-add-ic-tooltip`
- complie JS files: run `npm run build` 
- run python tests: `pytest`
- run java script tests: `npm run test-single`
- start local server `./manage.py runserver` 
- view changes in browser: http://localhost:8000/data/committees/pac-party/?cycle=2022
