### PR TITLE
6316 National Party Datatables Cycles Selector Limits

### DIFF
--- a/fec/data/templates/macros/filters/years.jinja
+++ b/fec/data/templates/macros/filters/years.jinja
@@ -1,4 +1,4 @@
-{% macro cycles(name, label, show_tooltip=True, multi_time_period_label=False) %}
+{% macro cycles(name, label, show_tooltip=True, multi_time_period_label=False, start_year=constants.START_YEAR, end_year=constants.END_YEAR) %}
 <fieldset class="js-filter js-dropdown filter" data-filter="checkbox">
   <label class="label t-inline-block">{{ label }}</label>
   {% if show_tooltip %}
@@ -14,7 +14,7 @@
     <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
     <div id="{{ name }}-dropdown" class="dropdown__panel" aria-hidden="true">
       <ul class="dropdown__list">
-      {% for year in range(constants.END_YEAR, constants.START_YEAR, -2) %}
+      {% for year in range(end_year, start_year, -2) %}
         <li class="dropdown__item">
           <input id="{{ name }}-checkbox-{{ year }}" name="{{ name }}" type="checkbox" value="{{ year }}" />
           <label class="dropdown__value" for="{{name}}-checkbox-{{ year }}">{{ year | fmt_year_range }}</label>

--- a/fec/data/templates/partials/national-party-account-disbursements-filter.jinja
+++ b/fec/data/templates/partials/national-party-account-disbursements-filter.jinja
@@ -20,7 +20,7 @@ Filter national party account disbursements
 <div class="filters__inner">
   {{ typeahead.field('committee_id', 'Spender name or ID') }}
   {{ typeahead.field('recipient_name', 'Recipient name or ID', allow_text=True) }}
-  {{ years.years('two_year_transaction_period', 'Report time period', start_year=2015)  }}
+  {{ years.cycles('two_year_transaction_period', 'Report time period', start_year=2013)  }}
   {{ date.field('disbursement_date', 'Disbursement date range') }}
 </div>
 <div class="js-accordion accordion--neutral restricted-fields" data-content-prefix="filter" data-open-first="false">

--- a/fec/data/templates/partials/national-party-account-receipts-filter.jinja
+++ b/fec/data/templates/partials/national-party-account-receipts-filter.jinja
@@ -20,7 +20,7 @@ Filter national party account disbursements
 <div class="filters__inner">
   {{ typeahead.field('committee_id', 'Recipient name or ID') }}
   {{ text.field('contributor_name', 'Source name or ID') }}
-  {{ years.cycles('two_year_transaction_period', 'Report time period', show_tooltip=True)  }}
+  {{ years.cycles('two_year_transaction_period', 'Report time period', show_tooltip=True, start_year=2013)  }}
   {{ date.field('contribution_receipt_date', 'Receipt date range') }}
 </div>
 <div class="js-accordion accordion--neutral restricted-fields" data-content-prefix="filter" data-open-first="false">


### PR DESCRIPTION
## Summary

- Resolves #6316 

Adding optional date constraints for the cycles selector, like we have for the years selector

### Required reviewers

- UX
- front-end?

## Impacted areas of the application

The cycle selector for the national party datatables but maybe every other cycle selector, too

## Screenshots

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/68ba1fc2-c8f5-495a-a78d-4f33ff85701d">

## Related PRs

nah

## How to test

- Pull the branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- Check the [national party disbursements datatable](http://127.0.0.1:8000/data/national-party-account-disbursements/) cycle filter
- Check the [national party receipts datatable](http://127.0.0.1:8000/data/national-party-account-receipts/) cycle filter
- Check other datatables cycle filters (unlikely to have been affected)