### PR TITLE
Add q_filer to Filter-this-data links

### DIFF
--- a/fec/data/templates/macros/entity-pages.jinja
+++ b/fec/data/templates/macros/entity-pages.jinja
@@ -14,7 +14,7 @@
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">{{ title }}</h3>
         <a class="heading__right button button--alt button--browse"
-           href="/data/filings/?committee_id={{ committee_id }}&cycle={{ cycle }}&{{ns.form_types}}">
+           href="/data/filings/?committee_id={{ committee_id }}&q_filer={{ committee_id }}&cycle={{ cycle }}&{{ns.form_types}}">
           Filter this data
         </a>
       </div>


### PR DESCRIPTION
## Summary
- Use `q_filer` (instead of `committee_id`)  as a parameter in `Filter this data  link` on Committee profile pages   to ensure resulting data table is filtered by the committee.

- Resolves #5540

**Possible followup work:**
- My instinct on other recent PRs to replace committee_id  with  `q_filer`  was to leave the existing `committee_id` in the  URL for clarity/readability  as  `q_filer` is somewhat "cryptic ".`
- Here are recent frontend PRs we did after adding the `q_filer` parameter to accommodate typeahead/free-text combo searches: [5512](https://github.com/fecgov/fec-cms/pull/5512), [5408]( https://github.com/fecgov/fec-cms/pull/5408)
- Should we  consider adding committee ID  back in those places and in this  PR ?

### Required reviewers

one developer

## Impacted areas of the application

modified:   data/templates/macros/entity-pages.jinja

-  

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## Related PRs
 [5512](https://github.com/fecgov/fec-cms/pull/5512)
 [5408]( https://github.com/fecgov/fec-cms/pull/5408)
 See [spreadhseet ](https://docs.google.com/spreadsheets/d/1AkQjXA2XMQfxlRyinSY0uynhf2ZRMh7l_BTWdJgHzXY/edit#gid=0)for related OpenFEC  PRs

## How to test

- checkout and run branch
- Test  all `Filter this data  links`  on Committee profile pages  > Filings tab to ensure resulting datatable is filtered by the committee

