### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Word wrapping, mostly committee name

### DIFF
--- a/fec/fec/static/scss/components/_data-container.scss
+++ b/fec/fec/static/scss/components/_data-container.scss
@@ -83,12 +83,12 @@
 // Data-container shrinks and floats
 @include media($lg) {
   .data-container__wrapper {
-    display: table;
+    display: flex;
+    flex-direction: row;
     width: 100%;
   }
 
   .data-container {
-    display: table-cell;
     width: calc(100% - 4rem);
     padding: 0;
   }
@@ -96,7 +96,6 @@
   .is-showing-filters {
     .data-container {
       width: calc(100% - 30rem);
-      display: table-cell;
     }
   }
 

--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -130,6 +130,17 @@
   }
 
   td {
+    max-width: max(9em, 20vw);
+    word-wrap: break-word;
+
+    @include media($med) {
+      max-width: max(9em, 30vw);
+    }
+    
+    @include media($lg) {
+      max-width: max(13em, 20vw);
+    }
+
     @include transition(padding-left, 0.2s);
     padding: u(1rem);
     border-left: 1px solid $neutral;

--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -51,10 +51,6 @@
   position: relative;
 }
 
-.dataTables_wrapper--panel {
-  overflow-x: hidden;
-}
-
 // Sortable headers
 
 .data-table {

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -195,7 +195,8 @@
   }
 
   [type="checkbox"] + label {
-    max-width: 90%;
+    max-width: min(18em, 90%);
+    word-wrap: break-word;
   }
 
   .dropdown__remove {

--- a/fec/fec/static/scss/components/_entity-header.scss
+++ b/fec/fec/static/scss/components/_entity-header.scss
@@ -55,6 +55,7 @@
   border-bottom: none;
   font-weight: bold;
   margin-bottom: 0;
+  word-wrap: break-word;
 }
 
 .entity__type {

--- a/fec/fec/static/scss/components/_messages.scss
+++ b/fec/fec/static/scss/components/_messages.scss
@@ -46,6 +46,10 @@
   @include u-icon-bg($info-circle, $primary);
 }
 
+p {
+  word-wrap: break-word;
+}
+
 .message--alert__bottom {
   border-top: 1px solid $gray;
   margin-top: u(1rem);

--- a/fec/fec/static/scss/components/_posts.scss
+++ b/fec/fec/static/scss/components/_posts.scss
@@ -26,6 +26,7 @@
 
   h3 {
     margin-bottom: u(.4rem);
+    word-wrap: break-word;
   }
 
   p {

--- a/fec/fec/static/scss/components/_search-bar.scss
+++ b/fec/fec/static/scss/components/_search-bar.scss
@@ -238,6 +238,11 @@ $search-button-width: u(5.6rem);
   }
 }
 
+.tt-suggestion__name.tt-suggestion {
+  display: block;
+  word-wrap: break-word;
+}
+
 .tt-suggestion__name.tt-suggestion__name {
   color: $base;
 }

--- a/fec/fec/static/scss/components/_side-nav.scss
+++ b/fec/fec/static/scss/components/_side-nav.scss
@@ -118,7 +118,14 @@
   @include media($med) {
     display: table-cell;
     width: 250px;
+
+    // All section siblings within .data-container__wrapper  
+    // will now get this width. These navs are using 250px widths.
+    & ~ section {
+      width: calc(100% - 250px);
+    }
   }
