### PR TITLE
Update meeting page templates for 10 am time for 2024

### DIFF
--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -48,7 +48,7 @@
         <div class="main__content--right">
           <section id="meetings-open-meetings" role="tabpanel" aria-hidden="true" aria-labelledby="open-meetings">
             <h2>Open meetings</h2>
-            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held on Thursdays at 10:30 a.m. at FEC headquarters, 1050 First Street NE, Washington, DC. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
+            <p>Open to the public. The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held on Thursdays at 10:00 a.m. at FEC headquarters, 1050 First Street NE, Washington, DC. Commission meeting agendas are usually published a week before a scheduled meeting.</p>
             <div class="filters--horizontal">
               <form action="" id="openmeetings_form" method="get" class="js-form-nav container">
                 <div class="filter">

--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -37,7 +37,7 @@
     </header>
 
     {% if self.meeting_type == 'O' %}
-      <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held on Thursdays at 10:30 a.m. at FEC headquarters, 1050 First Street NE, Washington, DC.</p>
+      <p>The Commission considers new regulations, advisory opinions and other public matters at open meetings, which are typically held on Thursdays at 10:00 a.m. at FEC headquarters, 1050 First Street NE, Washington, DC.</p>
       <p>Members of the public can attend any open meeting or hearing in person. Open meetings are also streamed live online. To attend in person, please bring a photo ID and be prepared to go through a security check. After security, attendees are escorted to the Commission's hearing room. Please check the meeting page for updates to the agenda, including cancellations.</p>
     {% elif self.meeting_type == 'E' %}
       <p>The Commission meets regularly in executive sessions to discuss pending enforcement actions, litigation and other matters that, by law, must be kept confidential.</p>


### PR DESCRIPTION
## Summary (required)

- Resolves #5998 

Changes time for open meetings from 10:30 a.m. to 10:00 a.m.

### Required reviewers

1 front end reviewer

## Impacted areas of the application

General components of the application that this PR will affect:

- Commission meeting landing page
- All Commission open meeting pages


