### PR TITLE
Fix server error on some reports

### DIFF
--- a/fec/home/templates/home/document_page.html
+++ b/fec/home/templates/home/document_page.html
@@ -27,7 +27,7 @@
     </header>
     {% if self.file_url %}
     <p class="t-sans t-normal">
-      <i class="icon icon--inline--right icon--inline--left i-document"></i><a href="{{ self.file_url }}">{{ self.title}}</a>
+      <i class="icon icon--inline--right icon--inline--left i-document"></i><a href="{{ self.file_url }}">{{ self.title }}</a>
       {% if self.extension is not '' %} | ({{ self.extension }}){% endif %}
       {% if self.size %} | ({{ self.size }}){% endif %}
     </p>

--- a/fec/home/templates/home/document_page.html
+++ b/fec/home/templates/home/document_page.html
@@ -27,7 +27,7 @@
     </header>
     <p class="t-sans t-normal">
       {% if self.file_url %}<i class="icon icon--inline--right icon--inline--left i-document"></i><a href="{{ self.file_url }}">{{ self.title}}</a>{% endif %}
-      {% if self.extension %} | ({{ self.extension }}){% endif %}
+      {% if self.extension is not '' %} | ({{ self.extension }}){% endif %}
       {% if self.size %} | ({{ self.size }}){% endif %}
     </p>
     <div class="main__content">

--- a/fec/home/templates/home/document_page.html
+++ b/fec/home/templates/home/document_page.html
@@ -25,11 +25,13 @@
        {% endspaceless %}
       </div>       
     </header>
+    {% if self.file_url %}
     <p class="t-sans t-normal">
-      {% if self.file_url %}<i class="icon icon--inline--right icon--inline--left i-document"></i><a href="{{ self.file_url }}">{{ self.title}}</a>{% endif %}
+      <i class="icon icon--inline--right icon--inline--left i-document"></i><a href="{{ self.file_url }}">{{ self.title}}</a>
       {% if self.extension is not '' %} | ({{ self.extension }}){% endif %}
       {% if self.size %} | ({{ self.size }}){% endif %}
     </p>
+    {% endif %}
     <div class="main__content">
       {% include 'partials/body-blocks.html' with blocks=self.body %}
     </div>


### PR DESCRIPTION
## Summary
The new logic that shows file extension on `DocumentPages(Reports about the fec)` was  causing some report pages to get a 500 server error with `index out of range` error. Since `self.file_extension` is a property on the model and not a field value it always returns "true" [Example 500 error](https://www.fec.gov/about/reports-about-fec/oig-reports/audit-agency-controls-governing-process-procurement-vendor-training-services-executive-summary/).

<img width="784" alt="Screen Shot 2023-10-13 at 9 25 19 PM" src="https://github.com/fecgov/fec-cms/assets/5572856/b10b0c2d-7068-4199-8e8d-6b3d36f5acfa">


This logic was added in https://github.com/fecgov/fec-cms/pull/5931

- Resolves #issue_number

### Required reviewers
One frontend

## Impacted areas of the application

Reports about the FEC pages that do not have a document associated with them like :
https://www.fec.gov/about/reports-about-fec/oig-reports/audit-agency-controls-governing-process-procurement-vendor-training-services-executive-summary/


modified:   home/templates/home/document_page.html


## How to test

- checkout and run branch
- Make sure  reports in the list that that have `Read more...` links on this page do not get 500 Server error
    - http://127.0.0.1:8000/about/reports-about-fec/oig-reports/?category=audit+report
    - These are reports using DocumentPage that do not reference a file, the page itself is the report.
- @rfultz , I also went ahead and conditionally removed  the paragraph tag with file link and info on pages that do not have a document per [your earlier suggestion](https://github.com/fecgov/fec-cms/pull/5931/files#r1340239967)
      
