### PR TITLE
[MERGE BEFORE 09/28/23 RELEASE] Add link to document page

### DIFF
--- a/fec/home/templates/home/document_page.html
+++ b/fec/home/templates/home/document_page.html
@@ -26,7 +26,7 @@
       </div>       
     </header>
     <p class="t-sans t-normal">
-      <i class="icon icon--inline--right icon--inline--left i-document"></i>{% if self.file_url %}<a href="{{ self.file_url }}">{{ self.title}}</a>{% endif %}
+      {% if self.file_url %}<i class="icon icon--inline--right icon--inline--left i-document"></i><a href="{{ self.file_url }}">{{ self.title}}</a>{% endif %}
       {% if self.extension %} | ({{ self.extension }}){% endif %}
       {% if self.size %} | ({{ self.size }}){% endif %}
     </p>

--- a/fec/home/templates/home/document_page.html
+++ b/fec/home/templates/home/document_page.html
@@ -22,9 +22,14 @@
         <div class="heading__right">
           <span class="t-sans">{{ self.display_date }}</span>
         </div>
-        {% endspaceless %}
-      </div>
+       {% endspaceless %}
+      </div>       
     </header>
+    <p class="t-sans t-normal">
+      <i class="icon icon--inline--right icon--inline--left i-document"></i>{% if self.file_url %}<a href="{{ self.file_url }}">{{ self.title}}</a>{% endif %}
+      {% if self.extension %} | ({{ self.extension }}){% endif %}
+      {% if self.size %} | ({{ self.size }}){% endif %}
+    </p>
     <div class="main__content">
       {% include 'partials/body-blocks.html' with blocks=self.body %}
     </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #5918

`DocumentPages`, otherwise not navigable on the site, are showing in search results. This is a temporary fix so users will be able to get to the document if they access a DocumentPage through a search result link.  A final solution for handling this issue is being researchd. See this [comment/mockup in issue](https://github.com/fecgov/fec-cms/issues/5918#issuecomment-1738106863)

### Required reviewers

one frontend

## Impacted areas of the application

Document pages in Reports about the FEC

## Screenshots

<img width="1138" alt="Screen Shot 2023-09-27 at 9 47 40 PM" src="https://github.com/fecgov/fec-cms/assets/5572856/1ac48bbc-99a2-4d0e-b6cd-0628f6d828b9">


## Related PRs

Related PRs against other branches:

There is a WIP/DRAFT PR that shows more options for the final solution https://github.com/fecgov/fec-cms/pull/5922

## How to test

- checkout and run branch
- You can login to Wagtail and navigate from the sidebar `Pages > Home > About > Reports about the FEC`, then go into one of the sections like `Agency Operations or FOiA` 
- Click the LIVE button  in the Status column to view these pages live
- Example page from screenshot above: http://127.0.0.1:8000/about/reports-about-fec/agency-operations/federal-employee-viewpoint-survey-small-agency-management-report-2020/
- You can't navigate to them on the site, but they are showing up in search results since they are Wagtail pages, so this is a stopgap measure to ensure users can get to the document if they access the page through a search result link.


