### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] 6378 Quotes in Search 2

### DIFF
--- a/fec/fec/static/js/modules/typeahead.js
+++ b/fec/fec/static/js/modules/typeahead.js
@@ -204,9 +204,7 @@ var individualDataset = {
   templates: {
     suggestion: function(datum) {
       return (
-        '<span><strong>Search individual contributions from: &ldquo;</strong>' +
-        datum.id +
-        '<strong>&rdquo;</strong></span>'
+        `<span><strong>Search individual contributions from: &ldquo;</strong>${datum.id}<strong>&rdquo;</strong></span>`
       );
     }
   }

--- a/fec/fec/static/js/modules/typeahead.js
+++ b/fec/fec/static/js/modules/typeahead.js
@@ -204,9 +204,9 @@ var individualDataset = {
   templates: {
     suggestion: function(datum) {
       return (
-        '<span><strong>Search individual contributions from:</strong> "' +
+        '<span><strong>Search individual contributions from: &ldquo;</strong>' +
         datum.id +
-        '"</span>'
+        '<strong>&rdquo;</strong></span>'
       );
     }
   }
@@ -228,7 +228,7 @@ var siteDataset = {
   templates: {
     suggestion: function(datum) {
       return (
-        '<span><strong>Search other pages:</strong> "' + datum.id + '"</span>'
+        '<span><strong>Search other pages: &ldquo;</strong>' + datum.id + '<strong>&rdquo;</strong></span>'
       );
     }
   }
@@ -248,7 +248,7 @@ var legalDataset = {
   templates: {
     suggestion: function(datum) {
       return (
-        '<span><strong>Search legal resources:</strong> "' + datum.id + '"</span>'
+        '<span><strong>Search legal resources: &ldquo;</strong>' + datum.id + '<strong>&rdquo;</strong></span>'
       );
     }
   }


### PR DESCRIPTION
## Summary

- Resolves #6378 

Stripping quotes from global search field

### Required reviewers

- Front-end
- Product manager(s)

## Impacted areas of the application

The global search and everywhere it links

## Known issues:
- Exact-match search terms will be bold and blue because they're an exact match.
- Search terms that we've altered on the way to the page aren't an exact match so they won't be bold or blue.

## Screenshots

| | Production  | This PR |
| ------------- | ------------- | ------------- |
| `tester` | <img width="219" alt="image" src="https://github.com/user-attachments/assets/bf7bd029-0a46-4508-8e0e-00d56abc2b03">  | <img width="218" alt="image" src="https://github.com/user-attachments/assets/9f3c6504-2440-42e0-96ec-b9e6c0b40527">  |
| `"tester"` | <img width="219" alt="image" src="https://github.com/user-attachments/assets/e29751da-7f24-4ae1-86f3-577431d3a538">  | <img width="217" alt="image" src="https://github.com/user-attachments/assets/9c76b48a-9137-4eea-9afc-9b3cde1a5df8">  |
| click legal | <img width="718" alt="image" src="https://github.com/user-attachments/assets/47a73c2a-438a-454e-be04-b037973b1772"> | <img width="719" alt="image" src="https://github.com/user-attachments/assets/4bf1dd8e-3dbf-4e45-a93e-a2cdfc1dd8cf"> |


## Related PRs

None

## How to test

- pull the branch
- `npm i`
- `npm run build`
- load a page and do a search for a term without quotes
- load a page and do a search for a term with quotes (the quotes should be stripped from the search)