### PR TITLE
Remove eqs.fec.gov references across the website

### DIFF
--- a/fec/home/templates/blocks/af_search.html
+++ b/fec/home/templates/blocks/af_search.html
@@ -39,10 +39,5 @@
         </div>
       </div>
     </div>
-    <div class="row">
-      <div class="message message--info">
-        <p>The administrative fine search includes all cases dating back to 2000. You can search all administrative fine cases using keywords, case number and committee name. For additional search filters, you can still search administrative fines using our legacy <a href="https://eqs.fec.gov" title="FEC Enforcement Query System">FEC Enforcement Query System</a>.</p>
-      </div>
-    </div>
   </div>
 </div>

--- a/fec/home/templates/blocks/af_search.html
+++ b/fec/home/templates/blocks/af_search.html
@@ -8,34 +8,32 @@
     </div>
     <div class="row">
       <div autocomplete="off" class="search__container u-padding--top">
-        <div class="search-controls__row">
-          <div class="search-controls__either">
-            <form action="/data/legal/search/admin_fines/">
-              <label for="af_no" class="label">Find by case number</label>
-              <div class="combo combo--search--medium combo--search--inline">
-                <input type="text" id="af_no" name="case_no" class="combo__input">
-                <button class="combo__button button--search button--standard" type="submit">
-                  <span class="u-visually-hidden">Search</span>
-                </button>
-              </div>
-            </form>
-            <span class="t-note t-sans search__example">Example: 2345</span>
-          </div>
-          <div class="search-controls__or search-controls__or--vertical">or</div>
-          <div class="search-controls__either">
-            <form action="/data/legal/search/admin_fines/">
-              <label for="search-input" class="label">Search by keyword</label>
-              <div class="combo combo--search--medium combo--search--inline">
-                <input id="search-input" type="text" name="search" class="combo__input">
-                <button class="combo__button button--search button--standard" type="submit">
-                  <span class="u-visually-hidden">Search</span>
-                </button>
-              </div>
-              <div class="row search__example">
-                <span class="t-note t-sans">Examples: charity, "federal election activity"</span>
-              </div>
-            </form>
-          </div>
+        <div class="search-controls__either">
+          <form action="/data/legal/search/admin_fines/">
+            <label for="af_no" class="label">Find by case number</label>
+            <div class="combo combo--search--medium combo--search--inline">
+              <input type="text" id="af_no" name="case_no" class="combo__input">
+              <button class="combo__button button--search button--standard" type="submit">
+                <span class="u-visually-hidden">Search</span>
+              </button>
+            </div>
+          </form>
+          <span class="t-note t-sans search__example">Example: 2345</span>
+        </div>
+        <div class="search-controls__or search-controls__or--vertical">or</div>
+        <div class="search-controls__either">
+          <form action="/data/legal/search/admin_fines/">
+            <label for="search-input" class="label">Search by keyword</label>
+            <div class="combo combo--search--medium combo--search--inline">
+              <input id="search-input" type="text" name="search" class="combo__input">
+              <button class="combo__button button--search button--standard" type="submit">
+                <span class="u-visually-hidden">Search</span>
+              </button>
+            </div>
+            <div class="row search__example">
+              <span class="t-note t-sans">Examples: charity, "federal election activity"</span>
+            </div>
+          </form>
         </div>
       </div>
     </div>

--- a/fec/home/templates/blocks/mur_search.html
+++ b/fec/home/templates/blocks/mur_search.html
@@ -8,34 +8,32 @@
     </div>
     <div class="row">
       <div autocomplete="off" class="search__container u-padding--top">
-        <div class="search-controls__row">
-          <div class="search-controls__either">
-            <form action="/data/legal/search/enforcement/">
-              <label for="mur_no" class="label">Find by MUR number</label>
-              <div class="combo combo--search--medium combo--search--inline">
-                <input type="text" id="mur_no" name="case_no" class="combo__input">
-                <button class="combo__button button--search button--standard" type="submit">
-                  <span class="u-visually-hidden">Search</span>
-                </button>
-              </div>
-            </form>
-            <span class="t-note t-sans search__example">Example: 4321</span>
-          </div>
-          <div class="search-controls__or search-controls__or--vertical">or</div>
-          <div class="search-controls__either">
-            <form action="/data/legal/search/enforcement/">
-              <label for="search-input" class="label">Search by keyword</label>
-              <div class="combo combo--search--medium combo--search--inline">
-                <input id="search-input" type="text" name="search" class="combo__input">
-                <button class="combo__button button--search button--standard" type="submit">
-                  <span class="u-visually-hidden">Search</span>
-                </button>
-              </div>
-              <div class="row search__example">
-                <span class="t-note t-sans">Examples: charity, "spending prohibitions"</span>
-              </div>
-            </form>
-          </div>
+        <div class="search-controls__either">
+          <form action="/data/legal/search/enforcement/">
+            <label for="mur_no" class="label">Find by MUR number</label>
+            <div class="combo combo--search--medium combo--search--inline">
+              <input type="text" id="mur_no" name="case_no" class="combo__input">
+              <button class="combo__button button--search button--standard" type="submit">
+                <span class="u-visually-hidden">Search</span>
+              </button>
+            </div>
+          </form>
+          <span class="t-note t-sans search__example">Example: 4321</span>
+        </div>
+        <div class="search-controls__or search-controls__or--vertical">or</div>
+        <div class="search-controls__either">
+          <form action="/data/legal/search/enforcement/">
+            <label for="search-input" class="label">Search by keyword</label>
+            <div class="combo combo--search--medium combo--search--inline">
+              <input id="search-input" type="text" name="search" class="combo__input">
+              <button class="combo__button button--search button--standard" type="submit">
+                <span class="u-visually-hidden">Search</span>
+              </button>
+            </div>
+            <div class="row search__example">
+              <span class="t-note t-sans">Examples: charity, "spending prohibitions"</span>
+            </div>
+          </form>
         </div>
       </div>
     </div>

