### PR TITLE
5488- Upgrade setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7
 gunicorn==19.10.0
-gevent==21.12.0
+gevent==22.10.2
 psycopg2==2.8.6
 requests==2.25.1
 urllib3==1.26.7
@@ -47,4 +47,3 @@ flake8==4.0.1
 pytest-django==3.10.0
 pytest-cov==2.11.1
 pytest-flake8==1.0.7
-setuptools==65.1.1 # Pinned to fix the deploy errors caused by the latest setuptool version 65.3.0


### PR DESCRIPTION
## Summary 

- Resolves #5488 

We pinned setuptools due to a previous deploy issue. It's a dependency of gevent. Upgrading gevent and un-pinning setuptools should both remove the  ReDOS vulnerability and cause less issues for us down the line. 

### Required reviewers

1 dev

## Screenshots
Before:
![Screen Shot 2023-01-11 at 3 57 45 PM](https://user-images.githubusercontent.com/66386084/211916338-4cb37485-6da8-46a6-9691-450743601b36.png)

After:
![Screen Shot 2023-01-11 at 4 05 31 PM](https://user-images.githubusercontent.com/66386084/211917655-364b2171-a7e4-4bf6-9be0-7975125f04d6.png)


## Related PRs

Related PRs against other branches:


## How to test

- pull latest develop (run requirements if you haven't recently)
- `snyk test --file=requirements.txt` shows current vulnerability
- checkout this branch
- `pip install -r requirements.txt`
- `pip freeze` setuptools should be updated
- `snyk test  --file=requirements.txt` shows zero vulnerabilities
-  `cd fec`
-  `python manage.py runserver`