### PR TITLE
Add width setting for .filters.is-open + .content__section

### DIFF
--- a/fec/fec/static/scss/components/_filters.scss
+++ b/fec/fec/static/scss/components/_filters.scss
@@ -342,6 +342,10 @@ $filter-button-width: u(4.6rem);
           display: block;
         }
       }
+      
+      & + .content__section {
+        width: calc(100% - 30rem);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5675 

Add a width for `.content__section` when the filter panel is open.

### Required reviewers

1 front end

## Impacted areas of the application

General components of the application that this PR will affect:

-  MUR search filter panel
- Admin fines search filter panel

## Screenshots

| Before | After |
| :----: | :----: |
| ![image](https://user-images.githubusercontent.com/12799132/228085555-8d1afb63-3ea1-44d9-ab7d-b9ae9438ab68.png) | ![image](https://user-images.githubusercontent.com/12799132/228088658-9797cb06-0013-4bce-8757-d9fe06b5f7d1.png) |
| ![image](https://user-images.githubusercontent.com/12799132/228085568-d6a5cfa9-695a-4c79-b805-5d2319924d76.png) | <![image](https://user-images.githubusercontent.com/12799132/228088965-fb3c50f3-c23c-488c-be84-cb5816d7edff.png) |

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
hotfix/committee-name-wordwraps | [link](https://github.com/fecgov/fec-cms/pull/5674)

## How to test

- Since [related hotfix](https://github.com/fecgov/fec-cms/pull/5674) changes are on the master branch, make sure you checkout master and do a `git pull` to make sure you have the latest. 
- Checkout this branch and get the master branch changes into this PR for testing by doing `git rebase master`. DO NOT commit any rebased changes, this is simply for testing this PR to apply all the necessary changes.
-  `npm run build-sass`
- `cd fec && ./manage.py runserver`
     - Ensure that the filter panels are now of appropriate width for the [MUR](http://127.0.0.1:8000/data/legal/search/enforcement/) and [AF](http://127.0.0.1:8000/data/legal/search/admin_fines/) filter panels.