### PR TITLE
Filing - change q_filer to committee_id

### DIFF
--- a/fec/data/templates/partials/filings-filter.jinja
+++ b/fec/data/templates/partials/filings-filter.jinja
@@ -29,8 +29,7 @@ Filter reports
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Filer</button>
   <div class="accordion__content">
-   
-    {{ typeahead.field('q_filer', 'Committee name or ID', '', allow_text=True) }}
+    {{ typeahead.field('committee_id', 'Committee name or ID', '', allow_text=True) }}
     {{ typeahead.field('candidate_id', 'Candidate name or ID', '', dataset='candidates') }}
     {{ states.field('state', type='Candidate') }}
     {{ office.checkbox() }}


### PR DESCRIPTION
## Summary

- Resolves #5707 

Changed the filings filter to use committee_id instead of q_filer

### Required reviewers



## Impacted areas of the application

General components of the application that this PR will affect:

-  

## Screenshots

Production on the left, this branch on the right
![image](https://github.com/fecgov/fec-cms/assets/26720877/bf0a5fb8-9535-4f07-b07e-f600d2a58cc1)


## Related PRs

None

## How to test

- pull the branch
- `npm run build`
- `./manage.py runserver`
- check that http://127.0.0.1:8000/data/filings/?data_type=processed&committee_id=C00780197 filters as it should (The Filer name column could be blank for the example ID and any other terminated committees)