### PR TITLE
Fix regulations search results counts on global legal search

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -82,9 +82,6 @@ def load_legal_search_results(query, query_type="all", offset=0, limit=20, **kwa
     if "statutes" in results:
         results["statutes_returned"] = len(results["statutes"])
 
-    if "regulations" in results:
-        results["regulations_returned"] = len(results["regulations"])
-
     if "advisory_opinions" in results:
         results["advisory_opinions_returned"] = len(results["advisory_opinions"])
 

--- a/fec/data/tests/test_legal_search.py
+++ b/fec/data/tests/test_legal_search.py
@@ -119,14 +119,13 @@ class TestLegalSearch(TestCase):
         _call_api_mock.return_value = {
             'advisory_opinions': [
                 {'no': 1, 'date': '2016'}, {'no': 2, 'date': '1999'}],
-            'statutes': [{}] * 4,
-            'regulations': [{}] * 5}
+            'statutes': [{}] * 4}
         results = api_caller.load_legal_search_results(query='president')
 
         assert len(results['advisory_opinions']) == 2
         assert results['advisory_opinions_returned'] == 2
         assert results['statutes_returned'] == 4
-        assert results['regulations_returned'] == 5
+
 
     # Test 7: OK
     @mock.patch.object(api_caller, 'load_legal_search_results')

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -215,6 +215,7 @@ def legal_search(request):
     results['regulations'] = regulations
     results['total_regulations'] = ecfr_results.get('meta', {}).get(
                                                     'total_count', 0)
+    results["regulations_returned"] = results['total_regulations']
 
     return render(request, 'legal-search-results.jinja', {
         'parent': 'legal',


### PR DESCRIPTION
## Summary (required)

- Resolves #6282

- The `api_caller` is currently still searching our api regulations endpoint ([which will be removed](https://github.com/fecgov/openFEC/issues/5827) ) and that is where is gets its `results["regulations_returned"]` count which differs from the count returned from new eCFR regulations search.

- Remove the reference to regulations in api_caller and add `results["regulations_returned"]`  to `legal_search()`  in `legal/views.py`

- Remove tests for `api_caller` that reference regulations. There are tests for  regulations  in`ecfr_caller` 


### Required reviewers

one team member (frontend, content, UX)

## Impacted areas of the application

Legal search boxes on these pages:
  https://www.fec.gov/data/legal/search/
  https://www.fec.gov/legal-resources/

Files changed:
modified:   data/api_caller.py
modified:   legal/views.py
modified:   data/tests/test_legal_search.py

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

## How to test

- checkout and run branch
- search for "105" on legal landing or legal global search
    - http://127.0.0.1:8000/data/legal/search/?search=105
- See correct counts for regulations returned
- Compare with incorrect counts on production
    - https://www.fec.gov/data/legal/search/?search=105
- `cd ../`  to fec-cms directory and run `pytest`

