### PR TITLE
update statutes example search

### DIFF
--- a/fec/legal/templates/layouts/legal-doc-search-results.jinja
+++ b/fec/legal/templates/layouts/legal-doc-search-results.jinja
@@ -45,7 +45,7 @@
       <div class="u-padding--left u-padding--right">
         <div class="message message--info">
           <p>
-            The statutes search feature includes the Federal Election Campaign Act (52 U.S.C. §§ 30101 to 30146), the Presidential Election Campaign Fund Act (26 U.S.C. §§ 9001 to 9013) and the Presidential Primary Matching Payment Account Act (26 U.S.C. §§ 9031 to 9042). You can search statutes using keywords and/or statutory citations (full or partial).
+            The statutes search feature includes the Federal Election Campaign Act (52 U.S.C. §§ 30101 to 30146), the Presidential Election Campaign Fund Act (26 U.S.C. §§ 9001 to 9013) and the Presidential Primary Matching Payment Account Act (26 U.S.C. §§ 9031 to 9042). You can search statutes using keywords from section titles and/or statutory citations.
           </p>
         </div>
       </div>

--- a/fec/legal/templates/legal-statutes-landing.jinja
+++ b/fec/legal/templates/legal-statutes-landing.jinja
@@ -31,7 +31,7 @@
         </div>
         <div class="row">
           <div class="usa-width-one-whole">
-            <span class="t-note t-sans search__example">Examples: spending; 52 U.S.C. §30123</span>
+            <span class="t-note t-sans search__example">Examples: contribution; 52; 30123</span>
           </div>
         </div>
       </div>

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -14,7 +14,11 @@
     </button>
   </div>
   <div class="combo combo--search--mini--example">
-    <span class="t-note t-sans search__example">Examples: spending; 52 U.S.C. §30123</span>
+        {% if result_type == 'statutes' %}
+          <span class="t-note t-sans search__example">Examples: contribution; 52; 30123</span>
+        {% else %}
+          <span class="t-note t-sans search__example">Examples: spending; 52 U.S.C §30123</span>
+        {% endif %}
   </div>
   <button type="button" class="button--keywords" aria-controls="keyword-modal" data-a11y-dialog-show="keyword-modal">More keyword options</button>
 


### PR DESCRIPTION
## Summary 

Able to seach Statues using  titles (e.g., 26 or 52) and sections (e.g., 9001 or 30109) or the document name description (e.g.,short title )

1. Update statutes  language search example in [statutes page](https://www.fec.gov/data/legal/statutes/) and [statutes search feature](https://www.fec.gov/data/legal/search/statutes/)
2. Update the language in the [information box](https://www.fec.gov/data/legal/search/statutes/?)  at the top of the search 


## Resolves # https://github.com/fecgov/openFEC/issues/5747
## Related # https://github.com/fecgov/FEC/issues/13147


### Required reviewers

1 UX and 1 Front end developer

## Impacted areas of the application

- Statutes search  

## Screenshots

**After:**
Statues Page:

<img width="1100" alt="Screen Shot 2024-03-26 at 8 18 31 AM" src="https://github.com/fecgov/fec-cms/assets/11650355/54f0039b-9aea-4f04-93c1-411a9a12adbd">

Statues Search:

<img width="1269" alt="Screen Shot 2024-03-26 at 8 17 23 AM" src="https://github.com/fecgov/fec-cms/assets/11650355/cbbb3ab0-47b2-483f-bfdc-0ce637328d6e">



## How to test

- Deploy this [test branch](https://app.circleci.com/pipelines/github/fecgov/fec-cms?branch=test-5747) to dev space and verify statues search example language changes and test the search functionality from the following links:

1. https://dev.fec.gov/data/legal/statutes/
2. https://dev.fec.gov/data/legal/search/statutes/?search=



