### PR TITLE
Faster keyword search for updates and html search for legacy meetings

### DIFF
--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -348,7 +348,7 @@ def index_meetings(request):
     executive_years = list(
         map(lambda x: x.year, executive_sessions.dates("date", "year", order="DESC"))
     )
-    
+
     # These clear the search field upon navigating tabs as requested by content team
     meetings_query = ""
     hearings_query = ""
@@ -375,10 +375,10 @@ def index_meetings(request):
         if active == "open-meetings":
             meetings_query = search
             """
-            Perform text search on agenda field for newer open meetings and imported_html field for older 
-            open meetings who's html cannot be searched by the wagtail.search.backends.database (<= 2017-04-27)
+            Perform text search on agenda field for newer open meetings and imported_html field for older
+            open meetings where html cannot be searched by the wagtail.search.backends.database (<= 2017-04-27)
             """
-            text_search_meetings = list(open_meetings.filter(Q(agenda__icontains=meetings_query) |  Q(imported_html__icontains=meetings_query)))
+            text_search_meetings = list(open_meetings.filter(Q(agenda__icontains=meetings_query) | Q(imported_html__icontains=meetings_query)))
             # Also use wagtail.search.backends.database (Postgres) to search open meeting pages
             open_meetings = list(open_meetings.search(meetings_query))
             # Combine the results, removing any duplicates
@@ -389,11 +389,11 @@ def index_meetings(request):
         if active == "hearings":
             hearings_query = search
             """
-            Perform text search on agenda field for newer hearings and imported_html field for older 
-            hearings who's html cannot be searched by the wagtail.search.backends.database (<= 2016-12-06)
+            Perform text search on agenda field for newer hearings and imported_html field for older
+            hearings where html cannot be searched by the wagtail.search.backends.database (<= 2016-12-06)
             """
-            text_search_hearings = list(hearings.filter(Q(agenda__icontains=hearings_query) |  Q(imported_html__icontains=hearings_query)))
-            # Also Use wagtail.search.backends.database (Postgres) to search heariing pages
+            text_search_hearings = list(hearings.filter(Q(agenda__icontains=hearings_query) | Q(imported_html__icontains=hearings_query)))
+            # Also Use wagtail.search.backends.database (Postgres) to search hearing pages
             hearings = list(hearings.search(hearings_query))
             # Combine the results, removing any duplicates
             hearings = hearings + [x for x in text_search_hearings if x not in hearings]

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -20,7 +20,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def search_updates(queryset,search):
+def search_updates(queryset, search):
     # Use icontains to search html in older pages that cannot be searched by the wagtail.search.backends.database
     results_html = queryset.filter(body__icontains=search)
     # Use wagtail.search.backends.database (Postgres) to search all pages
@@ -59,7 +59,7 @@ def get_records(category_list=None, year=None, search=None):
         )
 
     if search:
-        records = search_updates(records,search)
+        records = search_updates(records, search)
 
     return records
 
@@ -348,8 +348,7 @@ def index_meetings(request):
     executive_years = list(
         map(lambda x: x.year, executive_sessions.dates("date", "year", order="DESC"))
     )
-    
-    
+
     meetings_query = ""
     hearings_query = ""
     executive_query = ""
@@ -373,19 +372,14 @@ def index_meetings(request):
 
     if search:
         if active == "open-meetings":
-            #TRY ANNOTATE FUNCTION OR ALIAS TO PASS IN A REGEX
-            #reg=f"\\b{search}\\b"
-            #x = re.search(reg, imported_html)
-
             meetings_query = search
-
             # Use icontains to search imported_html in older pages that cannot be searched by the wagtail.search.backends.database
             legacy_meetings = list(open_meetings.filter(date__lte='2017-04-27').filter(imported_html__icontains=meetings_query))
             # Use wagtail.search.backends.database (Postgres) to search all open meeting pages
             open_meetings = list(open_meetings.search(meetings_query))
             # Combine the results, removing any duplicates
-            open_meetings=open_meetings+[x for x in legacy_meetings if x not in open_meetings]
-            # Sort results because db search does not recognize the order_by() of the original queryset
+            open_meetings = open_meetings + [x for x in legacy_meetings if x not in open_meetings]
+            # Sort results because db search does not recognize the order_by of the original queryset
             open_meetings.sort(key=attrgetter('date'), reverse=True)
 
         if active == "hearings":
@@ -395,8 +389,8 @@ def index_meetings(request):
             # Use wagtail.search.backends.database (Postgres) to search all heariing pages
             hearings = list(hearings.search(hearings_query))
             # Combine the results, removing any duplicates
-            hearings=hearings+[x for x in legacy_hearings if x not in hearings]
-            # Sort results because db search does not recognize the order_by() of the original queryset
+            hearings = hearings + [x for x in legacy_hearings if x not in hearings]
+            # Sort results because db search does not recognize the order_by of the original queryset
             hearings.sort(key=attrgetter('date'), reverse=True)
 
         if active == "executive-sessions":

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -21,11 +21,11 @@ logger = logging.getLogger(__name__)
 
 
 def search_updates(queryset, search):
