### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] 6429 NPA Single Page Updates

### DIFF
--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -219,10 +219,7 @@
             </div>
           </div>
           <div class="row u-margin-bottom">
-            <div class="usa-width-one-half t-block t-sans">raised by this committee from <strong><time>{{totals.coverage_start_date|date_full}}</time> to <time>{{totals.coverage_end_date|date_full}}</time>.</strong></div>
-            <div class="usa-width-one-half">
-              <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of account.</span>
-            </div>
+            <div class="t-block t-sans">raised by this committee from <strong><time>{{totals.coverage_start_date|date_full}}</time> to <time>{{totals.coverage_end_date|date_full}}</time>.</strong></div>
           </div>
         </div>
         <div class="content__section--ruled">

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -364,10 +364,7 @@
             </div>
           </div>
           <div class="row u-margin-bottom">
-            <span class="usa-width-one-half t-block t-sans">spent by this committee from <strong><time class="no-wrap">{{totals.coverage_start_date|date_full}}</time> to <time class="no-wrap">{{totals.coverage_end_date|date_full}}</time>.</strong></span>
-            <div class="usa-width-one-half">
-              <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of account.</span>
-            </div>
+            <span class="t-block t-sans">spent by this committee from <strong><time class="no-wrap">{{totals.coverage_start_date|date_full}}</time> to <time class="no-wrap">{{totals.coverage_end_date|date_full}}</time>.</strong></span>
           </div>
         </div>
         <div class="content__section--ruled">


### PR DESCRIPTION
## Summary

- Resolves #6429 

We're removing the "See the financial summary for a breakdown of each type of account" sentences from the NPA section of the single committee pages for raising and spending

### Required reviewers

- front-end
- UX
- SME

## Impacted areas of the application

The NPA sections of raising and spending on committee single pages

## Screenshots

![image](https://github.com/user-attachments/assets/c6a9ba3d-8c8f-4548-8235-82a92e8f511d)

![image](https://github.com/user-attachments/assets/e97ab4c0-ecad-43e3-bba2-add5c3fce306)


## Related PRs

None

## How to test

- Pull the branch
- `npm run build`
- `./manage.py runserver`
- Check a national party page