### PR TITLE
5421 Add connected organization to about committee

### DIFF
--- a/fec/data/templates/partials/committee/about-committee.jinja
+++ b/fec/data/templates/partials/committee/about-committee.jinja
@@ -44,6 +44,14 @@
           <td class="figure__label">Committee name:</td>
           <td class="figure__value">{{committee.name}}</td>
         </tr>
+        {% if is_SSF %}
+          <tr>
+            <td class="figure__label">Connected organization:</td>
+            <td class="figure__value">
+              {{ committee.affiliated_committee_name }}
+            </td>
+          </tr>
+        {% endif %}
         <tr>
           <td class="figure__label">Mailing address:</td>
           <td class="figure__value">


### PR DESCRIPTION
## Summary (required)

- Resolves #5421

This adds SSF's connected organization to their about committee section of their committee page

### Required reviewers
1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

-  About committee page

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)


## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- 
