### PR TITLE
Feature/5987 homepage barcharts to p

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -921,7 +921,7 @@ def house_senate_overview(request, office, cycle=None):
 
 
 def raising(request):
-    office = request.GET.get("office", "P")
+    office = request.GET.get("office", "P")  # The default for features like Who is raising the most
 
     election_year = int(
         request.GET.get("election_year", constants.DEFAULT_ELECTION_YEAR)
@@ -945,7 +945,7 @@ def raising(request):
 
 
 def spending(request):
-    office = request.GET.get("office", "S")
+    office = request.GET.get("office", "P")  # The default for features like Who is spending the most
 
     election_year = int(
         request.GET.get("election_year", constants.DEFAULT_ELECTION_YEAR)

--- a/fec/fec/static/js/widgets/contributions-by-state-box.js
+++ b/fec/fec/static/js/widgets/contributions-by-state-box.js
@@ -258,7 +258,7 @@ ContributionsByState.prototype.init = function() {
     election_full: true,
     // office: 'P',
     page: 1,
-    per_page: 200,
+    per_page: 100,
     sort_hide_null: false,
     sort_null_only: false,
     sort_nulls_last: false

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -114,7 +114,7 @@
 <script src="{% asset_for_js 'dataviz-common.js' %}"></script>
 <script src="{% asset_for_js 'election-lookup.js' %}"></script>
 <script>
-  //remove competing/confusing querystrings on homepage
+  // Remove competing/confusing querystrings on homepage
   $(function(){
     cleanURI()
     function cleanURI(){
@@ -126,8 +126,10 @@
     $('#main').on('change ', 'input, select', function(){
       cleanURI();
     })
-    //handle Chrome insconsistency with History API
-    $('.js-office').val('S');
+    {# Handle Chrome insconsistency with History API #}
+    $('.js-office').val('P');
+    {# This should be changed with /fec/home/templates_tags/top_entites.py #}
+    {# TODO: make this more elegant #}
     $('.js-election-year').val('2022')
     $('.js-chart-toggle').filter('[value=receipts]').prop('checked', true)
   });

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -126,11 +126,11 @@
     $('#main').on('change ', 'input, select', function(){
       cleanURI();
     })
-    {# Handle Chrome insconsistency with History API #}
+    {# Handle Chrome inconsistency with History API #}
     $('.js-office').val('P');
     {# This should be changed with /fec/home/templates_tags/top_entites.py #}
     {# TODO: make this more elegant #}
-    $('.js-election-year').val('2022')
+    $('.js-election-year').val('2024')
     $('.js-chart-toggle').filter('[value=receipts]').prop('checked', true)
   });
 </script>

--- a/fec/home/templates/partials/raising-spending.html
+++ b/fec/home/templates/partials/raising-spending.html
@@ -1,3 +1,4 @@
+{# The template for the homepage feature #}
 {% if FEATURES.barcharts %}
 {% load wagtailcore_tags %}
 {% load filters %}

--- a/fec/home/templatetags/top_entities.py
+++ b/fec/home/templatetags/top_entities.py
@@ -9,7 +9,9 @@ register = template.Library()
 
 @register.inclusion_tag('partials/raising-spending.html')
 def raising_spending(request):
-    office = request.GET.get('office', 'S')
+    office = request.GET.get('office', 'P')  # Sets the default office for the homepage feature
+    # If changing this, look at line 130 in /fec/home/templates/home/home_page.html
+    # TODO: make this more elegant
 
     election_year = int(request.GET.get('election_year', constants.DEFAULT_ELECTION_YEAR))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ gunicorn==19.10.0
 gevent==23.9.1
 psycopg2==2.8.6
 requests==2.31.0
+urllib3==1.26.7
 slacker==0.8.6
 whitenoise==5.2.0
 wagtail==4.2.3


### PR DESCRIPTION
## Summary

- Resolves #5987 

Updating the homepage 'Who is raising and spending the most' feature to default to presidential candidates and adjusting aggregate totals for the same


### Required reviewers

Anyone?

## Impacted areas of the application

The homepage barcharts

## Screenshots

<img width="978" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/2d9284e4-b5f0-4e91-ba79-45dd088537d4">

<img width="975" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/17538e50-faf8-420d-85c2-e8f41d52c2ab">

<img width="971" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/6daf63c6-fec9-43a4-b642-e5a31e507c35">


## Related PRs

None

## How to test

- pull the branch
- run `npm run build-js`
- `./manage.py runserver`
- check the [homepage](http://127.0.0.1:8000) that the barcharts default to P data and the `<select>` does, too
- check [raising by the numbers](http://127.0.0.1:8000/data/raising-bythenumbers/) for default offices and election years (P, 2024)
- check [spending by the numbers](http://127.0.0.1:8000/data/spending-bythenumbers/) for default offices and election years (P, 2024)