### PR TITLE
pinned setuptools to v71.1.0 to fix failing builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,6 @@ Faker==0.8.6
 pytest-django==3.10.0
 pytest-cov==4.1.0
 pre-commit==2.21.0 #client-side hook triggered by operations like git commit
+
+# CircleCI build
+setuptools==71.1.0 #pin to fix builds


### PR DESCRIPTION
## Summary (required)

- Resolves #6398

Pin setuptools to 71.1.0 to fix recent failing builds.

### Required reviewers

1 front end or backend

## Related PRs

Related PRs against other branches:

See ticket #6398 for associated branches and builds
