### PR TITLE
6414 Dates & Time Elements

### DIFF
--- a/fec/data/templates/partials/candidate/other-spending-tab.jinja
+++ b/fec/data/templates/partials/candidate/other-spending-tab.jinja
@@ -22,12 +22,12 @@
         <div class="usa-width-one-half">
           <span class="label">Support</span>
           <span class="t-big-data js-support"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full(time_tag=True)}} to {{cycle_end(max_cycle)|date_full(time_tag=True)}}.</strong></span>
         </div>
         <div class="usa-width-one-half">
           <span class="label">Oppose</span>
           <span class="t-big-data js-oppose"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>oppose</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>oppose</strong> from <strong>{{cycle_start(min_cycle)|date_full(time_tag=True)}} to {{cycle_end(max_cycle)|date_full(time_tag=True)}}.</strong></span>
         </div>
       </div>
 
@@ -68,12 +68,12 @@
         <div class="usa-width-one-half">
           <span class="label">Support</span>
           <span class="t-big-data js-support"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>support</strong> from <strong>{{cycle_start(min_cycle)|date_full(time_tag=True)}} to {{cycle_end(max_cycle)|date_full(time_tag=True)}}.</strong></span>
         </div>
         <div class="usa-width-one-half">
           <span class="label">Oppose</span>
           <span class="t-big-data js-oppose"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others to <strong>oppose</strong> from <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others to <strong>oppose</strong> from <strong>{{cycle_start(min_cycle)|date_full(time_tag=True)}} to {{cycle_end(max_cycle)|date_full(time_tag=True)}}.</strong></span>
         </div>
       </div>
       <table
@@ -103,7 +103,7 @@
       <div class="results-info results-info--simple js-other-spending-totals" data-spending-type="electioneering">
         <div class="usa-width-one-half">
           <span class="t-big-data js-total-electioneering u-margin--top"><img src="{{ static('img/loading-ellipsis.gif') }}" alt="Loading indicator"></span>
-          <span class="t-block t-sans">Spent by others that mentioned this candidate <strong>{{cycle_start(min_cycle)|date_full}} to {{cycle_end(max_cycle)|date_full}}.</strong></span>
+          <span class="t-block t-sans">Spent by others that mentioned this candidate <strong>{{cycle_start(min_cycle)|date_full(time_tag=True)}} to {{cycle_end(max_cycle)|date_full(time_tag=True)}}.</strong></span>
         </div>
       </div>
 

--- a/fec/data/templates/partials/candidate/raising.jinja
+++ b/fec/data/templates/partials/candidate/raising.jinja
@@ -48,7 +48,7 @@
             </div>
           </div>
           <div class="row">
-            <span class="usa-width-one-half t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>{{two_year_totals.coverage_start_date|date_full}} to {{two_year_totals.coverage_end_date|date_full}}.</strong></span>
+            <span class="usa-width-one-half t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>{{two_year_totals.coverage_start_date|date_full(time_tag=True)}} to {{two_year_totals.coverage_end_date|date_full(time_tag=True)}}.</strong></span>
             <div class="usa-width-one-half">
               <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of receipt.</span>
             </div>

--- a/fec/data/templates/partials/candidate/spending.jinja
+++ b/fec/data/templates/partials/candidate/spending.jinja
@@ -52,7 +52,7 @@
             </div>
           </div>
           <div class="row">
-            <span class="usa-width-one-half t-block t-sans">spent in total disbursements by this candidate's authorized committees from <strong>{{two_year_totals.coverage_start_date|date_full}} to {{two_year_totals.coverage_end_date|date_full}}.</strong></span>
+            <span class="usa-width-one-half t-block t-sans">spent in total disbursements by this candidate's authorized committees from <strong>{{two_year_totals.coverage_start_date|date_full(time_tag=True)}} to {{two_year_totals.coverage_end_date|date_full(time_tag=True)}}.</strong></span>
             <div class="usa-width-one-half">
               <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of disbursement.</span>
             </div>

--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -28,7 +28,7 @@
           </div>
         </div>
         <div class="row">
