### PR TITLE
[DON'T MERGE YET] - 5838 Addresses

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -132,10 +132,6 @@
             </div>
           </li>
         </ul>
-
-        <p>1050 First Street, NE<br>
-        Washington, DC 20463</p>
-
         <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
           <button class="button--standard button--envelope" type="button">Sign up for FECMail</button>
         </a>

--- a/fec/fec/static/scss/components/_contact-items.scss
+++ b/fec/fec/static/scss/components/_contact-items.scss
@@ -105,6 +105,14 @@
   }
 }
 
+.contact-item--map-pin {
+  &.contact-item::before {
+    @include u-icon-circle($map-pin, $primary, $inverse, 3.4rem);
+    background-position: 50%;
+    background-size: 60%;
+  }
+}
+
 .address span {
   display: block;
   margin-bottom: u(.8rem);

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -132,10 +132,6 @@
               </div>
             </li>
           </ul>
-
-          <p>1050 First Street, NE<br>
-          Washington, DC 20463</p>
-
           <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
             <button class="button--standard button--envelope" type="button">Sign up for FECMail</button>
           </a>

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -129,10 +129,6 @@
               </div>
             </li>
           </ul>
-
-          <p>1050 First Street, NE<br>
-          Washington, DC 20463</p>
-
           <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
             <button class="button--standard button--envelope" type="button">Sign up for FECMail</button>
           </a>

--- a/fec/home/blocks.py
+++ b/fec/home/blocks.py
@@ -48,6 +48,7 @@ class ContactItemBlock(blocks.StructBlock):
         ('hand', 'Hand delivery'),
         ('phone', 'Phone'),
         ('mail', 'Mail'),
+        ('map-pin', 'Map pin'),
         ('github', 'Github'),
         ('question-bubble', 'Question')
     ], required=True)
@@ -231,8 +232,14 @@ class ExampleParagraph(blocks.StructBlock):
 
 class EmployeeTitle(blocks.StructBlock):
     title = blocks.StreamBlock([
-        ('html_title', blocks.RawHTMLBlock(
-            blank=True, required=False, help_text='For footnote on title, use html block with &lt;sup&gt;1&lt;/sup&gt;')),
+        (
+            'html_title',
+            blocks.RawHTMLBlock(
+                blank=True,
+                required=False,
+                help_text='For footnote on title, use html block with &lt;sup&gt;1&lt;/sup&gt;'
+            )
+        ),
         ('text_title', blocks.CharBlock(blank=True, required=False)),
         ], blank=True, required=False)
 

--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -48,7 +48,7 @@
         <div class="main__content--right">
           <section id="meetings-open-meetings" role="tabpanel" aria-hidden="true" aria-labelledby="open-meetings">
             <h2>Open meetings</h2>
-            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters, 1050 First Street NE, Washington, DC, on Thursdays at 10:30 a.m. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
+            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters, 1050 First Street NE, Washington, DC. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
             <div class="filters--horizontal">
               <form action="" id="openmeetings_form" method="get" class="js-form-nav container">
                 <div class="filter">

--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -110,7 +110,7 @@
           </section>
           <section id="meetings-hearings" role="tabpanel" aria-hidden="true" aria-labelledby="hearings">
             <h2>Public hearings</h2>
-            <p>The Commission periodically holds public hearings at FEC headquarters, 1050 First Street NE, Washington DC. These hearings offer interested persons an opportunity to testify concerning proposed regulations and other matters that come before the Commission. This page lists upcoming public hearings as well as those held from 2005 through the present. Use the <a href="https://sers.fec.gov/fosers/" title="Searchable Electronic Rulemaking System">Searchable Electronic Rulemaking System (SERS)</a> to search for all archived rulemaking hearings.</p>
+            <p>The Commission periodically holds public hearings at FEC headquarters, 1050 First Street NE, Washington, DC. These hearings offer interested persons an opportunity to testify concerning proposed regulations and other matters that come before the Commission. This page lists upcoming public hearings as well as those held from 2005 through the present. Use the <a href="https://sers.fec.gov/fosers/" title="Searchable Electronic Rulemaking System">Searchable Electronic Rulemaking System (SERS)</a> to search for all archived rulemaking hearings.</p>
             <div class="filters--horizontal">
               <form action="" id="hearings_form" method="get" class="js-form-nav container">
                 <div class="filter">

--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -110,7 +110,7 @@
           </section>
           <section id="meetings-hearings" role="tabpanel" aria-hidden="true" aria-labelledby="hearings">
             <h2>Public hearings</h2>
