### PR TITLE
Update links to leadersthip pac csv files

### DIFF
--- a/fec/data/templates/partials/browse-data/committees.jinja
+++ b/fec/data/templates/partials/browse-data/committees.jinja
@@ -51,17 +51,17 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/2022/leadership2022.csv">2021–2022</a></li>
-                  <li><a href="/files/bulk-downloads/2020/leadership2020.csv">2019–2020</a></li>
-                  <li><a href="/files/bulk-downloads/2018/leadership2018.csv">2017–2018</a></li>
-                  <li><a href="/files/bulk-downloads/2016/leadership2016.csv">2015–2016</a></li>
-                  <li><a href="/files/bulk-downloads/2014/leadership2014.csv">2013–2014</a></li>
-                  <li><a href="/files/bulk-downloads/2012/leadership2012.csv">2011–2012</a></li>
-                  <li><a href="/files/bulk-downloads/2010/leadership2010.csv">2009–2010</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/leadership2022.csv">2021–2022</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/leadership2020.csv">2019–2020</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/leadership2018.csv">2017–2018</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/leadership2016.csv">2015–2016</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/leadership2014.csv">2013–2014</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/leadership2012.csv">2011–2012</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/leadership2010.csv">2009–2010</a></li>
                 </ul>
                 <p class="u-margin--top"><a href="/campaign-finance-data/leadership-pacs-and-sponsors-description">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
               </div>
-              <p>Candidates and members of Congress can create "leadership PACs" to raise funds to support other candidates for federal office. This file lists the PACs who have registered with the FEC as a leadership.</p>
+              <p>Candidates and members of Congress can create "leadership PACs" to raise funds to support other candidates for federal office. This file lists the PACs who have registered with the FEC as a leadership PAC.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #5471 

Changes /year/ to /data.fec.gov/.

Also added word "PAC" to last sentence of description.

### Required reviewers

One front end person to check links

## Impacted areas of the application

Data page for bulk downloads

