### PR TITLE
OIG - move background color to oig-logo instead of its parent

### DIFF
--- a/fec/fec/static/scss/components/_hero.scss
+++ b/fec/fec/static/scss/components/_hero.scss
@@ -116,14 +116,18 @@
     margin-top: 2rem;
   } // TODO: I don't like this one-off and am open to suggestions to get the margins correct
 
+  p {
+    margin-bottom: 1.2rem;
+  }
   @include media($lg) {
     .container {
       position: relative;
 
       a {
-        position: absolute;
+        // position: absolute;
         right: 0;
         top: 4rem;
+        margin-bottom: u(1.2rem);
       }
     }
     .grid--2-wide .grid__item {

--- a/fec/fec/static/scss/components/_hero.scss
+++ b/fec/fec/static/scss/components/_hero.scss
@@ -132,6 +132,7 @@
   }
 }
 .placeholder-oig-logo {
+  background: $neutral;
   background-image: url('../img/logo-oig-color.svg');
   background-size: 33%;
   background-repeat: no-repeat;

--- a/fec/home/templates/home/oig_landing_page.html
+++ b/fec/home/templates/home/oig_landing_page.html
@@ -11,7 +11,7 @@
     <div class="container">
       <h1 id="hero-heading">{{ self.title }}</h1>
       <div class="hero__content">{{ self.intro_message|safe }}</div>
-      {% if self.complaint_url is not null %}<a href="{{ self.complaint_url }}" class="button--cta-primary button--go">Submit a complaint</a>{% endif %}
+      {% if self.complaint_url is not null %}<a href="{{ self.complaint_url }}" class="button--cta-primary button--go">Submit a complaint about fraud, waste or abuse concerning FEC programs or personnel</a>{% endif %}
     </div>
   </section>
   {% if self.show_info_message is True and self.info_message is not '' %}

--- a/fec/home/templates/home/oig_landing_page.html
+++ b/fec/home/templates/home/oig_landing_page.html
@@ -26,7 +26,7 @@
   <div class="container">
     <div class="grid--2-wide grid--flex">
       {% if self.stats_content %}
-      <div class="grid__item card body-blocks">
+      <div class="grid__item card body-blocks" style="background:transparent;padding:0;">
         {% comment %}
         Wagtail did away with the .rich-text wrapper
         but we still have some style rules that rely on it


### PR DESCRIPTION
## Summary

- Resolves #6178 
- Resolves #6213 

Changing style rules for the logo/content block on the OIG page. Removed the background color and padding from the block so the content can set its own, though also moved those rules to the placeholder-oig-logo class

### Required reviewers

-UX

## Impacted areas of the application

Only the OIG landing page, the logo/content block and the submit button

## Screenshots

<img width="620" alt="image" src="https://github.com/fecgov/fec-cms/assets/26720877/cc8c5cce-2afb-424b-ba81-824e7af6fe1c">

![image](https://github.com/fecgov/fec-cms/assets/26720877/658011a7-3c79-4fd2-b629-bebf45117a76)

![image](https://github.com/fecgov/fec-cms/assets/26720877/49f20292-40da-4ecd-a701-d035616f6a38)


## Related PRs

None

## How to test
- check the screenshot …
- merge
- deploy
- publish my saved draft of the OIG page
