### PR TITLE
switch line_number filter to form_line_number for debts

### DIFF
--- a/fec/data/templates/partials/debts-filter.jinja
+++ b/fec/data/templates/partials/debts-filter.jinja
@@ -15,9 +15,9 @@
     {{ range.amount('amount_outstanding_close', 'Ending balance') }}
     <legend class="label  u-margin--top">Debt type</legend>
     <fieldset class="js-filter js-line-number-filters" data-filter="checkbox">
-      {{ checkbox.checkbox_dropdown_multiple('line_number', 'House or Senate committees', options=constants.line_numbers.debts.house_senate, legend=False, prefix='House or Senate committees:') }}
-      {{ checkbox.checkbox_dropdown_multiple('line_number', 'Presidential committees', options=constants.line_numbers.debts.presidential, legend=False, prefix='Presidential committees:') }}
-      {{ checkbox.checkbox_dropdown_multiple('line_number', 'PACs or party committees', options=constants.line_numbers.debts.pac_party, legend=False, prefix='PACs or party committees:') }}
+      {{ checkbox.checkbox_dropdown_multiple('form_line_number', 'House or Senate committees', options=constants.line_numbers.debts.house_senate, legend=False, prefix='House or Senate committees:') }}
+      {{ checkbox.checkbox_dropdown_multiple('form_line_number', 'Presidential committees', options=constants.line_numbers.debts.presidential, legend=False, prefix='Presidential committees:') }}
+      {{ checkbox.checkbox_dropdown_multiple('form_line_number', 'PACs or party committees', options=constants.line_numbers.debts.pac_party, legend=False, prefix='PACs or party committees:') }}
     </fieldset>
  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary (required)

- Resolves #5969 
switch line_number filter to new form_line_number filter that allows multiple inputs. Both form_line_number and line_number will work for a month to allow users a grace period, but then line_number will be removed. As it currently is not working satisfactorily for the front-end we should switch is as soon as possible to the the new hybrid property. 

### Required reviewers

1-2 devs, at least 1 front-end 

## Impacted areas of the application

General components of the application that this PR will affect:

-  Debts data tables

## Screenshots

![image](https://github.com/fecgov/fec-cms/assets/66386084/ad4c0f59-ea58-4169-a84b-5b483593b948)

## Related PRs

https://github.com/fecgov/openFEC/pull/5627

## How to test

deploy[ the api PR ](https://github.com/fecgov/openFEC/pull/5627) to dev 

- Make sure that FEC_API_URL is pointing to dev
- pull this branch
- cd fec
- python manage.py runserver
- Compare www to local  
-  Go to [debts data table ](http://127.0.0.1:8000/data/debts/)and add multiple line numbers. 
<img width="879" alt="Screen Shot 2023-11-13 at 8 53 12 AM" src="https://github.com/fecgov/fec-cms/assets/66386084/795eec89-a467-495e-acfa-2db3aa70ffd1">
http://127.0.0.1:8000/data/debts/