-          <span class="usa-width-one-half t-block t-sans">raised in total receipts by this committee from <strong>{{totals.coverage_start_date|date_full}} to {{totals.coverage_end_date|date_full}}.</strong></span>
+          <span class="usa-width-one-half t-block t-sans">raised in total receipts by this committee from <strong>{{totals.coverage_start_date|date_full(time_tag=True)}} to {{totals.coverage_end_date|date_full(time_tag=True)}}.</strong></span>
           <div class="usa-width-one-half">
             <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of receipt.</span>
           </div>
@@ -219,7 +219,7 @@
             </div>
           </div>
           <div class="row u-margin-bottom">
-            <div class="usa-width-one-half t-block t-sans">raised by this committee from <strong><time>{{totals.coverage_start_date|date_full}}</time> to <time>{{totals.coverage_end_date|date_full}}</time>.</strong></div>
+            <div class="usa-width-one-half t-block t-sans">raised by this committee from <strong><time>{{totals.coverage_start_date|date_full(time_tag=True)}}</time> to <time>{{totals.coverage_end_date|date_full(time_tag=True)}}</time>.</strong></div>
             <div class="usa-width-one-half">
               <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of account.</span>
             </div>

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -39,9 +39,9 @@
           </div>
           <div class="row">
             {% if not is_inaugural %}
-            <span class="usa-width-one-half t-block t-sans">spent in total disbursements by this committee from <strong>{{totals.coverage_start_date|date_full}} to {{totals.coverage_end_date|date_full}}.</strong></span>
+            <span class="usa-width-one-half t-block t-sans">spent in total disbursements by this committee from <strong>{{totals.coverage_start_date|date_full(time_tag=True)}} to {{totals.coverage_end_date|date_full(time_tag=True)}}.</strong></span>
             {% else %}
-            <span class="usa-width-one-half t-block t-sans">in total donations refunded by this committee from <strong>{{totals.coverage_start_date|date_full}} to {{totals.coverage_end_date|date_full}}.</strong></span>
+            <span class="usa-width-one-half t-block t-sans">in total donations refunded by this committee from <strong>{{totals.coverage_start_date|date_full(time_tag=True)}} to {{totals.coverage_end_date|date_full(time_tag=True)}}.</strong></span>
             {% endif %}
             <div class="usa-width-one-half">
               {% if not is_inaugural %}

--- a/fec/data/templatetags/filters.py
+++ b/fec/data/templatetags/filters.py
@@ -47,9 +47,18 @@ def date(value, fmt='%m/%d/%Y'):
 
 
 @library.filter
-def date_full(value, fmt='%B %d, %Y'):
+def date_full(value, fmt='%B %d, %Y', time_tag=False):
+    '''Format a date in the format of 'January 01, 2000'
+    :param value: date string to be formatted
+    :param fmt: requested format for the date. defaults to Month, DD, YYYY
+    :param time_tag: whether to wrap the returned date string in a <time> element
+    :returns: formatted string, optionally inside a <time>
+    '''
     if value is None:
         return None
+    if time_tag:
+        return format_html(ensure_date(value).strftime('<time datetime="%Y-%m-%d">' + fmt + '</time>'))
+
     return ensure_date(value).strftime(fmt)
 
 


### PR DESCRIPTION
## Summary

- Resolves #6414 

Trying to prevent line breaks from landing in the middle of dates so they're easier to read.

As a bonus, wrapping those long dates in `<time>` elements to make them a little more accessible.

### Required reviewers

- product manager?
- front-end?
- UX?
- content?

## Impacted areas of the application

Candidate profile pages
Committee profile pages

Site editors could also wrap dates in `<time></time>` such as
`<time>December 31, 1999</time>` or `<time datetime="1999-12-31">December 31, 1999</time>`
(if the `datetime` attribute is included, it should be in the ISO format of `YYYY-MM-DD`)

## Screenshots

Above: what this PR does
Below: _why_ (highlighted in blue)
![image](https://github.com/user-attachments/assets/fa5a83e1-a510-4303-8352-a7ea5559e5d0)


## Related PRs

None

## How to test

- Pull the branch
- `npm run build`
- Candidate pages - across the various widths, line breaks should not wrap
   - the dates in Total Receipts
   - the dates in Total disbursements
   - other long dates that appear (Month, dd, yyyy)
- A committee page
   - the date in Registration date   
   - the dates in Total Receipts
   - the dates in National party receipts (if that section exists)
   - the dates in Total disbursements
   - the dates in National party spending (if that section exists)
   - other long dates that appear (Month, dd, yyyy)