### PR TITLE
upgrade django v4.2.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.10
+Django==4.2.15
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary (required)

- Resolves #6376 

This PR upgrades django to remove security vulnerabilities. 

Note: we will not be able to upgrade django to v5 until wagtail is upgraded to version > 5.2 

### Required reviewers 1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  django


## How to test

- `git checkout feature/6376-upgrade-django`
- activate your virtual env
-  `pip install -r requirements.txt`
- `snyk test --file=requirements.txt --package-manager=pip` - make sure that django does not appear in list
- `./manage.py runserver` 