### PR TITLE
Ensure date is aligned right on heading w/ date

### DIFF
--- a/fec/fec/static/scss/components/_headings.scss
+++ b/fec/fec/static/scss/components/_headings.scss
@@ -119,6 +119,7 @@
     .heading__left {
       display: table-cell;
       width: 100%;
+      max-width: 100%;
     }
 
     .heading__right {

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/5959-right-align-date-heading'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/5959-right-align-date-heading'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 


### PR DESCRIPTION
## Summary
Ensure date is completely aligned right, on pages with `<header class="heading--main heading--with-date">`

- Resolves #5959

### Required reviewers
One team member

## Impacted areas of the application

Pages with `<header class="heading--main heading--with-date">` 
    - Document pages
    - Meeting pages 
    - Digest, Press Release, Record and Tips for Treasurers pages
    
modified:   fec/static/scss/components/_headings.scss

## Screenshots
### No matter how short the headline, the date is aligned right:

<img width="981" alt="Screen Shot 2023-11-07 at 1 08 23 AM" src="https://github.com/fecgov/fec-cms/assets/5572856/59f9fb95-46c2-4de2-a9d1-bbc031797704">


## How to test
@JonellaCulmer - If you need help getting your local working, let me know
- `git checkout feature/5959-right-align-date-heading`
- `npm run build-sass`
- check pages with `<header class="heading--main heading--with-date">` to ensure that the date is aligned right regardless of how short the headline text is. 
 Examples:
    -  http://127.0.0.1:8000/about/reports-about-fec/foia-reports/chief-foia-officer-report-fy-2013/
    - http://127.0.0.1:8000/updates/october-05-2023-open-meeting/ 
    - Also Digest, Press Release, Record and Tips for Treasurers pages
 - Test responsivity
 - Tip: You could go into inspector and edit a headline to make it shorter like the screenshot above.


