### PR TITLE
AO Comment deadlines display

### DIFF
--- a/fec/fec/static/scss/components/_posts.scss
+++ b/fec/fec/static/scss/components/_posts.scss
@@ -32,6 +32,10 @@
     font-family: $sans-serif;
     letter-spacing: -.3px;
     margin: u(0 0 1rem 0);
+
+    &.t-serif {
+    font-family: $serif
+    }
   }
 
   // Thumbnails

--- a/fec/legal/templates/legal-advisory-opinions-landing.jinja
+++ b/fec/legal/templates/legal-advisory-opinions-landing.jinja
@@ -70,9 +70,9 @@
     {% for ao in pending_aos %}
       <article class="post">
         <h3 class="pending-ao__title"><a href="/data/legal/advisory-opinions/{{ ao.no }}/">AO {{ ao.no }} {{ ao.name }}</a></h3>
-        <p class="t-sans">{{ ao.summary }}</p>
+        <p>{{ ao.summary }}</p>
           {% if ao.comment_deadline %}
-         <p><span class="t-serif"> Deadline for AO request comments: {{ ao.comment_deadline }}</span></p>
+         <p class="t-serif"> Deadline for AO request comments: {{ ao.comment_deadline }}</p>
           {% endif %}        
       </article>
     {% endfor %}

--- a/fec/legal/templates/legal-advisory-opinions-landing.jinja
+++ b/fec/legal/templates/legal-advisory-opinions-landing.jinja
@@ -63,7 +63,7 @@
   </div>
   <div class="content__section">
     <p>Once the Office of the General Counsel has determined that an advisory opinion request meets all of the requirements to move forward for consideration by the Commission, the request is made public and is available for public comment for ten days.</p>
-    <a class="button button--standard button--go" href="/legal-resources/advisory-opinions-process/#commenting">Learn how to comment</a>
+    <a class="button button--standard button--go" href="/legal-resources/advisory-opinions-process/#commenting-on-advisory-opinion-requests">Learn how to comment</a>
   </div>
   {% if pending_aos %}
   <div class="post-feed">
@@ -71,7 +71,9 @@
       <article class="post">
         <h3 class="pending-ao__title"><a href="/data/legal/advisory-opinions/{{ ao.no }}/">AO {{ ao.no }} {{ ao.name }}</a></h3>
         <p class="t-sans">{{ ao.summary }}</p>
-        <!-- <p>Deadline for comments: {{ ao.deadline }}</p> -->
+          {% if ao.comment_deadline %}
+         <p><span class="t-serif"> Deadline for AO request comments: {{ ao.comment_deadline }}</span></p>
+          {% endif %}        
       </article>
     {% endfor %}
   </div>
@@ -80,6 +82,11 @@
     <h3>No pending advisory opinions</h3>
   </div>
   {% endif %}
+<!-- TODO: Uncomment this if you want to see the resultng pending_aos dict with new ao.comment_deadline items added, or you could just view the hidden dict in the inspector. -->
+<!--
+  pending_aos DICT: <br><pre>{{ pending_aos_pretty }}</pre>
+<hr>
+-->
 </section>
 <section class="content__section content__section--narrow">
   <div class="heading--section">

--- a/fec/legal/templates/legal-advisory-opinions-landing.jinja
+++ b/fec/legal/templates/legal-advisory-opinions-landing.jinja
@@ -82,11 +82,6 @@
     <h3>No pending advisory opinions</h3>
   </div>
   {% endif %}
-<!-- TODO: Uncomment this if you want to see the resultng pending_aos dict with new ao.comment_deadline items added, or you could just view the hidden dict in the inspector. -->
-<!--
-  pending_aos DICT: <br><pre>{{ pending_aos_pretty }}</pre>
-<hr>
--->
 </section>
 <section class="content__section content__section--narrow">
   <div class="heading--section">

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -10,9 +10,9 @@ import json
 from data import api_caller
 from data import constants
 
-""" TODO This is a sample of penfing_aos for testing the regex and the view logic.
+""" TODO This is a sample of pending_aos for testing the regex and the view logic.
 This dict was created by making the exact same api call the api_caller does in the `pending_aos` variable below,
-then editing doc desctiptions Document descriptions can be further edited to test the logic and see how
+then editing doc descriptions Document descriptions can be further edited to test the logic and see how
 typos are either forgiven, or might break the regex or datetime parsing.
 REMOVE BEFORE FINAL PR.
 
@@ -384,7 +384,8 @@ def advisory_opinions_landing(request):
     ao_min_date = today - datetime.timedelta(weeks=26)
     recent_aos = api_caller.load_legal_search_results(
         query='',
-        query_type='advisory_opinions', ao_category=['F', 'W'],
+        query_type='advisory_opinions',
+        ao_category=['F', 'W'],
         ao_min_issue_date=ao_min_date
     )
 
