### PR TITLE
upgrade to pg v15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test
 
       # PostgreSQL
-      - image: cimg/postgres:13.8
+      - image: cimg/postgres:15.6
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: "trust"
@@ -31,7 +31,7 @@ jobs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
             sudo apt-get update -qq && sudo apt-get install -y build-essential postgresql-client
-            echo 'export PATH=/usr/lib/postgresql/13.8/bin/:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/lib/postgresql/15.6/bin/:$PATH' >> $BASH_ENV
             echo "en_US.UTF-8 UTF-8" | sudo tee /etc/locale.gen
             sudo locale-gen en_US.UTF-8
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ run into problems please
     * Python (the latest 3.10 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which
       includes `npm`).
-    * PostgreSQL (the latest 13 release).
+    * PostgreSQL (the latest 15 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/).
          * Read a [Windows tutorial](https://www.postgresqltutorial.com/install-postgresql/).
          * Read a [Linux tutorial](https://www.postgresql.org/docs/13/installation.html)


### PR DESCRIPTION
## Summary (required)

- Resolves #6140 

This ticket upgrades the circleci pipeline to postgres 15 to match production. 

Note: Frontend developers can now switch over to pg15 on their local machines. 

### Required reviewers 1-2 developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  circleci pipeline

## How to test

1. rerun circleci build on [this](https://app.circleci.com/pipelines/github/fecgov/fec-cms/3241/workflows/dc07fe48-eccb-4f21-b2f7-2c44e2ebc698/jobs/6680) branch 
2. verify the circleci pipeline runs on postgres 15 and pytest passes.  
