### PR TITLE
Update policy sitemaps in to match what is uploaded to Wagtail

### DIFF
--- a/fec/search/management/data/sitemap_html.xml
+++ b/fec/search/management/data/sitemap_html.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset>
-<url>
-<loc>https://www.fec.gov/updates/guidance-search/fec-provides-guidance-following-us-district-court-decision-crew-v-fec-316-f-supp-3d-349-ddc-2018/</loc>
-<lastmod>2020-04-01T00:00:00+00:00</lastmod>
-<meta property="article:published_time" content="2018-04-10" />
-</url>
-<url>
-<loc>https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/</loc>
-<lastmod>2020-04-06T00:00:00+00:00</lastmod>
-<meta property="article:published_time" content="2010-05-02" />
-</url>
-<url>
-<loc>https://www.fec.gov/updates/guidance-search/fec-statement-on-the-dc-circuit-court-of-appeals-decision-in/</loc>
-<lastmod>2020-04-01T00:00:00+00:00</lastmod>
-<meta property="article:published_time" content="2010-05-01" />
-</url>
-<url>
-<loc>https://www.fec.gov/updates/guidance-search/fec-statement-on-carey-fec/</loc>
-<lastmod>2020-04-01T00:00:00+00:00</lastmod>
-<meta property="article:published_time" content="2011-05-10" />
-</url>
-<url>
-<loc>https://www.fec.gov/updates/guidance-search/fec-statement-on-2/</loc>
-<lastmod>2020-04-01T00:00:00+00:00</lastmod>
-<meta property="article:published_time" content="2012-27-07" />
-</url>
-<url>
-<loc>https://www.fec.gov/updates/guidance-search/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/</loc>
-<lastmod>2020-04-01T00:00:00+00:00</lastmod>
-<meta property="article:published_time" content="2015-15-02" />
-</url>
-<url>
-<loc>https://www.fec.gov/updates/guidance-search/fec-adopts-interim-verification-procedure-for-filings-containing-possibly-false-or-fictitious-information/</loc>
-<lastmod>2020-04-01T00:00:00+00:00</lastmod>
-<meta property="article:published_time" content="2016-16-08" />
-</url>
-<url>
-  <loc>https://webforms.fec.gov/wfja/form99</loc>
-  <lastmod>2018-03-22T00:00:00+00:00</lastmod>
-</url>
+  <url>
+    <loc>https://www.fec.gov/updates/guidance-search/fec-provides-guidance-following-us-district-court-decision-crew-v-fec-316-f-supp-3d-349-ddc-2018/</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+    <meta property="article:published_time" content="2018-04-10" />
+  </url>
+  <url>
+    <loc>https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+    <meta property="article:published_time" content="2010-05-02" />
+  </url>
+  <url>
+    <loc>https://www.fec.gov/updates/guidance-search/fec-statement-on-the-dc-circuit-court-of-appeals-decision-in/</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+    <meta property="article:published_time" content="2010-05-01" />
+  </url>
+  <url>
+    <loc>https://www.fec.gov/updates/guidance-search/fec-statement-on-carey-fec/</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+    <meta property="article:published_time" content="2011-05-10" />
+  </url>
+  <url>
+    <loc>https://www.fec.gov/updates/guidance-search/fec-statement-on-2/</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+    <meta property="article:published_time" content="2012-27-07" />
+  </url>
+  <url>
+    <loc>https://www.fec.gov/updates/guidance-search/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+    <meta property="article:published_time" content="2015-15-02" />
+  </url>
+  <url>
+    <loc>https://www.fec.gov/updates/guidance-search/fec-adopts-interim-verification-procedure-for-filings-containing-possibly-false-or-fictitious-information/</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+    <meta property="article:published_time" content="2016-16-08" />
+  </url>
+  <url>
+    <loc>https://webforms.fec.gov/wfja/form99</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
 </urlset>

