### PR TITLE
[DRAFT] Links and metadata for single doc pages

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -724,7 +724,8 @@ class DocumentPage(ContentPage):
     @property
     def extension(self):
         # Return the file extension of file_url
-        return self.file_url.rsplit('.', 1)[1].upper()
+        if self.file_url:
+            return self.file_url.rsplit('.', 1)[1].upper()
 
 
 class DocumentFeedPage(ContentPage):
@@ -1372,7 +1373,7 @@ class ReportingDatesTable(Page):
         ('html', blocks.RawHTMLBlock()),
         ('internal_button', InternalButtonBlock()),
         ('external_button', ExternalButtonBlock()),
-        ('dates_table', ReportingTableBlock(blank=True, required=False,form_classname='title')),
+        ('dates_table', ReportingTableBlock(blank=True, required=False, form_classname='title')),
     ], blank=True, null=True, use_json_field=True, collapsed=False)
 
     footnotes = StreamField([

--- a/fec/home/templates/home/document_page.html
+++ b/fec/home/templates/home/document_page.html
@@ -18,9 +18,11 @@
       </ul>
       <div class="row">
         {% spaceless %}{# for inline blocks #}
-        <h1 class="heading__left">{% formatted_title self %}</h1>
+      <h1 class="heading__left"><a href="{{ self.file_url }}">{% formatted_title self %}</a></h1>
         <div class="heading__right">
-          <span class="t-sans">{{ self.display_date }}</span>
+          <span class="t-sans">{{ self.display_date }} |
+         <a href="{{ self.file_url }}">{{ self.extension }}</a>{% if self.size %} | ({{ self.size }}){% endif %}</span>
+
         </div>
         {% endspaceless %}
       </div>

--- a/fec/home/templates/home/document_page.html
+++ b/fec/home/templates/home/document_page.html
@@ -4,7 +4,16 @@
 {% load static %}
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
 
+
+
 {% block content %}
+
+<!--{% if "reports-about-fec" in request.path and page.content_type.model == "documentpage" and self.file_url %}
+    <meta http-equiv="refresh" content="0; url={% include_block self.file_url %}">
+{% endif %} -->
+
+
+
 
 {% include 'partials/breadcrumbs.html' with page=self links=self.get_ancestors style='secondary' %}
 
@@ -13,15 +22,22 @@
     <header class="heading--main heading--with-date">
       <ul class="tags">
         <li class="tag tag--secondary t-upper">
-     <a href="{{self.get_parent.url}}?category={{ self.category | cms_query_syntax }}&year={{ self.date | date:'Y' }}">{{ self.category }}</a>
+     <a href="{{self.get_parent.url}}?category={{ self.category | cms_query_syntax }}">{{ self.category }}</a>
         </li>
       </ul>
       <div class="row">
         {% spaceless %}{# for inline blocks #}
-      <h1 class="heading__left"><a href="{{ self.file_url }}">{% formatted_title self %}</a></h1>
+      <h1 class="heading__left">{% if self.file_url %}<a href="{{ self.file_url }}">{% formatted_title self %}</a>
+      {% else %}
+       {% formatted_title self %}
+      {% endif %}</h1>
         <div class="heading__right">
           <span class="t-sans">{{ self.display_date }} |
-         <a href="{{ self.file_url }}">{{ self.extension }}</a>{% if self.size %} | ({{ self.size }}){% endif %}</span>
+        {% if self.file_url %} <a href="{{ self.file_url }}">{{ self.extension }}</a>
+        {% else %}
+          {{ self.extension }}
+        {% endif %}
+        {% if self.size %} | ({{ self.size }}){% endif %}</span>
 
         </div>
         {% endspaceless %}
@@ -33,5 +49,15 @@
 </article>
 
 {% include 'partials/disclaimer.html' %}
+<script>
+// document.getElementsByClassName('main')[0].insertAdjacentHTML("beforebegin", "<p>You will be directed</p>")
+// setTimeout(() => {
+// var meta = document.createElement('meta');
+// meta.httpEquiv = "refresh" ;
+// meta.content = "3; url={% include_block self.file_url %}";
+// document.getElementsByTagName('head')[0].appendChild(meta);
+// }, "0");
+
+</script>
 
 {% endblock %}

--- a/fec/home/templates/home/document_page.html
+++ b/fec/home/templates/home/document_page.html
@@ -13,7 +13,7 @@
     <header class="heading--main heading--with-date">
       <ul class="tags">
         <li class="tag tag--secondary t-upper">
-          {{ self.category }}
+     <a href="{{self.get_parent.url}}?category={{ self.category | cms_query_syntax }}&year={{ self.date | date:'Y' }}">{{ self.category }}</a>
         </li>
       </ul>
       <div class="row">

--- a/fec/home/templates/partials/document.html
+++ b/fec/home/templates/partials/document.html
@@ -29,6 +29,6 @@
     </h3>
   {% endif %}
     <div class="post__meta">
-      <a class="tag tag--secondary" href="">{{ document.category }}</a>
+      <a class="tag tag--secondary" href="{{self.get_parent.url}}?category={{ document.category | cms_query_syntax }}">{{ document.category }}</a>
     </div>
 </article>

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -189,3 +189,10 @@ def get_file_type(value):
     file_type = "EXCEL" if xl else file_extension
 
     return file_type
+
+
+@register.filter(name='cms_query_syntax')
+def cms_query_syntax(string):
+    query = string.replace(' ', '+').lower()
+
+    return query


### PR DESCRIPTION
## Summary (required)

- Link to document on standalone document pages now that they pages show up in search results and can be navigated to. Also link the Category button above the title to the parent... filtered page for that `report-type/category/year`

    - Example page: https://www.fec.gov/about/reports-about-fec/agency-operations/fec-plan-for-agency-operations-in-the-absence-of-the-fiscal-year-2024-appropriation/

- **Background:** These pages are queried to populate a  document-feed . The link and metadata the user enters in the fields is used in their listing on the feed. They cannot be navigated to on the site, but because they are a published Wagtail pages, they can now be navigated to when they show up in search results.

- Resolves #5918

### Required reviewers

one content, one UX

## Impacted areas of the application

standalone document pages used to populate the feed

## Screenshots
<hr>

### Link from title:

![doc_title_linked](https://github.com/fecgov/fec-cms/assets/5572856/1245a19e-a9b7-4770-8a10-9285588f2fd4)

<hr>

### Link from document type:

![file_extension_linked2](https://github.com/fecgov/fec-cms/assets/5572856/e46bfe05-9ab8-47c9-af56-514ccabf06c2)

<hr>

### Also can link the category button to filtered parent: 
Example: `/about/reports-about-fec/oig-reports/?category=inspection+or+special+review+report&year=2023`

![link_category_btn](https://github.com/fecgov/fec-cms/assets/5572856/1f33b24a-24d2-4cc7-899a-851448f6c43a)


<hr>



## How to test
- [ ] Remove dev deploy task before merge

**Content/UX :** 
I can push to dev for testing once [PR #5908](https://github.com/fecgov/fec-cms/pull/5908) is merged

**Devs:**
- Checkout and run branch
-  In Wagtail go to Pages > Home >About > Reports about the FEC > Choose one of the categories
- View pages  live to test the link to document on the title and the docuement-type
- Test that the Category button above the title goes to a filtered page for that `report-type/category/year`


## System architecture updates (if applicable)

(If this pull request changes our [current system diagram](https://github.com/fecgov/FEC/wiki/2.-FEC-system-diagram), include a description of those changes here and create a new ticket to update the system diagram)
