### PR TITLE
Meeting page, remove reference to captions file

### DIFF
--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -55,7 +55,7 @@
     <div class="row">
       <div class="slab slab--neutral slab--inline">
         <h2 class="u-padding--left">Watch the meeting live</h2>
-        <p class="u-padding--left"> The webcast will include closed captions. The recorded webcast and audio will be posted on this page after the meeting ends.</p>
+        <p class="u-padding--left"> The webcast will include closed captions. The recorded webcast with closed captions and audio will be available on this page after the meeting ends.</p>
         <div class="u-margin--left u-margin--right">
           <div class="video__wrapper">
             <iframe width="100%" height="100%" src="https://www.youtube.com/embed/{{ self.live_video_embed }}?modestbranding=0&rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>

--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -55,7 +55,7 @@
     <div class="row">
       <div class="slab slab--neutral slab--inline">
         <h2 class="u-padding--left">Watch the meeting live</h2>
-        <p class="u-padding--left"> The webcast will include closed captions. The recorded video, audio and captions will be posted on this page after the meeting ends.</p>
+        <p class="u-padding--left"> The webcast will include closed captions. The recorded webcast and audio will be posted on this page after the meeting ends.</p>
         <div class="u-margin--left u-margin--right">
           <div class="video__wrapper">
             <iframe width="100%" height="100%" src="https://www.youtube.com/embed/{{ self.live_video_embed }}?modestbranding=0&rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>


### PR DESCRIPTION
## Summary (required)

- Resolves #6146

Remove language that previously referred to a separate caption file (transcript) being uploaded after meeting ends.

### Required reviewers

one

## Impacted areas of the application

General components of the application that this PR will affect:

modified:   home/templates/home/meeting_page.html

## How to test
- Look at the text on line 58 of  `home/templates/home/meeting_page.html` 


