### PR TITLE
5953-upgrade django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.21
+Django==3.2.23
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary (required)

- Resolves #5952 

Upgrade django to remove snyk vuln

NOTE: This is a blocker to upgrade to 4 https://github.com/cloud-gov/cg-django-uaa/issues/70
Extended support for 3 ends April 2024, we should keep this on our radar in early next year

### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

-  django

## How to test

- pull this branch
- activate virtual environment
- pip install -r requirements.txt
- cd fec
- python manage.py runserver

