### PR TITLE
Add adr and af to global legal search

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -82,9 +82,6 @@ def load_legal_search_results(query, query_type="all", offset=0, limit=20, **kwa
     if "statutes" in results:
         results["statutes_returned"] = len(results["statutes"])
 
-    if "regulations" in results:
-        results["regulations_returned"] = len(results["regulations"])
-
     if "advisory_opinions" in results:
         results["advisory_opinions_returned"] = len(results["advisory_opinions"])
 

--- a/fec/data/tests/test_legal_search.py
+++ b/fec/data/tests/test_legal_search.py
@@ -119,14 +119,12 @@ class TestLegalSearch(TestCase):
         _call_api_mock.return_value = {
             'advisory_opinions': [
                 {'no': 1, 'date': '2016'}, {'no': 2, 'date': '1999'}],
-            'statutes': [{}] * 4,
-            'regulations': [{}] * 5}
+            'statutes': [{}] * 4}
         results = api_caller.load_legal_search_results(query='president')
 
         assert len(results['advisory_opinions']) == 2
         assert results['advisory_opinions_returned'] == 2
         assert results['statutes_returned'] == 4
-        assert results['regulations_returned'] == 5
 
     # Test 7: OK
     @mock.patch.object(api_caller, 'load_legal_search_results')

--- a/fec/fec/static/scss/mixins/_utilities.scss
+++ b/fec/fec/static/scss/mixins/_utilities.scss
@@ -85,6 +85,14 @@
   width: 100%;
 }
 
+.u-break-titles {
+
+  li {
+  line-height: 1.4;
+  margin-bottom: u(1rem);
+  }
+}
+
 // u-icon-bg()
 //
 // Most basic mixin for using a variable svg as a background image

--- a/fec/fec/templates/partials/navigation/nav-legal.html
+++ b/fec/fec/templates/partials/navigation/nav-legal.html
@@ -17,7 +17,7 @@
         </div>
         <div class="u-padding--left col-md-3 col-lg-4">
           <div class="icon-heading icon-heading--magnifying-glass-circle">
-            <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/">Search across all legal resources</a></p>
+            <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/">Search across legal resources</a></p>
           </div>
           <div class="icon-heading icon-heading--magnifying-glass-circle">
             <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/policy-and-other-guidance/guidance-documents/">Search guidance documents</a></p>

--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -42,14 +42,8 @@
       </div>
       <div class="example--primary">
         <h4 class="example__title">Advanced searches:</h4>
-        <ul class="t-sans list--2-columns long-titles">
-          <style>
-          .long-titles li {
-          line-height: 1.4;
-          margin-bottom: 1rem;
-          }
-          </style>
-          <li><a href="/data/legal/search/admin_fines/">Administrative fines</a></li>
+        <ul class="t-sans list--2-columns u-break-titles">
+          <li class='legal-top' ><a href="/data/legal/search/admin_fines/">Administrative fines</a></li>
           <li><a href="/data/legal/search/advisory-opinions/">Advisory opinions</a></li>        
           <li><a href="/data/legal/search/adrs/">Alternative Dispute Resolutions</a></li>
           <!--<li><a href="/data/audit">Audits</a></li> -->

--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -17,16 +17,18 @@
 <div class="container main">
   <div class="grid--2-wide grid--flex">
     <div class="grid__item card t-left-aligned">
-      <h3>Search across all legal resources</h3>
+      <h3>Search across legal resources</h3>
       <div class="content__section">
         <form id="large-search" method="get" action="/data/legal/search/" autocomplete="off" class="search__container js-search">
           <div class="combo combo--search combo--search--inline">
             <select class="search__select select--alt js-search-type" name="search_type" aria-label="Select a search type">
-              <option value="all" selected>All sources</option>
-              <option value="statutes">Statutes</option>
-              <option value="regulations">Regulations</option>
-              <option value="advisory_opinions">Advisory opinions</option>
-              <option value="murs">Closed Matters Under Review</option>
+               <option value="all" selected>All sources</option>
+               <option value="admin_fines">Administrative fines</option>
+               <option value="advisory_opinions">Advisory opinions</option>
+               <option value="adrs">Alternative Dispute Resolutions</option>
+               <option value="murs">Closed Matters Under Review</option>
+               <option value="regulations">Regulations</option>
+               <option value="statutes">Statutes</option>
             </select>
             <input type="text" name="search" class="combo__input js-search-input"
             aria-label="Search">
