### PR TITLE
Update guides.html to update Guide URLs

### DIFF
--- a/fec/home/templates/home/candidate-and-committee-services/guides.html
+++ b/fec/home/templates/home/candidate-and-committee-services/guides.html
@@ -88,7 +88,7 @@
          <div class="grid__item">
            <img src="{% static 'img/thumbnail--pdf-guide.png' %}" alt="Icon representing a large PDF file">
            <span class="label">PDF Guide</span>
-           <a class="t-sans" href="/resources/cms-content/documents/candgui.pdf">Congressional candidates and committees campaign guide</a>
+           <a class="t-sans" href="/resources/cms-content/documents/policy-guidance/candgui.pdf">Congressional candidates and committees campaign guide</a>
          </div>
        </div>
       </section>
@@ -112,7 +112,7 @@
           <div class="grid__item">
             <img src="{% static 'img/thumbnail--pdf-guide.png' %}" alt="Icon representing a large PDF file">
             <span class="label">PDF Guide</span>
-            <a class="t-sans" href="/resources/cms-content/documents/partygui.pdf">Political party committees campaign guide</a>
+            <a class="t-sans" href="/resources/cms-content/documents/policy-guidance/partygui.pdf">Political party committees campaign guide</a>
           </div>
         </div>
       </section>
@@ -137,7 +137,7 @@
           <div class="grid__item">
             <img src="{% static 'img/thumbnail--pdf-guide.png' %}" alt="Icon representing a large PDF file">
             <span class="label">PDF Guide</span>
-            <a class="t-sans" href="/resources/cms-content/documents/colagui.pdf">Corporations and labor organizations campaign guide</a>
+            <a class="t-sans" href="/resources/cms-content/documents/policy-guidance/colagui.pdf">Corporations and labor organizations campaign guide</a>
           </div>
         </div>
       </section>
@@ -167,7 +167,7 @@
           <div class="grid__item">
             <img src="{% static 'img/thumbnail--pdf-guide.png' %}" alt="Icon representing a large PDF file">
             <span class="label">PDF Guide</span>
-            <a class="t-sans" href="/resources/cms-content/documents/nongui.pdf">Nonconnected committees campaign guide</a>
+            <a class="t-sans" href="/resources/cms-content/documents/policy-guidance/nongui.pdf">Nonconnected committees campaign guide</a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary (required)

Part of work in https://github.com/fecgov/fec-cms/issues/5828

Changes the URLS for the Guides on this page... 

 
Guides | Old URL | New URL
 
Candidate guide | (old) https://www.fec.gov/resources/cms-content/documents/candgui.pdf | (new) https://www.fec.gov/resources/cms-content/documents/policy-guidance/candgui.pdf
Party guide | (old) https://www.fec.gov/resources/cms-content/documents/partygui.pdf | (new) https://www.fec.gov/resources/cms-content/documents/policy-guidance/partygui.pdf
Corporate/Labor guide | (old) https://www.fec.gov/resources/cms-content/documents/colagui.pdf | (new) https://www.fec.gov/resources/cms-content/documents/policy-guidance/colagui.pdf
Nonconnected guide | (old) https://www.fec.gov/resources/cms-content/documents/nongui.pdf | (new) https://www.fec.gov/resources/cms-content/documents/policy-guidance/nongui.pdf


### Required reviewers

One content person - doublecheck new URL
One front end person - doublecheck code

## Impacted areas of the application

General components of the application that this PR will affect:

Links to the Guides on this page... https://www.fec.gov/help-candidates-and-committees/ and this page https://www.fec.gov/help-candidates-and-committees/guides/

## Screenshots
Updates this URL for each Guide.
 
![image](https://github.com/fecgov/fec-cms/assets/24437369/aa537d13-c6d2-4f43-a941-07a988cce5c0)

