### PR TITLE
Other legal resources links for search results page

### DIFF
--- a/fec/fec/static/scss/components/_sidebar.scss
+++ b/fec/fec/static/scss/components/_sidebar.scss
@@ -160,6 +160,22 @@
   }
 }
 
+// Used for aside content on legal resources search results page.
+// Nest inside the sticky-side element.
+//<aside class="sidebar sidebar--primary sidebar__inside-sticky-side">
+//  <h4 class="sidebar__title">Other legal resources</h4>
+//  <ul class="sidebar__content list--spacious">
+//    <li><a href="/legal-resources/enforcement/audit-search/">Audit reports</a></li>
+//    <li><a href="/legal-resources/court-cases/">Court cases</a></li>
+//    <li><a href="/legal-resources/policy-other-guidance/">Policy and other guidance</a></li>
+//  </ul>
+//</aside>
+
+.sidebar__inside-sticky-side {
+  padding-top: 15px;
+  background-color: #fff;
+}
+
 @media print {
   .sidebar {
     display: none;

--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -41,6 +41,14 @@
                  {% endif %}
             {% endfor %}
           </ul>
+          <aside class="sidebar sidebar--primary sidebar__inside-sticky-side">
+          <h4 class="sidebar__title">Other legal resources</h4>
+            <ul class="sidebar__content list--spacious">
+              <li><a href="/legal-resources/enforcement/audit-search/">Audit reports</a></li>
+              <li><a href="/legal-resources/court-cases/">Court cases</a></li>
+              <li><a href="/legal-resources/policy-other-guidance/">Policy and other guidance</a></li>
+            </ul>
+          </aside>
         </nav>
       </div>
 


### PR DESCRIPTION
## Summary (required)

Add a menu with "Other legal resources" links to the legal resources search results page.

- Resolves #6384

### Required reviewers

One frontend, One UX

## Impacted areas of the application

Legal resources search results page
modified:   fec/static/scss/components/_sidebar.scss
modified:   legal/templates/legal-search-results.jinja


## Screenshots

<img width="1189" alt="Screenshot 2024-07-26 at 6 28 41 PM" src="https://github.com/user-attachments/assets/bb8d09af-f157-40e3-b9b9-27950a3b51cd">


## How to test

- checkout branch and run `npm run build-sass`
- Go to http://127.0.0.1:8000/data/legal/search/ and see the new menu under results menu
- **Note:** This has to be inside the sticky sidebar, otherwise it would become obscured behind the sticky menu upon scrolling. As a result of that, it becomes hidden, along with the results menu, on smaller screens -- as other similar implementations of aside content that is on the same page as a sticky nav throughout the site. Example: https://www.fec.gov/data/elections/senate/
