### PR TITLE
Add robots.txt for prod 

### DIFF
--- a/fec/fec/templates/robots_prod.txt
+++ b/fec/fec/templates/robots_prod.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /search/*?query=*
+Disallow: /data/legal/search/*?search=*
+Disallow: /data/search/*?search=*

--- a/fec/fec/templates/robots_prod.txt
+++ b/fec/fec/templates/robots_prod.txt
@@ -1,4 +1,4 @@
 User-agent: *
-Disallow: /search/*?query=*
-Disallow: /data/legal/search/*?search=*
-Disallow: /data/search/*?search=*
+Disallow: /search/?*
+Disallow: /data/legal/search/?*
+Disallow: /data/search/?*

--- a/fec/fec/tests/test_robots.py
+++ b/fec/fec/tests/test_robots.py
@@ -17,15 +17,22 @@ def reload_url_conf():
 
 class TestRobots(TestCase):
 
-    def test_robots_txt_returns_200_stage(self):
+    def test_robots_txt_contains_disallow_stage(self):
 
         with self.settings(FEC_CMS_ENVIRONMENT='STAGING'):
             response = self.client.get('/robots.txt')
+            self.assertContains(
+                        response,
+                        "Disallow",
+                        count=None,
+                        status_code=200,
+                        msg_prefix='\"Disallow\" not found in response',
+                        html=False)
             self.assertEqual(response.status_code, 200)
 
-    def test_robots_txt_throws_404(self):
+    def test_robots_txt_exists(self):
 
         with self.settings(FEC_CMS_ENVIRONMENT='PRODUCTION'):
             reload_url_conf()
             response = self.client.get('/robots.txt')
-            self.assertEqual(response.status_code, 404)
+            self.assertEqual(response.status_code, 200)

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -22,14 +22,17 @@ urlpatterns = [
     re_path(r'^auth/', include(uaa_urls)),
     re_path(r'^admin/', include(wagtailadmin_urls)),
     re_path(r'^calendar/$', home_views.calendar),
-    re_path(r'^about/leadership-and-structure/commissioners/$', home_views.commissioners),
+    re_path(r'^about/leadership-and-structure/commissioners/$',
+            home_views.commissioners),
     re_path(r'^documents/', include(wagtaildocs_urls)),
-    re_path(r'^help-candidates-and-committees/question-rad/$', home_views.contact_rad),
+    re_path(r'^help-candidates-and-committees/question-rad/$',
+            home_views.contact_rad),
     re_path(r'^help-candidates-and-committees/guides/$', home_views.guides),
     re_path(r'^meetings/$', home_views.index_meetings, name="meetings_page"),
     re_path(r'^search/$', search_views.search, name='search'),
-    re_path(r'^legal-resources/policy-and-other-guidance/guidance-documents/$', search_views.policy_guidance_search,
-        name='policy-guidance-search'),
+    re_path(r'^legal-resources/policy-and-other-guidance/guidance-documents/$',
+            search_views.policy_guidance_search,
+            name='policy-guidance-search'),
     re_path(r'^updates/$', home_views.updates),
     re_path(r'', include('data.urls')),  # URLs for /data
     re_path(r'', include('legal.urls')),  # URLs for legal pages
@@ -53,11 +56,20 @@ if settings.FEC_CMS_ENVIRONMENT != 'LOCAL':
     # admin/login always must come before admin/, so place at beginning of list
     urlpatterns.insert(0, re_path(r'^admin/login', uaa_views.login, name='login'))
 
+# robots.txt configurations vary depending on environment
 if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION':
     urlpatterns += re_path(
         r'^robots\.txt$',
         TemplateView.as_view(
             template_name='robots.txt',
+            content_type='text/plain'
+        ),
+    ),
+elif settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION':
+    urlpatterns += re_path(
+        r'^robots\.txt$',
+        TemplateView.as_view(
+            template_name='robots_prod.txt',
             content_type='text/plain'
         ),
     ),


### PR DESCRIPTION
## Summary

- Resolves https://github.com/fecgov/fec-accounts/issues/466 

Add robots.txt for prod with disallow statements for dynamic search result queries and fix flake8 syntax issues

Google developer documentation on [useful robots.txt rules](https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt#useful-robots.txt-rules). This is what was referenced to create the disallow statements.

### Required reviewers

2 developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  robots.txt

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/5522-sitemap | [link](https://github.com/fecgov/fec-cms/pull/5579)

## How to test

- Checkout this branch
- `./manage.py runserver`
- Check robots.txt for local and lower environments: http://localhost:8000/robots.txt. This should disallow all search engine indexing.
- Stop the CMS app
- Add `export FEC_CMS_ENVIRONMENT=prod` to simulate production dependencies
- `./manage.py runserver`
- Check robots.txt again (http://localhost:8000/robots.txt), it should be the production environment configurations. This will disallow indexing of dynamic search queries on our search results page.