### PR TITLE
Remove rangy

### DIFF
--- a/fec/fec/wagtail_npm_dependencies/rangy
+++ b/fec/fec/wagtail_npm_dependencies/rangy
@@ -1,1 +1,0 @@
-../../../node_modules/rangy

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "numeral": "^1.5.3",
         "perfect-scrollbar": "0.6.2",
         "prop-types": "^15.7.2",
-        "rangy": "^1.3.0",
         "react": "^16.8.2",
         "react-dom": "^16.8.2",
         "react-input-mask": "^2.0.3",
@@ -13953,11 +13952,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/rangy": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rangy/-/rangy-1.3.0.tgz",
-      "integrity": "sha1-t8mnCuoF5djNx0qNTIJz1pcnGQQ="
     },
     "node_modules/raw-body": {
       "version": "2.4.0",
@@ -29929,11 +29923,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
-    },
-    "rangy": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rangy/-/rangy-1.3.0.tgz",
-      "integrity": "sha1-t8mnCuoF5djNx0qNTIJz1pcnGQQ="
     },
     "raw-body": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "numeral": "^1.5.3",
     "perfect-scrollbar": "0.6.2",
     "prop-types": "^15.7.2",
-    "rangy": "^1.3.0",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
     "react-input-mask": "^2.0.3",


### PR DESCRIPTION
## Summary (required)

- Resolves #5635 

This ticket resolves the vulnerability by removing the rangy package, which is no longer used in the project. It was previously used in the wagtail_hooks.py file. 

### Required reviewers 1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

- package.json 

## How to test
1. Checkout this branch 
2. `rm -rf node_modules`
3.  `npm install`
4.  `npm run build`
5.  `snyk test`
6.  `pytest`
7. `cd fec`
8. `python manage.py runserver`
