### PR TITLE
6182, 6183 National Party Accounts Data on Single Pages

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -123,7 +123,7 @@
                 {% if not is_inaugural %}
                 <li><a href="#individual-contribution-transactions">Individual contribution transactions</a></li>
                 {% endif %}
-                {% if FEATURES.nat_party_acct_rec_single %}
+                {% if FEATURES.nat_party_acct_rec_single and totals_national_party %}
                 <li><a href="#national-party-account-raising">National party headquarters, recounts and convention accounts</a></li>
                 {% endif %}
               </ul>
@@ -165,7 +165,7 @@
               {% else %}
               <li><a href="#disbursement-transactions">Refund transactions</a></li>
               {% endif %}
-              {% if FEATURES.nat_party_acct_dis_single %}
+              {% if FEATURES.nat_party_acct_dis_single and totals_national_party %}
                 <li><a href="#national-party-account-spending">National party headquarters, recounts and convention accounts</a></li>
               {% endif %}
             </ul>

--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -123,6 +123,9 @@
                 {% if not is_inaugural %}
                 <li><a href="#individual-contribution-transactions">Individual contribution transactions</a></li>
                 {% endif %}
+                {% if FEATURES.nat_party_acct_rec_single %}
+                <li><a href="#national-party-account-raising">National party headquarters, recounts and convention accounts</a></li>
+                {% endif %}
               </ul>
               {% endif %}
           </li>
@@ -161,6 +164,9 @@
               <li><a href="#disbursement-transactions">Disbursement transactions</a></li>
               {% else %}
               <li><a href="#disbursement-transactions">Refund transactions</a></li>
+              {% endif %}
+              {% if FEATURES.nat_party_acct_dis_single %}
+                <li><a href="#national-party-account-spending">National party headquarters, recounts and convention accounts</a></li>
               {% endif %}
             </ul>
             {% endif %}

--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -14,191 +14,191 @@
   <h2 id="section-3-heading">Raising</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'receipts')}}
-    {% if totals and committee_type not in ['C', 'E', 'I'] %}
-      <div id="total-receipts" class="entity__figure row">
-        <div class="heading--section heading--with-action">
-          <h3 class="heading__left">Total receipts</h3>
-          <a class="heading__right button--alt button--browse"
-            href="/data/receipts/?two_year_transaction_period={{ cycle }}&committee_id={{ committee_id }}">Filter all receipts</a>
-        </div>
-        <div class="content__section--narrow">
-          <div class="row u-margin-bottom">
-            <div class="usa-width-one-half">
-              <span class="t-big-data">{{ totals.receipts|currency }}</span>
-            </div>
-          </div>
-          <div class="row">
-            <span class="usa-width-one-half t-block t-sans">raised in total receipts by this committee from <strong>{{totals.coverage_start_date|date_full}} to {{totals.coverage_end_date|date_full}}.</strong></span>
-            <div class="usa-width-one-half">
-              <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of receipt.</span>
-            </div>
-          </div>
-        </div>
-        <div class="content__section--ruled">
-        <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
-      </div>
-      </div>
-    {% endif %}
-    {% if not is_inaugural %}
-    <div class="entity__figure" id="individual-contribution-transactions">
+  {% if totals and committee_type not in ['C', 'E', 'I'] %}
+    <div id="total-receipts" class="entity__figure row">
       <div class="heading--section heading--with-action">
-        <h3 class="heading__left">Individual contributions</h3>
+        <h3 class="heading__left">Total receipts</h3>
         <a class="heading__right button--alt button--browse"
-            href="/data/individual-contributions/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}">Filter this data</a>
+          href="/data/receipts/?two_year_transaction_period={{ cycle }}&committee_id={{ committee_id }}">Filter all receipts</a>
       </div>
