### PR TITLE
6410 jQuery Deprecations

### DIFF
--- a/fec/fec/static/js/legal.js
+++ b/fec/fec/static/js/legal.js
@@ -50,7 +50,7 @@ KeywordModal.prototype.handleSubmit = function(e) {
     $(this).val();
   });
   this.$excludeField.val();
-  this.$form.submit(); // TODO: jQuery deprecation? (.submit() )
+  this.$form.trigger('submit');
 };
 
 /**

--- a/fec/fec/static/js/legal/filters/CitationFilter.cjs
+++ b/fec/fec/static/js/legal/filters/CitationFilter.cjs
@@ -1,4 +1,5 @@
 const React = require('react');
+
 const PropTypes = require('prop-types');
 const URI = require('urijs');
 
@@ -63,7 +64,7 @@ class CitationFilter extends React.Component {
     return this.state.dropdownVisible ? 'block' : 'none';
   }
 
-  hideDropdown(e) {
+  hideDropdown() {
     this.setState({ dropdownVisible: false });
   }
 
@@ -91,7 +92,7 @@ class CitationFilter extends React.Component {
   }
 
   handleMouseOver(index) {
-    return e => {
+    return () => {
       this.setState({ highlightCitation: index });
     };
   }

--- a/fec/fec/static/js/legal/filters/CitationFilter.cjs
+++ b/fec/fec/static/js/legal/filters/CitationFilter.cjs
@@ -101,7 +101,7 @@ class CitationFilter extends React.Component {
 
     if (this.state.dropdownVisible) {
       // down arrow or tab
-      if (e.keyCode === 40 || e.keyCode === 9) {
+      if (e.which === 40 || e.which === 9) {
         e.preventDefault();
         if (highlightCitation < this.state.citations.length - 1) {
           this.setState({ highlightCitation: highlightCitation + 1 });
@@ -111,7 +111,7 @@ class CitationFilter extends React.Component {
       }
 
       // up arrow
-      if (e.keyCode === 38) {
+      if (e.which === 38) {
         if (highlightCitation > 0) {
           this.setState({ highlightCitation: highlightCitation - 1 });
         } else {
@@ -120,7 +120,7 @@ class CitationFilter extends React.Component {
       }
 
       // enter
-      if (e.keyCode === 13) {
+      if (e.which === 13) {
         this.setSelection(
           this.state.citations[this.state.highlightCitation].citation_text
         );

--- a/fec/fec/static/js/legal/filters/TextFilter.cjs
+++ b/fec/fec/static/js/legal/filters/TextFilter.cjs
@@ -1,11 +1,12 @@
 const React = require('react');
+
 const PropTypes = require('prop-types');
 
 const TooltipHelp = require('./TooltipHelp.cjs');
 
 function TextFilter(props) {
   function handleKeydown(e) {
-    if (e.keyCode === 13) {
+    if (e.which === 13) {
       props.getResults();
     }
   }

--- a/fec/fec/static/js/modules/audit-category-sub-category.js
+++ b/fec/fec/static/js/modules/audit-category-sub-category.js
@@ -7,7 +7,7 @@
 import { buildUrl } from './helpers.js';
 
 export function auditCategorySubcategory() {
-  $('#primary_category_id').change(function() { // TODO: jQuery deprecation
+  $('#primary_category_id').on('change', function() {
     var $select = $('#sub_category_id');
     $.getJSON(
       buildUrl(['audit-category'], {

--- a/fec/fec/static/js/modules/audit_tags.js
+++ b/fec/fec/static/js/modules/audit_tags.js
@@ -6,7 +6,7 @@ import { default as auditCategoryTemplate } from '../templates/audit_tags.hbs';
 export default function auditTags() {
   $('.data-container__tags').prepend(auditCategoryTemplate);
   $('.tag__category.sub').css('visibility', 'hidden');
-  $('#primary_category_id').change(function() { // TODO: jQuery deprecation
+  $('#primary_category_id').on('change', function() {
     const current_category = $('#primary_category_id option:selected').text();
     $('.tag__category.sub').css('visibility', 'hidden');
     $('.tag__item.primary').contents()[0].nodeValue = `Findings and issue category: ${current_category}`;
@@ -15,7 +15,7 @@ export default function auditTags() {
       : $('.tag__item.primary button').show();
   });
 
-  $('#sub_category_id').change(function() { // TODO: jQuery deprecation
+  $('#sub_category_id').on('change', function() {
     const current_sub = $('#sub_category_id option:selected').text();
     $('.tag__item.sub').contents()[0].nodeValue = `Sub Category: ${current_sub}`;
   });

--- a/fec/fec/static/js/modules/audit_tags.js
+++ b/fec/fec/static/js/modules/audit_tags.js
@@ -20,12 +20,12 @@ export default function auditTags() {
     $('.tag__item.sub').contents()[0].nodeValue = `Sub Category: ${current_sub}`;
   });
 
-  $('.js-close_sub').click(function() { // TODO: jQuery deprecation
+  $('.js-close_sub').on('click', function() {
     $('#primary_category_id').trigger('change');
     $('#sub_category_id').val('all');
   });
 
-  $('.js-close_primary').click(function() { // TODO: jQuery deprecation
+  $('.js-close_primary').on('click', function() {
     $('#primary_category_id').val('all');
     $('#primary_category_id').trigger('change');
     $('.tag__item.primary button').hide();

--- a/fec/fec/static/js/modules/calendar-tooltip.js
+++ b/fec/fec/static/js/modules/calendar-tooltip.js
@@ -34,6 +34,6 @@ CalendarTooltip.prototype.close = function() {
   this.$content.remove();
   this.exportDropdown.destroy();
   this.$container.removeClass('is-active');
-  this.$container.focus(); // TODO: jQuery deprecation
+  this.$container.trigger('focus');
   this.events.clear();
 };

--- a/fec/fec/static/js/modules/calendar.js
+++ b/fec/fec/static/js/modules/calendar.js
@@ -350,8 +350,8 @@ Calendar.prototype.managePopoverControl = function(e) {
   $popover
     .find('.fc-close')
     .attr('tabindex', '0')
-    .focus() // TODO: jQuery deprecation
+    .trigger('focus')
     .on('click', function() {
-      $target.focus(); // TODO: jQuery deprecation
+      $target.trigger('focus');
     });
 };

--- a/fec/fec/static/js/modules/calendar.js
+++ b/fec/fec/static/js/modules/calendar.js
@@ -338,8 +338,8 @@ Calendar.prototype.handleEventClick = function(calEvent, jsEvent) {
 
 // Simulate clicks when hitting enter on certain full-calendar elements
 Calendar.prototype.simulateClick = function(e) {
-  if (e.keyCode === 13) {
     $(e.target).click(); // TODO: jQuery deprecation
+  if (e.which === 13) {
   }
 };
 

--- a/fec/fec/static/js/modules/calendar.js
+++ b/fec/fec/static/js/modules/calendar.js
@@ -338,8 +338,8 @@ Calendar.prototype.handleEventClick = function(calEvent, jsEvent) {
 
 // Simulate clicks when hitting enter on certain full-calendar elements
 Calendar.prototype.simulateClick = function(e) {
-    $(e.target).click(); // TODO: jQuery deprecation
   if (e.which === 13) {
+    $(e.target).trigger('click');
   }
 };
 

--- a/fec/fec/static/js/modules/download.js
+++ b/fec/fec/static/js/modules/download.js
@@ -36,7 +36,7 @@ export function download(url, init, focus) {
   }
 
   if (focus) {
-    item.$button.focus(); // TODO: jQuery deprecation
+    item.$button.trigger('focus');
   }
 
   return item;

--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -120,7 +120,7 @@ Dropdown.prototype.handleFocusAway = function(e) {
 };
 
 Dropdown.prototype.handleKeyup = function(e) {
-  if (e.keyCode === KEYCODE_ESC) {
+  if (e.which === KEYCODE_ESC) {
     if (this.isOpen) {
       this.hide();
       this.$button.focus(); // TODO: jQuery deprecation
@@ -129,7 +129,7 @@ Dropdown.prototype.handleKeyup = function(e) {
 };
 
 Dropdown.prototype.handleCheckKeyup = function(e) {
-  if (e.keyCode === KEYCODE_ENTER) {
+  if (e.which === KEYCODE_ENTER) {
     $(e.target)
       .prop('checked', true)
       .change(); // TODO: jQuery deprecation

--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -132,7 +132,7 @@ Dropdown.prototype.handleCheckKeyup = function(e) {
   if (e.which === KEYCODE_ENTER) {
     $(e.target)
       .prop('checked', true)
-      .change(); // TODO: jQuery deprecation
+      .trigger('change');
   }
 };
 

--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -148,7 +148,7 @@ Dropdown.prototype.handleDropdownItemClick = function(e) {
   const $input = this.$selected.find('#' + $button.data('label'));
 
   if (!$button.hasClass('is-checked')) {
-    $input.click(); // TODO: jQuery deprecation
+    $input.trigger('click');
   }
 };
 

--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -88,7 +88,7 @@ Dropdown.prototype.show = function() {
   restoreTabindex(this.$panel);
   this.$panel.attr('aria-hidden', 'false');
   new PerfectScrollbar(this.$panel.get(0), { suppressScrollX: true });
-  this.$panel.find('input[type="checkbox"]:first').focus(); // TODO: jQuery deprecation (:first and .focus)
+  this.$panel.find('input[type="checkbox"]').first().trigger('focus');
   this.$button.addClass('is-active');
   this.isOpen = true;
 };
@@ -119,15 +119,21 @@ Dropdown.prototype.handleFocusAway = function(e) {
   }
 };
 
+/**
+ * @param {JQuery.Event} e
+ */
 Dropdown.prototype.handleKeyup = function(e) {
   if (e.which === KEYCODE_ESC) {
     if (this.isOpen) {
       this.hide();
-      this.$button.focus(); // TODO: jQuery deprecation
+      this.$button.trigger('focus');
     }
   }
 };
 