--- a/fec/home/templates/blocks/mur_search.html
+++ b/fec/home/templates/blocks/mur_search.html
@@ -39,10 +39,5 @@
         </div>
       </div>
     </div>
-    <div class="row">
-      <div class="message message--info">
-        <p>The MUR search feature includes all cases dating back to 1977. You can search all closed FEC MURs using keywords, MUR numbers, names of respondents and more. For additional search filters, you can still search MURs using our legacy <a href="https://eqs.fec.gov" title="FEC Enforcement Query System">FEC Enforcement Query System</a>.</p>
-      </div>
-    </div>
   </div>
 </div>

--- a/fec/legal/templates/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/legal-search-results-adrs.jinja
@@ -31,9 +31,6 @@
     <h3 class="tags__title">Viewing <span class="tags__count">{{ results.total_adrs }}</span>  filtered results for:</h3>
   </div>
 </div>
-<div class="message message--info u-no-margin-top">
-  <p>You can search all FEC ADR cases using keywords, ADR case numbers, names of respondents and more. For additional search filters, you can still search ADR cases using our legacy <a href="https://eqs.fec.gov" title="FEC Enforcement Query System">FEC Enforcement Query System</a>.</p>
-</div>
 {% endblock %}
 
 {% block results %}

--- a/fec/legal/templates/legal-search-results-afs.jinja
+++ b/fec/legal/templates/legal-search-results-afs.jinja
@@ -31,9 +31,6 @@
     <h3 class="tags__title">Viewing <span class="tags__count">{{ results.total_admin_fines }}</span>  filtered results for:</h3>
   </div>
 </div>
-<div class="message message--info u-no-margin-top">
-  <p>You can search all FEC administrative fine cases using keywords, administrative fine case numbers, names of respondents and more. For additional search filters, you can still search administrative fine cases using our legacy <a href="https://eqs.fec.gov" title="FEC Enforcement Query System">FEC Enforcement Query System</a>.</p>
-</div>
 {% endblock %}
 
 {% block results %}

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -55,12 +55,6 @@
   </div>
 {% endblock %}
 
-{% block message %}
-<div class="message message--info">
-  <p>The MUR search feature includes all cases dating back to 1977. You can search all closed FEC MURs using keywords, MUR numbers, names of respondents and more. For additional search filters, you can still search MURs using our legacy <a href="https://eqs.fec.gov" title="FEC Enforcement Query System">FEC Enforcement Query System</a>.</p>
-</div>
-{% endblock %}
-
 {% block results %}
 {% with murs = results.murs %}
 

--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -93,9 +93,6 @@
               {% else %}
                   {% if results["total_" + category] %}
                       {% with murs = results[category] %}
-                      <div class="message message--info">
-                        <p>The MUR search feature includes all cases dating back to 1977. You can search all closed FEC MURs using keywords, MUR numbers, names of respondents and more. For additional search filters, you can still search MURs using our legacy <a href="https://eqs.fec.gov" title="FEC Enforcement Query System">FEC Enforcement Query System</a>.</p>
-                      </div>
                       {% include 'partials/legal-search-results-mur.jinja' %}
                       {% endwith %}
                       <div class="results-info">


### PR DESCRIPTION
## Summary (required)

Removes references to eqs.fec.gov across the website.

### Required reviewers

1 developer, 1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

-  Global [legal search results page](http://localhost:8000/data/legal/search/?search_type=all&search=campaign)
- [MUR search page](http://localhost:8000/data/legal/search/murs/?search=campaign&search_type=murs)
- [AF search page](http://localhost:8000/data/legal/search/regulations/?search=campaign&search_type=regulations)
- [ADR search page](http://localhost:8000/data/legal/search/adrs/)(Feature to be released in the near future)
- MUR and AF wagtail search blocks on the [enforcement landing page](http://localhost:8000/legal-resources/enforcement/).

## Screenshots

Take a look at the pages

## How to test

- Pull down the PR and run it locally. Check out the pages linked in the implemented areas of the application section above 
