### PR TITLE
6080 - Update Election Search

### DIFF
--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -108,7 +108,7 @@
             <p>District maps on this page are approximate.</p>
         </div>
         <div class="message message--info js-map-message" aria-hidden="true">
-            Election maps and ZIP code search are only available for elections in {{ constants.DISTRICT_MAP_CUTOFF | fmt_year_range }} and future election years.
+            Election maps and ZIP code search are only available for elections in {{ constants.DISTRICT_MAP_CUTOFF }} and future election years.
         </div>
         <div class="js-upcoming-presidential"></div>
       </div>

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -108,7 +108,7 @@
             <p>District maps on this page are approximate.</p>
         </div>
         <div class="message message--info js-map-message" aria-hidden="true">
-            Election maps are only available for elections in {{ constants.DISTRICT_MAP_CUTOFF | fmt_year_range }} and future election years.
+            Election maps and ZIP code search are only available for elections in {{ constants.DISTRICT_MAP_CUTOFF | fmt_year_range }} and future election years.
         </div>
         <div class="js-upcoming-presidential"></div>
       </div>

--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -108,7 +108,7 @@
             <p>District maps on this page are approximate.</p>
         </div>
         <div class="message message--info js-map-message" aria-hidden="true">
-            District maps are only available for elections in {{ constants.DISTRICT_MAP_CUTOFF | fmt_year_range }} and future election years.
+            Election maps are only available for elections in {{ constants.DISTRICT_MAP_CUTOFF | fmt_year_range }} and future election years.
         </div>
         <div class="js-upcoming-presidential"></div>
       </div>

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -85,7 +85,6 @@ ElectionSearch.constructor = ElectionSearch;
  * element of the election search form
  */
 ElectionSearch.prototype.wakeTheMap = function() {
-  // console.log('ElectionSearch.wakeTheMap(e): ', e);
   if (!this.initialized) {
     document.removeEventListener('FEC-ElectionSearchInteraction', this.wakeTheMap);
     if (this.dormantMap) this.dormantMap.removeEventListener('click', this.wakeTheMap);
@@ -99,19 +98,13 @@ ElectionSearch.prototype.wakeTheMap = function() {
  * then initializes the interactive map
  */
 ElectionSearch.prototype.initInteractiveMap =function() {
-  // console.log('ElectionSearch.initInteractiveMap()');
-  // console.log('  this: ', this);
-  // console.log('  this.initialized: ', this.initialized);
   if (!this.initialized) {
-    // console.log('  if');
     if (this.dormantMap) {
-      // console.log('    if');
       this.dormantMap.classList.remove('dormant');
       this.dormantMap.removeAttribute('title');
       delete this.dormantMap;
     }
 
-    // console.log('this.map: ', this.map);
     this.map = new ElectionMap(this.$map.get(0), {
       drawStates: _.isEmpty(this.serialized),
       handleSelect: this.handleSelectMap.bind(this)
@@ -119,15 +112,10 @@ ElectionSearch.prototype.initInteractiveMap =function() {
 
     this.initialized = true;
 
-    // console.log('  calling the block');
     this.getUpcomingPresidentialElection();
     this.getUpcomingElections();
     this.performStateChange();
     this.handlePopState();
-    // console.log('  called the block');
-
-  } else {
-    // console.log('  else');
   }
 };
 

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -146,23 +146,26 @@ ElectionSearch.prototype.toggleComponents = function() {
   const shouldShowRedistrictingMsgForPA = this.$cycle.val() == 2018 && this.$state.val() == 'PA';
 
   // The map and its alternate message
-  theMap.setAttribute('aria-hidden', !shouldShowMap);
-  theMapDisclaimer.setAttribute('aria-hidden', !shouldShowMap);
-  theMapAltMessage.setAttribute('aria-hidden', shouldShowMap);
+  if (theMap) theMap.setAttribute('aria-hidden', !shouldShowMap);
+  if (theMapDisclaimer) theMapDisclaimer.setAttribute('aria-hidden', !shouldShowMap);
+  if (theMapAltMessage) theMapAltMessage.setAttribute('aria-hidden', shouldShowMap);
 
   // ZIP Code search
-  theZipSearchParts.forEach(el => {
-    if (shouldShowZip) {
-      el.classList.remove('is-disabled');
-      el.removeAttribute('disabled');
-    } else {
-      el.classList.add('is-disabled');
-      el.setAttribute('disabled', true);
-    }
-  });
+  if (theZipSearchParts) {
+    theZipSearchParts.forEach(el => {
+      if (shouldShowZip) {
+        el.classList.remove('is-disabled');
+        el.removeAttribute('disabled');
+      } else {
+        el.classList.add('is-disabled');
+        el.setAttribute('disabled', true);
+      }
+    });
+  }
 
   // Redistricting message
-  redistrictingMsgAccordion.setAttribute('aria-hidden', !shouldShowRedistrictingMsg);
+  if (redistrictingMsgAccordion)
+    redistrictingMsgAccordion.setAttribute('aria-hidden', !shouldShowRedistrictingMsg);
 
   // Pennsylvania redistricting message
   if (shouldShowRedistrictingMsgForPA) $('.pa-message').show();

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -119,13 +119,56 @@ ElectionSearch.prototype.initInteractiveMap =function() {
   }
 };
 
-ElectionSearch.prototype.updateRedistrictingMessage = function() {
-  if (this.$cycle.val() == 2018 && this.$state.val() == 'PA') {
-    $('.pa-message').show();
-  } else {
-    $('.pa-message').hide();
-  }
+/**
+ * Toggles various components' states based on election year and state
+ */
+ElectionSearch.prototype.toggleComponents = function() {
+  // The important years
+  const firstYearToOfferMap = parseInt(window.DISTRICT_MAP_CUTOFF);
+  const firstYearToOfferZip = parseInt(window.DISTRICT_MAP_CUTOFF);
+  const firstYearToShowRedistrictingMsg = 2020;
+
+  // The map elements
+  const theMap = document.querySelector('.election-map');
+  const theMapDisclaimer = document.querySelector('.js-map-approx-message');
+  const theMapAltMessage = document.querySelector('.js-map-message');
+  const theZipSearchParts = document.querySelectorAll(
+    '.search-controls__zip, \
+    .search-controls__zip input, \
+    .search-controls__zip button'
+  );
+  const redistrictingMsgAccordion = document.querySelector('.js-accordion[data-content-prefix="2022-redistricting"]');
+
+  // Should we show the map, zip, redistricting?
+  const shouldShowMap = this.$cycle.val() >= firstYearToOfferMap;
+  const shouldShowZip = this.$cycle.val() >= firstYearToOfferZip;
+  const shouldShowRedistrictingMsg = this.$cycle.val() >= firstYearToShowRedistrictingMsg;
+  const shouldShowRedistrictingMsgForPA = this.$cycle.val() == 2018 && this.$state.val() == 'PA';
+
+  // The map and its alternate message
+  theMap.setAttribute('aria-hidden', !shouldShowMap);
+  theMapDisclaimer.setAttribute('aria-hidden', !shouldShowMap);
+  theMapAltMessage.setAttribute('aria-hidden', shouldShowMap);
+
+  // ZIP Code search
+  theZipSearchParts.forEach(el => {
+    if (shouldShowZip) {
+      el.classList.remove('is-disabled');
+      el.removeAttribute('disabled');
+    } else {
+      el.classList.add('is-disabled');
+      el.setAttribute('disabled', true);
+    }
+  });
+
+  // Redistricting message
+  redistrictingMsgAccordion.setAttribute('aria-hidden', !shouldShowRedistrictingMsg);
+
+  // Pennsylvania redistricting message
+  if (shouldShowRedistrictingMsgForPA) $('.pa-message').show();
+  else $('.pa-message').hide();
 };
+
 ElectionSearch.prototype.performSearch = function() {
   document.dispatchEvent(new Event('FEC-ElectionSearchInteraction'));
   var inputs = this.$form.find(':input').not(this.$cycle);
@@ -140,11 +183,11 @@ ElectionSearch.prototype.performSearch = function() {
   }
 
   this.search();
-  this.updateRedistrictingMessage();
+  this.toggleComponents();
 };
 ElectionSearch.prototype.performStateChange = function() {
   this.handleStateChange();
-  this.updateRedistrictingMessage();
+  this.toggleComponents();
 };
 
 /**
@@ -304,7 +347,6 @@ ElectionSearch.prototype.getPresidentialElections = function() {
       }
     );
   } else {
-    this.$resultsHeading.hide();
     resultsItems.empty();
   }
   var obj = {

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -372,8 +372,8 @@ ElectionSearch.prototype.getUpcomingPresidentialElection = function() {
   var currentYear = now.getFullYear();
   var queryP = {
     state: 'US',
-    // Get upcoming presidential election year
-    cycle: currentYear + 4 - (currentYear % 4)
+    // Get upcoming presidential election year (unless the current year is an election year)
+    cycle: currentYear % 4 === 0 ? currentYear : currentYear + 4 - (currentYear % 4)
   };
   var presidentialUrl = helpers.buildUrl(['elections', 'search'], queryP);
   var self = this;

--- a/fec/fec/static/scss/components/_messages.scss
+++ b/fec/fec/static/scss/components/_messages.scss
@@ -175,6 +175,10 @@ p {
     &.message--inverse {
       background-position: u(2rem 2rem);
     }
+
+    &.js-map-message {
+      margin-top: 0;
+    }
   }
 
   .message--small {

--- a/tasks.py
+++ b/tasks.py
@@ -77,6 +77,7 @@ DEPLOY_RULES = (
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/6080-election-search'),
 )
 
 


### PR DESCRIPTION
## Summary

- Resolves #6080 

Updating some functionality on the election search page, generally targeting 

### Required reviewers

UX and front-end?

## Impacted areas of the application

The election search page's various components


## Screenshots

Before, with the problem areas circled
<img width="982" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/eaa6cea5-af95-4bf0-b45c-4c73600a3a34">

Afters
![image](https://github.com/fecgov/fec-cms/assets/26720877/7464bd25-166f-4f50-8c33-016efda5f427)

![image](https://github.com/fecgov/fec-cms/assets/26720877/456989aa-827e-4d53-bc01-0a885f30ea9a)

![image](https://github.com/fecgov/fec-cms/assets/26720877/d2e6e850-8cfc-4e92-9b97-593ea9077bfc)

![image](https://github.com/fecgov/fec-cms/assets/26720877/61f96648-97f9-4369-812e-0a5b328cd827)


## Related PRs

None

## How to test

- pull the branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- Check the [elections search page](http://127.0.0.1:8000/data/elections/
   - map should appear for 2024+ only
   - "District maps on this page" map disclaimer should appear for 2024+ only
   - "Election maps are only available…" message should appear < 2024
   - "Election maps are only available…" message should be top-aligned with the left column's content for >= medium widths
   - FIND BY ZIP CODE field and 🔍 button should only be active >= 2024
   - "Information about redistricting…" accordion item should only appear 2020+
   - "Information about 2018 Pennsylvania redistricting" message should only appear when 2018 and PA are both selected
   - nothing else should have changed