### PR TITLE
Padding to fix bottom cutoff of letters on usa banner

### DIFF
--- a/fec/fec/static/scss/components/_site-header.scss
+++ b/fec/fec/static/scss/components/_site-header.scss
@@ -153,6 +153,7 @@
     font-size: u(1.4rem);
     font-family: karla,sans-serif;
     letter-spacing: -.3px;
+    padding-bottom: 1px;
   }
 }
 


### PR DESCRIPTION
## Summary
Letters on the USA banner were being cutoff at the bottom. ("g" in `government` and "y" in` you know`). This PR adds 1px of padding to fix that.

- Resolves #5453


### Required reviewers

One UX -or- One Frontend

## Impacted areas of the application

General components of the application that this PR will affect:

USA-gov banner that appears on every page of the site
modified:   fec/static/scss/components/_site-header.scss

## Screenshots

<img width="1053" alt="Screen Shot 2022-11-01 at 5 53 31 PM" src="https://user-images.githubusercontent.com/5572856/199349138-a74ab8ae-f66d-44e1-81e4-407bb7f16206.png">


## How to test

- `npm run build-sass
- confirm that the "g" in` government` and "y" in `you know` are not cutoff at the bottom of USA banner.
- merge and celebrate!
