### PR TITLE
Update meeting_page.html to add sentence about cancellation to open meeting and hearing page templates

### DIFF
--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -42,7 +42,7 @@
     {% elif self.meeting_type == 'E' %}
       <p>The Commission meets regularly in executive sessions to discuss pending enforcement actions, litigation and other matters that, by law, must be kept confidential.</p>
     {% elif self.meeting_type == 'H' %}
-      <p>The Commission considers new regulations and other public matters at public hearings at FEC headquarters, 1050 First Street NE, Washington, DC. Members of the public can attend public hearings in person. Public hearings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.</p>
+      <p>The Commission considers new regulations and other public matters at public hearings at FEC headquarters, 1050 First Street NE, Washington, DC. Members of the public can attend public hearings in person. Public hearings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room. Please check the meeting page for updates to the agenda, including cancellations.</p>
     {% endif %}
 
     {% if self.additional_information %}

--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -38,7 +38,7 @@
 
     {% if self.meeting_type == 'O' %}
       <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held on Thursdays at 10:30 a.m. at FEC headquarters, 1050 First Street NE, Washington, DC.</p>
-      <p>Members of the public can attend any open meeting or hearing in person. Open meetings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room.</p>
+      <p>Members of the public can attend any open meeting or hearing in person. Open meetings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room. Please check the meeting page for updates to the agenda, including cancellations.</p>
     {% elif self.meeting_type == 'E' %}
       <p>The Commission meets regularly in executive sessions to discuss pending enforcement actions, litigation and other matters that, by law, must be kept confidential.</p>
     {% elif self.meeting_type == 'H' %}


### PR DESCRIPTION
## Summary (required)

 Adds “Please check the meeting page for updates to the agenda, including cancellations.” after the hard-coded sentence “After security, attendees are escorted to the Commission hearing room.” to both the open meeting page language and the hearing page language.

### Required reviewers

One front end code review
One content team or PM team member to review language

## Impacted areas of the application

General components of the application that this PR will affect:

Open meeting pages and hearing pages.

 