### PR TITLE
upgrade django 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.19
+Django==3.2.20
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary 

- Resolves #5791

To remediate snyk vulnerability, upgrade django from v3.2.19 to v3.2.20

### Required reviewers

1 developer

## Screenshots

**Before:**
![Screen Shot 2023-07-20 at 12 36 10 PM](https://github.com/fecgov/fec-cms/assets/11650355/bdb14a68-10d7-41b7-b529-64310f98e63d)

**After:**

![Screen Shot 2023-07-20 at 12 35 58 PM](https://github.com/fecgov/fec-cms/assets/11650355/c0c4f30d-23cb-4fbf-9525-b7c8fde1dc30)


## How to test
- run `git checkout develop`
- run `pyenv virtualenv venv-cms-5791` 
- run `pyenv activate venv-cms-5791`
- run `pip install -r requirements.txt`
- run `snyk test --file=requirements.txt --package-manager=pip` (ReDos vulnerability shows on django v3.9.19)
- run `git checkout feature/5791-upgrade-django`
- run `pip install -r requirements.txt`
- run `snyk test --file=requirements.txt --package-manager=pip` (ReDos vulnerability no longer appear)
- run `./manage.py runserver` (test cms datapages on browser )