-      <fieldset class="row toggles js-toggles">
-        <legend class="label">Group by:</legend>
-        <label for="toggle-itemized">
-          <input id="toggle-itemized" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="itemized-contributions" checked>
-          <span class="button--alt">All transactions</span>
-        </label>
-        <label for="toggle-state">
-          <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-state">
-          <span class="button--alt">State</span>
-        </label>
-        <label for="toggle-contribution-size">
-          <input id="toggle-contribution-size" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-contribution-size">
-          <span class="button--alt">Size</span>
-        </label>
-        <label for="toggle-employer">
-          <input id="toggle-employer" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-employer">
-          <span class="button--alt">Employer</span>
-        </label>
-        <label for="toggle-occupation">
-          <input id="toggle-occupation" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-occupation">
-          <span class="button--alt">Occupation</span>
-        </label>
-      </fieldset>
-      <div class="row">
-        <div id="by-state" class="panel-toggle-element" aria-hidden="true">
-          <div class="results-info results-info--simple">
-            {% if totals %}
-            <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
-            </div>
-            {% endif %}
-            <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-state">Export</button>
-          </div>
-          <div class="map-table">
-            <table
-                class="data-table data-table--heading-borders"
-                data-type="receipts-by-state"
-                data-committee="{{ committee.committee_id }}"
-                data-cycle="{{ cycle }}"
-              >
-              <thead>
-                <th scope="col">State</th>
-                <th scope="col">Total contributed</th>
-              </thead>
-            </table>
-          </div>
-          <div class="map-panel">
-            <div class="state-map" data-committee-id="{{ committee.committee_id }}" data-cycle="{{ cycle }}">
-              <div class="legend-container">
-                <span class="t-sans t-block">By state: total amount received</span>
-                <svg></svg>
-              </div>
-            </div>
+      <div class="content__section--narrow">
+        <div class="row u-margin-bottom">
+          <div class="usa-width-one-half">
+            <span class="t-big-data">{{ totals.receipts|currency }}</span>
           </div>
         </div>
-
-        <div id="by-contribution-size" class="panel-toggle-element" aria-hidden="true">
-          <div class="results-info results-info--simple">
-            {% if totals %}
-            <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
-            </div>
-            {% endif %}
-            <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="contribution-size">Export</button>
+        <div class="row">
+          <span class="usa-width-one-half t-block t-sans">raised in total receipts by this committee from <strong>{{totals.coverage_start_date|date_full}} to {{totals.coverage_end_date|date_full}}.</strong></span>
+          <div class="usa-width-one-half">
+            <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of receipt.</span>
           </div>
-          <table
-             class="data-table data-table--heading-borders"
-             data-type="contribution-size"
-             data-committee="{{ committee.committee_id }}"
-             data-cycle="{{ cycle }}">
-            <thead>
-              <th scope="col">Contribution size</th>
-              <th scope="col">Total contributed</th>
-            </thead>
-          </table>
         </div>
-        <div id="by-employer" class="panel-toggle-element" aria-hidden="true">
-          <div class="results-info results-info--simple">
-            {% if totals %}
-            <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
-            </div>
-            {% endif %}
-            <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-employer">Export</button>
+      </div>
+      <div class="content__section--ruled">
+      <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
+    </div>
+    </div>
+  {% endif %}
+  {% if not is_inaugural %}
+  <div class="entity__figure" id="individual-contribution-transactions">
+    <div class="heading--section heading--with-action">
+      <h3 class="heading__left">Individual contributions</h3>
+      <a class="heading__right button--alt button--browse"
+          href="/data/individual-contributions/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}">Filter this data</a>
+    </div>
+    <fieldset class="row toggles js-toggles">
+      <legend class="label">Group by:</legend>
+      <label for="toggle-itemized">
+        <input id="toggle-itemized" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="itemized-contributions" checked>
+        <span class="button--alt">All transactions</span>
+      </label>
+      <label for="toggle-state">
+        <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-state">
+        <span class="button--alt">State</span>
+      </label>
+      <label for="toggle-contribution-size">
+        <input id="toggle-contribution-size" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-contribution-size">
+        <span class="button--alt">Size</span>
+      </label>
+      <label for="toggle-employer">
+        <input id="toggle-employer" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-employer">
+        <span class="button--alt">Employer</span>
+      </label>
+      <label for="toggle-occupation">
+        <input id="toggle-occupation" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-occupation">
+        <span class="button--alt">Occupation</span>
+      </label>
+    </fieldset>
+    <div class="row">
+      <div id="by-state" class="panel-toggle-element" aria-hidden="true">
+        <div class="results-info results-info--simple">
+          {% if totals %}
+          <div class="u-float-left tag__category">
+            <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
           </div>