@@ -40,11 +42,19 @@
       </div>
       <div class="example--primary">
         <h4 class="example__title">Advanced searches:</h4>
-        <ul class="t-sans list--2-columns">
-          <li><a href="/data/legal/search/advisory-opinions/">Advisory opinions</a></li>
-          <li><a href="/data/legal/search/enforcement/">Closed Matters Under Review</a></li>
+        <ul class="t-sans list--2-columns long-titles">
+          <style>
+          .long-titles li {
+          line-height: 1.4;
+          margin-bottom: 1rem;
+          }
+          </style>
+          <li><a href="/data/legal/search/admin_fines/">Administrative fines</a></li>
+          <li><a href="/data/legal/search/advisory-opinions/">Advisory opinions</a></li>        
+          <li><a href="/data/legal/search/adrs/">Alternative Dispute Resolutions</a></li>
           <!--<li><a href="/data/audit">Audits</a></li> -->
-          <li><a href="/regulations">Regulations</a></li>
+          <li><a href="/data/legal/search/enforcement/">Closed Matters Under Review</a></li>
+          <li><a href="/data/legal/search/regulations/">Regulations</a></li>
           <li><a href="/data/legal/search/statutes">Statutes</a></li>
         </ul>
       </div>

--- a/fec/home/templates/purgecss-homepage/full.html
+++ b/fec/home/templates/purgecss-homepage/full.html
@@ -199,7 +199,7 @@
             </div>
             <div class="u-padding--left col-md-3 col-lg-4">
               <div class="icon-heading icon-heading--magnifying-glass-circle">
-                <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/">Search across all legal resources</a></p>
+                <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/">Search across legal resources</a></p>
               </div>
               <div class="icon-heading icon-heading--magnifying-glass-circle">
                 <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/policy-and-other-guidance/guidance-documents/">Search guidance documents</a></p>

--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -25,11 +25,13 @@
 <div class="main">
   <div class="container">
     <div class="row">
+
       <div class="sidebar-container sidebar-container--left">
         <nav class="sidebar sidebar--neutral side-nav js-sticky-side" data-sticky-container="main">
           <ul class="sidebar__content">
+            {% set document_types = ({'all': 'All','statutes': 'Statutes','regulations': 'Regulations','advisory_opinions': 'Advisory opinions','murs': 'Closed Matters Under Review', 'adrs': 'Alternative dispute resolutions', 'admin_fines': 'Administrative fines'}) %}
             {% for category in category_order %}
-                {% set category_title = "Closed Matters Under Review" if category == "murs" else category.replace('_', ' ').capitalize() %}
+              {% set category_title = document_types[category] %}
                 <li class="side-nav__item">
                     <a class="side-nav__link" href="#results-{{ category|replace('_', '-') }}">
                         {{ category_title }} ({{ results["total_" + category]|default(0) }})
@@ -42,14 +44,15 @@
 
       <section class="main__content--right">
         {% if query %}
-        <h1 class="main__title">Results for &ldquo;{{ query }}&rdquo;</h1>
+        <h1 class="main__title">Results for &ldquo;{{ query }}&rdquo; in {{document_types[result_type]}} </h1>
         {% endif %}
         {% for category in category_order %}
-          {% set category_title = "Closed Matters Under Review" if category == "murs" else category.replace('_', ' ').capitalize() %}
+        {% set category_title = document_types[category] %}
           <div id="results-{{ category|replace('_', '-') }}" class="content__section">
-              <div class="results-info results-info--simple">
+            {% if result_type == category or result_type == 'all' %}
+              <div class="results-info results-info--simple">             
                   <div class="results-info__left">
-                      <h2 class="results-info__title">{{ category_title }}</h2>
+                    <h2 class="results-info__title">{{ category_title }}</h2>
                   </div>
               {% if results["total_" + category] %}
                   <div class="results-info__right">
