### PR TITLE
Update disbursement search language

### DIFF
--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -10,7 +10,7 @@
         <i class="icon i-magnifying-glass icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <h4><a href="/data/disbursements">Disbursements</a></h4>
-          <p>Search select disbursements from committees by the recipient, purpose, amount and date. Excludes <a href="/help-candidates-and-committees/candidate-taking-receipts/#outside-spending">outside spending</a> to support or oppose candidates.</p>
+          <p>Search select disbursements from committees by the recipient, purpose, amount and date. Excludes <a href="/help-candidates-and-committees/candidate-taking-receipts/#outside-spending">outside spending</a> to support or oppose candidates and allocated federal/nonfederal disbursements.</p>
         </div>
       </li>
       <li>


### PR DESCRIPTION
## Summary

- Resolves #5914 

### Please review

Double check the language in the ticket "Search select disbursements from committees by the recipient, purpose, amount and date. Excludes outside spending to support or oppose candidates and allocated federal/nonfederal disbursements.” made it through to the PR