+          {% endif %}
+          <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-state">Export</button>
+        </div>
+        <div class="map-table">
           <table
               class="data-table data-table--heading-borders"
-              data-type="receipts-by-employer"
+              data-type="receipts-by-state"
               data-committee="{{ committee.committee_id }}"
               data-cycle="{{ cycle }}"
             >
             <thead>
-              <th scope="col">Employer</th>
+              <th scope="col">State</th>
               <th scope="col">Total contributed</th>
             </thead>
           </table>
-          {{ disclaimer.disclaimer('receipts', committee.committee_id, cycle) }}
         </div>
-
-        <div id="by-occupation" class="panel-toggle-element" aria-hidden="true">
-          <div class="results-info results-info--simple">
-            {% if totals %}
-            <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
-            </div>
-            {% endif %}
-            <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-occupation">Export</button>
-          </div>
-          <table
-              class="data-table data-table--heading-borders"
-              data-type="receipts-by-occupation"
-              data-committee="{{ committee.committee_id }}"
-              data-cycle="{{ cycle }}"
-            >
-            <thead>
-              <th scope="col">Occupation</th>
-              <th scope="col">Total contributed</th>
-            </thead>
-          </table>
-          {{ disclaimer.disclaimer('receipts', committee.committee_id, cycle) }}
-        </div>
-
-        <div id="itemized-contributions" class="panel-toggle-element">
-          <div class="results-info results-info--simple">
-            {% if totals %}
-            <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
-            </div>
-            {% endif %}
-            <div class="u-float-right">
-              <button type="button" class="js-export button button--cta button--export" data-export-for="itemized-receipts">Export</button>
-              <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="itemized-receipts" aria-hidden="true"></div>
+        <div class="map-panel">
+          <div class="state-map" data-committee-id="{{ committee.committee_id }}" data-cycle="{{ cycle }}">
+            <div class="legend-container">
+              <span class="t-sans t-block">By state: total amount received</span>
+              <svg></svg>
             </div>
           </div>
-          <table
-              class="data-table data-table--heading-borders"
-              data-type="itemized-receipts"
-              data-committee="{{ committee.committee_id }}"
-              data-cycle="{{ cycle }}"
-            >
-            <thead>
-              <th scope="col">Contributor name</th>
-              <th scope="col">Contributor state</th>
-              <th scope="col">Receipt date</th>
-              <th scope="col">Amount</th>
-            </thead>
-          </table>
         </div>
