### PR TITLE
Fix toc menu highlight bug

### DIFF
--- a/fec/fec/static/js/modules/toc.js
+++ b/fec/fec/static/js/modules/toc.js
@@ -22,6 +22,21 @@ function TOC(selector) {
   this.watchers = this.addWatchers();
   this.$menu.on('click', 'a', this.scrollTo.bind(this));
   $(window).on('resize', this.updateWatchers.bind(this));
+
+  // Handle inbound URL with hash
+  if (window.location.hash) {
+    var self = this;
+    /**
+    Call updateWatchers and scrollTo in 0-second setTimeout to
+    move to end of browser stack. This avoids intermittent/breaking
+    race condifion where inbound hash goes to its location before
+    TOC can respond to the scroll.
+    */
+    setTimeout(function() {
+     self.updateWatchers();
+    window.scrollTo(0, $(window.location.hash).offset().top + 20);
+    }, 0);
+   }
 }
 
 TOC.prototype.getSections = function() {
@@ -56,7 +71,7 @@ TOC.prototype.scrollTo = function(e) {
   e.preventDefault();
   var $link = $(e.target);
   var section = $link.attr('href');
-  var sectionTop = $(section).offset().top + 10;
+  var sectionTop = $(section).offset().top + 20;
   $('body, html').animate({
     scrollTop: sectionTop
   });

--- a/fec/fec/tests/js/toc.js
+++ b/fec/fec/tests/js/toc.js
@@ -50,7 +50,7 @@ describe('Table of contents', function() {
   it('scrolls to an item on click', function() {
     var $secondItem = this.toc.$menu.find('a[href="#section-2"]');
     var animate = sinon.spy($.prototype, 'animate');
-    var top = $('#section-2').offset().top + 10;
+    var top = $('#section-2').offset().top + 20;
     this.toc.scrollTo({target: $secondItem, preventDefault: function() {}});
     expect(animate).to.have.been.calledWith({scrollTop: top});
     animate.restore();


### PR DESCRIPTION
## Summary (required)
Links to TOC pages with a hash suffixed to the URL now land in the right location on page and highlight correct menu button

- Resolves issue #5532

### Required reviewers

one frontend or content

## Impacted areas of the application

	modified:   fec/static/js/modules/toc.js
	modified:   fec/tests/js/toc.js



Related PRs against other branches:

## How to test

Content team can test this on dev:
Examples:
- https://dev.fec.gov/legal-resources/policy-other-guidance/#interpretive-rules
- https://dev.fec.gov/legal-resources/policy-other-guidance/#proposals
This was also tested on the new menus on house and senate overview pages where the toc.js functionality is also used.

