### PR TITLE
5593-upgrade ua-parser-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "topojson-client": "^3.1.0",
         "tough-cookie": "^2.5.0",
         "tunnel-agent": "^0.6.0",
-        "ua-parser-js": "^0.7.24",
+        "ua-parser-js": "^0.7.33",
         "whatwg-fetch": "^3.5.0"
       },
       "devDependencies": {
@@ -16661,9 +16661,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.32",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
       "funding": [
         {
           "type": "opencollective",
@@ -32147,9 +32147,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
-      "version": "0.7.32",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw=="
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
     },
     "uglify-js": {
       "version": "3.6.7",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "topojson-client": "^3.1.0",
     "tough-cookie": "^2.5.0",
     "tunnel-agent": "^0.6.0",
-    "ua-parser-js": "^0.7.24",
+    "ua-parser-js": "^0.7.33",
     "whatwg-fetch": "^3.5.0"
   },
   "devDependencies": {
@@ -140,7 +140,7 @@
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-manifest-plugin": "^1.3.1"
   },
-"watch": {
+  "watch": {
     "build-js": {
       "extensions": "js,hbs",
       "patterns": "./fec/fec/static/js/**"


### PR DESCRIPTION
## Summary (required)

- Resolves #5593 

Upgrades ua-parser-ja to remediate snyk vulnerability

### Required reviewers

1-2 dev

## How to test

-  check out this branch
- activate your virtual env
- pip install -r requirements.txt
- rm -rf node_modules
- nvm install 18.13.0
- npm i &&  npm run build
- snyk test    (should just see one rangy vulnerability)
- pytest
- cd fec &&  python manage.py runserver

    