@@ -57,6 +60,7 @@
                   </div>
               {% endif %}
               </div>
+              {% endif %}
               {% if category == "statutes" %}
                   {% if results["total_" + category] %}
                       {% with statutes = results[category] %}
@@ -65,8 +69,8 @@
                       <div class="results-info">
                       <a class="button button--browse button--alt" href="/data/legal/search/{{ category }}/?search={{ query }}&search_type={{ category}}">All results</a>
                       </div>
-                  {% else %}
-                  {{ legal.no_results("statutes", category, query, fec_resources=['fec.gov']) }}
+                  {% elif not results["total_" + category] and (result_type == category or result_type == 'all') %}
+                  {{ legal.no_results("statutes", category, query, result_type, fec_resources=['fec.gov']) }}
                   {% endif %}
               {% elif category == "regulations" %}
                   {% if results["total_" + category] %}
@@ -76,8 +80,8 @@
                       <div class="results-info">
                       <a class="button button--browse button--alt" href="/data/legal/search/{{ category }}/?search={{ query }}">All results</a>
                       </div>
-                  {% else %}
-                  {{ legal.no_results("regulations", category, query, fec_resources=['Rulemaster', 'fec.gov']) }}
+                  {% elif not results["total_" + category] and (result_type == category or result_type == 'all') %}
+                  {{ legal.no_results("regulations", category, query, result_type, fec_resources=['Rulemaster', 'fec.gov']) }}
                   {% endif %}
               {% elif category == "advisory_opinions" %}
                   {% if results["total_" + category] %}
@@ -87,10 +91,10 @@
                       <div class="results-info">
                       <a class="button button--browse button--alt" href="/data/legal/search/{{ category | replace('_', '-') }}/?search={{ query }}&search_type={{ category}}">All results</a>
                       </div>
-                  {% else %}
-                  {{ legal.no_results("advisory opinions", category, query, fec_resources=['Advisory_Opinion', 'fec.gov']) }}
+                  {% elif not results["total_" + category] and (result_type == category or result_type == 'all') %}
+                  {{ legal.no_results("advisory opinions", category, query, result_type, fec_resources=['Advisory_Opinion', 'fec.gov']) }}
                   {% endif %}
-              {% else %}
+              {% elif category == "murs" %}
                   {% if results["total_" + category] %}
                       {% with murs = results[category] %}
                       {% include 'partials/legal-search-results-mur.jinja' %}
@@ -98,8 +102,30 @@
                       <div class="results-info">
                       <a class="button button--browse button--alt" href="/data/legal/search/enforcement/?search={{ query }}&search_type={{ category}}">All results</a>
                       </div>
-                  {% else %}
-                  {{ legal.no_results("enforcement matters", category, query, fec_resources=['Administrative_Fine', 'Alternative_Dispute_Resolution', 'Audit_Reports', 'Matters_Under_Review', 'Matters_Under_Review_Archived', 'fec.gov']) }}
+                  {% elif not results["total_" + category] and (result_type == category or result_type == 'all') %}
+                  {{ legal.no_results("enforcement matters", category, query, result_type, fec_resources=['Administrative_Fine', 'Alternative_Dispute_Resolution', 'Audit_Reports', 'Matters_Under_Review', 'Matters_Under_Review_Archived', 'fec.gov']) }}
+                  {% endif %}
+              {% elif category == "adrs" %}
+                  {% if results["total_" + category] %}
+                      {% with adrs = results[category] %}
+                      {% include 'partials/legal-search-results-adrs.jinja' %}
+                      {% endwith %}
+                      <div class="results-info">
+                      <a class="button button--browse button--alt" href="/data/legal/search/{{ category }}/?search={{ query }}">All results</a>
+                      </div>
+                  {% elif not results["total_" + category] and (result_type == category or result_type == 'all') %}
+                  {{ legal.no_results("alternative dispute resolutions", category, query, result_type, fec_resources=['Administrative_Fine', 'Alternative_Dispute_Resolution', 'Audit_Reports', 'Matters_Under_Review', 'Matters_Under_Review_Archived', 'fec.gov']) }}
+                  {% endif %}
+              {% else %}
+                  {% if results["total_" + category] %}
+                      {% with admin_fines = results[category] %}
+                      {% include 'partials/legal-search-results-afs.jinja' %}
+                      {% endwith %}
+                      <div class="results-info">
+                      <a class="button button--browse button--alt" href="/data/legal/search/{{ category }}/?search={{ query }}">All results</a>
+                      </div>
+                  {% elif not results["total_" + category] and (result_type == category or result_type == 'all') %}
+                  {{ legal.no_results("administrative fines", category, query, result_type, fec_resources=['Administrative_Fine', 'Alternative_Dispute_Resolution', 'Audit_Reports', 'Matters_Under_Review', 'Matters_Under_Review_Archived', 'fec.gov']) }}
                   {% endif %}
               {% endif %}
               </div>

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -88,7 +88,7 @@
 {% endif %}
 <form id="{{ location }}-search" action="/data/legal/search/" autocomplete="off" class="search__container">
   <div class="combo combo--search {{ size }}">
