### PR TITLE
Expand keyword search on /updates to include html content

### DIFF
--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -19,6 +19,20 @@ from home.models import (CommissionerPage, DigestPage, MeetingPage,
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+def search_updates(queryset,search):
+    results_html = []
+    for result in queryset:
+        # Convert body to string for pages with html blocks, and perform a string search
+        if "'type': 'html'" in str(result.body.raw_data):
+            body = str(result.body.raw_data)
+            if (str(search) in body):
+                results_html.append(result)
+
+    results = queryset.search(search)
+    # Remove duplicates where pages that have both html and other fields-types, may return results for both search options 
+    results = chain(results,  [x for x in results_html if x not in results])
+    
+    return results
 
 def replace_dash(string):
     # Leave the dash in place for non-filer publications
@@ -158,10 +172,10 @@ def updates(request):
             )
 
         if search:
-            press_releases = press_releases.search(search)
-            digests = digests.search(search)
-            records = records.search(search)
-            tips = tips.search(search)
+            press_releases = search_updates(press_releases, search)
+            digests = search_updates(digests, search)
+            records = search_updates(records, search)
+            tips = search_updates(tips, search)
 
     # Chain all the QuerySets together
     # via http://stackoverflow.com/a/434755/1864981

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -62,7 +62,7 @@ def get_records(category_list=None, year=None, search=None):
         )
 
     if search:
-        records = records.search(search)
+        records = search_updates(records,search)
 
     return records
 
@@ -76,7 +76,7 @@ def get_digests(year=None, search=None):
         )
 
     if search:
-        digests = digests.search(search)
+        digests = search_updates(digests, search)
 
     return digests
 
@@ -96,7 +96,7 @@ def get_press_releases(category_list=None, year=None, search=None):
         )
 
     if search:
-        press_releases = press_releases.search(search)
+        press_releases = search_updates(press_releases, search)
 
     return press_releases
 
@@ -111,7 +111,7 @@ def get_tips(year=None, search=None):
         )
 
     if search:
-        tips = tips.search(search)
+        tips = search_updates(tips, search)
 
     return tips
 

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'feature/6118-html-keyword-search-for-updates'),
+    ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/6118-html-keyword-search-for-updates'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )


### PR DESCRIPTION
## Summary (required)

- Resolves #6118
- Added `search_updates()` function to convert the body (on pages with html fields) to a string and do a Python string search on them
- Preserve superior existing backend Postgres search for pages with searchable fields types (non-html)
- Exclude duplicate search results  on rare occurrences where both search options return results for the same query because  a page has both html and other database-searchable fields

### Required reviewers
one frontend AND one UX or content

## Impacted areas of the application
The `/updates` keyword search
modified:   home/views.py

## Screenshots

Coming soon...

## How to test
This has been pushed to dev for testing, check with me to confirm its still live if you are testing there.

- checkout and run branch
- do a keyword search for a term that appears in an html block of a Digest, PressRelease, Record, or TipsForTreasurers page
    - Example search from issue: https://www.fec.gov/updates/?update_type=weekly-digest&search=MUR+6535
- do a keyword search for a term not in an html block of a Digest, PressRelease, Record, or TipsForTreasurers page

**Note:** The html search is a little slower when  searching across all updates (`Publication type`  set to `All` ) , but I am working in innovation sprint to optimize performance for a quicker return time. 


