### PR TITLE
Remove Null from display when amendment version is unknown

### DIFF
--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -35,18 +35,10 @@ var versionColumn = {
       return '<i class="icon-blank"></i>Not applicable';
     }
     var version = helpers.amendmentVersion(data);
-    if (version === 'Version unknown') {
-      return (
-        '<i class="icon-blank"></i>Version unknown<br>' +
-        '<i class="icon-blank"></i>' +
-        row.fec_file_id
-      );
-    } else {
-      if (row.fec_file_id !== null) {
+    if (row.fec_file_id !== null) {
         version = version + '<br><i class="icon-blank"></i>' + row.fec_file_id;
-      }
-      return version;
     }
+    return version;
   }
 };
 

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -419,7 +419,7 @@ function amendmentVersion(most_recent) {
   } else if (most_recent === false) {
     return '<i class="icon-circle--clock-reverse--inline--left"></i>Past version';
   } else {
-    return 'Version unknown';
+    return '<i class="icon-blank"></i>Version unknown';
   }
 }
 

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -119,19 +119,10 @@ var otherDocumentsColumns = [
     orderable: false,
     render: function(data, type, row) {
       var version = helpers.amendmentVersion(data);
-      if (version === 'Version unknown') {
-        return (
-          '<i class="icon-blank"></i>Version unknown<br>' +
-          '<i class="icon-blank"></i>' +
-          row.fec_file_id
-        );
-      } else {
-        if (row.fec_file_id !== null) {
-          version =
-            version + '<br><i class="icon-blank"></i>' + row.fec_file_id;
-        }
-        return version;
+      if (row.fec_file_id !== null) {
+          version = version + '<br><i class="icon-blank"></i>' + row.fec_file_id;
       }
+      return version;
     }
   },
   columns.dateColumn({
@@ -252,9 +243,7 @@ var statementsOfCandidacyColumns = [
       var version = helpers.amendmentVersion(data);
       if (version === 'Version unknown') {
         return (
-          '<i class="icon-blank"></i>Version unknown<br>' +
-          '<i class="icon-blank"></i>' +
-          row.fec_file_id
+          '<i class="icon-blank"></i>Version unknown<br>'
         );
       } else {
         if (row.fec_file_id !== null) {


### PR DESCRIPTION
## Summary (required)

Update the text under version column to display `Version unknown` instead of `Version unknown null` when `most_recent` flag is null.

- Resolves #2218 

### Required reviewers

1 content and 2 or more developers

## Impacted areas of the application

-  Candidate filings section, Committee filings section, Filings, Presidential reports, house-senate and pac-party report data tables.

## Screen shots:
Example: PAC and party committee reports (https://www.fec.gov/data/reports/pac-party/?two_year_transaction_period=1988&data_type=processed&min_receipt_date=01%2F01%2F1987&max_receipt_date=12%2F31%2F1988)

**Before:**
<img width="1131" alt="Screen Shot 2023-05-24 at 9 56 51 AM" src="https://github.com/fecgov/fec-cms/assets/11650355/a272e520-3bdd-45f3-ab45-182e2924926b">

**Now:**
<img width="1139" alt="Screen Shot 2023-05-24 at 9 58 45 AM" src="https://github.com/fecgov/fec-cms/assets/11650355/cc94bec7-ae26-4c7e-bdf2-75a1dd3f932d">


**From Transaction Time period > 2000** , there are cases when Version is Unknown and yet have `fec_file_id` 

<img width="1434" alt="Screen Shot 2023-05-30 at 11 47 21 AM" src="https://github.com/fecgov/fec-cms/assets/11650355/5a41c30e-36fe-416e-9e51-9b89ae7058be">


## How to test

- `git checkout` `feature/2218-drop-null-filing-table`
- `cd fec`
- `npm run build-js`
- run `pytest`
- run `./manage.py runserver`
- Test following URLs in browser

| Website sections | Prod URL's | Local URL's|
| ------   | ------  | ------  | 
|Candidate filings | https://www.fec.gov/data/candidate/P80003338/?tab=filings | http://localhost:8000/data/candidate/P80003338/?tab=filings|
|Committee filings | https://www.fec.gov/data/committee/C00000935/?tab=filings&cycle=1988| http://localhost:8000/data/committee/C00000935/?tab=filings&cycle=1988 |
|Filings | https://www.fec.gov/data/filings/?data_type=processed (sort by receipt_date ascending)| http://localhost:8000/data/filings/?data_type=processed (sort by receipt_date ascending)|
|Presidential committee reports | https://www.fec.gov/data/reports/presidential/?data_type=processed (sort by receipt_date ascending)  | http://127.0.0.1:8000/data/reports/presidential/?data_type=processed (sort by receipt_date ascending )|
|House and Senate committee reports | https://www.fec.gov/data/reports/house-senate/?data_type=processed (sort by receipt_date ascending)| http://localhost:8000/data/reports/house-senate/?data_type=processed (sort by receipt_date ascending) |
|PAC and party committee reports | https://www.fec.gov/data/reports/pac-party/?two_year_transaction_period=1988&data_type=processed&min_receipt_date=01%2F01%2F1987&max_receipt_date=12%2F31%2F1988 (sort by receipt_date ascending)| http://localhost:8000/data/reports/pac-party/?two_year_transaction_period=1988&data_type=processed&min_receipt_date=01%2F01%2F1987&max_receipt_date=12%2F31%2F1988 (sort by receipt_date ascending) |