### PR TITLE
upgrade python v3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: cimg/python:3.9-browsers
+      - image: cimg/python:3.10-browsers
         environment:
           TZ: America/New_York
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ run into problems please
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python (the latest 3.9 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
+    * Python (the latest 3.10 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which
       includes `npm`).
     * PostgreSQL (the latest 13 release).

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,8 +40,8 @@ cg-django-uaa==2.1.5
 
 # Testing
 coverage==7.0.3
-pytest==6.2.2
+pytest==8.0.2
 Faker==0.8.6
 pytest-django==3.10.0
-pytest-cov==2.11.1
+pytest-cov==4.1.0
 pre-commit==2.21.0 #client-side hook triggered by operations like git commit

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.x
+python-3.10.x


### PR DESCRIPTION
## Summary (required)

- Resolves #6058 

This pr upgrades python to version 3.10.13.

### Required reviewers 1-2 developers


## Impacted areas of the application

General components of the application that this PR will affect:

-  pytest
- circleci pipeline

## How to test-  pull the branch

1. Checkout this branch 
2. `pyenv install 3.10.13`
3. `pyenv virtualenv 3.10.13 <new test env>`
4. `pyenv activate <new test env>`
5. `pip install -r requirements.txt`
6. `npm i` 
7. `npm run build`
8. `pytest`
9. `cd fec`
10. `./manage.py runserver`
- check that the site's working as expected 