-    # Use icontains to search html in older pages that cannot be searched by the wagtail.search.backends.database
+    # Use icontains to cover html blocks which are not searched by the below wagtail.search.backends.database
     results_html = queryset.filter(body__icontains=search)
-    # Use wagtail.search.backends.database (Postgres) to search all pages
+    # Use wagtail.search.backends.database (Postgres) to search all pages' search_fields defined in page models
     results = queryset.search(search)
-    # Combine results, removing duplicates where pages that have both html and other fields-types, may return results for both search options
+    # Combine results, removing any duplicates
     results = chain(results,  [x for x in results_html if x not in results])
 
     return results

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -348,7 +348,8 @@ def index_meetings(request):
     executive_years = list(
         map(lambda x: x.year, executive_sessions.dates("date", "year", order="DESC"))
     )
-
+    
+    # These clear the search field upon navigating tabs as requested by content team
     meetings_query = ""
     hearings_query = ""
     executive_query = ""
@@ -373,23 +374,29 @@ def index_meetings(request):
     if search:
         if active == "open-meetings":
             meetings_query = search
-            # Use icontains to search imported_html in older pages that cannot be searched by the wagtail.search.backends.database
-            legacy_meetings = list(open_meetings.filter(date__lte='2017-04-27').filter(imported_html__icontains=meetings_query))
-            # Use wagtail.search.backends.database (Postgres) to search all open meeting pages
+            """
+            Perform text search on agenda field for newer open meetings and imported_html field for older 
+            open meetings who's html cannot be searched by the wagtail.search.backends.database (<= 2017-04-27)
+            """
+            text_search_meetings = list(open_meetings.filter(Q(agenda__icontains=meetings_query) |  Q(imported_html__icontains=meetings_query)))
+            # Also use wagtail.search.backends.database (Postgres) to search open meeting pages
             open_meetings = list(open_meetings.search(meetings_query))
             # Combine the results, removing any duplicates
-            open_meetings = open_meetings + [x for x in legacy_meetings if x not in open_meetings]
+            open_meetings = open_meetings + [x for x in text_search_meetings if x not in open_meetings]
             # Sort results because db search does not recognize the order_by of the original queryset
             open_meetings.sort(key=attrgetter('date'), reverse=True)
 
         if active == "hearings":
             hearings_query = search
-            # Use icontains to search imported_html in older pages that cannot be searched by the wagtail.search.backends.database
-            legacy_hearings = list(hearings.filter(date__lte='2016-12-06').filter(imported_html__icontains=hearings_query))
-            # Use wagtail.search.backends.database (Postgres) to search all heariing pages
+            """
+            Perform text search on agenda field for newer hearings and imported_html field for older 
+            hearings who's html cannot be searched by the wagtail.search.backends.database (<= 2016-12-06)
+            """
+            text_search_hearings = list(hearings.filter(Q(agenda__icontains=hearings_query) |  Q(imported_html__icontains=hearings_query)))
+            # Also Use wagtail.search.backends.database (Postgres) to search heariing pages
             hearings = list(hearings.search(hearings_query))
             # Combine the results, removing any duplicates
-            hearings = hearings + [x for x in legacy_hearings if x not in hearings]
+            hearings = hearings + [x for x in text_search_hearings if x not in hearings]
             # Sort results because db search does not recognize the order_by of the original queryset
             hearings.sort(key=attrgetter('date'), reverse=True)
 


### PR DESCRIPTION
## Summary (required)

- Resolves #
- Related issue:  #6118 
- Related PR: https://github.com/fecgov/fec-cms/pull/6214

- The [original PR](https://github.com/fecgov/fec-cms/pull/6214) for resolving un-searchable html in `/updates` searches worked, but the search was noticeably slow when searching across all update-types. This PR speeds that search up.
- This PR also combines  a more inclusive text-search with the existing  `wagtail.search.backends.database` search for  `Open meetiings` and `Hearings` which will find more results for all years in addition to resolving the issue of previously unsearchable legacy pages with `imported_html` content.

### Required reviewers

One dev
One UX or One Content

## Impacted areas of the application

-  `/updates` searches (PressRelease, WeeklyDigest, TipsForTreasurers and Record) 
-  Meetings page searches on `/meetings`

	modified:   home/views.py


## How to test
**Content/UX**:
Ask me to push to  featiure or dev and see bullets below for testing 
**Developers:**
- checkout and run branch

- Go to `/updates` and search for "MUR 6535" with "All" chosen in `Publication type`. This should be much faster than the same search on Production.
- Go to `/meetings` and search "Lorenzo Holloway". You should get more results than on Production, with results going back past 2016.
- Try other keyword searches for pages older that 2016 for both `/updates` and `/meetings`.

**Note:**:  Prior to this PR, a common pattern for listing Presenters separated by a slash in meeting pages, would not return results when searching individual names if there was not a space before and after the slash. For example, The built in db search will not find Lorenzo Holloway in `Joshua Blume/Lorenzo Holloway` but it will find it in `Joshua Blume / Lorenzo Holloway`.  With the changes in this PR,  searches will return all pages with the presenter's name, regardless of the syntax.