@@ -422,13 +423,10 @@ def advisory_opinions_landing(request):
 
                 # If a matche is found.
                 if pattern:
-
                     # group(1) is the date only, as input by user. Example. "October 24, 2022"
                     display_date = pattern.group(1)
-
                     # rm comma
                     parseable_date = display_date.replace(',', '')
-
                     # `parseable_date_time` example: October 24 2022 11:59PM
                     parseable_date_time = parseable_date + ' 11:59PM'
 
@@ -439,15 +437,16 @@ def advisory_opinions_landing(request):
                         # pass to avoid throwing a datetime error
                         pass
                     else:
-                        # Since  `parseable_date_time` is a valid date format, parse it into a Python-readable date.
+                        # Since  `parseable_date_time` is parseable date string, parse it into a Python-readable date.
                         # Example code_date_time: 2022-10-31 23:59:00
-
                         code_date_time = datetime.datetime.strptime(parseable_date_time, '%B %d %Y %I:%M%p')
 
                         # Check if `code_date_time` has not expired.
                         present = datetime.datetime.now()
                         if code_date_time > present:
                             comment_deadline = display_date
+
+                            # Append item to currently iterated pending_ao's dict
                             pending_ao['comment_deadline'] = comment_deadline
 
     return render(request, 'legal-advisory-opinions-landing.jinja', {  # TODO: FOR TESTING

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -2,9 +2,381 @@ from django.shortcuts import render
 from django.http import Http404
 
 import datetime
+import re
+
+# TO DO - can remove after testing
+import json
 
 from data import api_caller
 from data import constants
+
+""" TODO This is a sample of penfing_aos for testing the regex and the view logic.
+This dict was created by making the exact same api call the api_caller does in the `pending_aos` variable below,
+then editing doc desctiptions Document descriptions can be further edited to test the logic and see how
+typos are either forgiven, or might break the regex or datetime parsing.
+REMOVE BEFORE FINAL PR.
+
+"""
+pending_aos_sample = {
+    "advisory_opinions": [
+        {
+            "summary": "Contributions by irrevocable trust to candidates and political committees.",
+            "no": "2022-24",
+            "ao_citations": [],
+            "representative_names": ["Elias Law Group", "", ""],
+            "requestor_names": [""],
+            "documents": [
+                {
+                    "date": "2022-10-04T00:00:00",
+                    "description": "Request by Allen Blue (Comments due by October 24, 2022)",
+                    "document_id": 87165,
+                    "category": "AO Request, Supplemental Material, and Extensions of Time",
+                    "url": "/files/legal/aos/2022-24/202224R_1.pdf",
+                }
+            ],
+            "commenter_names": [],
+            "regulatory_citations": [],
+            "type": "advisory_opinions",
+            "aos_cited_by": [],
+            "doc_id": "advisory_opinions_2022-24",
+            "issue_date": "null",
+            "statutory_citations": [],
+            "entities": [
+                {"role": "Requestor", "name": "Mr. Allen Blue ", "type": "Individual"},
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Elias Law Group",
+                    "type": "Law Firm",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Mr. Ezra W. Reese Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Ms. Emma R. Anspach Esq.",
+                    "type": "Individual",
+                },
+            ],
+            "name": "Allen Blue",
+            "request_date": "2022-10-04",
+            "requestor_types": ["Individual"],
+            "is_pending": "true",
+            "status": "Pending",
+            "highlights": [],
+            "document_highlights": {},
+        },
+        {
+            "summary": "Corporate license of patented technology for political committee use in advertising.",
+            "no": "2022-23",
+            "ao_citations": [],
+            "representative_names": ["Berke Farah LLP", ""],
+            "requestor_names": ["DataVault Holdings, Inc."],
+            "documents": [
+                {
+                    "date": "2022-10-05T00:00:00",
+                    "description": "Extension of Time",
+                    "document_id": 87158,
+                    "category": "AO Request, Supplemental Material, and Extensions of Time",
+                    "url": "/files/legal/aos/2022-23/202223R_2.pdf",
+                },
+                {
+                    "date": "2022-09-22T00:00:00",
+                    "description": "Request by DataVault Holding's Inc. (Comments due by October 24, 2022)",
+                    "document_id": 87159,
+                    "category": "AO Request, Supplemental Material, and Extensions of Time",
+                    "url": "/files/legal/aos/2022-23/202223R_1.pdf",
+                },
+                {
+                    "date": "2022-09-22T00:00:00",
+                    "description": "TEST SECOND NON-DRAFT DOC WITH EXP DATE - \
+                        Request by DataVault Holding's Inc. (Comments due by October 30, 2022)",
+                    "document_id": 87151,
+                    "category": "AO Request, Supplemental Material, and Extensions of Time",
+                    "url": "/files/legal/aos/2022-23/202223R_1.pdf",
+                },
+            ],
+            "commenter_names": [],
+            "regulatory_citations": [],
+            "type": "advisory_opinions",
+            "aos_cited_by": [],
+            "doc_id": "advisory_opinions_2022-23",
+            "issue_date": "null",
+            "statutory_citations": [],
+            "entities": [
+                {
+                    "role": "Requestor",
+                    "name": "DataVault Holdings, Inc.",
+                    "type": "Corporation (including LLCs electing corporate status)",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Berke Farah LLP",
+                    "type": "Law Firm",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Mr. Elliot S. Berke Esq.",
+                    "type": "Individual",
+                },
+            ],
+            "name": "DataVault II",
+            "request_date": "2022-09-22",
+            "requestor_types": [
+                "Corporation (including LLCs electing corporate status)"
+            ],
+            "is_pending": "true",
+            "status": "Pending",
+            "highlights": [],
+            "document_highlights": {},
+        },
+        {
+            "summary": 'Corporate sale of non-fungible tokens ("NFTs") to political committees.',
+            "no": "2022-22",
+            "ao_citations": [],
+            "representative_names": ["", "Berke Farah LLP"],
+            "requestor_names": ["DataVault Holdings, Inc."],
+            "documents": [
+                {
+                    "date": "2022-10-05T00:00:00",
+                    "description": "Extension of Time",
+                    "document_id": 87156,
+                    "category": "AO Request, Supplemental Material, and Extensions of Time",
+                    "url": "/files/legal/aos/2022-22/202222R_2.pdf",
+                },
+                {
+                    "date": "2022-10-03T00:00:00",
+                    "description": "Request by DataVault Holdings, Inc. (Comments due by 10/03/2022)",
+                    "document_id": 87157,
+                    "category": "AO Request, Supplemental Material, and Extensions of Time",
+                    "url": "/files/legal/aos/2022-22/202222R_1.pdf",
+                },
+            ],
+            "commenter_names": [],
+            "regulatory_citations": [],
+            "type": "advisory_opinions",
+            "aos_cited_by": [],
+            "doc_id": "advisory_opinions_2022-22",
+            "issue_date": "null",
+            "statutory_citations": [],
+            "entities": [
+                {
+                    "role": "Requestor",
+                    "name": "DataVault Holdings, Inc.",
+                    "type": "Corporation (including LLCs electing corporate status)",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Mr. Elliot S. Berke Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Berke Farah LLP",
+                    "type": "Law Firm",
+                },
+            ],
+            "name": "DataVault I",
+            "request_date": "2022-10-03",
+            "requestor_types": [
+                "Corporation (including LLCs electing corporate status)"
+            ],
+            "is_pending": "true",
+            "status": "Pending",
+            "highlights": [],
+            "document_highlights": {},
+        },
+        {
+            "summary": "Payment for television advertisements featuring candidates that solicit funds \
+                for national party committee’s legal proceedings account.",
+            "no": "2022-21",
+            "ao_citations": [],
+            "representative_names": [
+                "",
+                "",
+                "Holtzman Vogel Baran Torchinsky & Josefiak PLLC",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "Elias Law Group",
+                "",
+                "",
+                "",
+                "",
+            ],
+            "requestor_names": [
+                "People for Patty Murray",
+                "DSCC",
+                "Bennet for Colorado",
+            ],
+            "documents": [
+                {
+                    "date": "2022-10-06T00:00:00",
+                    "description": "Comment on AOR 2022-21 by NRSC",
+                    "document_id": 87167,
+                    "category": "Comments and Ex parte Communications",
+                    "url": "/files/legal/aos/2022-21/202221C_2.pdf",
+                },
+                {
+                    "date": "2022-10-11T00:00:00",
+                    "description": "Comment on AOR 2022-21 by DSCC, Bennet for Colorado, and People for Patty Murray",
+                    "document_id": 87168,
+                    "category": "Comments and Ex parte Communications",
+                    "url": "/files/legal/aos/2022-21/202221C_3.pdf",
+                },
+                {
+                    "date": "2022-10-11T00:00:00",
+                    "description": "Comment on AOR 2022-21 by Campaign Legal Center",
+                    "document_id": 87169,
+                    "category": "Comments and Ex parte Communications",
+                    "url": "/files/legal/aos/2022-21/202221C_4.pdf",
+                },
+                {
+                    "date": "2022-10-13T00:00:00",
+                    "description": "Extension of Time",
+                    "document_id": 87170,
+                    "category": "AO Request, Supplemental Material, and Extensions of Time",
+                    "url": "/files/legal/aos/2022-21/202221R_2.pdf",
+                },
+                {
+                    "date": "2022-10-03T00:00:00",
+                    "description": "Comment on AOR 2022-21 by Campaign Legal Center",
+                    "document_id": 87171,
+                    "category": "Comments and Ex parte Communications",
+                    "url": "/files/legal/aos/2022-21/202221C_1.pdf",
+                },
+                {
+                    "date": "2022-09-23T00:00:00",
+                    "description": "Request by DSCC, Bennet for Colorado, and People for \
+                        Patty Murray (Comments due by October 6, 2022)",
+                    "document_id": 87166,
+                    "category": "AO Request, Supplemental Material, and Extensions of Time",
+                    "url": "/files/legal/aos/2022-21/202221R_1.pdf",
+                },
+            ],
+            "commenter_names": ["The NRSC", "Campaign Legal Center"],
+            "regulatory_citations": [],
+            "type": "advisory_opinions",
+            "aos_cited_by": [],
+            "doc_id": "advisory_opinions_2022-21",
+            "issue_date": "null",
+            "statutory_citations": [],
+            "entities": [
+                {
+                    "role": "Commenter",
+                    "name": "The NRSC",
+                    "type": "Party committee, national",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Mr. Jan Witold Baran Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Mr. Thomas J. Josefiak Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Holtzman Vogel Baran Torchinsky & Josefiak PLLC",
+                    "type": "Law Firm",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Mr. Michael Bayes Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Mr. Jason Torchinsky Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": " Jessica F. Johnson Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": " Matthew S Petersen Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Mr. Jonathan A. Peterson Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Ms. Jacquelyn K. Lopez Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Elias Law Group",
+                    "type": "Law Firm",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Ms. Shanna M. Reulbach Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Ms. Rachel L. Jacobs Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Requestor",
+                    "name": "People for Patty Murray",
+                    "type": "Federal candidate/candidate committee/officeholder",
+                },
+                {
+                    "role": "Requestor",
+                    "name": "DSCC",
+                    "type": "Party committee, national",
+                },
+                {
+                    "role": "Requestor",
+                    "name": "Bennet for Colorado",
+                    "type": "Federal candidate/candidate committee/officeholder",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Ms. Erin Chlopak Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Counsel/Representative",
+                    "name": "Mr. Saurav Ghosh Esq.",
+                    "type": "Individual",
+                },
+                {
+                    "role": "Commenter",
+                    "name": "Campaign Legal Center",
+                    "type": "Research/Public Interest/Educational Institution",
+                },
+            ],
+            "name": "DSCC, Bennet for Colorado, and People for Patty Murray",
+            "request_date": "2022-09-23",
+            "requestor_types": [
+                "Federal candidate/candidate committee/officeholder",
+                "Party committee, national",
+            ],
+            "is_pending": "true",
+            "status": "Pending",
+            "highlights": [],
+            "document_highlights": {},
+        },
+    ],
+    "total_advisory_opinions": 4,
+    "total_all": 4,
+}
 
 
 def advisory_opinions_landing(request):
@@ -12,23 +384,82 @@ def advisory_opinions_landing(request):
     ao_min_date = today - datetime.timedelta(weeks=26)
     recent_aos = api_caller.load_legal_search_results(
         query='',
-        query_type='advisory_opinions',
-        ao_category=['F', 'W'],
+        query_type='advisory_opinions', ao_category=['F', 'W'],
         ao_min_issue_date=ao_min_date
     )
-    pending_aos = api_caller.load_legal_search_results(
-        query='',
-        query_type='advisory_opinions',
-        ao_category='R',
-        ao_status='Pending'
-    )
-    return render(request, 'legal-advisory-opinions-landing.jinja', {
+
+    """ TODO: This calls the  sample data dict above for  so one can
+    edit doc descriptions for testing the regex and logic. Comment this and
+    uncomment the below api_caller query for live data. Remove this before merge.
+    """
+
+    pending_aos = pending_aos_sample
+
+    # pending_aos = api_caller.load_legal_search_results(
+    #     query='',
+    #     query_type='advisory_opinions',
+    #     ao_category='R',
+    #     ao_status='Pending'
+    # )
+
+    """ The following loop checks the currently iterated AO's doc for a document
+    of category: "AO Request, Supplemental Material, and Extensions of Time",and
+    if it matches the pattern in the regex, it parses the date.
+    If the date is not expired, then it adds an item to the AO's dict named 'comment_deadline',
+    which can then be accessed in the template as `pending_ao['comment_deadline']`.
+
+    """
+
+    for pending_ao in pending_aos['advisory_opinions']:
+        for doc in pending_ao.get('documents'):
+            if doc['category'] == 'AO Request, Supplemental Material, and Extensions of Time':
+
+                # This regex searches in the document desctription for a string in this format:
+                # "(Comments due by October 24, 2022)", case insensitive, forgiving for extra spaces.
+                pattern = re.search(r'(?i)\(\s*Comments\s*due\s*by\s*(([a-z,A-Z]+)\s*\d{1,2}\s*,*\s*\d{4})\s*\)',
+                    doc['description'])
+
+                # If a matche is found.
+
+                if pattern:
+
+                    # group(1) is the date only, as input by user. Example. "October 24, 2022"
+                    display_date = pattern.group(1)
+
+                    # rm comma
+                    parseable_date = display_date.replace(',', '')
+                    # `parseable_date_time` example: October 24 2022 11:59PM
+
+                    parseable_date_time = parseable_date + ' 11:59PM'
+                    # Check if `parseable_date_time` will parse.
+
+                    try:
+                        datetime.datetime.strptime(parseable_date_time,
+                                '%B %d %Y %I:%M%p')
+                    except ValueError:
+
+                        pass
+                    else:
+
+                        # Since  `parseable_date_time` is a valid date format, parse it into a Python-readable date.
+                        # Example code_date_time: 2022-10-31 23:59:00
+
+                        code_date_time = datetime.datetime.strptime(parseable_date_time,
+                                '%B %d %Y %I:%M%p')
+
+                        present = datetime.datetime.now()
+                        if code_date_time > present:
+                            comment_deadline = display_date
+                            pending_ao['comment_deadline'] = comment_deadline
+
+    return render(request, 'legal-advisory-opinions-landing.jinja', {  # TODO: FOR TESTING
         'parent': 'legal',
         'result_type': 'advisory_opinions',
         'display_name': 'advisory opinions',
         'recent_aos': recent_aos['advisory_opinions'],
         'pending_aos': pending_aos['advisory_opinions'],
         'social_image_identifier': 'advisory-opinions',
+        'pending_aos_pretty': json.dumps(pending_aos, sort_keys=False, indent=4),
     })
 
 

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -70,7 +70,7 @@ def advisory_opinions_landing(request):
                             # Append item to currently iterated AO's dict
                             pending_ao['comment_deadline'] = comment_deadline
 
-    return render(request, 'legal-advisory-opinions-landing.jinja', {  # TODO: FOR TESTING
+    return render(request, 'legal-advisory-opinions-landing.jinja', {
         'parent': 'legal',
         'result_type': 'advisory_opinions',
         'display_name': 'advisory opinions',

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -4,379 +4,8 @@ from django.http import Http404
 import datetime
 import re
 
-# TO DO - can remove after testing
-import json
-
 from data import api_caller
 from data import constants
-
-""" TODO This is a sample of pending_aos for testing the regex and the view logic.
-This dict was created by making the exact same api call the api_caller does in the `pending_aos` variable below,
-then editing doc descriptions Document descriptions can be further edited to test the logic and see how
-typos are either forgiven, or might break the regex or datetime parsing.
-REMOVE BEFORE FINAL PR.
-
-"""
-pending_aos_sample = {
-    "advisory_opinions": [
-        {
-            "summary": "Contributions by irrevocable trust to candidates and political committees.",
-            "no": "2022-24",
-            "ao_citations": [],
-            "representative_names": ["Elias Law Group", "", ""],
-            "requestor_names": [""],
-            "documents": [
-                {
-                    "date": "2022-10-04T00:00:00",
-                    "description": "Request by Allen Blue (Comments due by October 30, 2022)",
-                    "document_id": 87165,
-                    "category": "AO Request, Supplemental Material, and Extensions of Time",
-                    "url": "/files/legal/aos/2022-24/202224R_1.pdf",
-                }
-            ],
-            "commenter_names": [],
-            "regulatory_citations": [],
-            "type": "advisory_opinions",
-            "aos_cited_by": [],
-            "doc_id": "advisory_opinions_2022-24",
-            "issue_date": "null",
-            "statutory_citations": [],
-            "entities": [
-                {"role": "Requestor", "name": "Mr. Allen Blue ", "type": "Individual"},
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Elias Law Group",
-                    "type": "Law Firm",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Mr. Ezra W. Reese Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Ms. Emma R. Anspach Esq.",
-                    "type": "Individual",
-                },
-            ],
-            "name": "Allen Blue",
-            "request_date": "2022-10-04",
-            "requestor_types": ["Individual"],
-            "is_pending": "true",
-            "status": "Pending",
-            "highlights": [],
-            "document_highlights": {},
-        },
-        {
-            "summary": "Corporate license of patented technology for political committee use in advertising.",
-            "no": "2022-23",
-            "ao_citations": [],
-            "representative_names": ["Berke Farah LLP", ""],
-            "requestor_names": ["DataVault Holdings, Inc."],
-            "documents": [
-                {
-                    "date": "2022-10-05T00:00:00",
-                    "description": "Extension of Time",
-                    "document_id": 87158,
-                    "category": "AO Request, Supplemental Material, and Extensions of Time",
-                    "url": "/files/legal/aos/2022-23/202223R_2.pdf",
-                },
-                {
-                    "date": "2022-09-22T00:00:00",
-                    "description": "Request by DataVault Holding's Inc. (Comments due by October 30, 2022)",
-                    "document_id": 87159,
-                    "category": "AO Request, Supplemental Material, and Extensions of Time",
-                    "url": "/files/legal/aos/2022-23/202223R_1.pdf",
-                },
-                {
-                    "date": "2022-09-22T00:00:00",
-                    "description": "TEST SECOND NON-DRAFT DOC WITH EXP DATE - \
-                        Request by DataVault Holding's Inc. (Comments due by November 05, 2022)",
-                    "document_id": 87151,
-                    "category": "AO Request, Supplemental Material, and Extensions of Time",
-                    "url": "/files/legal/aos/2022-23/202223R_1.pdf",
-                },
-            ],
-            "commenter_names": [],
-            "regulatory_citations": [],
-            "type": "advisory_opinions",
-            "aos_cited_by": [],
-            "doc_id": "advisory_opinions_2022-23",
-            "issue_date": "null",
-            "statutory_citations": [],
-            "entities": [
-                {
-                    "role": "Requestor",
-                    "name": "DataVault Holdings, Inc.",
-                    "type": "Corporation (including LLCs electing corporate status)",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Berke Farah LLP",
-                    "type": "Law Firm",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Mr. Elliot S. Berke Esq.",
-                    "type": "Individual",
-                },
-            ],
-            "name": "DataVault II",
-            "request_date": "2022-09-22",
-            "requestor_types": [
-                "Corporation (including LLCs electing corporate status)"
-            ],
-            "is_pending": "true",
-            "status": "Pending",
-            "highlights": [],
-            "document_highlights": {},
-        },
-        {
-            "summary": 'Corporate sale of non-fungible tokens ("NFTs") to political committees.',
-            "no": "2022-22",
-            "ao_citations": [],
-            "representative_names": ["", "Berke Farah LLP"],
-            "requestor_names": ["DataVault Holdings, Inc."],
-            "documents": [
-                {
-                    "date": "2022-10-05T00:00:00",
-                    "description": "Extension of Time",
-                    "document_id": 87156,
-                    "category": "AO Request, Supplemental Material, and Extensions of Time",
-                    "url": "/files/legal/aos/2022-22/202222R_2.pdf",
-                },
-                {
-                    "date": "2022-10-03T00:00:00",
-                    "description": "Request by DataVault Holdings, Inc. (Comments due by 10/03/2022)",
-                    "document_id": 87157,
-                    "category": "AO Request, Supplemental Material, and Extensions of Time",
-                    "url": "/files/legal/aos/2022-22/202222R_1.pdf",
-                },
-            ],
-            "commenter_names": [],
-            "regulatory_citations": [],
-            "type": "advisory_opinions",
-            "aos_cited_by": [],
-            "doc_id": "advisory_opinions_2022-22",
-            "issue_date": "null",
-            "statutory_citations": [],
-            "entities": [
-                {
-                    "role": "Requestor",
-                    "name": "DataVault Holdings, Inc.",
-                    "type": "Corporation (including LLCs electing corporate status)",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Mr. Elliot S. Berke Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Berke Farah LLP",
-                    "type": "Law Firm",
-                },
-            ],
-            "name": "DataVault I",
-            "request_date": "2022-10-03",
-            "requestor_types": [
-                "Corporation (including LLCs electing corporate status)"
-            ],
-            "is_pending": "true",
-            "status": "Pending",
-            "highlights": [],
-            "document_highlights": {},
-        },
-        {
-            "summary": "Payment for television advertisements featuring candidates that solicit funds \
-                for national party committee’s legal proceedings account.",
-            "no": "2022-21",
-            "ao_citations": [],
-            "representative_names": [
-                "",
-                "",
-                "Holtzman Vogel Baran Torchinsky & Josefiak PLLC",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "Elias Law Group",
-                "",
-                "",
-                "",
-                "",
-            ],
-            "requestor_names": [
-                "People for Patty Murray",
-                "DSCC",
-                "Bennet for Colorado",
-            ],
-            "documents": [
-                {
-                    "date": "2022-10-06T00:00:00",
-                    "description": "Comment on AOR 2022-21 by NRSC",
-                    "document_id": 87167,
-                    "category": "Comments and Ex parte Communications",
-                    "url": "/files/legal/aos/2022-21/202221C_2.pdf",
-                },
-                {
-                    "date": "2022-10-11T00:00:00",
-                    "description": "Comment on AOR 2022-21 by DSCC, Bennet for Colorado, and People for Patty Murray",
-                    "document_id": 87168,
-                    "category": "Comments and Ex parte Communications",
-                    "url": "/files/legal/aos/2022-21/202221C_3.pdf",
-                },
-                {
-                    "date": "2022-10-11T00:00:00",
-                    "description": "Comment on AOR 2022-21 by Campaign Legal Center",
-                    "document_id": 87169,
-                    "category": "Comments and Ex parte Communications",
-                    "url": "/files/legal/aos/2022-21/202221C_4.pdf",
-                },
-                {
-                    "date": "2022-10-13T00:00:00",
-                    "description": "Extension of Time",
-                    "document_id": 87170,
-                    "category": "AO Request, Supplemental Material, and Extensions of Time",
-                    "url": "/files/legal/aos/2022-21/202221R_2.pdf",
-                },
-                {
-                    "date": "2022-10-03T00:00:00",
-                    "description": "Comment on AOR 2022-21 by Campaign Legal Center",
-                    "document_id": 87171,
-                    "category": "Comments and Ex parte Communications",
-                    "url": "/files/legal/aos/2022-21/202221C_1.pdf",
-                },
-                {
-                    "date": "2022-09-23T00:00:00",
-                    "description": "Request by DSCC, Bennet for Colorado, and People for \
-                        Patty Murray (Comments due by October 6, 2022)",
-                    "document_id": 87166,
-                    "category": "AO Request, Supplemental Material, and Extensions of Time",
-                    "url": "/files/legal/aos/2022-21/202221R_1.pdf",
-                },
-            ],
-            "commenter_names": ["The NRSC", "Campaign Legal Center"],
-            "regulatory_citations": [],
-            "type": "advisory_opinions",
-            "aos_cited_by": [],
-            "doc_id": "advisory_opinions_2022-21",
-            "issue_date": "null",
-            "statutory_citations": [],
-            "entities": [
-                {
-                    "role": "Commenter",
-                    "name": "The NRSC",
-                    "type": "Party committee, national",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Mr. Jan Witold Baran Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Mr. Thomas J. Josefiak Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Holtzman Vogel Baran Torchinsky & Josefiak PLLC",
-                    "type": "Law Firm",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Mr. Michael Bayes Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Mr. Jason Torchinsky Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": " Jessica F. Johnson Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": " Matthew S Petersen Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Mr. Jonathan A. Peterson Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Ms. Jacquelyn K. Lopez Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Elias Law Group",
-                    "type": "Law Firm",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Ms. Shanna M. Reulbach Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Ms. Rachel L. Jacobs Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Requestor",
-                    "name": "People for Patty Murray",
-                    "type": "Federal candidate/candidate committee/officeholder",
-                },
-                {
-                    "role": "Requestor",
-                    "name": "DSCC",
-                    "type": "Party committee, national",
-                },
-                {
-                    "role": "Requestor",
-                    "name": "Bennet for Colorado",
-                    "type": "Federal candidate/candidate committee/officeholder",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Ms. Erin Chlopak Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Counsel/Representative",
-                    "name": "Mr. Saurav Ghosh Esq.",
-                    "type": "Individual",
-                },
-                {
-                    "role": "Commenter",
-                    "name": "Campaign Legal Center",
-                    "type": "Research/Public Interest/Educational Institution",
-                },
-            ],
-            "name": "DSCC, Bennet for Colorado, and People for Patty Murray",
-            "request_date": "2022-09-23",
-            "requestor_types": [
-                "Federal candidate/candidate committee/officeholder",
-                "Party committee, national",
-            ],
-            "is_pending": "true",
-            "status": "Pending",
-            "highlights": [],
-            "document_highlights": {},
-        },
-    ],
-    "total_advisory_opinions": 4,
-    "total_all": 4,
-}
 
 
 def advisory_opinions_landing(request):
@@ -396,17 +25,9 @@ def advisory_opinions_landing(request):
         ao_status='Pending'
     )
 
-    """ TODO: For testing only. the below line overrides the `pending_aos` var above,
-    using the "pending_aos_sample" data dict at the top of the file. So one can edit doc
-    descriptions for testing the regex and logic. To use above live api_caller query instead,
-    comment out or remove the line below. (Delete this comment and line below before merge.)
-
-    """
-    pending_aos = pending_aos_sample
-
     """ The following loop checks the currently iterated AO's doc dict for a document
-    of category: "AO Request, Supplemental Material, and Extensions of Time", and
-    if it matches the pattern in the regex, it parses the date.
+    of category: "AO Request, Supplemental Material, and Extensions of Time",
+    and if it matches the pattern in the regex, it parses the date.
     If the date is not expired, then it adds an item to the AO's dict named 'comment_deadline',
     which can then be accessed in the template as `pending_ao['comment_deadline']`.
 
@@ -421,7 +42,7 @@ def advisory_opinions_landing(request):
                 pattern = re.search(r'(?i)\(\s*Comments\s*due\s*by\s*(([a-z,A-Z]+)\s*\d{1,2}\s*,*\s*\d{4})\s*\)',
                     doc['description'])
 
-                # If a matche is found.
+                # If a match is found.
                 if pattern:
                     # group(1) is the date only, as input by user. Example. "October 24, 2022"
                     display_date = pattern.group(1)
@@ -438,7 +59,7 @@ def advisory_opinions_landing(request):
                         pass
                     else:
                         # Since  `parseable_date_time` is parseable date string, parse it into a Python-readable date.
-                        # Example code_date_time: 2022-10-31 23:59:00
+                        # Example code_date_time: 2022-10-24 23:59:00
                         code_date_time = datetime.datetime.strptime(parseable_date_time, '%B %d %Y %I:%M%p')
 
                         # Check if `code_date_time` has not expired.
@@ -446,7 +67,7 @@ def advisory_opinions_landing(request):
                         if code_date_time > present:
                             comment_deadline = display_date
 
-                            # Append item to currently iterated pending_ao's dict
+                            # Append item to currently iterated AO's dict
                             pending_ao['comment_deadline'] = comment_deadline
 
     return render(request, 'legal-advisory-opinions-landing.jinja', {  # TODO: FOR TESTING
@@ -456,8 +77,6 @@ def advisory_opinions_landing(request):
         'recent_aos': recent_aos['advisory_opinions'],
         'pending_aos': pending_aos['advisory_opinions'],
         'social_image_identifier': 'advisory-opinions',
-        # TODO: For testing only. rm b4 merge.
-        'pending_aos_pretty': json.dumps(pending_aos, sort_keys=False, indent=4),
     })
 
 

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -403,8 +403,8 @@ def advisory_opinions_landing(request):
     """
     pending_aos = pending_aos_sample
 
-    """ The following loop checks the currently iterated AO's doc for a document
-    of category: "AO Request, Supplemental Material, and Extensions of Time",and
+    """ The following loop checks the currently iterated AO's doc dict for a document
+    of category: "AO Request, Supplemental Material, and Extensions of Time", and
     if it matches the pattern in the regex, it parses the date.
     If the date is not expired, then it adds an item to the AO's dict named 'comment_deadline',
     which can then be accessed in the template as `pending_ao['comment_deadline']`.
@@ -436,6 +436,7 @@ def advisory_opinions_landing(request):
                     try:
                         datetime.datetime.strptime(parseable_date_time, '%B %d %Y %I:%M%p')
                     except ValueError:
+                        # pass to avoid throwing a datetime error
                         pass
                     else:
                         # Since  `parseable_date_time` is a valid date format, parse it into a Python-readable date.
@@ -456,6 +457,7 @@ def advisory_opinions_landing(request):
         'recent_aos': recent_aos['advisory_opinions'],
         'pending_aos': pending_aos['advisory_opinions'],
         'social_image_identifier': 'advisory-opinions',
+        # TODO: For testing only. rm b4 merge.
         'pending_aos_pretty': json.dumps(pending_aos, sort_keys=False, indent=4),
     })
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5400
- Adds view logic and template changes to display AO comment deadlines extracted from document descriptions
- Update `How to Comment` link to point to anchor

### Required reviewers

UX/Frontend

## Impacted areas of the application
  AO Landing page
	modified:   legal/templates/legal-advisory-opinions-landing.jinja
	modified:   legal/views.py

## Screenshots

<img width="906" alt="Screen Shot 2022-10-24 at 9 57 09 PM" src="https://user-images.githubusercontent.com/5572856/197664161-a9cd6725-9ca2-4c8e-99af-0d806a698977.png">


## Related PRs

## How to test

- Checkout and run branch
- Since there are currently no AOs with pending comment dates, there is sample data dict in the view called `pending_aos_sample` . This is the data output from the exact same call to the api that the `pending_aos var`  makes to api_caller with the document descriptions edited allow some AOs comment dates to show on page. (See comment on line 399)
- Edit the doc description "Comments due by..."  section to test reliability of the regex and view logic 
- Edit the doc description "Comments due by..." section to see what typos are forgiven and which are not(case insensitivity and extra spaces, 1-digit month without leading zero).
- To cover all edge cases, `AO 2022-23` in the sample data has two non-draft documents with comment deadlines.  Although Jason confirmed that this would not be a normal occurrence, I would wager on it happening some time in the future, so the last document added, is the one used to extract the deadline. 
- If it's helpful to see what the pending_aos' json dicts look like after the view logic adds the `comment_deadline` to it ,  you can uncomment lines 86-89 of the template. This renders a formatted version of the resulting `pending_aos` sample data to the page. (See comment on line 407 of the view for explanation.)
- You could also test the regex, saved  here https://regex101.com/r/6ymj4l/1

**Note:**
The temporary testing code is the only way I could think of to make it easy for devs to test and have confidence in the logic given that there are no pending dates in live data at time of submitting the PR.  
-  [x] Once this WIP is tested, I can push a cleaner PR that represents the final version of the view and template 

