### PR TITLE
Remove unused node pkgs, es6-weak-map and es5-ext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,6 @@
         "d3": "^3.5.17",
         "dompurify": "^2.5.6",
         "draftail": "^1.4.1",
-        "es5-ext": "^0.10.64",
-        "es6-weak-map": "^2.0.3",
         "eventemitter2": "^6.4.9",
         "fullcalendar": "3.3.1",
         "graceful-fs": "^4.2.10",
@@ -7512,6 +7510,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
       "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "es5-ext": "^0.10.64",
@@ -9034,6 +9033,7 @@
       "version": "0.10.64",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
       "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -9050,6 +9050,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "d": "1",
@@ -9061,6 +9062,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
       "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d": "^1.0.2",
@@ -9074,6 +9076,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d": "1",
@@ -9635,6 +9638,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
       "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d": "^1.0.1",
@@ -9741,6 +9745,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "d": "1",
@@ -9834,6 +9839,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "type": "^2.7.2"
@@ -16592,6 +16598,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/nise": {
@@ -21809,6 +21816,7 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
       "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
     "d3": "^3.5.17",
     "dompurify": "^2.5.6",
     "draftail": "^1.4.1",
-    "es5-ext": "^0.10.64",
-    "es6-weak-map": "^2.0.3",
     "eventemitter2": "^6.4.9",
     "fullcalendar": "3.3.1",
     "graceful-fs": "^4.2.10",


### PR DESCRIPTION
## Summary (required)

Remove unused node packages `es6-weak-map` and `es5-ext` from package*.json files

- Resolves [#6275](https://github.com/fecgov/fec-cms/issues/6275)

### Required reviewers

2 developers

## How to test

- run `git checkout feature/6275-delete-es5-ext`
- run `pyenv virtualenv activate <new virtualenv>`
- run `pyenv activate <new virtualenv>`
- run `pip install -r requirements.txt`
- run `pip install -r requirements-dev.txt`
- run `rm -rf node_modules`
- run `npm i`
- run `npm run build`
- run `npm run test-single`
- run `cd fec`
- run server: `./manage.py runserver` (CMS app runs OK without any errors)
