### PR TITLE
Feature/4988 upgrade circleci docker image pg13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test
 
       # PostgreSQL
-      - image: cimg/postgres:12.8
+      - image: cimg/postgres:13.8
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: "trust"
@@ -31,7 +31,7 @@ jobs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
             sudo apt-get update -qq && sudo apt-get install -y build-essential postgresql-client
-            echo 'export PATH=/usr/lib/postgresql/12.8/bin/:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/lib/postgresql/13.8/bin/:$PATH' >> $BASH_ENV
             echo "en_US.UTF-8 UTF-8" | sudo tee /etc/locale.gen
             sudo locale-gen en_US.UTF-8
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ run into problems please
     * Python (the latest 3.9 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which
       includes `npm`).
-    * PostgreSQL (the latest 12 release).
+    * PostgreSQL (the latest 13 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/).
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/).
-         * Read a [Linux tutorial](https://www.postgresql.org/docs/11/installation.html)
+         * Read a [Linux tutorial](https://www.postgresql.org/docs/13/installation.html)
            (or follow your OS package manager).
 
 2. Set up your Node environment — learn how to do this with 18F’s


### PR DESCRIPTION
## Summary (required)

- Resolves #4988 

This ticket upgrades the circleci postgres docker image from v12.8 to v13.8 (This is the latest compatible 13.X version [documentation](https://circleci.com/developer/images/image/cimg/postgres))

### Required reviewers 1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  circleci postgres docker image

## Related PRs

Related PRs against other branches: [Upgrade Aurora postgresql 10 to Aurora postgresql 13 on dev space openFEC#4993](https://github.com/fecgov/openFEC/issues/4993)


## How to test
- rerun circleci build on feature/4988-upgrade-circleci-docker-image-pg13 branch.
(https://app.circleci.com/pipelines/github/fecgov/fec-cms?branch=feature%2F4988-upgrade-circleci-docker-image-pg13)
- verify the container circleci, install system dependencies tasks on circleci now run on postgres 13.8
- verify that pytests run OK