--- a/fec/search/management/data/sitemap_pdf.xml
+++ b/fec/search/management/data/sitemap_pdf.xml
@@ -1,259 +1,259 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1m.pdf</loc>
-<lastmod>2020-04-131T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1mi.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2019-10_EO13892.pdf</loc>
-<lastmod>2020-04-28T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/candgui.pdf</loc>
-<lastmod>2021-12-07T10:00:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/guideline-for-presentation-good-order.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm5.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2023_12.pdf</loc>
-<lastmod>2023-08-17T10:42:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2011-11_EO13892.pdf</loc>
-<lastmod>2020-04-28T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2013-14_EO13892.pdf</loc>
-<lastmod>2020-04-28T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2016-02_EO13892.pdf</loc>
-<lastmod>2020-04-28T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2010-13_EO13892.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2007-13_EO13892.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2009-11.pdf</loc>
-<lastmod>2021-06-10T08:45:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2007-09_EO13892.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2007-08_EO13892.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2006-11_EO13892.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2013-16_EO13892.pdf</loc>
-<lastmod>2020-04-28T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2013-09_EO13892.pdf</loc>
-<lastmod>2020-04-28T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2011-13_EO13892.pdf</loc>
-<lastmod>2020-04-28T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2011-02_EO13892.pdf</loc>
-<lastmod>2020-04-28T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2002-01_EO13892.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/partygui.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/colagui.pdf</loc>
-<lastmod>2021-03-10T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/nongui.pdf</loc>
-<lastmod>2020-12-10T15:00:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf</loc>
-<lastmod>2022-05-17T17:00:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1i.pdf</loc>
-<lastmod>2022-05-17T17:00:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm2.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm2i.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3i.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3post.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3posti.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3p.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3pi.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3ppost.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3pposti.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3l.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3li.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3x.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3xi.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3xe.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3xei.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm4.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm4i.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm5i.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm6.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm6i.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm8.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm8i.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm9.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecform9i.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm13.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm13i.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/commissioners_tips_2016_EO13892.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/guideline-for-presentation-good-order_appendices.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/respondent_guide.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/internal_controls_polcmtes_07_EO13892.pdf</loc>
-<lastmod>2020-04-13T15:30:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQs-PACs_last_visited_september_21_2020.pdf</loc>
-<lastmod>2020-09-23T11:00:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQ-Candidate_Committees_last_visited_may_5_2021.pdf</loc>
-<lastmod>2021-05-05T15:00:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQ-Party_Committees_last_visited_may_5_2021.pdf</loc>
-<lastmod>2021-05-05T15:00:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQ-Other_Filers_last_visited_may_5_2021.pdf</loc>
-<lastmod>2021-05-05T15:00:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQ-RAD_Processes_last_visited_may_5_2021.pdf</loc>
-<lastmod>2021-05-05T15:00:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQs-Internal_Controls_last_visited_may_5_2021.pdf</loc>
-<lastmod>2021-05-05T15:00:00+00:00</lastmod>
-</url>
-<url>
-<loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQs-Joint_Fundraising_Committees__last_visited_may_5_2021.pdf</loc>
-<lastmod>2021-05-05T15:00:00+00:00</lastmod>
-</url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1m.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1mi.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2019-10_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/candgui.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/guideline-for-presentation-good-order.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm5.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2023_12.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2011-11_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2013-14_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2016-02_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2010-13_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2007-13_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2009-11.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2007-09_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2007-08_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2006-11_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2013-16_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2013-09_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2011-13_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2011-02_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2002-01_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/partygui.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/colagui.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/nongui.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1i.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm2.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm2i.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3i.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3post.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3posti.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3p.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3pi.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3ppost.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3pposti.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3l.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3li.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3x.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3xi.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3xe.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3xei.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm4.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm4i.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm5i.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm6.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm6i.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm8.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm8i.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm9.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecform9i.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm13.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm13i.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/commissioners_tips_2016_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/guideline-for-presentation-good-order_appendices.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/respondent_guide.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/internal_controls_polcmtes_07_EO13892.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQs-PACs_last_visited_september_21_2020.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQ-Candidate_Committees_last_visited_may_5_2021.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQ-Party_Committees_last_visited_may_5_2021.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQ-Other_Filers_last_visited_may_5_2021.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQ-RAD_Processes_last_visited_may_5_2021.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQs-Internal_Controls_last_visited_may_5_2021.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQs-Joint_Fundraising_Committees__last_visited_may_5_2021.pdf</loc>
+    <lastmod>2023-08-17T10:00:00+00:00</lastmod>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary (required)

When we did the switch-over to the new policy-guidance sitemap configuration for search.gov, all the lastmod dates were updated to ensure indexing. This PR updates the sitemaps we keep in version control to match those.

### Required reviewers

one team member

## Impacted areas of the application

The xml sitemaps here are just for version control and do not impact the application

## Related PRs
https://github.com/fecgov/fec-cms/pull/5845
https://github.com/fecgov/fec-cms/pull/5862

How to test:
Make sure the content in these sitemaps matches those online:
https://www.fec.gov/resources/cms-content/documents/sitemap_pdf.xml


