### PR TITLE
[MERGE WITH GIT FLOW] Hotfix/use new codecov uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
             sudo rm -rf .env
             python3 -m venv .env
             . .env/bin/activate
-            pip install -U pip setuptools wheel codecov
             pip install -r requirements.txt
 
       - run:
@@ -86,10 +85,17 @@ jobs:
             pytest
 
       - run:
-          name: Perform post-test work
+          name: Upload coverage report to codecov
           command: |
             . .env/bin/activate
-            codecov
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+            ./codecov -t ${CODECOV_TOKEN} -v
             cd fec; DJANGO_SETTINGS_MODULE=fec.settings.production python manage.py collectstatic --noinput -v 0
 
       - store_artifacts:

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ boto3==1.7.21
 cg-django-uaa==2.1.4
 
 # Testing
-coverage==5.5
+coverage==7.0.3
 pytest==6.2.2
 Faker==0.8.6
 pytest-django==3.10.0


### PR DESCRIPTION
## Summary 

- Resolves https://github.com/fecgov/openFEC/issues/5400 

Our deploys are failing because codecov removed/deprecated their uploader package. To fix this, we have to move to their new [universal uploader](https://docs.codecov.com/docs/codecov-uploader).

### Required reviewers - 1-2 developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  circleci pipeline 
- requirements.txt


## How to test

- view pipeline on circleCI: hhttps://app.circleci.com/pipelines/github/fecgov/fec-cms/2590/workflows/5ab27894-dfd2-4ed3-a258-82db62343796/jobs/5952

- view codecov report: https://app.codecov.io/github/fecgov/fec-cms/commit/556dcb6be61cd8e7cc5e2aee472fb7fdedf1c506

Other way to test: 

1. Create new branch based off of this branch : `git branch <new-branch-name> hotfix/use-new-codecov-uploader` 
2. Make any change to the code
3. Commit changes and push branch 
4. View pipeline in circle ci and ensure that the step "Upload coverage report to codecov" is successful 
5. Check that report is successfully uploaded to codecov 
6. Create a test pull request, ensure that codecov bot leaves a comment 