-    {% set document_types = (('all', 'All'),('statutes', 'Statutes'),('regulations', 'Regulations'),('advisory_opinions', 'Advisory opinions'),('murs', 'Closed Matters Under Review')) %}
+    {% set document_types = (('all', 'All'),('statutes', 'Statutes'),('regulations', 'Regulations'),('advisory_opinions', 'Advisory opinions'),('murs', 'Closed Matters Under Review'), ('adrs', 'Alternative dispute resolutions'), ('admin_fines', 'Administrative fines')) %}
     <select class="search__select {{select_class}}" name="search_type" aria-label="Select a document type">
       {% for value, name in document_types %}
       <option value="{{ value }}" {% if result_type == value %}selected{% endif %}>{{ name }}</option>
@@ -106,10 +106,12 @@
 </form>
 {% endmacro %}
 
-{% macro no_results(display_name, result_type, query, fec_resources=None) %}
+{% macro no_results(display_name, result_type, query, search ,fec_resources=None) %}
 <div class="message message--no-icon">
   <h2 class="message__title">No results</h2>
+  {% if search == result_type or search == 'all' %}
   <p>Sorry, we didn&rsquo;t find any {{ display_name }} matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your query{% endif %}.</p>
+  {% endif %}
   <div class="message--alert__bottom">
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -186,42 +186,45 @@ def legal_search(request):
     Updated_ecfr_query_string = transform_ecfr_query_string(query)
     result_type = request.GET.get('search_type', 'all')
     results = {}
-    ecfr_results = {}
-    regulations = {}
+    # ecfr_results = {}
+    # regulations = {}
 
     # Only hit the API if there's an actual query
     if query:
         results = api_caller.load_legal_search_results(query, result_type,
-                                                       limit=3)
-        ecfr_results = ecfr_caller.fetch_ecfr_data(Updated_ecfr_query_string,
-                                                   limit=3, page=1)
+                                                        limit=3)
+        
+        # Only search regulations if result type is all or regulations
+        if result_type == 'all' or result_type == 'regulations':                                           
+            ecfr_results = ecfr_caller.fetch_ecfr_data(Updated_ecfr_query_string,
+                                                       limit=3, page=1)
+            if 'results' in ecfr_results:
 
-        if 'results' in ecfr_results:
-            regulations = [{
-                        "doc_id": None,
-                        "document_highlights": {},
-                        "highlights": [obj['headings']['part'],
-                                       obj['full_text_excerpt']],
-                        "name": obj['headings']['section'],
-                        "no": obj['hierarchy']['section'],
-                        "type": None,
-                        "url":  (
-                            "https://www.ecfr.gov/current/title-11/"
-                            f"chapter-{obj['hierarchy']['chapter']}/"
-                            f"section-{obj['hierarchy']['section']}"
-                        )
-                        } for obj in ecfr_results['results']]
+                regulations = [{
+                            "doc_id": None,
+                            "document_highlights": {},
+                            "highlights": [obj['headings']['part'],
+                                        obj['full_text_excerpt']],
+                            "name": obj['headings']['section'],
+                            "no": obj['hierarchy']['section'],
+                            "type": None,
+                            "url":  (
+                                "https://www.ecfr.gov/current/title-11/"
+                                f"chapter-{obj['hierarchy']['chapter']}/"
+                                f"section-{obj['hierarchy']['section']}"
+                            )
+                            } for obj in ecfr_results['results']]
 