-            <p>The Commission periodically holds public hearings at its headquarters in Washington, DC. These hearings offer interested persons an opportunity to testify concerning proposed regulations and other matters that come before the Commission. This page lists upcoming public hearings as well as those held from 2005 through the present. Use the <a href="https://sers.fec.gov/fosers/" title="Searchable Electronic Rulemaking System">Searchable Electronic Rulemaking System (SERS)</a> to search for all archived rulemaking hearings.</p>
+            <p>The Commission periodically holds public hearings at FEC headquarters, 1050 First Street NE, Washington DC. These hearings offer interested persons an opportunity to testify concerning proposed regulations and other matters that come before the Commission. This page lists upcoming public hearings as well as those held from 2005 through the present. Use the <a href="https://sers.fec.gov/fosers/" title="Searchable Electronic Rulemaking System">Searchable Electronic Rulemaking System (SERS)</a> to search for all archived rulemaking hearings.</p>
             <div class="filters--horizontal">
               <form action="" id="hearings_form" method="get" class="js-form-nav container">
                 <div class="filter">

--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -48,7 +48,7 @@
         <div class="main__content--right">
           <section id="meetings-open-meetings" role="tabpanel" aria-hidden="true" aria-labelledby="open-meetings">
             <h2>Open meetings</h2>
-            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:30 a.m. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
+            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters, 1050 First Street NE, Washington, DC, on Thursdays at 10:30 a.m. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
             <div class="filters--horizontal">
               <form action="" id="openmeetings_form" method="get" class="js-form-nav container">
                 <div class="filter">

--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -37,7 +37,7 @@
     </header>
 
     {% if self.meeting_type == 'O' %}
-      <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters on Thursdays at 10:30 a.m.</p>
+      <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held at FEC headquarters, 1050 First Street NE, Washington, DC</p>
       <p>Members of the public can attend any open meeting or hearing in person. Open meetings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.</p>
     {% elif self.meeting_type == 'E' %}
       <p>The Commission meets regularly in executive sessions to discuss pending enforcement actions, litigation and other matters that, by law, must be kept confidential.</p>

--- a/fec/home/templates/purgecss-homepage/full.html
+++ b/fec/home/templates/purgecss-homepage/full.html
@@ -856,10 +856,6 @@
   </div>
                 </li>
               </ul>
-    
-              <p>1050 First Street, NE<br>
-              Washington, DC 20463</p>
-    
               <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
                 <button class="button--standard button--envelope" type="button">Sign up for FECMail</button>
               </a>
@@ -944,4 +940,3 @@
         </form>
       </div>
     </div></body></html>
-    

--- a/fec/home/templates/purgecss-homepage/navs.html
+++ b/fec/home/templates/purgecss-homepage/navs.html
@@ -341,10 +341,6 @@
                 </div>
               </li>
             </ul>
-  
-            <p>1050 First Street, NE<br>
-            Washington, DC 20463</p>
-  
             <a href="https://public.govdelivery.com/accounts/USFEC/subscriber/topics?qsp=CODE_RED" target="_blank" rel="noopener">
               <button class="button--standard button--envelope" type ="button">Sign up for FECMail</button>
             </a>
@@ -352,5 +348,4 @@
         </div>
       </footer>
   </body>
-  </html>
-    
+  </html>   


### PR DESCRIPTION
## Summary

- Resolves #5838 


### Required reviewers

- UX
- Front-end?

## Impacted areas of the application

- Wagtail admin now has a "Map pin" option
- Contact Items can now show a map pin icon
- Site footer no longer includes an address
   - Homepage
   - Data pages
   - Wagtail template pages

## Screenshots

Site footer, before & after:
![image](https://github.com/fecgov/fec-cms/assets/26720877/c591e9e9-90e5-4394-90c0-e42c2d6a60f6)

New option while editing a contact item:
<img width="202" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/e33ab812-428f-4e85-bc30-18b292957938">

Map pin icon:
<img width="232" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/9c4c9ae0-7b0d-421c-91b0-714e1eb68e15">


## Related PRs

None

## How to test

- pull the branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- [Homepage](http://127.0.0.1:8000/) shouldn't have address in footer
- [Data pages](http://127.0.0.1:8000/data/) shouldn't have address in footer
- [Wagtail pages](http://127.0.0.1:8000/help-candidates-and-committees/) shouldn't have address in footer
- Map pin:
   - Edit /settings/dev.py to include the code chunk below
   - Edit a **_LOCAL_** Wagtail page that uses a Contact Item
   - Preview (or save and view) that page to check that the map pin icon appears

Code for dev.py:
```Python
ALLOWED_HOSTS = [
    '.fec.gov',
    '.app.cloud.gov',
    '127.0.0.1',
]
```