### PR TITLE
Remove banners from sitemap and search index

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -556,7 +556,7 @@ class HomePageBannerAnnouncement(Page):
         )
     ]
 
-    def get_sitemap_urls(self, *args):
+    def get_sitemap_urls(self, request=None):
         return []
 
 
@@ -590,7 +590,7 @@ class AlertForEmergencyUseOnly(Page):
         )
     ]
     
-    def get_sitemap_urls(self, *args):
+    def get_sitemap_urls(self,request=None):
         return []
 
 

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -556,6 +556,9 @@ class HomePageBannerAnnouncement(Page):
         )
     ]
 
+    def get_sitemap_urls(self, *args):
+        return []
+
 
 class AlertForEmergencyUseOnly(Page):
     # Home page banner alert
@@ -586,6 +589,9 @@ class AlertForEmergencyUseOnly(Page):
             requires approval by Amy Kort or Wei Luo prior to deployment."
         )
     ]
+    
+    def get_sitemap_urls(self, *args):
+        return []
 
 
 class CustomPage(Page):


### PR DESCRIPTION
## Summary (required)

- Resolves #6149
`HomePageBannerAnnouncement` and `AlertForEmergencyUseOnly` pages will not show up in Wagtail sitemap and site search.

- [ ] Once this is merged, we need to contact search.gov to ask them to remove the specific banners entries that are in the index. We should send a list of [all (live or draft) banners Wagtail](https://www.fec.gov/admin/pages/9777/) to search.gov because likely at some each one was live and thus added to index. 
 

- [ ] Confirm that they no longer appear on production sitemap or sesrch results after search.gov removes them from index
     - Spot check by [searching 'option'](https://www.fec.gov/search/?query=option&type=site) or [searching 'offline](https://www.fec.gov/search/?query=offline&type=site) the global search box 
    - Opening `https://www.fec.gov/sitemap-wagtail.xml/` and doing a "Ctl-f" search for "banner".  

### Required reviewers
one frontend, one content

## Impacted areas of the application

models.py
https://www.fec.gov/sitemap-wagtail.xml


## How to test

- While on develop or any other branch go to sitemap:   http://127.0.0.1:8000/sitemap-wagtail.xml/  and do a text search (Cmd-f ) on the page for "banner". You should  find  banners in the sitemap
-  checkout and run branch
- Do the same search. Should not find any banners.


