### PR TITLE
[DRAFT] Remove prefix and suffix from site-search results

### DIFF
--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -66,13 +66,26 @@ def web_app_url(path):
     return "{}{}".format(settings.FEC_APP_URL, path)
 
 
+@register.filter(name='remove_title_pre_suf_fix')
+def remove_title_pre_suf_fix(str):
+    """
+    Removes 'FEC | ' prefix and ' - FEC.gov' suffix' from search.gov search result title
+    """
+    str = re.sub(r'(^FEC \| | - FEC\.gov$)', '', str)
+    return str
+
+
 @register.filter()
 def highlight_matches(text):
     """
     Replaces the highlight markers with span tags for Search.gov website search results.
     Because format_html uses str.format, remove { and } because they are special characters.
     """
+    
+    #text = remove_result_pre_suf_fix(text)
     cleaned_text = text.replace("{", "").replace("}", "")
+    
+
     highlighted_text = cleaned_text.replace(
         "\ue000", '<span class="t-highlight">'
     ).replace("\ue001", "</span>")
@@ -189,3 +202,5 @@ def get_file_type(value):
     file_type = "EXCEL" if xl else file_extension
 
     return file_type
+
+

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -81,11 +81,7 @@ def highlight_matches(text):
     Replaces the highlight markers with span tags for Search.gov website search results.
     Because format_html uses str.format, remove { and } because they are special characters.
     """
-    
-    #text = remove_result_pre_suf_fix(text)
     cleaned_text = text.replace("{", "").replace("}", "")
-    
-
     highlighted_text = cleaned_text.replace(
         "\ue000", '<span class="t-highlight">'
     ).replace("\ue001", "</span>")

--- a/fec/search/templates/search/search.html
+++ b/fec/search/templates/search/search.html
@@ -162,7 +162,7 @@
                 {% for result in results.site.results %}
                   <li class="post post--icon">
                     <h3>
-                      <i class="icon icon--inline--left {% if result.icon == 'page' %}i-document{% else %}i-table{% endif %}"></i><a href="{{ result.url }}">{{ result.title | highlight_matches }}</a>
+                      <i class="icon icon--inline--left {% if result.icon == 'page' %}i-document{% else %}i-table{% endif %}"></i><a href="{{ result.url }}">{{ result.title | remove_title_pre_suf_fix | highlight_matches }}</a>
                     </h3>
                     <div class="post__path t-small t-sans">{{ result.url }}</div>
                     <p class="post__preview t-note">{{ result.snippet | highlight_matches }}</p>


### PR DESCRIPTION
## Summary (required)

Filter to remove the FEC-related prefix and suffixes from search.gov, site-search results.

- Resolves #5945


### Required reviewers

one frontend,  one UX/content

## Impacted areas of the application

Site search result listings titles

	modified:   home/templatetags/filters.py
	modified:   search/templates/search/search.html 

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)



## How to test

- Checkout and run branch
- `export SEARCHGOV_API_ACCESS_KEY=<get key from CF env vars>`
- Test global site-search searching on  your local. 
- The results will be prod (www.fec.gov) urls, but you can compare results to the same search on prod to verify that the pre/suf fixes were stripped out on your local's search results page

 

## System architecture updates (if applicable)

(If this pull request changes our [current system diagram](https://github.com/fecgov/FEC/wiki/2.-FEC-system-diagram), include a description of those changes here and create a new ticket to update the system diagram)
