### PR TITLE
Office template anchors and rich-text

### DIFF
--- a/fec/home/templates/home/office_page.html
+++ b/fec/home/templates/home/office_page.html
@@ -16,7 +16,7 @@ v{% load wagtailimages_tags %}
     {% for block in self.offices %}
     <div class="main__content--full"> 
      {% if block.block_type == 'office' %}
-       <a name="{{ block.value.office_title | slugify }}"></a>
+       <a id="{{ block.value.office_title | slugify }}"></a>
        {% if not block.value.hide_title %}
          <h2 class="content__section--ruled-responsive methodology-block t-serif office-title">{{ block.value.office_title }}</h2>
        {% endif %}
@@ -43,7 +43,9 @@ v{% load wagtailimages_tags %}
             </div>
            {% endif %}
            {% if block.value.extra_info %}
-             {{ block.value.extra_info }}
+             <div class='rich_text'>
+               {{ block.value.extra_info }}
+             </div>
            {% endif %}
       </div>
       <div class="sidebar-container sidebar-container--right offices-contact">

--- a/fec/home/templates/home/office_page.html
+++ b/fec/home/templates/home/office_page.html
@@ -43,7 +43,7 @@ v{% load wagtailimages_tags %}
             </div>
            {% endif %}
            {% if block.value.extra_info %}
-             <div class='rich_text'>
+             <div class='rich-text'>
                {{ block.value.extra_info }}
              </div>
            {% endif %}

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/6142-office_template-anchors-rich-text'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/6142-office_template-anchors-rich-text'),
 )
 
 


### PR DESCRIPTION
## Summary

- Resolves #6146

- Changes the office-sections anchors from `<a name=`... to `<a id=...` because `<a name` is deprecated and not what editors are looking for when creating an anchor-link(#) to a place in the page.
- Wraps the `extra info` field in rich-text class to make sure it styles rich-text elements as expected. 

### Required reviewers 
1 reviewer (UX, content, developer) 
Ask to have it deployed to feature if you prefer to test it there

## Impacted areas of the application
File(s) modified
modified:   home/templates/home/office_page.html

General components of the application that this PR will affect:
- office-sections anchors 
- `extra info` Wagtail  rich-text field 
 

## How to test
- Checkout and run branch or ask to have it deployed to feature space for testing
- Create or test an existing  Office page to make sure the section anchors work.
    - You can see the anchor name in the inspector directly  above each office-section with the syntax `<a id=...>`
    - Or just use the slugified version of the `Office title field`. (Slugified means: replace spaces with dashes and make it all lowercase)
- Create an element in the `extra-info` Wagtail field like a bulleted list to see that it is rendered with bullets in the browser.


