### PR TITLE
Update bool operator syntax for Elasticsearch simple_query_string and excludes

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -65,7 +65,7 @@ def load_search_results(query, query_type=None):
         }
 
 
-def load_legal_search_results(query, query_exclude, query_type="all", offset=0, limit=20, **kwargs):
+def load_legal_search_results(query, query_exclude=None, query_type="all", offset=0, limit=20, **kwargs):
     filters = dict((key, value) for key, value in kwargs.items() if value)
 
     # Apply type filter if only looking for one type

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -65,7 +65,7 @@ def load_search_results(query, query_type=None):
         }
 
 
-def load_legal_search_results(query, query_type="all", offset=0, limit=20, **kwargs):
+def load_legal_search_results(query, query_exclude, query_type="all", offset=0, limit=20, **kwargs):
     filters = dict((key, value) for key, value in kwargs.items() if value)
 
     # Apply type filter if only looking for one type
@@ -75,6 +75,8 @@ def load_legal_search_results(query, query_type="all", offset=0, limit=20, **kwa
     filters["hits_returned"] = limit
     filters["from_hit"] = offset
     filters["q"] = query
+    filters["q_exclude"] = query_exclude
+
     results = _call_api("legal", "search", **filters)
     results["limit"] = limit
     results["offset"] = offset

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -65,7 +65,7 @@ def load_search_results(query, query_type=None):
         }
 
 
-def load_legal_search_results(query, query_exclude=None, query_type="all", offset=0, limit=20, **kwargs):
+def load_legal_search_results(query, query_exclude="", query_type="all", offset=0, limit=20, **kwargs):
     filters = dict((key, value) for key, value in kwargs.items() if value)
 
     # Apply type filter if only looking for one type

--- a/fec/data/tests/test_legal_search.py
+++ b/fec/data/tests/test_legal_search.py
@@ -10,6 +10,7 @@ from data import api_caller
 from data import ecfr_caller
 from data import legal_test_data
 from legal import views
+from legal.views import parse_query
 
 client = Client()
 
@@ -197,3 +198,31 @@ class TestLegalSearch(TestCase):
             "MUR 1: There were no data for commission_votes action at index 1"
             not in log_contents
         )
+
+
+# Tests parsing legal query and extracting exclude parameters.
+class TestParseQuery:
+    def test_parse_query_no_exclude(self):
+        query = "in-kind contribution"
+        result = parse_query(query)
+        assert result == (query, "")
+
+    def test_parse_query_single_exclude(self):
+        query = "-in-kind contribution"
+        result = parse_query(query)
+        assert result == ("contribution", "in-kind")
+
+    def test_parse_query_multiple_exclude(self):
+        query = "in-kind contribution -travel -authorization"
+        result = parse_query(query)
+        assert result == ("in-kind contribution", "travel authorization")
+
+    def test_parse_query_exclude_with_spaces(self):
+        query = "in-kind -authorization contribution"
+        result = parse_query(query)
+        assert result == ("in-kind contribution", "authorization")
+
+    def test_parse_query_empty_string(self):
+        query = ""
+        result = parse_query(query)
+        assert result == ("", "")

--- a/fec/data/tests/test_legal_search.py
+++ b/fec/data/tests/test_legal_search.py
@@ -53,7 +53,7 @@ class TestLegalSearch(TestCase):
         )
         assert response.status_code == 200
         load_legal_search_results.assert_called_once_with(
-            'in kind donation', 'all', limit=3
+            'in kind donation', '', 'all', limit=3
         )
 
     # Test4 : This test is checking against the static data on
@@ -81,14 +81,13 @@ class TestLegalSearch(TestCase):
     def test_transform_ecfr_query_string(self):
         # Define input query string
         input_query_string = (
-            '((coordinated OR communications) OR (in-kind AND' +
-            ' contributions) OR ("independent expenditure")) AND (-travel)'
+            '(coordinated | communications)|(in-kind + contributions)|("independent expenditure") -travel'
         )
 
         # Expected output after transformation
         expected_output = (
-            '((coordinated | communications) | (in-kind' +
-            ' contributions) | ("independent expenditure")) -travel'
+            '(coordinated | communications)|(in-kind' +
+            ' contributions)|("independent expenditure") -travel'
         )
 
         # Apply transformation
