### PR TITLE
Unobscure date-filter placeholder text

### DIFF
--- a/fec/fec/static/scss/elements/_forms.scss
+++ b/fec/fec/static/scss/elements/_forms.scss
@@ -235,3 +235,7 @@ button {
     opacity: 0.5;
   }
 }
+
+.range__input input {
+  padding: u(0 .7rem)
+}

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/5844-unobscure-placeholder-text'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'feature/5844-unobscure-placeholder-text'),
+    ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )


### PR DESCRIPTION
## Summary
Reduce padding to unobscure date-filter placeholder text

- Resolves #5844

### Required reviewers

one team member

## Impacted areas of the application

Data and legal Datatable filters that have `mm/dd/yyyy` placeholder text

modified:   fec/static/scss/elements/_forms.scss

## Screenshots

<img width="523" alt="Screen Shot 2023-09-13 at 12 41 09 AM" src="https://github.com/fecgov/fec-cms/assets/5572856/0cffc0ab-fe26-483c-8e04-03ce66e17b0b">


## How to test
 - [x] **Remove dev deploy task before merge**
 
 **Content/UX teams**
 - This is pushed to dev space for testing:
 - Check that placeholder text on data and legal datatables shows full text `mm/dd/yyyy`
    - https://dev.fec.gov/data/loans/ (hover over `Incurrred date` fields)
    - https://dev.fec.gov/data/legal/search/murs/
  - Are there any others not covered by this CSS change?

 **Devs:**
- checkout branch
-`npm run build-sass`
- Check that placeholder text on data and legal datatables shows full text `mm/dd/yyyy`
    - http://127.0.0.1:8000/data/loans/ (hover over `Incurrred date` fields)
    - http://127.0.0.1:8000/data/legal/search/murs/
 - Check any others you can think of...were any missed by this css change?

 