### PR TITLE
Corrects styling of AM to a.m. for open meeting first paragraph

### DIFF
--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -37,7 +37,7 @@
     </header>
 
     {% if self.meeting_type == 'O' %}
-      <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:30 AM</p>
+      <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:30 a.m.</p>
       <p>Members of the public can attend any open meeting or hearing in person. Open meetings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.</p>
     {% elif self.meeting_type == 'E' %}
       <p>The Commission meets regularly in executive sessions to discuss pending enforcement actions, litigation and other matters that, by law, must be kept confidential.</p>


### PR DESCRIPTION
## Summary (required)

- Resolves #5698 

Updates the first sentence of the open meeting page template to correct AM to a.m. (to follow Content Guide rule).

No second period is needed according to GPO Style Manual if sentence ends with a.m.

### Required reviewers

One front-end to make sure page isn't broken by this

## Impacted areas of the application

Meeting pages

How to test:
First sentence of the open meeting page should end with a.m.