+      </div>
+
+      <div id="by-contribution-size" class="panel-toggle-element" aria-hidden="true">
+        <div class="results-info results-info--simple">
+          {% if totals %}
+          <div class="u-float-left tag__category">
+            <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
+          </div>
+          {% endif %}
+          <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="contribution-size">Export</button>
+        </div>
+        <table
+            class="data-table data-table--heading-borders"
+            data-type="contribution-size"
+            data-committee="{{ committee.committee_id }}"
+            data-cycle="{{ cycle }}">
+          <thead>
+            <th scope="col">Contribution size</th>
+            <th scope="col">Total contributed</th>
+          </thead>
+        </table>
+      </div>
+      <div id="by-employer" class="panel-toggle-element" aria-hidden="true">
+        <div class="results-info results-info--simple">
+          {% if totals %}
+          <div class="u-float-left tag__category">
+            <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
+          </div>
+          {% endif %}
+          <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-employer">Export</button>
+        </div>
+        <table
+            class="data-table data-table--heading-borders"
+            data-type="receipts-by-employer"
+            data-committee="{{ committee.committee_id }}"
+            data-cycle="{{ cycle }}"
+          >
+          <thead>
+            <th scope="col">Employer</th>
+            <th scope="col">Total contributed</th>
+          </thead>
+        </table>
+        {{ disclaimer.disclaimer('receipts', committee.committee_id, cycle) }}
+      </div>
+
+      <div id="by-occupation" class="panel-toggle-element" aria-hidden="true">
+        <div class="results-info results-info--simple">
+          {% if totals %}
+          <div class="u-float-left tag__category">
+            <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
+          </div>
+          {% endif %}
+          <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-occupation">Export</button>
+        </div>
+        <table
+            class="data-table data-table--heading-borders"
+            data-type="receipts-by-occupation"
+            data-committee="{{ committee.committee_id }}"
+            data-cycle="{{ cycle }}"
+          >
+          <thead>
+            <th scope="col">Occupation</th>
+            <th scope="col">Total contributed</th>
+          </thead>
+        </table>
+        {{ disclaimer.disclaimer('receipts', committee.committee_id, cycle) }}
+      </div>
+
+      <div id="itemized-contributions" class="panel-toggle-element">
+        <div class="results-info results-info--simple">
+          {% if totals %}
+          <div class="u-float-left tag__category">
+            <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
+          </div>
+          {% endif %}
+          <div class="u-float-right">
+            <button type="button" class="js-export button button--cta button--export" data-export-for="itemized-receipts">Export</button>
+            <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="itemized-receipts" aria-hidden="true"></div>
+          </div>
+        </div>
+        <table
+            class="data-table data-table--heading-borders"
+            data-type="itemized-receipts"
+            data-committee="{{ committee.committee_id }}"
+            data-cycle="{{ cycle }}"
+          >
+          <thead>
+            <th scope="col">Contributor name</th>
+            <th scope="col">Contributor state</th>
+            <th scope="col">Receipt date</th>
+            <th scope="col">Amount</th>
+          </thead>
+        </table>
       </div>
     </div>
-    {% endif %}
+  </div>
+  {% endif %}
 
-    {% if FEATURES.nat_party_acct_rec_single %}
+  {% if totals_national_party and FEATURES.nat_party_acct_rec_single %}
     <div id="national-party-account-raising" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">
@@ -215,7 +215,7 @@
         <div class="content__section--narrow">
           <div class="row u-margin-bottom">
             <div class="usa-width-one-half">
-              <span class="t-big-data">{{ totals.receipts|currency }}</span>
+              <span class="t-big-data">{{ totals_national_party.total_receipts|currency }}</span>
             </div>
           </div>
           <div class="row u-margin-bottom">
@@ -251,6 +251,6 @@
         </thead>
       </table>
     </div>
