### PR TITLE
increase memory for prod to 1.5

### DIFF
--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -2,7 +2,7 @@
 applications:
   - name: cms
     instances: 4
-    memory: 1G
+    memory: 1.5G
     disk_quota: 1G
     stack: cflinuxfs4
     buildpacks:


### PR DESCRIPTION
## Summary (required)

- Resolves #6310 

Increases memory in CMS prod to 1.5G per instance as a follow-up item to the CPU entitlement meeting. 

### Required reviewers

1 dev (PM already approved)
