### PR TITLE
ADR Canonical - Alternate row striping by disposition

### DIFF
--- a/fec/legal/templates/legal-adr.jinja
+++ b/fec/legal/templates/legal-adr.jinja
@@ -122,8 +122,9 @@
           {% endfor %}
         {% endfor %}
         <!-- Appending rows for non_monetary_terms and non_monetary_terms_respondents -->
-        {% if adr['non_monetary_terms']|length > 1 %}
-        <tr class="{% if  adr.collated_dispositions | length % 2 == 0 %}row-color-normal{% else %}row-color-contrast{% endif %}">
+        {% if adr['non_monetary_terms']|length > 0 %}
+          {% set row_class = "row-color-normal" if adr.collated_dispositions | length is even else "row-color-contrast" %}
+          <tr class="{{ row_class }}">
               <td rowspan="{{ adr['non_monetary_terms_respondents'] | length }}">
                 {% for non_monetary_term in adr.non_monetary_terms %}
                   {{ non_monetary_term }}{% if loop.index < loop.length %};{% endif %}
@@ -135,7 +136,7 @@
                 <td>{{ adr.non_monetary_terms_respondents[0] }}</td>
           </tr>
           {% for second_respondent_and_beyond in adr.non_monetary_terms_respondents[1:] %}
-          <tr class="{% if  adr.collated_dispositions | length % 2 == 0 %}row-color-normal{% else %}row-color-contrast{% endif %}">
+          <tr class="{{ row_class }}">
             <td>{{ second_respondent_and_beyond }}</td></tr>
           {% endfor %}
         {% endif %}

--- a/fec/legal/templates/legal-adr.jinja
+++ b/fec/legal/templates/legal-adr.jinja
@@ -122,7 +122,7 @@
         {% endfor %}
         <!-- Appending rows for non_monetary_terms and non_monetary_terms_respondents -->
         {% if adr['non_monetary_terms']|length > 1 %}
-          <tr>
+        <tr class="{% if  adr.collated_dispositions | length % 2 == 0 %}row-color-normal{% else %}row-color-contrast{% endif %}">
               <td rowspan="{{ adr['non_monetary_terms_respondents'] | length }}">
                 {% for non_monetary_term in adr.non_monetary_terms %}
                   {{ non_monetary_term }}{% if loop.index < loop.length %};{% endif %}
@@ -134,7 +134,8 @@
                 <td>{{ adr.non_monetary_terms_respondents[0] }}</td>
           </tr>
           {% for second_respondent_and_beyond in adr.non_monetary_terms_respondents[1:] %}
-              <tr><td>{{ second_respondent_and_beyond }}</td></tr>
+          <tr class="{% if  adr.collated_dispositions | length % 2 == 0 %}row-color-normal{% else %}row-color-contrast{% endif %}">
+            <td>{{ second_respondent_and_beyond }}</td></tr>
           {% endfor %}
         {% endif %}
       </tbody>

--- a/fec/legal/templates/legal-adr.jinja
+++ b/fec/legal/templates/legal-adr.jinja
@@ -108,9 +108,10 @@
       </thead>
       <tbody>
         {% for disposition in adr.collated_dispositions %}
+          {% set dispositionloop = loop %}
           {% for penalty in adr.collated_dispositions[disposition] %}
             {% for entry in adr.collated_dispositions[disposition][penalty] %}
-              <tr>
+            <tr class="{{ dispositionloop.cycle('row-color-normal', 'row-color-contrast') }}">
                 {% if loop.first %}
                 <td rowspan="{{ adr.collated_dispositions[disposition][penalty] | length }}">{{ disposition }}</td>
                 <td rowspan="{{ adr.collated_dispositions[disposition][penalty] | length }}"> {{ penalty | currency or '' }} </td>


### PR DESCRIPTION
## Summary (required)

- Resolves #6228
- Check whether the number of collated adrs is odd or even to determine the style of the appended  rows that follow (non_monetary_terms).

### Required reviewers

One dev

## Impacted areas of the application

adr canonical page

## Related PRs

https://github.com/fecgov/fec-cms/pull/6216

## How to test

- checkout and run branch
- Find an ADR with multiple rows in the disposition table and check correct alternating row styles
- An ADRs with only one non-monetary term for testing the change from `>1` to `>0` : http://127.0.0.1:8000/data/legal/alternative-dispute-resolution/1151/