-    {% endif %}{#- /NATIONAL PARTY -#}
+  {% endif %}{#- /NATIONAL PARTY -#}
   </div>
 </section>

--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -197,5 +197,60 @@
       </div>
     </div>
     {% endif %}
+
+    {% if FEATURES.nat_party_acct_rec_single %}
+    <div id="national-party-account-raising" class="entity__figure row">
+      <div class="content__section">
+        <div class="heading--section heading--with-action">
+          <h3 class="heading__left">National party headquarters, recounts and convention accounts</h3>
+          {#- only offer to filter the data / link to the datatable if that flag is on, too -#}
+          {% if FEATURES.nat_party_acct_receipts %}
+          <a
+            class="heading__right button--alt button--browse"
+            href="/data/national-party-account-receipts/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}"
+            >Filter this data
+          </a>
+          {% endif %}
+        </div>
+        <div class="content__section--narrow">
+          <div class="row u-margin-bottom">
+            <div class="usa-width-one-half">
+              <span class="t-big-data">{{ totals.receipts|currency }}</span>
+            </div>
+          </div>
+          <div class="row u-margin-bottom">
+            <div class="usa-width-one-half t-block t-sans">raised by this committee from <strong><time>{{totals.coverage_start_date|date_full}}</time> to <time>{{totals.coverage_end_date|date_full}}</time>.</strong></div>
+            <div class="usa-width-one-half">
+              <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of account.</span>
+            </div>
+          </div>
+        </div>
+        <div class="content__section--ruled">
+          <div class="row">
+            <div class="results-info results-info--simple">
+              <div class="u-float-left tag__category">
+                <div class="tag__item">Coverage dates: <time>{{totals.coverage_start_date|date}}</time> to <time>{{transaction_end|date}}</time></div>
+              </div>
+              <div class="u-float-right">
+                <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="national-party-account-raising" aria-hidden="true">
+                </div>
+                <button type="button" class="js-export button button--cta button--export" data-export-for="national-party-account-raising">Export</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="national-party-account-raising" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">
+        <thead>
+          <tr>
+            <th scope="col">Source name</th>
+            <th scope="col">Party account</th>
+            <th scope="col">Receipt date</th>
+            <th scope="col">Amount</th>
+          </tr>
+        </thead>
+      </table>
+    </div>
+    {% endif %}{#- /NATIONAL PARTY -#}
   </div>
 </section>

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -14,7 +14,7 @@
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'disbursements')}}
 
-    {% if totals and committee_type not in ['C', 'E', 'I'] %}
+  {% if totals and committee_type not in ['C', 'E', 'I'] %}
     <div id="total-disbursements" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">
@@ -341,8 +341,9 @@
         </table>
       </div>
     </div>
-    
-    {% if FEATURES.nat_party_acct_dis_single %}
+  {% endif %}
+
+  {% if totals_national_party and FEATURES.nat_party_acct_dis_single %}
     <div id="national-party-account-spending" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">
@@ -359,7 +360,7 @@
         <div class="content__section--narrow">
           <div class="row u-margin-bottom">
             <div class="usa-width-one-half">
-              <span class="t-big-data">{{ totals.disbursements|currency }}</span>
+              <span class="t-big-data">{{ totals_national_party.total_disbursements|currency }}</span>
             </div>
           </div>
           <div class="row u-margin-bottom">
@@ -390,12 +391,11 @@
             <th scope="col">Recipient name</th>
             <th scope="col">Party account</th>
             <th scope="col">Description</th>
-            <th scope="col">Receipt date</th>
+            <th scope="col">Disbursement date</th>
             <th scope="col">Amount</th>
           </tr>
         </thead>
       </table>
     </div>
-    {% endif %}{#- /NATIONAL PARTY -#}
-  {% endif %}
+  {% endif %}{#- /NATIONAL PARTY -#}
 </section>

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -341,5 +341,61 @@
         </table>
       </div>
     </div>
+    
+    {% if FEATURES.nat_party_acct_dis_single %}
+    <div id="national-party-account-spending" class="entity__figure row">
+      <div class="content__section">
+        <div class="heading--section heading--with-action">
+          <h3 class="heading__left">National party headquarters, recounts and convention accounts</h3>
+          {#- only offer to filter the data / link to the datatable if that flag is on, too -#}
+          {% if FEATURES.nat_party_acct_receipts %}
+          <a
+            class="heading__right button--alt button--browse"
+            href="/data/national-party-account-disbursements/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}"
+            >Filter this data
+          </a>
+          {% endif %}
+        </div>
+        <div class="content__section--narrow">
+          <div class="row u-margin-bottom">
+            <div class="usa-width-one-half">
+              <span class="t-big-data">{{ totals.disbursements|currency }}</span>
+            </div>
+          </div>
+          <div class="row u-margin-bottom">
+            <span class="usa-width-one-half t-block t-sans">spent by this committee from <strong><time class="no-wrap">{{totals.coverage_start_date|date_full}}</time> to <time class="no-wrap">{{totals.coverage_end_date|date_full}}</time>.</strong></span>
+            <div class="usa-width-one-half">
+              <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of account.</span>
+            </div>
+          </div>
+        </div>
+        <div class="content__section--ruled">
+          <div class="row">
+            <div class="results-info results-info--simple">
+              <div class="u-float-left tag__category">
+                <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
+              </div>
+              <div class="u-float-right">
+                <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="national-party-account-spending" aria-hidden="true">
+                </div>
+                <button type="button" class="js-export button button--cta button--export" data-export-for="national-party-account-spending">Export</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="national-party-account-spending" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">
+        <thead>
+          <tr>
+            <th scope="col">Recipient name</th>
+            <th scope="col">Party account</th>
+            <th scope="col">Description</th>
+            <th scope="col">Receipt date</th>
+            <th scope="col">Amount</th>
+          </tr>
+        </thead>
+      </table>
+    </div>
+    {% endif %}{#- /NATIONAL PARTY -#}
   {% endif %}
 </section>

--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -190,6 +190,7 @@ class TestCommittee(TestCase):
         load_reports_and_totals_mock.return_value = (
             self.STOCK_REPORTS,
             self.STOCK_TOTALS,
+            False
         )
         load_endpoint_results_mock.return_value = mock.MagicMock()
         load_committee_statement_of_organization_mock.return_value = {
@@ -257,6 +258,7 @@ class TestCommittee(TestCase):
                 "total_independent_contributions": 11000.0,
                 "total_independent_expenditures": 4262.0,
             },
+            False
         )
         template_variables = views.get_committee("C001", 2018)
 
@@ -282,6 +284,7 @@ class TestCommittee(TestCase):
         load_reports_and_totals_mock.return_value = (
             {"report_type_full": "POST INAUGURAL SUPPLEMENT", "report_type": "90S"},
             {"receipts": 85530042.0, "contribution_refunds": 966240.0},
+            False
         )
 
         committee = views.get_committee("C001", 2018)
@@ -364,6 +367,7 @@ class TestCommittee(TestCase):
                 "last_debts_owed_to_committee": 1000,
                 "total_exp_subject_limits": None,
             },
+            False
         )
 
         template_variables = views.get_committee("C001", 2018)
@@ -472,6 +476,7 @@ class TestCommittee(TestCase):
         load_reports_and_totals_mock.return_value = (
             self.STOCK_REPORTS,
             self.STOCK_TOTALS,
+            False
         )
 
         template_variables = views.get_committee("C001", 2018)
@@ -524,6 +529,7 @@ class TestCommittee(TestCase):
         load_reports_and_totals_mock.return_value = (
             self.STOCK_REPORTS,
             self.STOCK_TOTALS,
+            False
         )
         load_endpoint_results_mock.return_value = mock.MagicMock()
         load_committee_statement_of_organization_mock.return_value = {

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -398,7 +398,7 @@ def get_committee(committee_id, cycle):
     # we set cycle = fallback_cycle
     cycle = fallback_cycle if cycle_out_of_range else cycle
 
-    reports, totals = load_reports_and_totals(
+    reports, totals, totals_national_party = load_reports_and_totals(
         committee_id, cycle, cycle_out_of_range, fallback_cycle
     )
 
@@ -562,6 +562,7 @@ def get_committee(committee_id, cycle):
         "report_type": report_type,
         "reports": reports,
         "totals": totals,
+        "totals_national_party": totals_national_party,
         "min_receipt_date": utils.three_days_ago(),
         "context_vars": context_vars,
         "party_full": committee["party_full"],
@@ -677,12 +678,23 @@ def load_reports_and_totals(committee_id, cycle, cycle_out_of_range, fallback_cy
         path, form_category="REPORT", most_recent=True, **filters
     )
 
-    # (4)call committee/{committee_id}/totals? under tag:financial
+    # (4) Call committee/{committee_id}/totals? under tag:financial
     # get financial totals
     path = "/committee/" + committee_id + "/totals/"
     totals = api_caller.load_first_row_data(path, **filters)
 
-    return reports, totals
+    # (5) Call national_party/totals/? for national party accounts
+    # otherwise set totals_national_party to False (for use in templates)
+    if committee_id in [
+        "C00010603", "C00042366", "C00000935", "C00003418", "C00027466", "C00075820", "C00255695", "C00418103",
+        "C00370221", "C00428664", "C00279802", "C00266759", "C00331314", "C00111476", "C00129668"
+    ]:
+        path = "/national_party/totals/"
+        totals_national_party = api_caller.load_first_row_data(path, **filters)
+    else:
+        totals_national_party = False
+
+    return reports, totals, totals_national_party
 
 
 def load_committee_history(committee_id, cycle=None):

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -79,6 +79,8 @@ FEATURES = {
     'map': bool(env.get_credential('FEC_FEATURE_HOME_MAP', '')),
     'nat_party_acct_receipts': bool(env.get_credential('FEC_FEATURE_NAT_PARTY_ACCT_RECEIPTS', '')),
     'nat_party_acct_disbursements': bool(env.get_credential('FEC_FEATURE_NAT_PARTY_ACCT_DISBURSEMENTS', '')),
+    'nat_party_acct_rec_single': bool(env.get_credential('FEC_FEATURE_NAT_PARTY_ACCT_REC_SINGLE', '')),
+    'nat_party_acct_dis_single': bool(env.get_credential('FEC_FEATURE_NAT_PARTY_ACCT_DIS_SINGLE', '')),
     'pac_party': bool(env.get_credential('FEC_FEATURE_PAC_PARTY', '')),
     'pac_snapshot': bool(env.get_credential('FEC_FEATURE_PAC_SNAPSHOT', '')),
     'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
@@ -110,6 +112,8 @@ if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:
     FEATURES['house_senate_overview_totals'] = True
     FEATURES['nat_party_acct_receipts'] = True
     FEATURES['nat_party_acct_disbursements'] = True
+    FEATURES['nat_party_acct_rec_single'] = True
+    FEATURES['nat_party_acct_dis_single'] = True
 
 # Application definition
 INSTALLED_APPS = (

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -365,6 +365,53 @@ const individualContributionsColumns = [
   })
 ];
 
+const nationalPartyRaisingColumns = [
+  {
+    data: 'contributor_name',
+    className: 'all',
+    orderable: false
+  },
+  {
+    data: 'party_account_type',
+    className: 'all',
+    orderable: false
+  },
+  dateColumn({
+    data: 'contribution_receipt_date',
+    className: 'min-tablet hide-panel column--small'
+  }),
+  currencyColumn({
+    data: 'contribution_receipt_amount',
+    className: 'min-desktop hide-panel column--number t-mono'
+  })
+];
+
+const nationalPartySpendingColumns = [
+  {
+    data: 'recipient_name',
+    className: 'all',
+    orderable: false
+  },
+  {
+    data: 'party_account',
+    className: 'all',
+    orderable: false
+  },
+  {
+    data: 'disbursement_description',
+    className: 'all',
+    orderable: false
+  },
+  dateColumn({
+    data: 'disbursement_date',
+    className: 'min-tablet hide-panel column--small'
+  }),
+  currencyColumn({
+    data: 'disbursement_amount',
+    className: 'min-desktop hide-panel column--number t-mono'
+  })
+];
+
 const aggregateCallbacks = {
   afterRender: barsAfterRender.bind(undefined, undefined)
 };
@@ -624,6 +671,60 @@ $(function() {
               two_year_transaction_period: cycle
             },
             columns: ecItemizedDisbursementColumns,
+            callbacks: aggregateCallbacks,
+            order: [[3, 'desc']],
+            useExport: true,
+            singleEntityItemizedExport: true,
+            paginator: SeekPaginator,
+            hideEmptyOpts: {
+              dataType: 'disbursements',
+              name: window.context.name,
+              reason: missingDataReason('disbursements'),
+              timePeriod: window.context.timePeriod
+            }
+          })
+        );
+        break;
+      case 'national-party-account-raising':
+        path = ['national_party', 'schedule_a'],
+        // For raising/spending tabs, use previous cycle if provided
+        cycle = window.context.cycle || $table.attr('data-cycle');
+        DataTable_FEC.defer(
+          $table,
+          _extend({}, tableOpts, {
+            path: path,
+            query: {
+              committee_id: committeeId,
+              two_year_transaction_period: cycle
+            },
+            columns: nationalPartyRaisingColumns,
+            callbacks: aggregateCallbacks,
+            order: [[2, 'desc']],
+            useExport: true,
+            singleEntityItemizedExport: true,
+            paginator: SeekPaginator,
+            hideEmptyOpts: {
+              dataType: 'disbursements',
+              name: window.context.name,
+              reason: missingDataReason('disbursements'),
+              timePeriod: window.context.timePeriod
+            }
+          })
+        );
+        break;
+      case 'national-party-account-spending':
+        path = ['national_party', 'schedule_b'],
+        // For raising/spending tabs, use previous cycle if provided
+        cycle = window.context.cycle || $table.attr('data-cycle');
+        DataTable_FEC.defer(
+          $table,
+          _extend({}, tableOpts, {
+            path: path,
+            query: {
+              committee_id: committeeId,
+              two_year_transaction_period: cycle
+            },
+            columns: nationalPartySpendingColumns,
             callbacks: aggregateCallbacks,
             order: [[3, 'desc']],
             useExport: true,

--- a/fec/fec/static/scss/elements/_elements.scss
+++ b/fec/fec/static/scss/elements/_elements.scss
@@ -38,6 +38,10 @@ main {
   }
 }
 
+time {
+  white-space: nowrap;
+}
+
 [aria-hidden=true] {
   display: none !important;
 }


### PR DESCRIPTION
## Summary

- Resolves #6182 
- Resolves #6183 

Adding the "National party headquarters, recounts and convention accounts" sections to single committee pages

### Required reviewers

- UX
- front-end
- data SME

## Impacted areas of the application

The single pages for committees

## Screenshots

<img width="312" alt="image" src="https://github.com/user-attachments/assets/9a308cfd-e3f0-4f90-b073-f2addd343be3">

<img width="313" alt="image" src="https://github.com/user-attachments/assets/44258dcf-d442-404a-abfe-d22d24208b49">

<img width="874" alt="image" src="https://github.com/user-attachments/assets/a2ef8a1d-cb47-421f-83c4-95d94ac9ca35">

<img width="873" alt="image" src="https://github.com/user-attachments/assets/accdc2ed-6086-453e-b22b-41cac26c89a5">


## Related PRs

nah

## KNOWN ISSUES / QUESTIONS
- **SME**: Right now the National party sections will appear on every committee's page. What are the rules to show it? e.g. when `committee.designation == '[?]'`
- **UX**:
   - Should the new section have _both_ kinds of coverage dates flags? (the sentence and the tag-like version)
   - Should the new section have both the "See the financial…" sentence _and_ the Export button?
   - Having both sections has given us too many top/bottom borders

## How to test

- Pull the branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- Test the feature flag negative
   - Edit base.py
   - Comment out lines 115 and/or 116, (`nat_party_acct_rec_single`, `nat_party_acct_dis_single`) (put a `#` at the front)
   - Save
   - Load a national party's page
   - Line 115 should have removed "National party headquarters, recounts and convention accounts" from the Raising tab—from the left menu and from the page's data
   - Line 116 should have removed "National party headquarters, recounts and convention accounts" from the Spending tab—from the left menu and from the page's data
- Test the feature flags
   - Edit base.py
   - Restore lines 115 and/or 116, (`nat_party_acct_rec_single`, `nat_party_acct_dis_single`)
   - Save
   - Load a national party's page
   - Line 115 should have added "National party headquarters, recounts and convention accounts" to Raising
   - Line 116 should have added "National party headquarters, recounts and convention accounts" to Spending
- Find a committee who isn't a national party committee, make sure its Raising and Spending tabs don't mention "National party headquarters…" at all **_THIS ISN'T CURRENTLY WORKING–SEE THE KNOWN ISSUES_**
- Check a national party committee ([C00000935](http://127.0.0.1:8000/data/committee/C00000935/) is the example in the comps)
- For both raising and spending:
   - Left menu "National party headquarters…" option should appear and jump correctly
   - Data should be accurate
   - New datatable should be functional (sorting, paging)
   - "Filter this data" button should link correctly
   - "Export" button should work correctly
   - Other sections' tables should work correctly (there was an issue early on where the "Disbursements" tables were fragmenting)