### PR TITLE
Allow cycle greater than DEFAULT_TIME_PERIOD to show efiling data

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -593,12 +593,11 @@ def get_committee(committee_id, cycle):
             template_variables["spending_summary"] = utils.process_spending_data(totals)
             template_variables["cash_summary"] = utils.process_cash_data(totals)
 
-    # If in the current cycle, check for raw filings in the last three days
-    if cycle == utils.current_cycle():
+    # When cycle >= constants.DEFAULT_TIME_PERIOD, check for raw filings in the last three days
+    if cycle >= constants.DEFAULT_TIME_PERIOD:
         # (4)call efile/filings under tag: efiling
         path = "/efile/filings/"
         filters = {
-            "cycle": cycle,
             "committee_id": committee["committee_id"],
             "min_receipt_date": template_variables["min_receipt_date"]
         }


### PR DESCRIPTION
## Summary (required)
On the committee profile page, we will show Raw filing when cycle is greater than DEFAULT_TIME_PERIOD (now is 2022).

- Resolves #5588 

### Required reviewers
1 dev

## Impacted areas of the application
committee profile page

## How to test
1) checkout branch
2) test urls
http://127.0.0.1:8000/data/committee/C00099259/?tab=filings&cycle=2024
http://127.0.0.1:8000/data/committee/C00766162/?tab=filings
http://127.0.0.1:8000/data/committee/C00781443/?tab=filings
