### PR TITLE
5904 About Menu: Intro to Campaign Finance and Elections

### DIFF
--- a/fec/fec/static/scss/components/_icon-headings.scss
+++ b/fec/fec/static/scss/components/_icon-headings.scss
@@ -170,6 +170,17 @@
   }
 }
 
+.icon-heading--election-circle {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($election, $inverse, $secondary-contrast, $size);
+    background-size: 70%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+}
+
 // icons for homepage - legal resources (on primary [blue] slab)
 .icon-heading--mallet-circle {
   &::before {

--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -97,8 +97,9 @@
   a:after {
     // Adding the double right-angle quote (») here since it's only decorative and not actually a closing quote
     // (for accessibility and SEO)
-    content: " »";
+    content: "\00A0 »"; // \00A0 is a non-breaking space to prevent wraps
     line-height: 1em;
+    position: absolute;
   }
 }
 

--- a/fec/fec/templates/partials/navigation/nav-about.html
+++ b/fec/fec/templates/partials/navigation/nav-about.html
@@ -3,7 +3,7 @@
     <div class="mega__inner">
       <div class="row">
         <div class="u-padding--left d-sm-none d-md-none col-lg-1">&nbsp;</div>
-        <div class="u-padding--left col-lg-10">
+        <div class="u-padding--left col-lg-6">
           <ul class="t-sans list--1-2-2-3-columns u-padding--top">
             <li class="mega__item"><a href="/about/">All about the FEC</a></li>
             <li class="mega__item"><a href="/updates/">News and announcements</a></li>
@@ -15,6 +15,11 @@
             <li class="mega__item"><a href="/about/#working-with-the-fec">Working with the FEC</a></li>
             <li class="mega__item"><a href="/contact/">Contact</a></li>
           </ul>
+        </div>
+        <div class="u-padding--left col-lg-4">
+          <div class="icon-heading icon-heading--election-circle">
+            <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/">Introduction to campaign finance and elections</a></p>
+          </div>
         </div>
       </div>
     </div>

--- a/fec/home/templates/purgecss-homepage/full.html
+++ b/fec/home/templates/purgecss-homepage/full.html
@@ -212,19 +212,31 @@
     
           </li>
           <li class="site-nav__item site-nav__item--secondary" data-submenu="about">
-            <a href="#0" class="site-nav__link "   id="mega-menu-1620314819148-7" aria-haspopup="true" aria-controls="mega-menu-1620314819148-8" aria-expanded="false">
+            <a href="#0" class="site-nav__link" tabindex="-1" style="">
               <span class="site-nav__link__title">About</span>
             </a>
-            <div class="mega-container" id="mega-menu-1620314819148-8" role="group" aria-expanded="false" aria-hidden="true" aria-labelledby="mega-menu-1620314819148-7">
+            <div class="mega-container is-open" id="mega-menu-1697570035205-8" role="group" aria-expanded="true" aria-hidden="false">
       <div class="mega mega--secondary">
         <div class="mega__inner">
           <div class="row">
             <div class="u-padding--left d-sm-none d-md-none col-lg-1">&nbsp;</div>
-            <div class="u-padding--left col-lg-10">
+            <div class="u-padding--left col-lg-6">
               <ul class="t-sans list--1-2-2-3-columns u-padding--top">
-                <li class="mega__item"><a href="/about/">All about the FEC</a></li>
-                <li class="mega__item"><a href="/contact/">Contact</a></li>
+                <li class="mega__item"><a href="/about/" tabindex="-1" class="">All about the FEC</a></li>
+                <li class="mega__item"><a href="/updates/" tabindex="-1">News and announcements</a></li>
+                <li class="mega__item"><a href="/meetings/" tabindex="-1">Commission meetings</a></li>
+                <li class="mega__item"><a href="/about/mission-and-history/" tabindex="-1">Mission and history</a></li>
+                <li class="mega__item"><a href="/about/leadership-and-structure/" tabindex="-1">Leadership and structure</a></li>
+                <li class="mega__item"><a href="/about/reports-about-fec/" tabindex="-1">Reports about the FEC</a></li>
+                <li class="mega__item"><a href="/about/careers/" tabindex="-1">Careers</a></li>
+                <li class="mega__item"><a href="/about/#working-with-the-fec" tabindex="-1">Working with the FEC</a></li>
+                <li class="mega__item"><a href="/contact/" tabindex="-1">Contact</a></li>
               </ul>
+            </div>
+            <div class="u-padding--left col-lg-4">
+              <div class="icon-heading icon-heading--election-circle">
+                <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/" tabindex="-1">Introduction to campaign finance and elections</a></p>
+              </div>
             </div>
           </div>
         </div>

--- a/fec/home/templates/purgecss-homepage/navs.html
+++ b/fec/home/templates/purgecss-homepage/navs.html
@@ -199,17 +199,17 @@
   
         </li>
         <li class="site-nav__item site-nav__item--secondary" data-submenu="about">
-          <a href="#0" class="site-nav__link" tabindex="-1" id="mega-menu-1623176509339-7" aria-haspopup="true" aria-controls="mega-menu-1623176509339-8" aria-expanded="false">
+          <a href="#0" class="site-nav__link" tabindex="-1" style="">
             <span class="site-nav__link__title">About</span>
           </a>
-          <div class="mega-container" id="mega-menu-1623176509339-8" role="group" aria-expanded="false" aria-hidden="true" aria-labelledby="mega-menu-1623176509339-7">
+          <div class="mega-container is-open" id="mega-menu-1697570035205-8" role="group" aria-expanded="true" aria-hidden="false">
     <div class="mega mega--secondary">
       <div class="mega__inner">
         <div class="row">
           <div class="u-padding--left d-sm-none d-md-none col-lg-1">&nbsp;</div>
-          <div class="u-padding--left col-lg-10">
+          <div class="u-padding--left col-lg-6">
             <ul class="t-sans list--1-2-2-3-columns u-padding--top">
-              <li class="mega__item"><a href="/about/" tabindex="-1">All about the FEC</a></li>
+              <li class="mega__item"><a href="/about/" tabindex="-1" class="">All about the FEC</a></li>
               <li class="mega__item"><a href="/updates/" tabindex="-1">News and announcements</a></li>
               <li class="mega__item"><a href="/meetings/" tabindex="-1">Commission meetings</a></li>
               <li class="mega__item"><a href="/about/mission-and-history/" tabindex="-1">Mission and history</a></li>
@@ -219,6 +219,11 @@
               <li class="mega__item"><a href="/about/#working-with-the-fec" tabindex="-1">Working with the FEC</a></li>
               <li class="mega__item"><a href="/contact/" tabindex="-1">Contact</a></li>
             </ul>
+          </div>
+          <div class="u-padding--left col-lg-4">
+            <div class="icon-heading icon-heading--election-circle">
+              <p class="t-sans t-small icon-heading__text"><a href="/introduction-campaign-finance/" tabindex="-1">Introduction to campaign finance and elections</a></p>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Resolves #5904 

Adding "Introduction to Campaign Finance and Elections" to the site's main nav

BONUS: I tweaked the layout of the right-angle quotes so they don't wrap to the next line

### Required reviewers

- Content for text and link accuracy
- UX for appearance

## Impacted areas of the application

The site nav (every page across the site)

## Screenshots

Current
<img width="1093" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/2c24d34a-387f-4b6e-b6bf-e5dcad6e994a">

This PR's version of the About menu with the Data menu open for comparison
<img width="1089" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/50c98e24-2a15-4dfc-ba5d-60134b93903e">

Example of the wrapping I tried to fix (campaign finance statistics)
<img width="406" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/0152445b-cd05-4686-90ef-f0196412871c">

Smallest XS width
<img width="465" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/df13719d-ff2f-4902-94c7-c9706bd2c97c">

Smallest small width
<img width="642" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/d090016a-e431-4b08-b3a6-b0c9d93ee149">

Smallest medium width
<img width="859" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/9d6c16af-206e-4ea1-9ab6-ae13ce494ddd">


## How to test

- pull the branch
- `npm run build`
- `./manage.py runserver`
- load any page on the site
- check the About menu for accurate links and layout _across all widths_
- check that line breaks aren't separating the right-angle quotes (») from their text _across all widths_