+/**
+ * @param {JQuery.Event} e
+ */
 Dropdown.prototype.handleCheckKeyup = function(e) {
   if (e.which === KEYCODE_ENTER) {
     $(e.target)
@@ -224,14 +230,14 @@ Dropdown.prototype.selectItem = function($input) {
     if (next.length) {
       $(next[0])
         .find('input[type="checkbox"]')
-        .focus(); // TODO: jQuery deprecation
+        .trigger('focus');
     } else if (prev.length) {
       $(prev[0])
         .find('input[type="checkbox"]')
-        .focus(); // TODO: jQuery deprecation
+        .trigger('focus');
     }
   } else {
-    this.$selected.find('input[type="checkbox"]').focus(); // TODO: jQuery deprecation
+    this.$selected.find('input[type="checkbox"]').trigger('focus');
   }
 };
 

--- a/fec/fec/static/js/modules/election-map.js
+++ b/fec/fec/static/js/modules/election-map.js
@@ -166,7 +166,7 @@ ElectionMap.prototype.drawBackgroundDistricts = function(districts) {
     .map(function(district) {
       return Math.floor(district / 100);
     })
-    .unique() // TODO: jQuery deprecation
+    .uniqueSort()
     .value();
   var stateDistricts = _filter(districtFeatures.features, function(
     feature

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -220,7 +220,7 @@ ElectionSearch.prototype.getUpcomingElections = function() {
  * Handle a change event on the zip code fields
  */
 ElectionSearch.prototype.handleZipChange = function() {
-  this.$state.val('').change(); // TODO: jQuery deprecation
+  this.$state.val('').trigger('change');
   this.$district.val('');
 };
 

--- a/fec/fec/static/js/modules/filters/date-filter.js
+++ b/fec/fec/static/js/modules/filters/date-filter.js
@@ -334,7 +334,7 @@ DateFilter.prototype.handleGridItemSelect = function(e) {
     this.$grid.find('li').unbind('mouseenter mouseleave'); // TODO: jQuery deprecation (.unbind())
     this.setValue(value);
     this.$grid.addClass('is-invalid');
-    $nextItem.focus(); // TODO: jQuery deprecation
+    $nextItem.trigger('focus');
   }
 };
 

--- a/fec/fec/static/js/modules/filters/date-filter.js
+++ b/fec/fec/static/js/modules/filters/date-filter.js
@@ -136,8 +136,8 @@ DateFilter.prototype.fromQuery = function(query) {
 
 DateFilter.prototype.setValue = function(value) {
   value = ensureArray(value);
-  this.$minDate.val(value[0]).change(); // TODO: jQuery deprecation
-  this.$maxDate.val(value[1]).change(); // TODO: jQuery deprecation
+  this.$minDate.val(value[0]).trigger('change');
+  this.$maxDate.val(value[1]).trigger('change');
 };
 
 DateFilter.prototype.handleModifyEvent = function(e, opts) {
@@ -146,12 +146,12 @@ DateFilter.prototype.handleModifyEvent = function(e, opts) {
   if (opts.filterName === this.name) {
     this.maxYear = parseInt(opts.filterValue);
     this.minYear = this.maxYear - 1;
-    this.$minDate.val('01/01/' + this.minYear.toString()).change(); // TODO: jQuery deprecation
+    this.$minDate.val('01/01/' + this.minYear.toString()).trigger('change');
     if (this.maxYear === today.getFullYear()) {
       today = moment(today).format('MM/DD/YYYY');
-      this.$maxDate.val(today).change(); // TODO: jQuery deprecation
+      this.$maxDate.val(today).trigger('change');
     } else {
-      this.$maxDate.val('12/31/' + this.maxYear.toString()).change(); // TODO: jQuery deprecation
+      this.$maxDate.val('12/31/' + this.maxYear.toString()).trigger('change');
     }
     this.validate();
   }

--- a/fec/fec/static/js/modules/filters/date-filter.js
+++ b/fec/fec/static/js/modules/filters/date-filter.js
@@ -239,29 +239,32 @@ DateFilter.prototype.handleMinDateSelect = function() {
   this.$grid.find('.is-active').removeClass('is-active');
   $dateBegin.addClass('is-active');
 
-  this.$grid.find('li').hover( // TODO: jQuery deprecation
-    function() {
-      var dateBeginNum = parseInt(
-        $(this)
-          .parent()
-          .attr('data-year') + $(this).attr('data-month')
-      );
-      var dateEndNum = parseInt(
-        $dateEnd.parent().attr('data-year') + $dateEnd.attr('data-month')
-      );
+  this.$grid.find('li')
+    .on('mouseenter',
+      function() {
+        var dateBeginNum = parseInt(
+          $(this)
+            .parent()
+            .attr('data-year') + $(this).attr('data-month')
+        );
+        var dateEndNum = parseInt(
+          $dateEnd.parent().attr('data-year') + $dateEnd.attr('data-month')
+        );
 
-      if (dateBeginNum <= dateEndNum) {
-        self.$grid.removeClass('is-invalid');
-        self.handleDateGridRange($(this), $dateEnd);
-      } else {
-        self.$grid.addClass('is-invalid');
+        if (dateBeginNum <= dateEndNum) {
+          self.$grid.removeClass('is-invalid');
+          self.handleDateGridRange($(this), $dateEnd);
+        } else {
+          self.$grid.addClass('is-invalid');
+        }
       }
-    },
-    function() {
-      self.handleDateGridRange($dateBegin, $dateEnd);
-      $dateBegin.addClass('is-active');
-    }
-  );
+    )
+    .on('mouseleave',
+      function() {
+        self.handleDateGridRange($dateBegin, $dateEnd);
+        $dateBegin.addClass('is-active');
+      }
+    );
 };
 
 DateFilter.prototype.handleMaxDateSelect = function() {
@@ -276,31 +279,34 @@ DateFilter.prototype.handleMaxDateSelect = function() {
   this.$grid.find('.is-active').removeClass('is-active');
   $dateEnd.addClass('is-active');
 
-  this.$grid.find('li').hover( // TODO: jQuery deprecation
-    function() {
-      // turn dates to numbers for comparsion
-      // to make sure hover date range is valid
-      var dateBeginNum = parseInt(
-        $dateBegin.parent().attr('data-year') + $dateBegin.attr('data-month')
-      );
-      var dateEndNum = parseInt(
-        $(this)
-          .parent()
-          .attr('data-year') + $(this).attr('data-month')
-      );
+  this.$grid.find('li')
+    .on('mouseenter',
+      function() {
+        // turn dates to numbers for comparsion
+        // to make sure hover date range is valid
+        var dateBeginNum = parseInt(
+          $dateBegin.parent().attr('data-year') + $dateBegin.attr('data-month')
+        );
+        var dateEndNum = parseInt(
+          $(this)
+            .parent()
+            .attr('data-year') + $(this).attr('data-month')
+        );
 
-      if (dateBeginNum <= dateEndNum) {
-        self.$grid.removeClass('is-invalid');
-        self.handleDateGridRange($dateBegin, $(this));
-      } else {
-        self.$grid.addClass('is-invalid');
+        if (dateBeginNum <= dateEndNum) {
+          self.$grid.removeClass('is-invalid');
+          self.handleDateGridRange($dateBegin, $(this));
+        } else {
+          self.$grid.addClass('is-invalid');
+        }
       }
-    },
-    function() {
-      self.handleDateGridRange($dateBegin, $dateEnd);
-      $dateEnd.addClass('is-active');
-    }
-  );
+    )
+    .on('mouseleave',
+      function() {
+        self.handleDateGridRange($dateBegin, $dateEnd);
+        $dateEnd.addClass('is-active');
+      }
+    );
 };
 
 DateFilter.prototype.handleGridItemSelect = function(e) {

--- a/fec/fec/static/js/modules/filters/date-filter.js
+++ b/fec/fec/static/js/modules/filters/date-filter.js
@@ -337,7 +337,7 @@ DateFilter.prototype.handleGridItemSelect = function(e) {
       ? this.$maxDate
       : this.$submit;
     this.$grid.removeClass('pick-min pick-max');
-    this.$grid.find('li').unbind('mouseenter mouseleave'); // TODO: jQuery deprecation (.unbind())
+    this.$grid.find('li').off('mouseenter mouseleave');
     this.setValue(value);
     this.$grid.addClass('is-invalid');
     $nextItem.trigger('focus');

--- a/fec/fec/static/js/modules/filters/election-filter.js
+++ b/fec/fec/static/js/modules/filters/election-filter.js
@@ -43,7 +43,7 @@ ElectionFilter.prototype.fromQuery = function(query) {
     this.$cycles
       .find('input[value="' + cycle + ':' + full + '"]')
       .prop('checked', true)
-      .change(); // TODO: jQuery deprecation
+      .trigger('change');
   }
   return this;
 };
@@ -80,7 +80,7 @@ ElectionFilter.prototype.handleElectionChange = function(e) {
     .find('input')
     .eq(0)
     .prop('checked', true)
-    .change(); // TODO: jQuery deprecation
+    .trigger('change');
 };
 
 ElectionFilter.prototype.handleCycleChange = function(e) {
@@ -89,9 +89,9 @@ ElectionFilter.prototype.handleCycleChange = function(e) {
     .split(':');
   this.$cycle
     .val(selected[0])
-    .change() // TODO: jQuery deprecation
+    .trigger('change')
     .attr('checked', true);
-  this.$full.val(selected[1]).change(); // TODO: jQuery deprecation
+  this.$full.val(selected[1]).trigger('change');
   this.setTag();
 };
 

--- a/fec/fec/static/js/modules/filters/filter-base.js
+++ b/fec/fec/static/js/modules/filters/filter-base.js
@@ -49,7 +49,7 @@ Filter.prototype.setValue = function(value) {
   const $input = this.$input.data('temp')
     ? this.$elm.find('#' + this.$input.data('temp'))
     : this.$input;
-  $input.val(prepareValue($input, value)).change(); // TODO: jQuery deprecation
+  $input.val(prepareValue($input, value)).trigger('change');
   return this;
 };
 

--- a/fec/fec/static/js/modules/filters/filter-panel.js
+++ b/fec/fec/static/js/modules/filters/filter-panel.js
@@ -54,7 +54,7 @@ FilterPanel.prototype.show = function(focus) {
     this.$body
       .find('input, select, button:not(.js-filter-close)')
       .first()
-      .focus(); // TODO: jQuery deprecation
+      .trigger('focus');
   }
 };
 
@@ -65,7 +65,7 @@ FilterPanel.prototype.hide = function() {
   }
   this.$body.removeClass('is-open');
   this.$content.attr('aria-hidden', true);
-  this.$focus.focus(); // TODO: jQuery deprecation
+  this.$focus.trigger('focus');
   removeTabindex(this.$form);
   $('body').removeClass('is-showing-filters');
   this.isOpen = false;

--- a/fec/fec/static/js/modules/filters/filter-set.js
+++ b/fec/fec/static/js/modules/filters/filter-set.js
@@ -141,7 +141,7 @@ FilterSet.prototype.handleTagRemoved = function(e, opts) {
     const type = $input.get(0).type;
 
     if (type === 'checkbox' || type === 'radio') {
-      $input.click(); // TODO: jQuery deprecation
+      $input.trigger('click');
     } else if (type === 'text') {
       $input.val('').trigger('change');
     }

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -147,7 +147,7 @@ FilterTypeahead.prototype.handleKeypress = function(e) {
     this.$field.attr('aria-expanded', 'false');
   }
 
-  if (e.keyCode === 13) {
+  if (e.which === 13) {
     this.handleSubmit(e);
   }
 };

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -12,7 +12,7 @@ const ID_PATTERN = /^\w{9}$/;
 
 function slugify(value) {
   return value
-    .trim() // TODO: jQuery deprecation
+    .trim()
     .replace(/\s+/g, '-')
     .replace(/[^a-z0-9:._-]/gi, '');
 }

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -211,7 +211,7 @@ FilterTypeahead.prototype.handleSubmit = function(e) {
 };
 
 FilterTypeahead.prototype.clearInput = function() {
-  this.$field.typeahead('val', null).change(); // TODO: jQuery deprecation
+  this.$field.typeahead('val', null).trigger('change');
   this.disableButton();
 };
 
@@ -239,7 +239,7 @@ FilterTypeahead.prototype.appendCheckbox = function(opts) {
   }
   var checkbox = $(template_checkbox(data));
   checkbox.appendTo(this.$selected);
-  checkbox.find('input').change(); // TODO: jQuery deprecation
+  checkbox.find('input').trigger('change');
   this.clearInput();
 };
 

--- a/fec/fec/static/js/modules/filters/select-filter.js
+++ b/fec/fec/static/js/modules/filters/select-filter.js
@@ -29,7 +29,7 @@ SelectFilter.prototype.fromQuery = function(query) {
 SelectFilter.prototype.setValue = function(value) {
   this.$input.find('option[selected]').prop('selected', false);
   this.$input.find('option[value="' + value + '"]').prop('selected', true);
-  this.$input.change(); // TODO: jQuery deprecation
+  this.$input.trigger('change');
 };
 
 SelectFilter.prototype.handleChange = function(e) {

--- a/fec/fec/static/js/modules/filters/text-filter.js
+++ b/fec/fec/static/js/modules/filters/text-filter.js
@@ -46,7 +46,7 @@ TextFilter.prototype.handleChange = function() {
   // set the button focus within a timeout
   // to prevent change event from firing twice
   setTimeout(function() {
-    button.focus(); // TODO: jQuery deprecation
+    button.trigger('focus');
   }, 0);
 
   if (value.length > 0) {

--- a/fec/fec/static/js/modules/filters/toggle-filter.js
+++ b/fec/fec/static/js/modules/filters/toggle-filter.js
@@ -16,7 +16,7 @@ ToggleFilter.prototype.fromQuery = function(query) {
   this.$elm
     .find('input[value="' + query[this.name] + '"]')
     .prop('checked', true)
-    .change(); // TODO: jQuery deprecation
+    .trigger('change');
 };
 
 ToggleFilter.prototype.handleChange = function(e) {

--- a/fec/fec/static/js/modules/filters/validate-date-filters.js
+++ b/fec/fec/static/js/modules/filters/validate-date-filters.js
@@ -121,8 +121,8 @@ ValidateDateFilter.prototype.fromQuery = function(query) {
     ? query['min_' + this.name]
     : defaultStart;
   var maxDate = query['max_' + this.name] ? query['max_' + this.name] : now;
-  this.$minDate.val(minDate).change(); // TODO: jQuery deprecation
-  this.$maxDate.val(maxDate).change(); // TODO: jQuery deprecation
+  this.$minDate.val(minDate).trigger('change');
+  this.$maxDate.val(maxDate).trigger('change');
   return this;
 };
 

--- a/fec/fec/static/js/modules/form-nav.js
+++ b/fec/fec/static/js/modules/form-nav.js
@@ -27,5 +27,5 @@ FormNav.prototype.clearNamesIfNull = function(e) {
     }
   }
 
-  if (e.type == 'change') this.form.submit(); // TODO: jQuery deprecation
+  if (e.type == 'change') this.form.trigger('submit');
 };

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -601,7 +601,7 @@ export function getCookie(name) {
   if (document.cookie && document.cookie != '') {
     let cookies = document.cookie.split(';');
     for (let i = 0; i < cookies.length; i++) {
-      let cookie = $.trim(cookies[i]); // TODO: remove jQuery.trim as it's been deprecated
+      let cookie = cookies[i].trim();
       // Does this cookie string begin with the name we want?
       if (cookie.substring(0, name.length + 1) == name + '=') {
         cookieValue = decodeURIComponent(cookie.substring(name.length + 1));

--- a/fec/fec/static/js/modules/maps.js
+++ b/fec/fec/static/js/modules/maps.js
@@ -315,7 +315,7 @@ function appendStateMap($parent, results, cached) {
       return displayed.indexOf(each) === -1;
     }) || _last(ids);
   $parent.append(candidateStateMapTemplate(results));
-  const $select = $parent.find('.state-map:last select'); // TODO: jQuery deprecation (:last)
+  const $select = $parent.find('.state-map').last().find('select');
   $select.val(value);
   $select.trigger('change');
   updateButtonsDisplay($parent);

--- a/fec/fec/static/js/modules/search.js
+++ b/fec/fec/static/js/modules/search.js
@@ -31,8 +31,8 @@ export default function Search($el, opts) {
 
   $(document.body).on('keyup', function(e) {
     // Focus search on "/"
-      $input.first().focus(); // TODO: jQuery deprecation
     if (e.which === KEYCODE_SLASH) {
+      $input.first().trigger('focus');
     }
   });
 }

--- a/fec/fec/static/js/modules/search.js
+++ b/fec/fec/static/js/modules/search.js
@@ -31,8 +31,8 @@ export default function Search($el, opts) {
 
   $(document.body).on('keyup', function(e) {
     // Focus search on "/"
-    if (e.keyCode === KEYCODE_SLASH) {
       $input.first().focus(); // TODO: jQuery deprecation
+    if (e.which === KEYCODE_SLASH) {
     }
   });
 }

--- a/fec/fec/static/js/modules/skip-nav.js
+++ b/fec/fec/static/js/modules/skip-nav.js
@@ -23,11 +23,14 @@ Skipnav.prototype.findTarget = function() {
     .filter(':visible')[0];
 };
 
+/**
+ * @param {JQuery.Event} e
+ */
 Skipnav.prototype.focusOnTarget = function(e) {
   e.preventDefault();
 
   if (e.which === 13 || e.type === 'click') {
     this.$target.attr('tabindex', '0');
-    this.$target.focus(); // TODO: jQuery deprecation
+    this.$target.trigger('focus');
   }
 };

--- a/fec/fec/static/js/modules/skip-nav.js
+++ b/fec/fec/static/js/modules/skip-nav.js
@@ -26,7 +26,7 @@ Skipnav.prototype.findTarget = function() {
 Skipnav.prototype.focusOnTarget = function(e) {
   e.preventDefault();
 
-  if (e.keyCode === 13 || e.type === 'click') {
+  if (e.which === 13 || e.type === 'click') {
     this.$target.attr('tabindex', '0');
     this.$target.focus(); // TODO: jQuery deprecation
   }

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -631,7 +631,7 @@ DataTable_FEC.prototype.checkFromQuery = function(){
       // ...if they are not already checked
       for (let box of queryBoxes) {
         if (!($(box).is(':checked'))) {
-              $(box).prop('checked', true).change(); // TODO: jQuery deprecation
+              $(box).prop('checked', true).trigger('change');
         }
        }
       }, 0);
@@ -643,7 +643,7 @@ DataTable_FEC.prototype.checkFromQuery = function(){
       // ...if they are not already checked
       for (let box of queryBoxes) {
         if (!($(box).is(':checked'))) {
-              $(box).prop('checked', true).change(); // TODO: jQuery deprecation
+              $(box).prop('checked', true).trigger('change');
         }
        }
       }

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -225,7 +225,7 @@ export function modalRenderFactory(template, fetch) {
               $modal.find('.js-pdf_url').remove();
             }
             // Set focus on the close button
-            $('.js-hide').focus(); // TODO: jQuery deprecation
+            $('.js-hide').trigger('focus');
 
             // When under $large-screen
             // TODO figure way to share these values with CSS.
@@ -250,7 +250,7 @@ export function modalRenderFactory(template, fetch) {
 }
 
 function hidePanel(api, $modal) {
-  $('.row-active .js-panel-button').focus(); // TODO: jQuery deprecation
+  $('.row-active .js-panel-button').trigger('focus');
   $('.js-panel-toggle tr').toggleClass('row-active', false);
   $('body').toggleClass('panel-active', false);
   $modal.attr('aria-hidden', 'true');

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -119,7 +119,7 @@ TopEntities.prototype.updateElectionYearOptions = function(office) {
     if (currentOption.css('display') == 'none') {
       $('#election-year')
         .val(minFutureYear)
-        .change(); // TODO: jQuery deprecation
+        .trigger('change');
     }
   } else {
     // show all options/enable for Safari!

--- a/fec/fec/static/js/pages/contact-form.js
+++ b/fec/fec/static/js/pages/contact-form.js
@@ -43,8 +43,8 @@ ContactForm.prototype.initTypeahead = function() {
     //focus away to prompt removal of error state, if present. Could only focus into...
     //...another field, Attempts to focusout, or focus onto body, did not work.
     $('#id_u_contact_title')
-      .blur(); // TODO: jQuery deprecation
       .trigger('focus')
+      .trigger('blur');
   });
 };
 

--- a/fec/fec/static/js/pages/contact-form.js
+++ b/fec/fec/static/js/pages/contact-form.js
@@ -43,8 +43,8 @@ ContactForm.prototype.initTypeahead = function() {
     //focus away to prompt removal of error state, if present. Could only focus into...
     //...another field, Attempts to focusout, or focus onto body, did not work.
     $('#id_u_contact_title')
-      .focus() // TODO: jQuery deprecation
       .blur(); // TODO: jQuery deprecation
+      .trigger('focus')
   });
 };
 

--- a/fec/fec/static/js/pages/datatable-audit.js
+++ b/fec/fec/static/js/pages/datatable-audit.js
@@ -7,7 +7,7 @@ import { audit as cols_audit } from '../modules/columns.js';
 import { DataTable_FEC, modalRenderRow } from '../modules/tables.js';
 
 // for sub category filter-tag and results
-$(document).bind( // TODO: jQuery deprecation
+$(document).on(
   'ready ajaxComplete',
   '#sub_category_id',
   showSubCategory

--- a/fec/fec/static/js/pages/election-reporting-dates-tables.js
+++ b/fec/fec/static/js/pages/election-reporting-dates-tables.js
@@ -350,7 +350,7 @@ ReportingDates.prototype.mediaQueryResponse = function(mql) {
       for (const close of jsmodalClose) {
         close.addEventListener('click', () => {
           jsmodal[0].setAttribute('aria-hidden', 'true');
-          close.focus(); // TODO: jQuery deprecation
+          close.trigger('focus');
         });
       }
     });

--- a/fec/fec/static/js/pages/reporting-dates-tables.js
+++ b/fec/fec/static/js/pages/reporting-dates-tables.js
@@ -336,7 +336,7 @@ ReportingDates.prototype.mediaQueryResponse = function(mql) {
       for (const close of jsmodalClose) {
         close.addEventListener('click', () => {
           jsmodal[0].setAttribute('aria-hidden', 'true');
-          close.focus(); // TODO: jQuery deprecation
+          close.trigger('focus');
         });
       }
     });

--- a/fec/fec/templates/404.html
+++ b/fec/fec/templates/404.html
@@ -7,8 +7,7 @@
     <div class="message message--alert message--big">
       <h1 class="message__title">Page not found</h1>
       <p>Sorry, we couldn't find the page you're looking for.</p>
-      {# TODO: jQuery deprecation of .click() #}
-      <p>We work hard to keep our URLs up to date, but please let us know if you think something is missing or broken. Use the <a href="javascript:$('.js-feedback.feedback__toggle.button--cta-secondary').click();" style="text-decoration:none">feedback box</a> on the bottom of any page or <a href="https://www.fec.gov/contact/">contact the FEC</a>.</p>
+      <p>We work hard to keep our URLs up to date, but please let us know if you think something is missing or broken. Use the <a href="javascript:$('.js-feedback.feedback__toggle.button--cta-secondary').trigger('click');" style="text-decoration:none">feedback box</a> on the bottom of any page or <a href="https://www.fec.gov/contact/">contact the FEC</a>.</p>
     </div>
   </div>
 </section>

--- a/fec/fec/templates/500.html
+++ b/fec/fec/templates/500.html
@@ -7,9 +7,8 @@
   <div class="container">
     <div class="message message--alert message--big">
       <h1 class="message__title">Server error</h1>
-      {# TODO: jQuery deprecation of .click() #}
       <p>Sorry, this page failed to load. Check the FEC’s <a href="https://www.fec.gov/status">API status page</a> to see if we are experiencing a temporary outage. If not, please try again, and thanks for your patience.</p>
-      <p>If you'd like to contact our team, use the <a href="javascript:$('.js-feedback.feedback__toggle.button--cta-secondary').click();" style="text-decoration:none">feedback box</a> on the bottom of any page or <a href="https://www.fec.gov/contact/">contact the FEC</a>.</p>
+      <p>If you'd like to contact our team, use the <a href="javascript:$('.js-feedback.feedback__toggle.button--cta-secondary').trigger('click');" style="text-decoration:none">feedback box</a> on the bottom of any page or <a href="https://www.fec.gov/contact/">contact the FEC</a>.</p>
     </div>
   </div>
 </section>

--- a/fec/fec/tests/js/calendar.js
+++ b/fec/fec/tests/js/calendar.js
@@ -250,17 +250,17 @@ describe('calendar tooltip', function() {
   });
 
   it('closes on click away', function() {
-    $(document.body).click(); // TODO: jQuery deprecation
+    $(document.body).trigger('click');
     expect($('.cal-details').length).to.equal(0);
   });
 
   it('stays open if you click inside it', function() {
-    this.calendarTooltip.$content.find('a').click(); // TODO: jQuery deprecation
+    this.calendarTooltip.$content.find('a').trigger('click');
     expect($('.cal-details').length).to.equal(1);
   });
 
   it('closes on clicking the close button', function() {
-    this.calendarTooltip.$content.find('.js-close').click(); // TODO: jQuery deprecation
+    this.calendarTooltip.$content.find('.js-close').trigger('click');
     expect($('.cal-details').length).to.equal(0);
   });
 

--- a/fec/fec/tests/js/checkbox-filter.js
+++ b/fec/fec/tests/js/checkbox-filter.js
@@ -136,7 +136,7 @@ describe('checkbox filters', function() {
     });
 
     it('removes checkbox on clicking the button', function() {
-      this.filter.$elm.find('.js-remove').click(); // TODO: jQuery deprecation
+      this.filter.$elm.find('.js-remove').trigger('click');
       expect(this.filter.$elm.find('li').length).to.equal(0);
     });
 

--- a/fec/fec/tests/js/checkbox-filter.js
+++ b/fec/fec/tests/js/checkbox-filter.js
@@ -79,19 +79,19 @@ describe('checkbox filters', function() {
     });
 
     it('sets loaded-once on the input after loading', function() {
-      this.$input.prop('checked', true).change(); // TODO: jQuery deprecation
+      this.$input.prop('checked', true).trigger('change');
       expect(this.$input.data('loaded-once')).to.be.true;
       expect(this.$label.attr('class')).to.not.equal('is-loading');
     });
 
     it('adds the loading class if it has loaded once', function() {
-      this.$input.prop('checked', true).change(); // TODO: jQuery deprecation
-      this.$input.prop('checked', false).change(); // TODO: jQuery deprecation
+      this.$input.prop('checked', true).trigger('change');
+      this.$input.prop('checked', false).trigger('change');
       expect(this.$label.attr('class')).to.equal('is-loading');
     });
 
     it('triggers the add event on checking a checkbox', function() {
-      this.$input.prop('checked', true).change(); // TODO: jQuery deprecation
+      this.$input.prop('checked', true).trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:added', [
         {
           key: 'president',
@@ -104,7 +104,7 @@ describe('checkbox filters', function() {
     });
 
     it('triggers remove event on unchecking a checkbox', function() {
-      this.$input.prop('checked', false).change(); // TODO: jQuery deprecation
+      this.$input.prop('checked', false).trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:removed', [
         {
           key: 'president',

--- a/fec/fec/tests/js/contact-form.js
+++ b/fec/fec/tests/js/contact-form.js
@@ -82,7 +82,7 @@ describe('Contact form', function() {
     $('#id_u_committee').val('12345');
     $('#id_u_other_reason').val('Some other reason');
     $('select').val('other');
-    this.form.$cancel.click(); // TODO: jQuery deprecation
+    this.form.$cancel.trigger('click');
     expect(this.form.committeeId.val()).to.equal('');
     expect($('select').val()).to.equal(null);
     expect($('#id_u_other_reason').val()).to.equal('');

--- a/fec/fec/tests/js/contact-form.js
+++ b/fec/fec/tests/js/contact-form.js
@@ -69,12 +69,12 @@ describe('Contact form', function() {
   });
 
   it('shows the other reason box when other is selected', function() {
-    this.form.category.val('other').change(); // TODO: jQuery deprecation
+    this.form.category.val('other').trigger('change');
     expect(this.form.otherReason.is(':visible')).to.be.true;
   });
 
   it('hides the other reason box when another value is selected', function() {
-    this.form.category.val('option-1').change(); // TODO: jQuery deprecation
+    this.form.category.val('option-1').trigger('change');
     expect(this.form.otherReason.is(':visible')).to.be.false;
   });
 

--- a/fec/fec/tests/js/cycle-select.js
+++ b/fec/fec/tests/js/cycle-select.js
@@ -59,7 +59,7 @@ describe('cycle select', function() {
     });
 
     it('changes the query string on change', function() {
-      this.cycleSelect.$elm.val('2014').change(); // TODO: jQuery deprecation
+      this.cycleSelect.$elm.val('2014').trigger('change');
       expect(CycleSelect.prototype.setUrl).to.have.been.calledWith(window.location.href + '?cycle=2014');
     });
   });
@@ -88,7 +88,7 @@ describe('cycle select', function() {
     });
 
     it('changes the query string on change', function() {
-      this.cycleSelect.$cycles.find('[name="cycle-toggle-cycle-1"]').val('2014').change(); // TODO: jQuery deprecation
+      this.cycleSelect.$cycles.find('[name="cycle-toggle-cycle-1"]').val('2014').trigger('change');
       expect(
         CycleSelect.prototype.setUrl
       ).to.have.been.calledWith(
@@ -128,7 +128,7 @@ describe('cycle select', function() {
     });
 
     it('changes the query string on change', function() {
-      this.cycleSelect.$elm.val('2014').change(); // TODO: jQuery deprecation
+      this.cycleSelect.$elm.val('2014').trigger('change');
       var url = URI(window.location.href);
       url.path('2014/');
       expect(CycleSelect.prototype.setUrl).to.have.been.calledWith(url.toString());

--- a/fec/fec/tests/js/date-filter.js
+++ b/fec/fec/tests/js/date-filter.js
@@ -122,7 +122,7 @@ describe('date filter', function() {
     });
 
     it('triggers an add event with all the right properties', function() {
-      this.filter.$minDate.val('01/01/2015').change(); // TODO: jQuery deprecation
+      this.filter.$minDate.val('01/01/2015').trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:added', [
         {
           key: 'min_date',
@@ -139,14 +139,14 @@ describe('date filter', function() {
 
     it('triggers a remove event if the field has no value', function() {
       this.filter.$minDate.val('01/01/2015');
-      this.filter.$minDate.val('').change(); // TODO: jQuery deprecation
+      this.filter.$minDate.val('').trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:removed');
     });
 
     it('triggers a rename event if the field had a value', function() {
       this.filter.$minDate.val('01/01/2015');
       this.filter.$minDate.data('had-value', true);
-      this.filter.$minDate.val('02/01/2015').change(); // TODO: jQuery deprecation
+      this.filter.$minDate.val('02/01/2015').trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:renamed');
       expect(this.filter.$minDate.data('loaded-once')).to.be.true;
     });

--- a/fec/fec/tests/js/dropdowns.js
+++ b/fec/fec/tests/js/dropdowns.js
@@ -65,15 +65,15 @@ describe('dropdown', function() {
     });
 
     it('toggles', function() {
-      this.dropdown.$button.click(); // TODO: jQuery deprecation
+      this.dropdown.$button.trigger('click');
       expect(isOpen(this.dropdown)).to.be.true;
-      this.dropdown.$button.click(); // TODO: jQuery deprecation
+      this.dropdown.$button.trigger('click');
       expect(isClosed(this.dropdown)).to.be.true;
     });
 
     it('handles a check', function() {
       var checkbox = this.dropdown.$panel.find('#A');
-      checkbox.click(); // TODO: jQuery deprecation
+      checkbox.trigger('click');
       expect(checkbox.is(':checked')).to.be.true;
     });
 
@@ -103,8 +103,8 @@ describe('dropdown', function() {
 
     it('unchecks an input', function() {
       var checkbox = this.dropdown.$panel.find('#B');
-      checkbox.click(); // TODO: jQuery deprecation
-      checkbox.click(); // TODO: jQuery deprecation
+      checkbox.trigger('click');
+      checkbox.trigger('click');
       var dropdownItem = this.dropdown.$panel.find('.dropdown__item--selected');
       expect(dropdownItem.hasClass('is-checked')).to.be.false;
     });
@@ -121,8 +121,8 @@ describe('dropdown', function() {
 
     it('removes an unchecked input', function() {
       var checkbox = this.dropdown.$panel.find('#B');
-      checkbox.click(); // TODO: jQuery deprecation
-      checkbox.click(); // TODO: jQuery deprecation
+      checkbox.trigger('click');
+      checkbox.trigger('click');
       expect(checkbox.is(':checked')).to.be.false;
       this.dropdown.handleCheckboxRemoval(checkbox);
       var selectedItems = this.dropdown.$selected.find('.dropdown__item');

--- a/fec/fec/tests/js/election-search.js
+++ b/fec/fec/tests/js/election-search.js
@@ -67,22 +67,22 @@ describe('election search', function() {
   });
 
   it('should disable the district select when state is not set', function() {
-    this.el.$state.val('').change(); // TODO: jQuery deprecation
+    this.el.$state.val('').trigger('change');
     expect(this.el.$district.prop('disabled')).to.be.true;
   });
 
   it('should disable the district select when state is set and the state does not have districts', function() {
-    this.el.$state.val('AS').change(); // TODO: jQuery deprecation
+    this.el.$state.val('AS').trigger('change');
     expect(this.el.$district.prop('disabled')).to.be.true;
   });
 
   it('should enable the district select when state is set and the state has districts', function() {
-    this.el.$state.val('VA').change(); // TODO: jQuery deprecation
+    this.el.$state.val('VA').trigger('change');
     expect(this.el.$district.prop('disabled')).to.be.false;
   });
 
   it('should clear the state select and disable the district select when the zip select is set', function() {
-    this.el.$zip.val('19041').change(); // TODO: jQuery deprecation
+    this.el.$zip.val('19041').trigger('change');
     expect(this.el.$state.val()).to.equal('');
     expect(this.el.$district.prop('disabled')).to.be.true;
   });
@@ -93,7 +93,7 @@ describe('election search', function() {
   });
 
   it('should serialize state and district inputs', function() {
-    this.el.$state.val('VA').change(); // TODO: jQuery deprecation
+    this.el.$state.val('VA').trigger('change');
     this.el.$district.val('01');
     expect(this.el.serialize()).to.deep.equal({
       cycle: '2016',

--- a/fec/fec/tests/js/statistical-summary-archive.js
+++ b/fec/fec/tests/js/statistical-summary-archive.js
@@ -83,8 +83,8 @@ describe('Tablefilter', function() {
     describe('disableNonPresYears', function() {
         beforeEach(function() {
             this.disableNonPresYears = spy(Tablefilter.prototype, 'disableNonPresYears');
-            this.chooseYear.val('1982').change(); // TODO: jQuery deprecation
-            this.chooseFiler.val('presidential').change(); // TODO: jQuery deprecation
+            this.chooseYear.val('1982').trigger('change');
+            this.chooseFiler.val('presidential').trigger('change');
             this.filter.showTable();
 
         });

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -106,7 +106,7 @@ describe('data table', function() {
     });
 
     it('does nothing on click', function() {
-      this.table.$exportButton.click(); // TODO: jQuery deprecation
+      this.table.$exportButton.trigger('click');
       expect(DataTable_FEC.prototype.export).not.to.have.been.called;
     });
   });

--- a/fec/fec/tests/js/toggle-filter.js
+++ b/fec/fec/tests/js/toggle-filter.js
@@ -60,7 +60,7 @@ describe('toggle filters', function() {
   });
 
   it('calls handleChange() on change', function() {
-    this.filter.$elm.find('#efiling').prop('checked', true).change(); // TODO: jQuery deprecation
+    this.filter.$elm.find('#efiling').prop('checked', true).trigger('change');
     expect(this.handleChange).to.have.been.called;
   });
 
@@ -94,7 +94,7 @@ describe('toggle filters', function() {
     });
 
     it('triggers rename event on changing the toggle', function() {
-      this.$fixture.find('#efiling').prop('checked', true).change(); // TODO: jQuery deprecation
+      this.$fixture.find('#efiling').prop('checked', true).trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:renamed', [
         {
           key: 'data_type-toggle',

--- a/fec/fec/tests/js/typeahead-filter.js
+++ b/fec/fec/tests/js/typeahead-filter.js
@@ -121,10 +121,10 @@ describe('FilterTypeahead', function() {
     var enableButton = spy(this.FilterTypeahead, 'enableButton');
     var disableButton = spy(this.FilterTypeahead, 'disableButton');
 
-    // this.FilterTypeahead.$field.typeahead('val', 'FAKE CANDIDATE').change(); // TODO: jQuery deprecation
+    // this.FilterTypeahead.$field.typeahead('val', 'FAKE CANDIDATE').trigger('change');
     // expect(enableButton).to.have.been.called;
 
-    // this.FilterTypeahead.$field.typeahead('val', '').change(); // TODO: jQuery deprecation
+    // this.FilterTypeahead.$field.typeahead('val', '').trigger('change');
     // expect(disableButton).to.have.been.called;
 
     // this.FilterTypeahead.enableButton.restore();


### PR DESCRIPTION
## Summary

- Resolves #6410 

### Required reviewers

- front-end
- UX?

## Impacted areas of the application

A chunk of the front-end interactivity where jQuery is involved, specifically the [deprecated parts](https://api.jquery.com/category/deprecated/) of it. Specifically:

- `.bind()` → `.on()`
- `.blur()` → `.trigger('blur')`
- `.change()` → `.trigger('change')` and `.on('change', 𝑓)`
- `.click()` → `.trigger('click)` and `.on('click', 𝑓)`
- `:first` → `.first()`
- `.focus()` → `.trigger('focus')`
- `.hover()` → `.on('mouseenter', 𝑓).on('mouseleave', 𝑓)`
- `.keyCode` → `.which`
- `:last` → `.last()`
- `.trim()` → native String `.trim()`
- `.unbind()` → `.off()`
- `.unique()` → `.sortUnique()`

## Screenshots

No visible changes

## Related PRs

None

## How to test

- Pull the branch