### PR TITLE
6206 upgrade dompurify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "d3": "3.5.5",
         "datatables.net": "^1.11.3",
         "datatables.net-responsive": "^2.2.7",
-        "dompurify": "^2.2.7",
+        "dompurify": "^2.5.5",
         "draftail": "^1.4.1",
         "es5-ext": "^0.10.64",
         "es6-weak-map": "2.0.1",
@@ -5034,9 +5034,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
-      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.5.tgz",
+      "integrity": "sha512-FgbqnEPiv5Vdtwt6Mxl7XSylttCC03cqP5ldNT2z+Kj0nLxPHJH4+1Cyf5Jasxhw93Rl4Oo11qRoUV72fmya2Q=="
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -22986,9 +22986,9 @@
       }
     },
     "dompurify": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
-      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.5.tgz",
+      "integrity": "sha512-FgbqnEPiv5Vdtwt6Mxl7XSylttCC03cqP5ldNT2z+Kj0nLxPHJH4+1Cyf5Jasxhw93Rl4Oo11qRoUV72fmya2Q=="
     },
     "domutils": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "d3": "3.5.5",
     "datatables.net": "^1.11.3",
     "datatables.net-responsive": "^2.2.7",
-    "dompurify": "^2.2.7",
+    "dompurify": "^2.5.5",
     "draftail": "^1.4.1",
     "es6-weak-map": "2.0.1",
     "es5-ext": "^0.10.64",


### PR DESCRIPTION
## Summary (required)

- Resolves #6206 

Upgrades dompurify (still being used) to [the latest MSIE compatible version](https://www.npmjs.com/package/dompurify?activeTab=readme) 

I upgraded to the MSIE compatible version as I don't think we have guidance on whether we can fully drop IE, but that meeting is to be scheduled? @rfultz 

### Required reviewers

1 dev

## Impacted areas of the application

-  API helpers



## How to test
 run snyk test --file=package.json on develop (should see es5 snyk issue)
 rm -rf node_modules
 npm i && npm run build
 snyk test --file=package.json (should no longer see issue)
 cd fec
 python manage.py runserver

