### PR TITLE
Replace committee_id with q_filer

### DIFF
--- a/fec/fec/static/js/modules/table-columns.js
+++ b/fec/fec/static/js/modules/table-columns.js
@@ -114,7 +114,7 @@ function createElectionColumns(context) {
           urlBase = ['reports', 'house-senate'];
         }
         var url = helpers.buildAppUrl(urlBase, {
-          committee_id: row.committee_ids,
+          q_filer: row.committee_ids,
           cycle: context.election.cycle,
           is_amended: 'false'
         });


### PR DESCRIPTION
## Summary (required)

- Resolves #5480 

Election profile pages > Candidate financial totals tab > Source-reports-link (View all) does not filter the committee ID correctly.

Replace committee_id filter with q_filer 

### Required reviewers

2 frontend developers

## Impacted areas of the application

- Election profile pages 

## Screenshots
Before:


**For Presidential election profile pages:**
<img width="1431" alt="Screen Shot 2022-12-08 at 11 51 01 AM" src="https://user-images.githubusercontent.com/11650355/206514016-20d449cf-f66d-4c29-bc3d-3bd374d5c9ab.png">

<img width="1435" alt="Screen Shot 2022-12-08 at 11 36 59 AM" src="https://user-images.githubusercontent.com/11650355/206511590-48c2fca8-2102-4b5f-943e-025656bacd03.png">

__________________________________________________________________________________________________________

 **House/Senate election profile pages:**

<img width="1435" alt="Screen Shot 2022-12-08 at 11 16 20 AM" src="https://user-images.githubusercontent.com/11650355/206504041-23d26cba-f73e-4fa5-a6b0-56dac5e5f5dd.png">

<img width="1437" alt="Screen Shot 2022-12-08 at 11 45 47 AM" src="https://user-images.githubusercontent.com/11650355/206512762-6e46a102-7cf5-44b7-9014-4389d489aad8.png">



Changes in this PR:




**For Presidential election profile pages**:

<img width="1434" alt="Screen Shot 2022-12-08 at 11 28 56 AM" src="https://user-images.githubusercontent.com/11650355/206508831-9ccda17a-fc59-4e03-b5a4-e0f79053ff23.png">

<img width="1435" alt="Screen Shot 2022-12-08 at 11 31 36 AM" src="https://user-images.githubusercontent.com/11650355/206508838-e6d6fab1-f69a-4a74-af41-b0336d66fe7b.png">

**For House/Senate election profile pages:**

<img width="1435" alt="Screen Shot 2022-12-08 at 11 53 56 AM" src="https://user-images.githubusercontent.com/11650355/206515027-9d5a3ffb-6360-4549-9844-372d0bf3638d.png">

<img width="1431" alt="Screen Shot 2022-12-08 at 11 55 10 AM" src="https://user-images.githubusercontent.com/11650355/206515031-b683d340-70ab-4a20-9ff1-3486c06b8a0e.png">



## How to test


-  checkout  branch `feature/5480-replace-cmteid-with-qfiler-filter`
- npm run build-js
- run pytest
- ./mange.py runserver
- Test endpoints: **Election profile pages > Candidate financial totals tab > Source-reports-link (View all) filter by qfiler correctly.**
- House elections, sample url
          - Prod:https://www.fec.gov/data/elections/house/CA/01/2022/ 
          - Local: http://localhost:8000/data/elections/house/CA/01/2022/ 
- Presidentail elections, sample url:
        - Prod: https://www.fec.gov/data/elections/president/2020/
        - Local: http://localhost:8000/data/elections/president/2020/

