### PR TITLE
6207-pin sqlparse to remove snyk vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.10
+Django==4.2.13
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7
@@ -16,6 +16,7 @@ CacheControl==0.11.5
 cachetools==1.0.2
 github3.py==3.2.0
 django-utils-six==2.0 # pinning until other packages support Django 3.x
+sqlparse==0.5.0  # brought in by Django, pinning until django updates min version
 
 
 # Development


### PR DESCRIPTION
## Summary (required)

- Resolves #6207 

Sqlparse is brought in by Django, we need to pin it to remove a snyk vulnerability until Django updates their min version (they have not yet in the current version) 


### Required reviewers

2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  Django 

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)
1. in dev `snyk test --file=requirements.txt --package-manager=pip`
2. Create new virtualenv 
3. `pyenv activate <new virtualenv>`
4. `pip install -r requirements.txt`
5. `npm install`
6. `npm run build`
7. `pytest`
8. `cd fec/`
9. `./manage.py runserver`
10. pytest
11. `snyk test --file=requirements.txt --package-manager=pip` sqlparse vuln should be gone