### PR TITLE
5607 - Election pages methodology buttons

### DIFF
--- a/fec/data/templates/house-senate-overview.jinja
+++ b/fec/data/templates/house-senate-overview.jinja
@@ -23,8 +23,8 @@
     <div id="options" class="container main">
       <div class="sidebar-container sidebar-container--left">
         <div class="js-sticky-side" data-sticky-container="options">
-          <nav class="sidebar sidebar--neutral side-nav js-toc">
-            <ul class="sidebar__content">
+          <nav class="sidebar sidebar--neutral side-nav">
+            <ul class="sidebar__content js-toc">
               {% if FEATURES.house_senate_overview_summary %} 
               <li class="side-nav__item">
                 <a class="side-nav__link" href="#summary">Election summary</a>


### PR DESCRIPTION
## Summary

- Resolves #5607 

The Methodology buttons on [/data/elections/house/](https://www.fec.gov/data/elections/house/) and [/data/elections/senate/](https://www.fec.gov/data/elections/senate/) aren't/weren't working; in addition, the console is showing a warning and 1-2 errors

HT @johnnyporkchops for the research and solution!

### Required reviewers

A front-end or UX

## Impacted areas of the application

The House and Senate election pages

## Screenshots

No visible changes

## Related PRs

None

## How to test

- Open the House or Senate election pages for localhost (linked below) or Production (linked above)
   - Check the console that there's a warning (yellow) and 1-2 errors (red)
   - Click any/all of the Methodology buttons—they should do nothing
- Pull the branch
- `npm run build`
- Open the [House](http://127.0.0.1:8000/data/elections/house/) or [Senate](http://127.0.0.1:8000/data/elections/senate/) election pages for localhost
   - [ ] Check that the console is empty
   - [ ] Click any of the Methodology buttons–they should open their related methodology
   - [ ] Scroll the page to the bottom and make sure the "Explore U.S. Senate election data" button in the side column stays docked under and with the side nav

