### PR TITLE
Remove PACronyms from committees data page

### DIFF
--- a/fec/data/templates/partials/browse-data/committees.jinja
+++ b/fec/data/templates/partials/browse-data/committees.jinja
@@ -124,13 +124,4 @@
       </li>
     </ul>
   </div>
-  <div class="content__section--ruled-responsive">
-    <h3>PACronyms</h3>
-    <p>"PACronyms" refers to acronyms, abbreviations, initials and common names of federal political action committees (PACs). The Public Records Office can provide assistance in finding information about a specific PAC, including the PAC's PACronym.</p>
-  </div>
-  <ul class="list--buttons">
-    <li>
-      <a class="button button--cta button--go" href="/introduction-campaign-finance/how-to-research-public-records/pacs-parties-and-other-committees/">Learn more about how to research PACs and party committees</a>
-    </li>
-  </ul>
 </section>


### PR DESCRIPTION
## Summary (required)

- Resolves #5717 

Removes PACroynms paragraph and button from the Committees data page

### Required reviewers

1 front-end

## Screenshots

**BEFORE**
<img width="861" alt="Screen Shot 2023-05-01 at 3 24 08 PM" src="https://user-images.githubusercontent.com/31663028/235515389-a0dbcd18-d449-43f3-9842-65892e8c2a4b.png">

**AFTER:**
- [ ] Section in pink no longer appears


branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

## How to test
- [ ] Check to make sure the page still looks good
- [ ] PACronyms paragraph at the bottom of the page is gone