### PR TITLE
5481 min/max dates in URLs

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -826,6 +826,8 @@ def elections_president(request, cycle):
 
     cycles = [each for each in cycles if each % 4 == 0]
 
+    election_duration = election_durations.get(office[0].upper(), 2)
+
     tab = request.GET.get("tab", "").replace("/", "")
     legacy_tabs = {
         "contributions": "#individual-contributions",
@@ -846,6 +848,7 @@ def elections_president(request, cycle):
             "office_code": office[0],
             "parent": "data",
             "cycle": cycle,
+            "election_duration": election_duration,
             "cycles": cycles,
             "title": utils.election_title(cycle, office),
             "social_image_identifier": "data",


### PR DESCRIPTION
## Summary

- Resolves #5481 

The $ links were broken on `/data/elections/president/` [Communication costs](https://www.fec.gov/data/elections/president/#communication-costs) and [Electioneering communication](https://www.fec.gov/data/elections/president/#electioneering-communication).

The templates were referencing `election_duration` which didn't exist. Simply adding that variable fixed the date issue and shouldn't complicate anything else.

### Required reviewers

Someone to approve the code, maybe someone else to be another check for the functionality?

## Impacted areas of the application

Some of the links in the tables of `/data/elections/president/`

## Screenshots

No visual changes


## How to test

- pull branch
- `npm i` just in case
- `npm run build` just in case
- `./manage.py runserver`
- Check the presidential tables on [localhost](http://127.0.0.1:8000/data/elections/president/2020/) and [production](https://www.fec.gov/data/elections/president/2020/)
   - [Communication costs](http://127.0.0.1:8000/data/elections/president/2020/#communication-costs) table, roll over the currency links, make sure `min_date` and `max_date` are correct
   - [Electioneering communication](http://127.0.0.1:8000/data/elections/president/2020/#electioneering-communication) table, roll over the currency links, make sure `min_date` and `max_date` are correct
