### PR TITLE
Fix ADR and MUR cannonical pages

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 import requests
 import inspect
 
@@ -129,20 +128,6 @@ def load_legal_mur(mur_no):
     if mur["mur_type"] == "current":
         complainants = []
         for participant in mur["participants"]:
-            citations = []
-            for stage in participant["citations"]:
-                for url in participant["citations"][stage]:
-                    if "uscode" in url:
-                        section = re.search("section=([0-9]+)", url).group(1)
-                        citations.append({"text": section, "url": url})
-                    if "cfr" in url:
-                        title_no = re.search("titlenum=([0-9]+)", url).group(1)
-                        part_no = re.search("partnum=([0-9]+)", url).group(1)
-                        section_no = re.search("sectionnum=([0-9]+)", url).group(1)
-                        text = "%s C.F.R. %s.%s" % (title_no, part_no, section_no)
-                        citations.append({"text": text, "url": url})
-            participant["citations"] = citations
-
             if "complainant" in participant["role"].lower():
                 complainants.append(participant["name"])
 
@@ -187,26 +172,12 @@ def load_legal_adr(adr_no):
 
     complainants = []
     for participant in adr["participants"]:
-        citations = []
-        for stage in participant["citations"]:
-            for url in participant["citations"][stage]:
-                if "uscode" in url:
-                    section = re.search("section=([0-9]+)", url).group(1)
-                    citations.append({"text": section, "url": url})
-                if "cfr" in url:
-                    title_no = re.search("titlenum=([0-9]+)", url).group(1)
-                    part_no = re.search("partnum=([0-9]+)", url).group(1)
-                    section_no = re.search("sectionnum=([0-9]+)", url).group(1)
-                    text = "%s C.F.R. %s.%s" % (title_no, part_no, section_no)
-                    citations.append({"text": text, "url": url})
-        participant["citations"] = citations
-
         if "complainant" in participant["role"].lower():
             complainants.append(participant["name"])
 
     adr["disposition_text"] = [d["action"] for d in adr["commission_votes"]]
 
-    adr["collated_dispositions"] = collate_dispositions(adr["dispositions"])
+    adr["collated_dispositions"] = collate_dispositions(adr["adr_dispositions"])
     adr["complainants"] = complainants
     adr["participants_by_type"] = _get_sorted_participants_by_type(adr)
 


### PR DESCRIPTION
## Summary

Remove references to participant citations object for both MUR and ADR. Update dictionary name for ADR dispositions

### Required reviewers

1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

- MUR cannonical page
- ADR cannonical page

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/4793-adr-parameters | [link](https://github.com/fecgov/openFEC/pull/5250/files)

## How to test

- Checkout this branch
- Go to any MUR cannonical page, make sure citations are there and page loads. Ex: http://localhost:8000/data/legal/matter-under-review/8013/
- Go to any ADR cannonical page, make sure page loads: http://localhost:8000/data/legal/alternative-dispute-resolution/954/