### PR TITLE
5622-Add 2023-2024 links

### DIFF
--- a/fec/data/templates/partials/browse-data/bulk-data.jinja
+++ b/fec/data/templates/partials/browse-data/bulk-data.jinja
@@ -8,6 +8,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2024/weball24.zip">2023–2024</a></li>          
             <li><a href="/files/bulk-downloads/2022/weball22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/weball20.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/weball18.zip">2017–2018</a></li>
@@ -41,6 +42,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2024/cn24.zip">2023–2024</a></li>          
             <li><a href="/files/bulk-downloads/2022/cn22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/cn20.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/cn18.zip">2017–2018</a></li>
@@ -74,6 +76,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2024/ccl24.zip">2023–2024</a></li>            
             <li><a href="/files/bulk-downloads/2022/ccl22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/ccl20.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/ccl18.zip">2017–2018</a></li>
@@ -97,6 +100,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2024/webl24.zip">2023–2024</a></li>            
             <li><a href="/files/bulk-downloads/2022/webl22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/webl20.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/webl18.zip">2017–2018</a></li>
@@ -121,6 +125,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2024/cm24.zip">2023–2024</a></li>
             <li><a href="/files/bulk-downloads/2022/cm22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/cm20.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/cm18.zip">2017–2018</a></li>
@@ -154,6 +159,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2024/webk24.zip">2023–2024</a></li>            
             <li><a href="/files/bulk-downloads/2022/webk22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/webk20.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/webk18.zip">2017–2018</a></li>
@@ -178,6 +184,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2024/indiv24.zip">2023–2024</a></li>
             <li><a href="/files/bulk-downloads/2022/indiv22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/indiv20.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/indiv18.zip">2017–2018</a></li>
@@ -211,6 +218,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2024/pas224.zip">2023–2024</a></li>          
             <li><a href="/files/bulk-downloads/2022/pas222.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/pas220.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/pas218.zip">2017–2018</a></li>
@@ -243,6 +251,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered u-margin--bottom">
+            <li><a href="/files/bulk-downloads/2024/oth24.zip">2023–2024</a></li>            
             <li><a href="/files/bulk-downloads/2022/oth22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/oth20.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/oth18.zip">2017–2018</a></li>
@@ -276,6 +285,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2024/oppexp24.zip">2023–2024</a></li>            
             <li><a href="/files/bulk-downloads/2022/oppexp22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/oppexp20.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/oppexp18.zip">2017–2018</a></li>

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -16,6 +16,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2024/candidate_summary_2024.csv">2023–2024</a></li>                  
                   <li><a href="/files/bulk-downloads/2022/candidate_summary_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/candidate_summary_2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/2018/candidate_summary_2018.csv">2017–2018</a></li>
@@ -177,6 +178,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2024/Form2Filer_2024.csv">2023–2024</a></li>
                   <li><a href="/files/bulk-downloads/2022/Form2Filer_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/Form2Filer_2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/2018/Form2Filer_2018.csv">2017–2018</a></li>

--- a/fec/data/templates/partials/browse-data/committees.jinja
+++ b/fec/data/templates/partials/browse-data/committees.jinja
@@ -16,6 +16,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2024/committee_summary_2024.csv">2023–2024</a></li>                  
                   <li><a href="/files/bulk-downloads/2022/committee_summary_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/committee_summary_2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/2018/committee_summary_2018.csv">2017–2018</a></li>
@@ -51,6 +52,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/data.fec.gov/leadership2024.csv">2023–2024</a></li>
                   <li><a href="/files/bulk-downloads/data.fec.gov/leadership2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/data.fec.gov/leadership2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/data.fec.gov/leadership2018.csv">2017–2018</a></li>
@@ -76,7 +78,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/data.fec.gov/lobbyist.csv">2007–2022</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/lobbyist.csv">2007–2024</a></li>
                 </ul>
                 <p class="u-margin--top"><a href="/campaign-finance-data/lobbyistregistrant-committees-file-description">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
               </div>
@@ -97,6 +99,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2024/Form1Filer_2024.csv">2023-2024</a></li>
                   <li><a href="/files/bulk-downloads/2022/Form1Filer_2022.csv">2021-2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/Form1Filer_2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/2018/Form1Filer_2018.csv">2017–2018</a></li>

--- a/fec/data/templates/partials/browse-data/filings-reports.jinja
+++ b/fec/data/templates/partials/browse-data/filings-reports.jinja
@@ -69,7 +69,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/data.fec.gov/UnverifiedCommittees.csv">2016–2022</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/UnverifiedCommittees.csv">2016–2024</a></li>
                 </ul>
                 <p class="u-margin--top"><a href="/campaign-finance-data/unverified-filers-file-description">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
               </div>

--- a/fec/data/templates/partials/browse-data/raising.jinja
+++ b/fec/data/templates/partials/browse-data/raising.jinja
@@ -30,7 +30,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                  <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/data.fec.gov/lobbyist_bundle.csv">2009–2022</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/lobbyist_bundle.csv">2009–2024</a></li>
                 </ul>
                 <p class="u-margin--top"><a href="/campaign-finance-data/lobbyist-bundled-contributions-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
               </div>

--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -25,6 +25,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2024/independent_expenditure_2024.csv">2023–2024</a></li>                  
                   <li><a href="/files/bulk-downloads/2022/independent_expenditure_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/independent_expenditure_2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/2018/independent_expenditure_2018.csv">2017–2018</a></li>
@@ -59,6 +60,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2024/ElectioneeringComm_2024.csv">2023–2024</a></li>
                   <li><a href="/files/bulk-downloads/2022/ElectioneeringComm_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/ElectioneeringComm_2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/2018/ElectioneeringComm_2018.csv">2017–2018</a></li>
@@ -86,6 +88,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2024/CommunicationCosts_2024.csv">2023–2024</a></li>
                   <li><a href="/files/bulk-downloads/2022/CommunicationCosts_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/CommunicationCosts_2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/2018/CommunicationCosts_2018.csv">2017–2018</a></li>


### PR DESCRIPTION
## Summary (required)

- Resolves #5622 

Adds the links for the 2023-2024 bulk data sets.

### Required reviewers
1 dev

## Impacted areas of the application
bulk download section


## Screenshots
Before:
![Screen Shot 2023-02-24 at 9 49 41 AM](https://user-images.githubusercontent.com/66386084/221208517-c7cc3a8b-73ce-4ad2-b76a-8a517665a128.png)

After:
![Screen Shot 2023-02-24 at 9 50 26 AM](https://user-images.githubusercontent.com/66386084/221208655-ac82b2e3-6434-41ef-8be3-dcca4c98ce00.png)



## How to test

- pyenv virtualenv 3.9.15 test-links
- pyenv activate test-links
- pip install -r requirements.txt
- nvm install 18.13
- npm i &&  npm run build
- cd fec
- ./manage.py runserver


