### PR TITLE
Allow CustomPage as child of AboutLandingPage

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -781,7 +781,7 @@ class AboutLandingPage(Page):
         ('sections', OptionBlock())
     ], null=True, use_json_field=True)
 
-    subpage_types = ['ResourcePage', 'DocumentFeedPage', 'ReportsLandingPage', 'OfficePage']
+    subpage_types = ['ResourcePage', 'DocumentFeedPage', 'ReportsLandingPage', 'OfficePage', 'CustomPage']
 
     content_panels = Page.content_panels + [
         FieldPanel('hero'),


### PR DESCRIPTION
## Summary (required)

- Resolves #6204

Allow CustomPage as child of AboutLandingPage

### Required reviewers

one team member

## Impacted areas of the application

AboutLandingPage template child page options

Modified: home/models.py


## How to test

- checkout and run branch
- Verify that, in Wagtail,  you can add a custom page as a child page of `about/ `(AboutLandingPage template)
