### PR TITLE
Setup pre-commit git hook

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,0 @@
-# flake8 rules here should mimic those in /pytest.ini
-# /pytest.ini is used by pytest
-# while IDEs like Visual Studio Code and Cornflakes read this file
-[flake8]
-ignore = E127,E128,W503
-max-line-length = 120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: end-of-file-fixer
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+        args: [--line-length=120]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,8 @@
 # The flake8 settings here are used by `/pytest` and `/pytest --linting`
 
 [pytest]
-addopts = --cov=fec fec --flake8 --cov-report term-missing  -ra
+addopts = --cov=fec fec  --cov-report term-missing  -ra
 DJANGO_SETTINGS_MODULE = fec.settings.dev
-flake8-max-line-length = 120
-flake8-ignore = E127 E128 W503
 
 norecursedirs = migrations wagtail_npm_dependencies static
 # norecursedirs are to keep pytest linting from checking

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,6 @@ cg-django-uaa==2.1.4
 coverage==5.5
 pytest==6.2.2
 Faker==0.8.6
-flake8==4.0.1
 pytest-django==3.10.0
 pytest-cov==2.11.1
-pytest-flake8==1.0.7
+pre-commit==2.21.0 #client-side hook triggered by operations like git commit


### PR DESCRIPTION
## Summary (required)

 pre-commit hook is run first, before you even type in a commit message. 
-  inspect the snapshot that's about to be committed
-  to make sure tests run OK
-  inspect the code for linting errors

- Resolves #5578 

pre-commit scripts run automatically every time a file change event occurs in a Git repository

### Required reviewers

2 or more developers

## How to test

- checkout branch: `git checkout feature/5578-setup-precommit-hook`
- create new python virtualenv: `pyenv virtualenv 3.9.14 venv-cms`
- activate python virtualenv: `pyenv activate venv-cms`
- install requirements : `pip install -r requirements.txt` 
- run: `pre-commit install`
-  in case you run into error shown below:
           ```
              [ERROR] Cowardly refusing to install hooks with `core.hooksPath` set.
              hint: `git config --unset-all core.hooksPath`
              ```
     - run: `git config --global --unset-all core.hooksPath` #Unset old global core hooks setting
- update a python file (ex:remove new line at the end of the file)
- stage the changes: `git add -p`
- commit changes:  `git commit` (this is when pre-commit hook will flag changes made to python file and prevent from committing the changes to the branch)
- fix the syntax, stage the file and commit the changes.
