### PR TITLE
Fix hidden-rows-bug on Wagtail tableblocks

### DIFF
--- a/fec/fec/static/css/customize-editor.css
+++ b/fec/fec/static/css/customize-editor.css
@@ -82,18 +82,17 @@ li.sequence-member .sequence-member-inner .sequence-type-list .sequence-containe
 }
 
 
+/* Overrides to table blocks' CSS to fix bug that hides table rows in Wagtail editor. */
 
-/* Overrides to ReportingDatesTable template to allow full table to show in editor immeditaely. */
-
-div[data-contentpath="reporting_dates_table"] div[id*="-value-table-handsontable-container"] {
-  height:auto  !important;
+div[id*="-handsontable-container"] {
+  height: auto !important;
   margin-top: 30px;
 }
 
-div[id*="-value-table-handsontable-container"] .ht_master.handsontable {
-  height: auto  !important;
+div[id*="-handsontable-container"] .ht_master.handsontable {
+  height: auto !important;
 }
 
-div.ht_master.handsontable div.wtHolder {
-  height: auto  !important;
+div.ht_master.handsontable .wtHolder {
+  height: auto !important;
 }

--- a/fec/fec/static/css/customize-editor.css
+++ b/fec/fec/static/css/customize-editor.css
@@ -80,19 +80,3 @@ li.sequence-member .sequence-member-inner .sequence-type-list .sequence-containe
 .richtext ol ol ol li {
   list-style-type: lower-roman;
 }
-
-
-/* Overrides to table blocks' CSS to fix bug that hides table rows in Wagtail editor. */
-
-div[id*="-handsontable-container"] {
-  height: auto !important;
-  margin-top: 30px;
-}
-
-div[id*="-handsontable-container"] .ht_master.handsontable {
-  height: auto !important;
-}
-
-div.ht_master.handsontable .wtHolder {
-  height: auto !important;
-}

--- a/fec/home/blocks.py
+++ b/fec/home/blocks.py
@@ -6,7 +6,8 @@ from wagtail.snippets.blocks import SnippetChooserBlock
 
 """options for wagtail default table_block """
 core_table_options = {
-    'renderer': 'html'
+    'renderer': 'html',
+    'renderAllRows': True,
 }
 
 
@@ -175,7 +176,8 @@ class CustomTableBlock(blocks.StructBlock):
         'rowHeaders': True,
         'height': 108,
         'language': 'en',
-        'renderer': 'html'
+        'renderer': 'html',
+        'renderAllRows': True,
     }
 
     custom_table = blocks.StreamBlock([
@@ -200,7 +202,8 @@ class ReportingTableBlock(blocks.StructBlock):
         'rowHeaders': False,
         'height': 108,
         'language': 'en',
-        'renderer': 'html'
+        'renderer': 'html',
+        'renderAllRows': True,
     }
 
     table = TableBlock(table_options=reporting_table_options)

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/5910-fix-tableblock-hidden-rows'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/5910-fix-tableblock-hidden-rows'),
 )
 
 


### PR DESCRIPTION
## Summary
- Fix hidden-rows-bug on Wagtail tableblocks using HandsonTable's setting: [renderallrows](https://handsontable.com/docs/javascript-data-grid/api/options/#renderallrows)
- Resolves #5910

### Required reviewers

one content team member and @djgarr. One developer optional.

## Impacted areas of the application

Wagtail templates that use `TableBlock, CustomTableBlock and ReportingTableBlock`

modified:   fec/static/css/customize-editor.css
modified:   fec/home/blocks.py

## Related PRs
Fixed only for Reporting dates tables in https://github.com/fecgov/fec-cms/pull/5786 using CSS -- now expanded to cover all tableblocks with a setting instead of CSS.

## How to test
   - [ ] Remove feature deploy task before merge
   
**Content team:** 
This is  pushed this to feature for testing.
- Open pages with `tableblocks` in Wagtail to see that all table rows are visible and editable:
     - https://fec-feature-cms.app.cloud.gov/legal-resources/regulations/explanations-and-justifications/citation-index-parts-103-104/
     - https://fec-feature-cms.app.cloud.gov/legal-resources/enforcement/audit-reports/unauthorized-committee-audit-reports/latinos-for-america-first-2020/
     - @djgarr:  Can you please check your Reporting dates table that  is in draft ?: https://fec-feature-cms.app.cloud.gov/admin/pages/12944/edit/

**Developers:**
- Checkout and run branch
- Edit pages in Wagtail with large tables to make sure you can see and edit all rows in tableblocks
  - http://127.0.0.1:8000/legal-resources/regulations/explanations-and-justifications/citation-index-parts-103-104/
  - http://127.0.0.1:8000/legal-resources/enforcement/audit-reports/unauthorized-committee-audit-reports/latinos-for-america-first-2020/
  - This Reporting dates table is in draft: http://127.0.0.1:8000/admin/pages/12944/edit/
  


