### PR TITLE
Remove unused slacker python package and notify function

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -5,9 +5,6 @@
 set -o errexit
 set -o pipefail
 
-# Send out Slack notifications (off for now)
-# invoke notify
-
 cd fec
 # Run migrations
 ./manage.py makemigrations

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,4 +45,4 @@ pre-commit==2.21.0 #client-side hook triggered by operations like git commit
 faker==26.0.0
 
 # CircleCI build
-setuptools==71.1.0 #pin to fix builds
+setuptools==73.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ gevent==23.9.1
 psycopg==3.1.8
 requests==2.32.3
 urllib3==2.2.2
-slacker==0.8.6
 whitenoise==5.2.0
 wagtail==5.2.6
 Jinja2==3.1.4

--- a/tasks.py
+++ b/tasks.py
@@ -6,7 +6,6 @@ import cfenv
 
 from invoke import run  # noqa: F401
 from invoke import task
-from slacker import Slacker
 
 env = cfenv.AppEnv()
 
@@ -74,7 +73,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/6400-remove-slacker'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
@@ -174,22 +173,3 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False):
 
     # Needed by CircleCI
     return sys.exit(0)
-
-
-@task
-def notify(ctx):
-    try:
-        meta = json.load(open('.cfmeta'))
-    except OSError:
-        meta = {}
-    slack = Slacker(env.get_credential('FEC_SLACK_TOKEN'))
-    slack.chat.post_message(
-        env.get_credential('FEC_SLACK_CHANNEL', '#fec'),
-        'deploying branch {branch} of app {name} to space {space} by {user}'.format(
-            name=env.name,
-            space=env.space,
-            user=meta.get('user'),
-            branch=meta.get('branch'),
-        ),
-        username=env.get_credential('FEC_SLACK_BOT', 'fec-bot'),
-    )

--- a/tasks.py
+++ b/tasks.py
@@ -73,7 +73,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'feature/6400-remove-slacker'),
+    ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )


### PR DESCRIPTION
## Summary 

- Resolves #6400 

1. Remove unused notify code block and slack environment variabless
2. Delete archived slacker package from requirements.txt file
3. Bump setuptools to v73.0.0

### Required reviewers

one developer


## How to test

- deploy a test branch to `dev` space. CMS app should deploy successfully, with setuptools v73.0.1

