### PR TITLE
Add legal search to global search autosuggest

### DIFF
--- a/fec/fec/static/js/modules/typeahead.js
+++ b/fec/fec/static/js/modules/typeahead.js
@@ -234,13 +234,34 @@ var siteDataset = {
   }
 };
 
+/* When clicked, this will submit the query to the legal search form 
+ */
+var legalDataset = {
+  display: 'id',
+  source: function(query, syncResults) {
+    syncResults([
+      {
+        id: helpers.sanitizeValue(query),
+        type: 'legal'
+      }
+    ]);
+  },
+  templates: {
+    suggestion: function(datum) {
+      return (
+        '<span><strong>Search legal resources:</strong> "' + datum.id + '"</span>'
+      );
+    }
+  }
+};
+
 var datasets = {
   candidates: candidateDataset,
   committees: committeeDataset,
   auditCandidates: auditCandidateDataset,
   auditCommittees: auditCommitteeDataset,
   allData: [candidateDataset, committeeDataset],
-  all: [candidateDataset, committeeDataset, individualDataset, siteDataset]
+  all: [candidateDataset, committeeDataset, individualDataset, siteDataset, legalDataset]
 };
 
 var typeaheadOpts = {
@@ -311,6 +332,11 @@ Typeahead.prototype.select = function(event, datum) {
       datum.id;
   } else if (datum.type === 'site') {
     this.searchSite(datum.id);
+  } else if (datum.type === 'legal') {
+    window.location =
+      this.url +
+      'legal/search/?search_type=all&search=' +
+      datum.id;
   } else {
     window.location = this.url + datum.type + '/' + datum.id;
   }

--- a/fec/fec/static/js/modules/typeahead.js
+++ b/fec/fec/static/js/modules/typeahead.js
@@ -234,8 +234,7 @@ var siteDataset = {
   }
 };
 
-/* When clicked, this will submit the query to the legal search form 
- */
+/* When clicked, this will submit the query to the legal search form */
 var legalDataset = {
   display: 'id',
   source: function(query, syncResults) {

--- a/fec/fec/static/scss/components/_search-bar.scss
+++ b/fec/fec/static/scss/components/_search-bar.scss
@@ -283,7 +283,8 @@ $search-button-width: u(5.6rem);
   padding: u(1rem .5rem);
 }
 
-.tt-dataset-0 {
+.tt-dataset-0,
+.tt-dataset-1 {
   border-bottom: 1px solid $base;
 }
 

--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -58,7 +58,15 @@
                     </div>
                 {% if results["total_" + category] %}
                     <div class="results-info__right">
-                    <span class="results-info__details">1&ndash;{{ results[category + "_returned"] }} of <a href="/data/legal/search/{{ category | replace('_', '-') }}/?search={{ query }}&search_type={{ category}}"><strong>{{ results["total_" + category] }}</strong> results</a></span>
+                      <span class="results-info__details">1&ndash;{{ results[category + "_returned"] }} of 
+                        {% if category == 'admin_fines' %}
+                          <a href="/data/legal/search/{{ category }}/?search={{ query }}&search_type={{ category}}">
+                        {% else %}
+                          <a href="/data/legal/search/{{ category | replace('_', '-') }}/?search={{ query }}&search_type={{ category}}">
+                        {% endif %}
+                          <strong>{{ results["total_" + category] }}</strong> results
+                        </a>
+                      </span>
                     </div>
                 {% endif %}
                 </div>    


### PR DESCRIPTION
## Summary

- Resolves #6350 

- Adds legal search to global search autosuggest
- Also adds small fix to admin fines link in legal search results

### Required reviewers

1 front end
1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

- Global site autosuggest
- Legal search results page

## Screenshots

### Global search with search legal resources option
<img width="234" alt="Screenshot 2024-06-27 at 3 34 34 PM" src="https://github.com/fecgov/fec-cms/assets/12799132/751478fe-a7f5-4074-b5a0-72857f8fe9c3">

### Fix admin fines link
<img width="807" alt="Screenshot 2024-06-27 at 4 08 10 PM" src="https://github.com/fecgov/fec-cms/assets/12799132/51dd2f2d-c0e3-45b7-8a01-a08a0cf32c70">

## How to test

- checkout this branch
- `npm run build`
- `./manage.py runserver`
- Try to use the global search box on any page. 
     - Check the bottom of the list to see if the "search legal resources" option is there. 
     - Click on the "search legal resources" option and make sure that the query is passed to the legal search results page.
- Test the admin fines link on legal search results page: http://localhost:8000/data/legal/search/?search_type=all&search=test
