### PR TITLE
upgrade gitpython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ django-utils-six==2.0 # pinning until other packages support Django 3.x
 
 # Development
 invoke==0.15.0
-GitPython==3.1.30
+GitPython==3.1.32
 requests-mock==1.3.0
 pdbpp==0.9.1
 lxml==4.9.1


### PR DESCRIPTION
## Summary 
upgrade gitpython to v3.1.32

- Resolves #5860 

### Required reviewers

1 developer


## How to test

- run `git checkout develop`
- run `snyk test --file=requirements.txt --package-manager=pip` (Terminal output show gitpython as vulnerable package)
- run `git checkout feature/5860-upgrade-gitpython`
- run `pyenv activate venv-cms`
- run `pip install -r requirements.txt` 
- run `snyk test --file=requirements.txt --package-manager=pip` (Terminal output **no longer shows** gitpython as vulnerable package)
