### PR TITLE
Update open meeting time

### DIFF
--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -48,7 +48,7 @@
         <div class="main__content--right">
           <section id="meetings-open-meetings" role="tabpanel" aria-hidden="true" aria-labelledby="open-meetings">
             <h2>Open meetings</h2>
-            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:00 a.m. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
+            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:30 a.m. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
             <div class="filters--horizontal">
               <form action="" id="openmeetings_form" method="get" class="js-form-nav container">
                 <div class="filter">

--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -37,7 +37,7 @@
     </header>
 
     {% if self.meeting_type == 'O' %}
-      <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:00 a.m.</p>
+      <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:30 AM</p>
       <p>Members of the public can attend any open meeting or hearing in person. Open meetings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.</p>
     {% elif self.meeting_type == 'E' %}
       <p>The Commission meets regularly in executive sessions to discuss pending enforcement actions, litigation and other matters that, by law, must be kept confidential.</p>


### PR DESCRIPTION
## Summary (required)

- Resolves #5510 
Update open meeting time to 10:30

### Required reviewers

1 content reviewer

## Impacted areas of the application

General components of the application that this PR will affect:

- Commission meeting landing page
- All Commission open meeting pages

## Screenshots

### Commission meeting landing page
<img width="980" alt="Screen Shot 2022-12-07 at 3 25 22 PM" src="https://user-images.githubusercontent.com/12799132/206288670-84462bf8-1291-4bed-a451-b1c62fc7c6bc.png">

### Commission open meeting page example
<img width="986" alt="Screen Shot 2022-12-07 at 3 25 57 PM" src="https://user-images.githubusercontent.com/12799132/206288668-27af966d-5a70-4dee-9606-36251ec47088.png">

## How to test

- See screenshot, if that looks good, feel free to merge