### PR TITLE
Document highlights for MUR/ADR on global legal search results

### DIFF
--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -105,8 +105,11 @@
                     {% endif %}
                 {% elif category == "murs" %}
                     {% if results["total_" + category] %}
-                        {% with murs = results[category] %}
+                  
+                        {% with murs = results[category], nested_in_global_search=true %}
                         {% include 'partials/legal-search-results-mur.jinja' %}
+                        
+                        
                         {% endwith %}
                         <div class="results-info">
                         <a class="button button--browse button--alt" href="/data/legal/search/enforcement/?search={{ query }}&search_type={{ category}}">All results</a>
@@ -116,7 +119,7 @@
                     {% endif %}
                 {% elif category == "adrs" %}
                     {% if results["total_" + category] %}
-                        {% with adrs = results[category] %}
+                        {% with adrs = results[category], nested_in_global_search=true %}
                         {% include 'partials/legal-search-results-adrs.jinja' %}
                         {% endwith %}
                         <div class="results-info">

--- a/fec/legal/templates/partials/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/partials/legal-search-results-adrs.jinja
@@ -34,10 +34,16 @@
             {% set filters_category_type = selected_doc_category_ids | length > 0 %}
             {# Check for set keyword queries #}
             {% set filters_keyword = query | length > 0 %}
-            
+
             {# Only show documents when categories or keywords are set #}
             {% if filters_category_type or filters_keyword %}
               {% for document in adr.documents %}
+
+              {# When including this template in legal-search-results.jinja #}
+              {% if nested_in_global_search %}
+                {# Only show documents that have keyword matches #}
+                {% set show_document =  adr.document_highlights[loop.index0 | string] %}   
+              {% else %}
                 {# This will show documents in all 3 scenarios:
                   - When there is a keyword query and selected document categories
                   - When there are selected document categories and no keyword query
@@ -45,8 +51,9 @@
                 {% set category_match = (filters_category_type and document.category_match) or not filters_category_type %}
                 {% set keyword_match = (filters_keyword and document.text_match) or not filters_keyword %}
                 {% set show_document = category_match and keyword_match  %}
+              {% endif %}
 
-              {%if show_document %}
+              {% if show_document %}
                 <div class="post--icon u-padding--top">
                   <span class="icon icon--inline--left i-document"></span>
                   <a href="{{document.url}}">
@@ -82,7 +89,6 @@
                     </div>
                   </div>
                   {% endif %}
-                    
                 {% endif %}
                 <ul class="tags u-padding--bottom">
                   <li class="tag__category tag__category--doc">

--- a/fec/legal/templates/partials/legal-search-results-mur.jinja
+++ b/fec/legal/templates/partials/legal-search-results-mur.jinja
@@ -64,15 +64,22 @@
           {% endif %}
           </div>
           <div class="legal-search-result__hit u-padding--left--small split__cell">
+
             {# Check for set document categories #}
             {% set filters_category_type = selected_doc_category_ids | length > 0 %}
             {# Check for set keyword queries #}
             {% set filters_keyword = query | length > 0 %}
-            
+
             {# Only show documents when categories or keywords are set #}
             {% if filters_category_type or filters_keyword %}
             {% for document in mur.documents %}
-            
+
+            {# When including this template in legal-search-results.jinja #}
+            {% if nested_in_global_search %}
+              {# Only show documents that have keyword matches #}
+              {% set show_document =  mur.document_highlights[loop.index0 | string] %}
+
+            {% else %}
               {# This will show documents in all 3 scenarios:
                 - When there is a keyword query and selected document categories
                 - When there is selected document categories and no keyword query
@@ -80,8 +87,9 @@
               {% set category_match = (filters_category_type and document.category_match) or not filters_category_type %}
               {% set keyword_match = (filters_keyword and document.text_match) or not filters_keyword %}
               {% set show_document = category_match and keyword_match  %}
-
-              {%if show_document %}
+              {% endif %}
+ 
+              {% if show_document  %}
                 <div class="post--icon u-padding--top">
                   <span class="icon icon--inline--left i-document"></span>
                   <a href="{{document.url}}">
@@ -129,7 +137,6 @@
                     </div>
                   </div>
                   {% endif %}
-                    
                 {% endif %}
                 {% if mur.mur_type == 'current' %}
                     <ul class="tags u-padding--bottom">


### PR DESCRIPTION
## Summary (required)
- Fixes bug on global legal search results page that was preventing document highlights for MUR/ADR from being included. 
- Set a boolean for a specific rendering of documents when MUR/ADR partial is included in `legal-search-results.jinja`
- Maintain the existing logic to conditionally render docs on MUR/ADR datatables only when keyword or doc type filters are applied.

- Resolves #6334

### Required reviewers

One frontend, one UX

## Impacted areas of the application
Global legal search results page
modified:   legal/templates/legal-search-results.jinja
modified:   legal/templates/partials/legal-search-results-adrs.jinja
modified:   legal/templates/partials/legal-search-results-mur.jinja 

## Screenshots

<img width="1053" alt="Screenshot 2024-07-30 at 8 28 21 PM" src="https://github.com/user-attachments/assets/e87e5205-4845-4785-850c-036344ed8016">


## How to test

- checkout and run branch
- Search  a keyword on http://127.0.0.1:8000/data/legal/search/?search_type=murs
- Search  a keyword on http://127.0.0.1:8000/data/legal/search/?search_type=adrs
- Verify that document with keyword match highlights are now included in results (and no docs without highlights)
- Confirm that documents on MUR and ADR datatables still render correctly.  Docs should only be included when there is a keyword query and/or document type filters applied -- the same way it works currently on prod.
