### PR TITLE
Add Type to footer button

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -137,7 +137,7 @@
         Washington, DC 20463</p>
 
         <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
-          <button class="button--standard button--envelope">Sign up for FECMail</button>
+          <button class="button--standard button--envelope" type="button">Sign up for FECMail</button>
         </a>
       </div>
     </div>

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -137,7 +137,7 @@
           Washington, DC 20463</p>
 
           <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
-            <button class="button--standard button--envelope">Sign up for FECMail</button>
+            <button class="button--standard button--envelope" type="button">Sign up for FECMail</button>
           </a>
         </div>
       </div>

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -134,7 +134,7 @@
           Washington, DC 20463</p>
 
           <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
-            <button class="button--standard button--envelope">Sign up for FECMail</button>
+            <button class="button--standard button--envelope" type="button">Sign up for FECMail</button>
           </a>
         </div>
       </div>

--- a/fec/home/templates/purgecss-homepage/full.html
+++ b/fec/home/templates/purgecss-homepage/full.html
@@ -861,7 +861,7 @@
               Washington, DC 20463</p>
     
               <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
-                <button class="button--standard button--envelope">Sign up for FECMail</button>
+                <button class="button--standard button--envelope" type="button">Sign up for FECMail</button>
               </a>
             </div>
           </div>

--- a/fec/home/templates/purgecss-homepage/navs.html
+++ b/fec/home/templates/purgecss-homepage/navs.html
@@ -346,7 +346,7 @@
             Washington, DC 20463</p>
   
             <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
-              <button class="button--standard button--envelope">Sign up for FECMail</button>
+              <button class="button--standard button--envelope" type ="button">Sign up for FECMail</button>
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #5573 

This PR adds an explicit type to the footer button so we can upgrade babel and es packages. 

### Required reviewers - 1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  footer

## How to test

1. Navigate to the home page - http://127.0.0.1:8000/ 
2. Scroll down to the footer
3. Click the button that states "Sign up for FECMail"
4. Ensure that the button works still

Other links to try: 
- http://127.0.0.1:8000/calendar/?calendar_category_id=25&calendar_category_id=26&calendar_category_id=27 (base.html)
- http://127.0.0.1:8000/data/raising-bythenumbers/ 
