### PR TITLE
5121 MUR election cycle bug fix

### DIFF
--- a/fec/legal/templates/partials/legal-search-results-mur.jinja
+++ b/fec/legal/templates/partials/legal-search-results-mur.jinja
@@ -30,7 +30,7 @@
       </div>
       <div class="simple-table__cell no--pad">
         {% if mur.mur_type == 'current' %}
-        <div class="u-margin--bottom u-padding--top--med u-margin--left"><strong>Election cycle(s):</strong> {{ '; '.join(mur['election_cycles'] | map('string') | sort) }}</div>
+        <div class="u-margin--bottom u-padding--top--med u-margin--left"><strong>Election cycle(s):</strong> {{ '; '.join(mur['election_cycles'] | map('string') | unique | sort) }}</div>
         {% endif %}
         {% if mur.mur_type == 'current' %}
         {# Archived MUR subjects are a tree-structure so we don't render them inline #}


### PR DESCRIPTION
## Summary (required)

- Resolves [#5121](https://github.com/fecgov/openFEC/issues/5121)

Removes non-unique values in election cycle for MUR. After discussing with OGC, only displaying the unique values for MURs is a better depiction of the data. 

### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

-  MUR search/tables

## Screenshots
After:
<img width="848" alt="Screen Shot 2022-10-27 at 2 54 36 PM" src="https://user-images.githubusercontent.com/66386084/198374915-6c651324-370f-4c19-aaf7-bd9bcc5901a0.png">

Before:
<img width="768" alt="Screen Shot 2022-10-27 at 2 55 13 PM" src="https://user-images.githubusercontent.com/66386084/198374981-4852b6db-6d27-4d70-a888-ca0e113c4f71.png">


## How to test
https://www.fec.gov/data/legal/search/murs/?search=&case_respondents=&case_min_open_date=&case_max_open_date=&case_min_close_date=&case_max_close_date=&offset=40#results-murs
(Specifically look at 7882)

Pull the branch
- `cd fec`
- `python manage.py runserver`
- http://127.0.0.1:8000/data/legal/search/murs/?search=&case_respondents=&case_min_open_date=&case_max_open_date=&case_min_close_date=&case_max_close_date=&offset=40#results-murs
