### PR TITLE
Exclude duplicate press releases in /updates 

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -447,7 +447,8 @@ class PressReleasePage(ContentPage):
 
     search_fields = ContentPage.search_fields + [
         index.FilterField('category'),
-        index.FilterField('date')
+        index.FilterField('date'),
+        index.FilterField('url_path')
     ]
 
     @property

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -68,7 +68,8 @@ def get_digests(year=None, search=None):
 
 
 def get_press_releases(category_list=None, year=None, search=None):
-    press_releases = PressReleasePage.objects.live()
+    # Exclude duplicate(aliased) pages in /guidance-search/ path
+    press_releases = PressReleasePage.objects.live().exclude(url_path__contains='guidance-search')
 
     if category_list:
         for category in category_list:

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/rm-duplicate-press-releases'),
 )
 
 


### PR DESCRIPTION
## Summary
- Exclude aliased press release pages under the guidance-search path from listings on https://www.fec.gov/updates/
- Resolves #5970
- Still need to resolve [this conversation](https://github.com/fecgov/fec-proxy/pull/379#issuecomment-1778531308) before doing this
### Required reviewers

one frontend, one content

## Impacted areas of the application

General components of the application that this PR will affect:
Press release listings on https://www.fec.gov/updates/

modified:   home/models.py
modified:   home/views.py

## Screenshots
**Only one listing for  FEC issues interim reporting guidance for national party committee accounts**
<img width="715" alt="Screen Shot 2023-10-25 at 12 54 57 PM" src="https://github.com/fecgov/fec-cms/assets/5572856/971dd785-982e-4076-b009-6729962788a4">


## How to test

**Content team**
- On feature space go to https://fec-feature-cms.app.cloud.gov/updates/?page=2&update_type=press-release&year=2015
- Confirm that even though there is an alias of the National party accounts press release under `/updates/guidance-search/`, there is only one listed at the URL above.
    Original and its alias:
    - https://fec-feature-cms.app.cloud.gov/updates/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/
    - https://fec-feature-cms.app.cloud.gov/updates/guidance-search/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/
 - You can see how on prod, both show up :  https://www.fec.gov/updates/?page=2&update_type=press-release&year=2015


**Developers:**
- checkout and run branch
- Use the filter dropdwon on [/updates](http://127.0.0.01:8000/updates) to filter for pages that have an alias under `udates/guidance-search/ ` parent (or use example links below)
- Confirm that there are no duplicates, where there are currently on production
- Example: 
      - Prod:  https://www.fec.gov/updates/?page=2&update_type=press-release&year=2015
      - Local: http://127.0.0.1:8000/updates/?page=2&update_type=press-release&year=2015
   
