### PR TITLE
6347 - Remove links and permissions for polyfill.io

### DIFF
--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -40,7 +40,6 @@ class AddSecureHeaders(MiddlewareMixin):
                 "'unsafe-inline'",
                 "'unsafe-eval'",
                 "https://dap.digitalgov.gov",
-                "https://polyfill.io/",
                 "https://www.google.com/recaptcha/",
                 "https://ssl.google-analytics.com",
                 "https://www.google-analytics.com",

--- a/fec/fec/templates/500-status.html
+++ b/fec/fec/templates/500-status.html
@@ -12,7 +12,6 @@
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
     {% endblock %}
-    <script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Object.assign"></script>
   </head>
 
   <body class="status-mode {% block body_class %}{% endblock %}">

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -15,7 +15,6 @@
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% asset_for_css 'base.css' %}">
     {% endblock %}
-    <script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Object.assign"></script>
   </head>
 
   <body class="{% block body_class %}{% endblock %}">


### PR DESCRIPTION
## Summary

- Resolves #6347 

We're removing all references to the polyfill.io domain

### Required reviewers

- One front-end?

## Impacted areas of the application

The base template and the 404 page reference the domain and its permissions are in middleware.

It looks like we were only using it for `Object.assign`—[which is very well supported](https://caniuse.com/?search=object.assign)—so this shouldn't be an issue, especially since our own polyfills file includes `Object.assign`

## Screenshots

No visual changes

## Related PRs

None

## How to test

- Pull the branch
- `npm i` (probably not necessary)
- `npm run build` (probably not necessary)
- `./manage.py runserver`
- Things don't break?
- Open to suggestions for how to test a polyfill being requested if we don't have technology that requires that polyfill