### PR TITLE
Upgrade Urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gunicorn==19.10.0
 gevent==23.9.1
 psycopg2==2.8.6
 requests==2.31.0
-urllib3==1.26.7
+urllib3==1.26.18
 slacker==0.8.6
 whitenoise==5.2.0
 wagtail==4.2.3


### PR DESCRIPTION
## Summary (required)

- Resolves #6007

This ticket removes a security vulnerability by upgrading urllib3 to v1.26.18.

### Required reviewers 1 developer 

## Impacted areas of the application

General components of the application that this PR will affect:

-  server-side API calls

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- Check out this branch 
- `snyk test --file=requirements.txt --package-manager=pip` (ensure urllib3 is not listed)
- `pip install -r requirements.txt`
- `cd fec/`
-  `./manage.py runserver`
-  `pytest`
- Test pages with server-side calls like the candidate or committee profile pages