-    results['regulations'] = regulations
-    results['total_regulations'] = ecfr_results.get('meta', {}).get(
-                                                    'total_count', 0)
+                results['regulations'] = regulations
+                results["total_regulations"] = ecfr_results.get('meta', {}).get( 'total_count', 0)
+                results["regulations_returned"] =  '3' if results["total_regulations"] > 3 else results["total_regulations"]
 
     return render(request, 'legal-search-results.jinja', {
         'parent': 'legal',
         'query': query,
         'results': results,
         'result_type': result_type,
-        'category_order': get_legal_category_order(results),
+        'category_order': get_legal_category_order(results, result_type),
         'social_image_identifier': 'legal',
     })
 
@@ -461,12 +464,19 @@ def legal_doc_search_statutes(request):
         'social_image_identifier': 'legal',
     })
 
-
-def get_legal_category_order(results):
+def get_legal_category_order(results, result_type):
+#def get_legal_category_order(results):
     """ Return categories in pre-defined order, moving categories with empty
-        results to the end.
+        results to the end. Move chosen category(result_type) to top when not searching 'all'
     """
-    categories = ["advisory_opinions", "murs", "regulations", "statutes"]
-    category_order = [x for x in categories if results.get("total_" + x, 0) > 0] +\
+    
+    categories = ["advisory_opinions", "murs", "regulations", "statutes", "adrs", "admin_fines"]
+    category_order = [x for x in categories if results.get("total_" + x, 0) > 0]  +\
         [x for x in categories if results.get("total_" + x, 0) == 0]
+    
+    # Default to 'advisory_opinions' if result type is 'all', because we dont want 'all' in category_order 
+    result_type = "advisory_opinions" if result_type == 'all' else result_type
+    # Move chosen search type to the top if not searching 'all'
+    category_order.insert(0, category_order.pop(category_order.index(result_type)))
+
     return category_order


### PR DESCRIPTION
## Summary (required)

- Resolves #6270

- Add `Admin-fines` and `ADRs` to global search
- Only show results for chosen category when not searching all
- Only search regulations if it is the chosen category, or searching 'All'
- Move chosen category to the top of category_order 
        - The previous `get_legal_category_order()` function did not reorder the results-display or the left menu   if there were no results at all. The side effect being blank spaces above the no-results display and confusing ordering in the left menu.
        To see what I mean , just comment out the below line and do a search for "xcvh",  choosing `admin-fines`:
        
      ```  
        category_order.insert(0, category_order.pop(category_order.index(result_type)))
        
        ```
      


### Required reviewers

**required:** one developer 
**optional?:**  one content or UX

## Impacted areas of the application
The lsearch box on legal landing page: https://www.fec.gov/legal-resources/
The global legal search : https://www.fec.gov/data/legal/search/

Files changed:
	modified:   data/api_caller.py
	modified:   fec/templates/partials/navigation/nav-legal.html
	modified:   home/templates/home/legal/legal_resources_landing.html
	modified:   home/templates/purgecss-homepage/full.html
	modified:   legal/templates/legal-search-results.jinja
	modified:   legal/templates/macros/legal.jinja
	modified:   legal/views.py
	modified:   fec/static/scss/mixins/_utilities.scss


## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## Related PRs

Related PRs against other branches:

https://github.com/fecgov/fec-cms/pull/6318

## How to test

- checkout branch and run `npm run build`
- Test searches on  http://127.0.0.1:8000/data/legal/search/
- Test a no results search like "xcvh"
- A search that returns all is "9004"
- A search that returns alll but statutes is "105"
- On http://127.0.0.1:8000/legal-resources/, verify the `ordering, capitalization` for the list and dropdown choices on 
 

