### PR TITLE
Hotfix/5701 add 2024 pres export links

### DIFF
--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -83,11 +83,12 @@
           <button type="button" class="js-accordion-trigger accordion__button">Presidential candidate map exports</button>
           <div class="accordion__content">
             <p>This data summarizes financial information disclosed by presidential candidates who have reported at least $100,000 in contributions from individuals <strong>other than the candidate</strong>.</p>
-            <p>The 2020 files contain financial activity through {{ monthly_coverage_date }} for presidential monthly filers and through {{ quarterly_coverage_date }} for presidential quarterly filers.</p>
+            <p>The {{ default_presidential_year }} files contain financial activity through the most recent filing. The historical files contain financial activity through December 31 of the corresponding election year.</p>
             <h6 class="t-no-rules">Overall candidate summary</h6>
             <i class="icon i-download icon--absolute--left"></i>
             <div class="content__section--indent-left">
               <ul class="list--flat-bordered u-no-margin">
+                <li><a href="/files/bulk-downloads/Presidential_Map/2024/2024_overall_summary.csv">2024</a></li>
                 <li><a href="/files/bulk-downloads/Presidential_Map/2020/2020_overall_summary.csv">2020</a></li>
                 <li><a href="/files/bulk-downloads/Presidential_Map/2016/2016_overall_summary.csv">2016</a></li>
                 <li><a href="/files/bulk-downloads/Presidential_Map/2012/2012_overall_summary.csv">2012</a></li>
@@ -98,6 +99,7 @@
             <i class="icon i-download icon--absolute--left"></i>
             <div class="content__section--indent-left">
               <ul class="list--flat-bordered u-no-margin">
+                <li><a href="/files/bulk-downloads/Presidential_Map/2024/Contributions_by_Size.csv">2024</a></li>
                 <li><a href="/files/bulk-downloads/Presidential_Map/2020/Contributions_by_Size.csv">2020</a></li>
                 <li><a href="/files/bulk-downloads/Presidential_Map/2016/Contributions_by_Size.csv">2016</a></li>
                 <li><a href="/files/bulk-downloads/Presidential_Map/2012/Contributions_by_Size.csv">2012</a></li>
@@ -108,6 +110,7 @@
             <i class="icon i-download icon--absolute--left"></i>
             <div class="content__section--indent-left">
               <ul class="list--flat-bordered u-no-margin">
+                <li><a href="/files/bulk-downloads/Presidential_Map/2024/Contributions_by_3Zip.csv">2024</a></li>
                 <li><a href="/files/bulk-downloads/Presidential_Map/2020/Contributions_by_3Zip.csv">2020</a></li>
                 <li><a href="/files/bulk-downloads/Presidential_Map/2016/Contributions_by_3Zip.csv">2016</a></li>
                 <li><a href="/files/bulk-downloads/Presidential_Map/2012/Contributions_by_3Zip.csv">2012</a></li>

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -114,6 +114,7 @@ def search(request):
 def browse_data(request):
     monthly_coverage_date = utils.get_presidential_coverage_date("M")
     quarterly_coverage_date = utils.get_presidential_coverage_date("Q")
+    default_presidential_year = constants.DEFAULT_PRESIDENTIAL_YEAR
     return render(
         request,
         "browse-data.jinja",
@@ -123,6 +124,7 @@ def browse_data(request):
             "social_image_identifier": "data",
             "monthly_coverage_date": monthly_coverage_date,
             "quarterly_coverage_date": quarterly_coverage_date,
+            "default_presidential_year": default_presidential_year,
         },
     )
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5701 

- 2024 links for presidential candidate map exports is added
- Update the coverage date sentence

### Required reviewers

1 reviewer

## Screenshots

<img width="691" alt="Screen Shot 2023-04-18 at 1 39 18 PM" src="https://user-images.githubusercontent.com/12799132/232859459-04bca3dd-68ba-4c01-89f9-25e9a8095a41.png">


## How to test

- Check the Presidential map candidate exports box to make sure that the 2024 links and the sentence is updated according to the ticket
http://127.0.0.1:8000/data/browse-data/?tab=candidates