@@ -110,7 +109,8 @@ class TestLegalSearch(TestCase):
             data={'search': 'in kind donation', 'search_type': 'statutes'}
         )
         assert response.status_code == 200
-        load_legal_search_results.assert_called_once_with('in kind donation',
+
+        load_legal_search_results.assert_called_once_with('in kind donation', '',
                                                           'statutes', offset=0)
 
     # # Test 6: OK
@@ -139,12 +139,14 @@ class TestLegalSearch(TestCase):
         calls = [
             mock.call(
                 query='',
+                query_exclude='',
                 query_type='advisory_opinions',
                 ao_min_issue_date=ao_min_date,
                 ao_category=['F', 'W']
             ),
             mock.call(
                 query='',
+                query_exclude='',
                 query_type='advisory_opinions',
                 ao_status='Pending',
                 ao_category='R'

--- a/fec/fec/static/js/legal.js
+++ b/fec/fec/static/js/legal.js
@@ -61,7 +61,7 @@ KeywordModal.prototype.generateQueryString = function() {
   this.$fields.each(function() {
     const $input = $(this);
     if ($input.val() && includeQuery) {
-      includeQuery = includeQuery + '|' + '(' + self.parseValue($input) + ')';
+      includeQuery = includeQuery + ' | ' + '(' + self.parseValue($input) + ')';
     } else if ($input.val()) {
       includeQuery = '(' + self.parseValue($input) + ')';
     }
@@ -70,7 +70,7 @@ KeywordModal.prototype.generateQueryString = function() {
   if (this.$excludeField.val()) {
     excludeQuery = self.parseValue(this.$excludeField);
   }
-  var queryString =  includeQuery + excludeQuery;
+  var queryString = includeQuery + excludeQuery;
   return queryString;
 };
 
@@ -98,7 +98,7 @@ KeywordModal.prototype.parseValue = function($input) {
       .map(function(word) {
         return ' -' + word;
       })
-      .join(' ');
+      .join('');
   }
 };
 

--- a/fec/fec/static/js/legal.js
+++ b/fec/fec/static/js/legal.js
@@ -74,7 +74,7 @@ KeywordModal.prototype.combineFields = function() {
   });
 
   if (this.$excludeField.val() && query) {
-    query = '(' + query + ')+(' + self.parseValue(this.$excludeField) + ')';
+    query = '(' + query + ') + (' + self.parseValue(this.$excludeField) + ')';
   } else if (this.$excludeField.val()) {
     query = self.parseValue(this.$excludeField);
   }

--- a/fec/fec/static/js/legal.js
+++ b/fec/fec/static/js/legal.js
@@ -67,14 +67,14 @@ KeywordModal.prototype.combineFields = function() {
   this.$fields.each(function() {
     var $input = $(this);
     if ($input.val() && query) {
-      query = query + ' OR ' + '(' + self.parseValue($input) + ')';
+      query = query + '|' + '(' + self.parseValue($input) + ')';
     } else if ($input.val()) {
       query = '(' + self.parseValue($input) + ')';
     }
   });
 
   if (this.$excludeField.val() && query) {
-    query = '(' + query + ') & (' + self.parseValue(this.$excludeField) + ')';
+    query = '(' + query + ')+(' + self.parseValue(this.$excludeField) + ')';
   } else if (this.$excludeField.val()) {
     query = self.parseValue(this.$excludeField);
   }
@@ -91,13 +91,13 @@ KeywordModal.prototype.parseValue = function($input) {
   var words = $input.val().split(' ');
   var operator = $input.data('operator');
   if (operator === 'and') {
-    return words.join(' & ');
+    return words.join('+');
   } else if (operator === 'or') {
-    return words.join(' OR ');
+    return words.join('|');
   } else if (operator === 'exact') {
     return '"' + $input.val() + '"';
   } else if (operator === 'exclude') {
-    return '-' + words.join(' -');
+    return '-' + words.join('%2B');
   }
 };
 

--- a/fec/fec/static/js/legal/Filters.cjs
+++ b/fec/fec/static/js/legal/Filters.cjs
@@ -57,7 +57,7 @@ function Filters(props) {
             TooltipHelp={{
               addTooltip: true,
               message:
-                'Refine a keyword search by using AND, OR, “ ”, -, to expand or limit results.',
+                'Refine a keyword search by using +, |, “ ”, -, to expand or limit results.',
               verticalPosition: 'above',
               horizontalPosition: 'left'
             }}

--- a/fec/fec/static/js/modules/keyword-modal.js
+++ b/fec/fec/static/js/modules/keyword-modal.js
@@ -49,7 +49,7 @@ KeywordModal.prototype.handleSubmit = function(e) {
   const searchQuery = this.generateQueryString();
   let query = URI(window.location.search)
     .removeSearch('search')
-    .addSearch('search', searchQuery)
+    .addSearch('search', searchQuery);
 
   this.dialog.hide();
   // Event record for GTM
@@ -78,7 +78,7 @@ KeywordModal.prototype.generateQueryString = function() {
   if (this.$excludeField.val()) {
     excludeQuery = self.parseValue(this.$excludeField);
   }
-  var queryString =  includeQuery + excludeQuery;
+  var queryString = includeQuery + excludeQuery;
   return queryString;
 };
 

--- a/fec/fec/static/js/modules/keyword-modal.js
+++ b/fec/fec/static/js/modules/keyword-modal.js
@@ -69,14 +69,14 @@ KeywordModal.prototype.combineFields = function() {
   this.$fields.each(function() {
     var $input = $(this);
     if ($input.val() && query) {
-      query = query + ' OR ' + '(' + self.parseValue($input) + ')';
+      query = query + ' | ' + '(' + self.parseValue($input) + ')';
     } else if ($input.val()) {
       query = '(' + self.parseValue($input) + ')';
     }
   });
 
   if (this.$excludeField.val() && query) {
-    query = '(' + query + ') AND (' + self.parseValue(this.$excludeField) + ')';
+    query = '(' + query + ') + (' + self.parseValue(this.$excludeField) + ')';
   } else if (this.$excludeField.val()) {
     query = self.parseValue(this.$excludeField);
   }
@@ -96,13 +96,14 @@ KeywordModal.prototype.parseValue = function($input) {
     .split(' ');
   var operator = $input.data('operator');
   if (operator === 'and') {
-    return words.join(' AND ');
+    return words.join(' + ');
   } else if (operator === 'or') {
-    return words.join(' OR ');
+    return words.join(' | ');
   } else if (operator === 'exact') {
     return '"' + $input.val().replace(/"/g, '') + '"';
   } else if (operator === 'exclude') {
-    return '-' + words.join(' -');
+    // Remove first dash, replace subsequent dashes with +
+    return $input.val().replace(/-/, '').replace(/-/g, '+'); 
   }
 };
 

--- a/fec/fec/static/js/modules/keyword-modal.js
+++ b/fec/fec/static/js/modules/keyword-modal.js
@@ -69,7 +69,7 @@ KeywordModal.prototype.generateQueryString = function() {
   this.$fields.each(function() {
     const $input = $(this);
     if ($input.val() && includeQuery) {
-      includeQuery = includeQuery + '|' + '(' + self.parseValue($input) + ')';
+      includeQuery = includeQuery + ' | ' + '(' + self.parseValue($input) + ')';
     } else if ($input.val()) {
       includeQuery = '(' + self.parseValue($input) + ')';
     }
@@ -106,7 +106,7 @@ KeywordModal.prototype.parseValue = function($input) {
       .map(function(word) {
         return ' -' + word;
       })
-      .join(' ');
+      .join('');
   }
 };
 

--- a/fec/home/templates/partials/legal-keyword-modal.html
+++ b/fec/home/templates/partials/legal-keyword-modal.html
@@ -43,11 +43,11 @@
             </thead>
             <tbody>
               <tr class="simple-table__row">
-                <td class="simple-table__cell">OR</td>
+                <td class="simple-table__cell">|</td>
                 <td class="simple-table__cell">or</td>
               </tr>
               <tr class="simple-table__row">
-                <td class="simple-table__cell">AND</td>
+                <td class="simple-table__cell">+</td>
                 <td class="simple-table__cell">and</td>
               </tr>
               <tr class="simple-table__row">

--- a/fec/legal/templates/layouts/legal-doc-search-results.jinja
+++ b/fec/legal/templates/layouts/legal-doc-search-results.jinja
@@ -6,7 +6,7 @@
 {% set result_entities = results.get(result_type, []) %}
 
 {% block title %}
-  {% if query or query_exclude %}
+  {% if query %}
   Searching {{ document_type_display_name }} for &ldquo;{{ query }}&rdquo;
   {% else %}
   Search {{ document_type_display_name }}
@@ -60,12 +60,12 @@
     <div class="u-padding--left u-padding--right">
       <div class="message message--no-icon">
         <h2 class="message__title">No results</h2>
-        <p>Sorry, we didn&rsquo;t find any documents matching {% if query or query_exclude %}<span class="t-bold">{{ query }}{{ query_exclude }}</span>{% else %}your search{% endif %}.</p>
+        <p>Sorry, we didn&rsquo;t find any documents matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your search{% endif %}.</p>
         <div class="message--alert__bottom">
           <p>Think this was a mistake?</p>
           <ul class="list--buttons">
             {% if query %}
-            <li><a class="button button--standard" href="/search/?query={{ query }}&query_exclude={{ query_exclude }}">Try FEC.gov</a></li>
+            <li><a class="button button--standard" href="/search/?query={{ query }}">Try FEC.gov</a></li>
             {% endif %}
             <li><a class="button button--standard" href="mailto:{{ WEBMANAGER_EMAIL }}">Email our team</a></li>
             <li><a class="button button--standard" href="https://github.com/fecgov/fec/issues">File an issue</a></li>

--- a/fec/legal/templates/layouts/legal-doc-search-results.jinja
+++ b/fec/legal/templates/layouts/legal-doc-search-results.jinja
@@ -6,7 +6,7 @@
 {% set result_entities = results.get(result_type, []) %}
 
 {% block title %}
-  {% if query %}
+  {% if query or query_exclude %}
   Searching {{ document_type_display_name }} for &ldquo;{{ query }}&rdquo;
   {% else %}
   Search {{ document_type_display_name }}
@@ -60,12 +60,12 @@
     <div class="u-padding--left u-padding--right">
       <div class="message message--no-icon">
         <h2 class="message__title">No results</h2>
-        <p>Sorry, we didn&rsquo;t find any documents matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your search{% endif %}.</p>
+        <p>Sorry, we didn&rsquo;t find any documents matching {% if query or query_exclude %}<span class="t-bold">{{ query }}{{ query_exclude }}</span>{% else %}your search{% endif %}.</p>
         <div class="message--alert__bottom">
           <p>Think this was a mistake?</p>
           <ul class="list--buttons">
             {% if query %}
-            <li><a class="button button--standard" href="/search/?query={{ query }}">Try FEC.gov</a></li>
+            <li><a class="button button--standard" href="/search/?query={{ query }}&query_exclude={{ query_exclude }}">Try FEC.gov</a></li>
             {% endif %}
             <li><a class="button button--standard" href="mailto:{{ WEBMANAGER_EMAIL }}">Email our team</a></li>
             <li><a class="button button--standard" href="https://github.com/fecgov/fec/issues">File an issue</a></li>
@@ -104,7 +104,8 @@
 
           // Check if the tag is 'query' and remove it from the URL search parameters
           if (tag === 'query') {
-            url.searchParams.delete('search');
+              url.searchParams.delete('search');
+              url.searchParams.delete('search_exclude');
           // Check if the tag starts with 'doc_category_' for document types
           } else if (tag && tag.startsWith('doc_category_')) { // Check if tag is not null or undefined
             // Get the index from the tag

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -11,7 +11,7 @@
 {% block filters %}
   <input id="sort" type="hidden" name="sort" value="{{ sort }}">
   <div class="filters__inner">
-    {{ legal.keyword_search(result_type, query) }}
+    {{ legal.keyword_search(result_type, query, query_exclude) }}
     <div class="filter">
       <label class="label" for="case_no">MUR number</label>
       <input id="case_no" name="case_no" type="text" value="{{ case_no }}">
@@ -70,9 +70,9 @@
   </div>
   <div class="js-filter-tags data-container__tags u-no-padding-left">
     <ul class="tags">
-      {% if query %}
+      {% if query or query_exclude %}
         <li data-tag-category="query" class="tag__category">
-          <div data-removable="true" class="tag__item">{{ query }}<button class="button js-close tag__remove" data-tag="query"><span class="u-visually-hidden">Remove</span></button></div>
+          <div data-removable="true" class="tag__item">{{ query }} {% if query and query_exclude %} + {% endif %}{% if query_exclude %}({{ query_exclude }}){% endif %}<button class="button js-close tag__remove" data-tag="query"><span class="u-visually-hidden">Remove</span></button></div>
         </li>
       {% endif %}
       {% if case_no %}

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -11,7 +11,7 @@
 {% block filters %}
   <input id="sort" type="hidden" name="sort" value="{{ sort }}">
   <div class="filters__inner">
-    {{ legal.keyword_search(result_type, query, query_exclude) }}
+    {{ legal.keyword_search(result_type, query) }}
     <div class="filter">
       <label class="label" for="case_no">MUR number</label>
       <input id="case_no" name="case_no" type="text" value="{{ case_no }}">
@@ -70,9 +70,9 @@
   </div>
   <div class="js-filter-tags data-container__tags u-no-padding-left">
     <ul class="tags">
-      {% if query or query_exclude %}
+      {% if query %}
         <li data-tag-category="query" class="tag__category">
-          <div data-removable="true" class="tag__item">{{ query }} {% if query and query_exclude %} + {% endif %}{% if query_exclude %}({{ query_exclude }}){% endif %}<button class="button js-close tag__remove" data-tag="query"><span class="u-visually-hidden">Remove</span></button></div>
+          <div data-removable="true" class="tag__item">{{ query }}<button class="button js-close tag__remove" data-tag="query"><span class="u-visually-hidden">Remove</span></button></div>
         </li>
       {% endif %}
       {% if case_no %}

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -3,8 +3,8 @@
   <label class="label t-inline-block" for="search-input">Search keywords</label>
   <div class="tooltip__container">
    <button class="tooltip__trigger"><span class="u-visually-hidden">Learn more</span></button>
-   <div class="tooltip tooltip--left tooltip--above">
-      <p class="tooltip__content tooltip__content">Refine a keyword search by using AND, OR, “ ”, -, to expand or limit results.</p>
+   <div class="tooltip tooltip--left tooltip--under">
+      <p class="tooltip__content tooltip__content">Refine a keyword search by using +, |, “ ”, -, to expand or limit results.</p>
    </div>
   </div>
   <div class="combo combo--search--mini no-mar-b">

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -1,4 +1,4 @@
-{% macro keyword_search(result_type, query) %}
+{% macro keyword_search(result_type, query, query_exclude) %}
 <div class="filter">
   <label class="label t-inline-block" for="search-input">Search keywords</label>
   <div class="tooltip__container">
@@ -8,7 +8,7 @@
    </div>
   </div>
   <div class="combo combo--search--mini no-mar-b">
-    <input id="search-input" type="text" name="search" class="combo__input"{% if query %} value="{{ query }}"{% endif %}>
+    <input id="search-input" type="text" name="search" class="combo__input"{% if query or query_exclude %} value="{{ query }}{% if query and query_exclude %} + {% endif %}{% if query_exclude %}({{ query_exclude }}){% endif %}"{% endif %}>
     <button class="combo__button button--search button--standard" type="submit">
       <span class="u-visually-hidden">Search</span>
     </button>
@@ -82,7 +82,7 @@
   </fieldset>
 {% endmacro %}
 
-{% macro search(location, result_type, query, button_color="button--standard", select_class="select--alt-primary") %}
+{% macro search(location, result_type, query, query_exclude, button_color="button--standard", select_class="select--alt-primary") %}
 {% if location == 'hero' %}
   {% set size = 'combo--search--large' %}
 {% endif %}
@@ -106,7 +106,7 @@
 </form>
 {% endmacro %}
 
-{% macro no_results(display_name, result_type, query, search, fec_resources=None) %}
+{% macro no_results(display_name, result_type, query, query_exclude, search, fec_resources=None) %}
 <div class="message message--no-icon">
   <h2 class="message__title">No results</h2>
   {% if search == result_type or search == 'all' %}
@@ -115,8 +115,8 @@
   <div class="message--alert__bottom">
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">
-      {% if query %}
-       <li><a class="button button--standard" href="/search/?query={{ query }}">Try FEC.gov</a></li>
+      {% if query or query_exclude %}
+       <li><a class="button button--standard" href="/search/?query={{ query }}&query_exclude={{ query_exclude }}">Try FEC.gov</a></li>
       {% endif %}
       <li><a class="button button--standard" href="mailto:{{ WEBMANAGER_EMAIL }}">Email our team</a></li>
       <li><a class="button button--standard" href="https://github.com/fecgov/fec/issues">File an issue</a></li>

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -82,7 +82,7 @@
   </fieldset>
 {% endmacro %}
 
-{% macro search(location, result_type, query, query_exclude, button_color="button--standard", select_class="select--alt-primary") %}
+{% macro search(location, result_type, query, button_color="button--standard", select_class="select--alt-primary") %}
 {% if location == 'hero' %}
   {% set size = 'combo--search--large' %}
 {% endif %}

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -1,4 +1,4 @@
-{% macro keyword_search(result_type, query, query_exclude) %}
+{% macro keyword_search(result_type, query) %}
 <div class="filter">
   <label class="label t-inline-block" for="search-input">Search keywords</label>
   <div class="tooltip__container">
@@ -8,7 +8,7 @@
    </div>
   </div>
   <div class="combo combo--search--mini no-mar-b">
-    <input id="search-input" type="text" name="search" class="combo__input"{% if query or query_exclude %} value="{{ query }}{% if query and query_exclude %} + {% endif %}{% if query_exclude %}({{ query_exclude }}){% endif %}"{% endif %}>
+    <input id="search-input" type="text" name="search" class="combo__input" value="{{ query }}">
     <button class="combo__button button--search button--standard" type="submit">
       <span class="u-visually-hidden">Search</span>
     </button>
@@ -106,7 +106,7 @@
 </form>
 {% endmacro %}
 
-{% macro no_results(display_name, result_type, query, query_exclude, search, fec_resources=None) %}
+{% macro no_results(display_name, result_type, query, search, fec_resources=None) %}
 <div class="message message--no-icon">
   <h2 class="message__title">No results</h2>
   {% if search == result_type or search == 'all' %}
@@ -115,8 +115,8 @@
   <div class="message--alert__bottom">
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">
-      {% if query or query_exclude %}
-       <li><a class="button button--standard" href="/search/?query={{ query }}&query_exclude={{ query_exclude }}">Try FEC.gov</a></li>
+      {% if query %}
+       <li><a class="button button--standard" href="/search/?query={{ query }}">Try FEC.gov</a></li>
       {% endif %}
       <li><a class="button button--standard" href="mailto:{{ WEBMANAGER_EMAIL }}">Email our team</a></li>
       <li><a class="button button--standard" href="https://github.com/fecgov/fec/issues">File an issue</a></li>

--- a/fec/legal/templates/partials/legal-keyword-modal.jinja
+++ b/fec/legal/templates/partials/legal-keyword-modal.jinja
@@ -43,11 +43,11 @@
             </thead>
             <tbody>
               <tr class="simple-table__row">
-                <td class="simple-table__cell">OR</td>
+                <td class="simple-table__cell">|</td>
                 <td class="simple-table__cell">or</td>
               </tr>
               <tr class="simple-table__row">
-                <td class="simple-table__cell">AND</td>
+                <td class="simple-table__cell">+</td>
                 <td class="simple-table__cell">and</td>
               </tr>
               <tr class="simple-table__row">

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -173,7 +173,7 @@ def admin_fine_page(request, admin_fine_no):
 
 # Transform boolean queries for eCFR API
 # Query string:
-# ((coordinated OR communications) OR (in-kind AND contributions) OR
+# ((coordinated | communications) | (in-kind AND contributions) |
 # ("independent expenditure")) AND (-authorization)
 # eCFR query string transformation:
 # (coordinated | communications) | (in-kind contributions) |
@@ -183,7 +183,7 @@ def transform_ecfr_query_string(query_string):
 
     # Define the replacements for eCFR query string
     replacements = [
-        (r'\((-[^)]*)\)', r'\1'),  # Removes parentheses around on statement
+        (r' \+', ''),  # Replace space+ with empty string
     ]
 
     # Apply replacements sequentially
@@ -474,7 +474,7 @@ def legal_doc_search_statutes(request):
     query = request.GET.get('search', '')
     offset = request.GET.get('offset', 0)
 
-    results = api_caller.load_legal_search_results(query, None, 'statutes',
+    results = api_caller.load_legal_search_results(query, '', 'statutes',
                                                    offset=offset)
 
     return render(request, 'legal-search-results-statutes.jinja', {


### PR DESCRIPTION
## Summary (required)

- Resolves #6360 

This updates the query string syntax that is used on the web UI as well as what is submitted in the API query string. Refer to the [ticket](https://github.com/fecgov/fec-cms/issues/6360) for the syntax.

### Required reviewers

1 Developer
1 UX

## Impacted areas of the application

General components of the application that this PR will affect:

- More keyword search for all legal documents (MURs, ADRs, AFs, AOs, Statutes)
   - https://fec-feature-cms.app.cloud.gov/data/legal/search/murs/
   - https://fec-feature-cms.app.cloud.gov/data/legal/search/adrs/
   - https://fec-feature-cms.app.cloud.gov/data/legal/search/admin_fines/
   - https://fec-feature-cms.app.cloud.gov/data/legal/search/statutes/
   - https://fec-feature-cms.app.cloud.gov/data/legal/search/advisory-opinions/

<img width="801" alt="Screenshot 2024-08-09 at 12 02 00 PM" src="https://github.com/user-attachments/assets/6635b908-18b5-434e-9e93-201c9f0414b3">


## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/add_case_respondents_and_exclude | [link](https://github.com/fecgov/openFEC/pull/5916)

## How to test

- checkout this branch
- `npm run build`
- `./manage.py runserver`
- Go to each of the legal searches and perform boolean search using the "more keyword options" box or constructing your own query.
   - http://127.0.0.1:8000/data/legal/search/murs/
   - http://127.0.0.1:8000/data/legal/search/adrs/
   - http://127.0.0.1:8000/data/legal/search/admin_fines/
   - http://127.0.0.1:8000/data/legal/search/statutes/
   - http://127.0.0.1:8000/data/legal/search/advisory-opinions/
