### PR TITLE
fix the snytax error in pre-commit yaml file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@ repos:
     rev: 6.0.0
     hooks:
     -   id: flake8
-        args: [--line-length=120]
+        args: [--max-line-length=120]


### PR DESCRIPTION
## Summary (required)
flake8  flagged snytax error when `git commit` is ran on local branch before pushing the changes. Invalid argument given in pre-commit-config.yaml. 

- Replace  `--line-length` with `--max-line-length` in pre-commit-config.yaml
 

### Required reviewers

one developer


## Screenshots
**Before:** 
```
(venv-cms-dev) F611836M:fec-cms pkasireddy$ git commit
fix end of files.........................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 2

usage: flake8 [options] file file ...
flake8: error: unrecognized arguments: --line-length=120
```

**After:**

```
(venv-cms-dev) F611836M:fec-cms pkasireddy$ git commit
fix end of files.........................................................Passed
flake8...............................................(no files to check)Skipped
[feature/fix-precommit-syntax a52e696b] Update the argument to --max-line-length
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Related PRs
#5578 


## How to test
-  checkout branch
- run `pytest`
- update any python file
- stage the changed file
- run `git commit` (no flake8 error in terminal)
