### PR TITLE
6027 - Remove Grey from Election Search Maps

### DIFF
--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -237,8 +237,8 @@ ElectionMap.prototype.handleReset = function(e) {
  */
 ElectionMap.prototype.hide = function() {
   this.elm.setAttribute('aria-hidden', 'true');
-  this.mapMessage.setAttribute('aria-hidden', 'false');
-  this.mapApproxMessage.setAttribute('aria-hidden', 'true');
+  if (this.mapMessage) this.mapMessage.setAttribute('aria-hidden', 'false');
+  if (this.mapApproxMessage) this.mapApproxMessage.setAttribute('aria-hidden', 'true');
 };
 
 /**

--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -16,8 +16,13 @@ var FEATURE_TYPES = {
 var STATE_ZOOM_THRESHOLD = 4;
 
 var defaultOpts = {
-  colorScale: colorbrewer.Set1
+  colorScale_states: colorbrewer.Set1,
+  colorScale_districts: colorbrewer.Set1
 };
+// Doing the district color adjustment here in case Object.assign isn't supported
+defaultOpts.colorScale_districts = Object.assign({}, colorbrewer.Set1);
+// Delete the last color for dists because the grey gets lost over our current map tiles
+delete defaultOpts.colorScale_districts['9'];
 
 var boundsOverrides = {
   200: { coords: [64.06, -152.23], zoom: 3 } // eslint-disable-line quote-props
@@ -60,8 +65,8 @@ function getDistrictPalette(scale) {
 function ElectionMap(elm, opts) {
   this.elm = elm;
   this.opts = _.extend({}, defaultOpts, opts);
-  this.statePalette = getStatePalette(this.opts.colorScale);
-  this.districtPalette = getDistrictPalette(this.opts.colorScale);
+  this.statePalette = getStatePalette(this.opts.colorScale_states);
+  this.districtPalette = getDistrictPalette(this.opts.colorScale_districts);
   this.mapMessage = document.querySelector('.js-map-message');
   this.mapApproxMessage = document.querySelector('.js-map-approx-message');
   this.initialized = false;


### PR DESCRIPTION
## Summary

- Resolves #6027 

Removing the grey from the palette for district colors because it gets lost against our current map tiles

### Required reviewers

One?

## Impacted areas of the application

The district-level colors of the election search maps

## Screenshots

Districts
| Before | After | 
| :-- | :-- |
| <img width="465" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/dd3beef8-203e-4ba0-b213-a1bd133d4f42"> | ![dists-after](https://github.com/fecgov/fec-cms/assets/26720877/08cea16b-07c9-4a8c-92ad-7e067e35cd90) |
| Looking especially at FL 8, 17, and 26… |  (east of Orlando, south of Tampa, and west of Miami) |

States
| Before and currently | Why we didn't change the palette for states |
| :-- | :-- |
| ![states-before](https://github.com/fecgov/fec-cms/assets/26720877/40c564e8-d639-4853-9384-9c1dd1f6c948) | ![states-after](https://github.com/fecgov/fec-cms/assets/26720877/d6649c38-ac1d-47ba-8b86-9b0d4f68d89f) |
| WA, CO, NM, IL, MI, RI are grey but still clear | Chains of states the same color: NV, ID, WY, CO, OK, TX and MT, ND, SD and MO, AR, KY and GA, SC, NC |

## Related PRs

None

## How to test

- pull the branch locally
- `npm run build-js`
- `./manage.py runserver`
- the election search maps for the [homepage](http://127.0.0.1:8000/), [data landing page](http://127.0.0.1:8000/data/), and [elections pages](http://127.0.0.1:8000/data/elections/)
   - [ ] states should include the grey option (WA's an easy check)
   - [ ] the districts maps should _not_ include the grey, but states with fewer than nine districts never used the grey, so check states larger than eight districts