+
 }
 
 @include media($med) {

--- a/fec/fec/static/scss/components/_tags.scss
+++ b/fec/fec/static/scss/components/_tags.scss
@@ -70,6 +70,10 @@
   margin: u(.5rem .5rem 0 0);
 
   .tag__item {
+    line-height: 1.25em;
+    max-width: 15em;
+    word-wrap: break-word;
+    
     @extend .tag;
     position: relative;
 


### PR DESCRIPTION
## Summary

- Resolves #issue_number

Fixing lots of word wraps across the site.

### Required reviewers

- code approver
- appearance approver

## Impacted areas of the application

- Multiple additions of `word-wrap: break-word;` site-wide. In addition:
- Every datatable <td> now has a maximum width
- On committee pages, there are now width limits for the page title (committee name) 
- On committee pages, About this committee, the values column now has width limits
- Datatable lookup ("Typeahead") filters now have width limits
- Site search ("Typeahead") in the upper nav now has width limits
- Search page results now have width limits
- Seems like there are more

## Screenshots
| Before | After |
| :----: | :----: |
| ![image](https://user-images.githubusercontent.com/26720877/227352152-df498ed1-629b-4c05-bfa6-fe46b272250f.png) | ![image](https://user-images.githubusercontent.com/26720877/227352278-d5b879be-856f-44e3-bc83-86ad9f6e02a4.png) |
| ![image](https://user-images.githubusercontent.com/26720877/227352606-1acaa396-e8ca-4d2b-9d7e-9c4b7ce923ff.png) | ☝🏼  |
| ![image](https://user-images.githubusercontent.com/26720877/227353106-ca372cdc-ec17-451a-b90c-e7f79b61930f.png) | ![image](https://user-images.githubusercontent.com/26720877/227353206-3f396e3e-7e8c-4db1-90d1-898a19e1468d.png) |
| ![image](https://user-images.githubusercontent.com/26720877/227353484-8241026d-8fa4-4f64-a0ee-9c58956ff91c.png) | ![image](https://user-images.githubusercontent.com/26720877/227353626-0cf26fa8-17f7-4078-9659-f52d395b63ba.png) |
| ![image](https://user-images.githubusercontent.com/26720877/227353905-52755d41-a2e6-4928-a928-a3a1b319e6b0.png) | ![image](https://user-images.githubusercontent.com/26720877/227353998-79e47416-a6bb-4b76-bd00-7014fe59d3a9.png) |
| ![image](https://user-images.githubusercontent.com/26720877/227354956-2b2bbfc7-6c19-4390-9ab7-df2c8960a75a.png) | ☝🏼 |
| ![image](https://user-images.githubusercontent.com/26720877/227355457-eefbbd29-177e-4674-a54e-807e86ed7803.png) | ![image](https://user-images.githubusercontent.com/26720877/227355521-49680afb-b048-446b-9cc8-e00180849cd3.png) |
| ![image](https://user-images.githubusercontent.com/26720877/227355855-8623a10a-d645-4005-b9b3-acb32bc6a01c.png) | ![image](https://user-images.githubusercontent.com/26720877/227356644-00cbc88b-ea2c-4609-b742-4ee06974b67a.png) |
| ![image](https://user-images.githubusercontent.com/26720877/227356938-a038dd00-d35e-4046-9d18-f697f7c3ef52.png) | ![image](https://user-images.githubusercontent.com/26720877/227357045-759c651e-a3c8-4cd0-a8a2-f198facc0384.png) |
| ![image](https://user-images.githubusercontent.com/26720877/227357293-7dc3fcb0-8fa0-46e9-bb3f-4ae850023f9e.png) | ![image](https://user-images.githubusercontent.com/26720877/227357330-f66b4c1a-35ad-474f-a100-226275a22ccc.png) |

## Related PRs

None

## How to test

To see it broken, check
[https://www.fec.gov/data/committees/]()
- Look for the really long committee names (broken table, skewed left column)
- Filter the table by one of those committee names (broken lookup, broken filter in left column, broken tag above table, broken table)
- Click that committee name (broken committee page name)
- Do a search for one of those committee names (broken search results page)

To test the fix:
- Pull the branch
- `npm run build`
- `./manage.py runserver`

**ON MULTIPLE WIDTHS:**

- Check [localhost committees](http://127.0.0.1:8000/data/committees/)
   - Make sure the table columns look good across the widths
   - Check the lookup on the left while looking for one of those super long committee names
- Filter the table(s) by a super long committee name
   - Is the filter on the left column correctly sized?
   - Is the tag above the table correct?
- Click a committee name to go to that committee's page
   - Make sure the title of the page (the committee name) looks right
   - About this committee: make sure committee and treasurer name are correct
- Do a search for a long committee
   - Make sure search results look right

**OTHER BREAKING CHANGES?**
Are there other places these changes might adversely affect the appearance? Tables with fewer (or many more) columns? Unusual search results or filtering…?