### PR TITLE
5843 - Election search map tiles

### DIFF
--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -33,6 +33,7 @@ class AddSecureHeaders(MiddlewareMixin):
                 "data:",
                 "https://*.ssl.fastly.net",
                 "https://www.google-analytics.com",
+                "https://tiles.stadiamaps.com/tiles/",
             ],
             "script-src": [
                 "'self'",


### PR DESCRIPTION
## Summary

- Resolves #5843 

Adding `"https://tiles.stadiamaps.com/tiles/"` to our img-src CORS policy

### Required reviewers

One

## Impacted areas of the application

Technically site-wide but only election search pages will benefit.

## Screenshots

Current (broken) and fixed
![image](https://github.com/fecgov/fec-cms/assets/26720877/c5485f8c-4c28-43cd-9652-17611be1e015)

## Related PRs

None

## How to test

- pull the branch
- `./manage.py runserver`
- Check the homepage and the [elections search page](http://127.0.0.1:8000/data/elections/) to make sure the image tiles load
