### PR TITLE
Contribs map - initial sort by individual_itemized_contributions

### DIFF
--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -339,7 +339,7 @@ ContributionsByState.prototype.loadInitialData = function() {
   let instance = this;
 
   let highestRaisingQuery = Object.assign({}, this.baseStatesQuery, {
-    sort: '-receipts',
+    sort: '-individual_itemized_contributions',
     per_page: 1,
     sort_hide_null: true
   });


### PR DESCRIPTION
## Summary

We're changing the sort key of the Where Contributions Come From map


### Required reviewers

1?

## Impacted areas of the application

The WCCF map

## Screenshots

Should be no visible differences
<img width="850" alt="image" src="https://user-images.githubusercontent.com/26720877/233112585-21a8b2f2-69b4-4767-addc-f79572203a34.png">

## Related PRs

none

## How to test

- pull the branch
- `npm run build-js`
- `./manage.py runserver`
- for [Raising btn](http://127.0.0.1:8000/data/raising-bythenumbers/), make sure the map loads a candidate with numbers to show

