### PR TITLE
upgrade node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            nvm install 18.13.0
-            nvm use 18.13.0
-            nvm alias default 18.13.0
+            nvm install 18.17.1
+            nvm use 18.17.1
+            nvm alias default 18.17.1
             sudo npm install -g npm
             npm install
             npm rebuild sass

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,8 +110,8 @@
         "webpack-manifest-plugin": "^1.3.1"
       },
       "engines": {
-        "node": "18.13.0",
-        "npm": "8.19.3"
+        "node": "18.17.1",
+        "npm": "9.6.7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -135,8 +135,8 @@
   },
   "browserslist": "last 2 versions, > 1%, IE 10",
   "engines": {
-    "node": "18.13.0",
-    "npm": "8.19.3"
+    "node": "18.17.1",
+    "npm": "9.6.7"
   },
   "license": "CC0-1.0"
 }


### PR DESCRIPTION
## Summary (required)

NPM 10 was released and it's not compatible with node versions below 18.17. We are currently pulling in the most recent NPM version in the circle config for API. I'm upgrading CMS to keep consistent across repos


## Reviewers
2 devs 

## Related Issues
Upgrade e-regs: https://github.com/fecgov/fec-eregs/issues/789
Upgrade pattern-library: https://github.com/fecgov/fec-pattern-library/issues/218
API research fix: https://github.com/fecgov/openFEC


## How to test
-pull branch
-nvm install 18.17.1 (should be on npm 9.6.7)
-rm -rf node_modules
-npm i && npm run build
-flask run