### PR TITLE
5896-upgrade django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.20
+Django==3.2.21
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary

- Resolves #5896 

Upgrades django to 3.2.21

### Required reviewers

1 dev

### Screenshots
Before: 
![Screen Shot 2023-09-13 at 10 00 30 AM](https://github.com/fecgov/fec-cms/assets/66386084/51433e83-97b9-4054-a186-596389b7182b)

After:
![Screen Shot 2023-09-13 at 9 59 16 AM](https://github.com/fecgov/fec-cms/assets/66386084/038f5ed1-8a09-4891-92fd-592c68905248)

## How to test
- `git checkout develop`
- `pyenv virtualenv venv-cms-5896` 
- `pyenv activate venv-cms-5896`
-  `pip install -r requirements.txt`
-  `npm i && npm run build`   (maybe need `nvm install 18.17.1`)
- `snyk test --file=requirements.txt --package-manager=pip` 
- `gh pr checkout 5909` 
- `pip install -r requirements.txt`
- `snyk test --file=requirements.txt --package-manager=pip` 
- `./manage.py runserver` 