### PR TITLE
Increment circleCI cache key to v2 to fix failing builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,9 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+          - v2-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-fec-cms-dependencies-
+          - v2-fec-cms-dependencies-
 
       - run:
           name: Install python dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           paths:
             - ./.env
             - ./node_modules
-          key: v1-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+          key: v2-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
 
       - run:
           name: Ensure database is available


### PR DESCRIPTION
## Summary

Today we experienced failing builds due to CircleCI caching bad node_modules. This will increment the circleCI cache key to v2 to update the cache and fix failing builds.

### Required reviewers

1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  CircleCI builds

## Related failed builds

Related PRs against other branches:

branch | PR
------ | ------
develop | [link](https://app.circleci.com/pipelines/github/fecgov/fec-cms/3448/workflows/196632af-eb98-4db0-8f8b-2c7e251c498f/jobs/6916)
feature/5259-document-type-filter-2 | [link](https://app.circleci.com/pipelines/github/fecgov/fec-cms/3446/workflows/5d171e49-2473-463d-91e4-e72f76698b7f/jobs/6911)

## How to test

- Make sure that circleCI build passes for develop