### PR TITLE
Bump wagtail to 5.2.6 to fix vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ requests==2.32.3
 urllib3==1.26.18
 slacker==0.8.6
 whitenoise==5.2.0
-wagtail==5.2
+wagtail==5.2.6
 Jinja2==3.1.4
 django_jinja==2.11.0
 CacheControl==0.11.5


### PR DESCRIPTION
## Summary
Bump wagtail to 5.2.6 to fix snyk-reported vulnerability
- Resolves #6394

### Required reviewers

1-2 devs

## Impacted areas of the application

Wagtail.
modified:   requirements.txt

## How to test
- checkout this branch
- activate a virtual env
- Before installing requirements.txt, run `snyk test --file=requirements.txt`
- You should see:  
```
✗ Regular Expression Denial of Service (ReDoS) (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-WAGTAIL-7443632] in wagtail@5.2

```
- `pip install -r requirements.txt`
- Run snyk test again
- You should no longer see the vulnerability
- You could also verify that wagtail is upgraded to 5.2.6 by running server and logging into Wagtail admin 
- Or drop into the python interpreter and verify :

```
python
>>> import wagtail
>>> wagtail.VERSION

```

