### PR TITLE
Fix legal resources seach 

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -68,15 +68,13 @@ def load_search_results(query, query_type=None):
 def load_legal_search_results(query, query_type="all", offset=0, limit=20, **kwargs):
     filters = dict((key, value) for key, value in kwargs.items() if value)
 
-    # Apply specific parameters if only looking for one type
-    if query or query_type != "all":
-        filters["hits_returned"] = limit
+    # Apply type filter if only looking for one type
+    if query_type != "all":
         filters["type"] = query_type
-        filters["from_hit"] = offset
 
-        if query:
-            filters["q"] = query
-
+    filters["hits_returned"] = limit
+    filters["from_hit"] = offset
+    filters["q"] = query
     results = _call_api("legal", "search", **filters)
     results["limit"] = limit
     results["offset"] = offset


### PR DESCRIPTION
## Summary (required)

- Resolves #5668 

Legal Search with type 'all' is currently broken. This PR fixes the current issue by removing the type filter when searching for all document types

### Required reviewers

1-2 devs

## Impacted areas of the application

-  Legal Search

## How to test

- activate your virtual environment
- cd fec
- cd python manage.py runserver
- http://127.0.0.1:8000/data/legal/search/?search_type=all&search=102.2
- or deploy to dev
- https://dev.fec.gov/data/legal/search/?search_type=all&search=102.2
- https://www.fec.gov/data/legal/search/?search_type=all&search=102.2
- pytest
Test other searches 