### PR TITLE
Update district map cutoff to 2024

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -8,7 +8,7 @@ END_YEAR = 2024
 DEFAULT_TIME_PERIOD = 2024  # Change after the April quarterly report (4/15/25)
 DEFAULT_ELECTION_YEAR = 2024  # Change after election day (11/5/24)
 DEFAULT_PRESIDENTIAL_YEAR = 2024  # Change after April quarterly after mid-terms (4/15/25)
-DISTRICT_MAP_CUTOFF = 2018  # The year we show district maps for on election pages
+DISTRICT_MAP_CUTOFF = 2024  # The year we show district maps for on election pages
 
 states = OrderedDict([
     ('AL', 'Alabama'),


### PR DESCRIPTION
## Summary (required)

In order to deploy a hotfix, I needed to revert this to 2018 so that it wouldn't get deployed premature of the actual release going out next week on 4/25. This PR changes the `DISTRICT_MAP_CUTOFF` back to 2024 so that the release cut for 4/25 will have this update.