### PR TITLE
Limit 10 candidates for contribution by size and state

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -1122,10 +1122,10 @@ export function initSpendingTables(className, pageContext, options) {
   });
 }
 
-function refreshTables(e, pageContext) {
+export function refreshTables(e, pageContext) {
   const $comparison = $('#comparison');
   const selected_count = $('#comparison input[type="checkbox"]:checked').length;
-  // Once ten checkboxes are checked, disable the dropdown and disanle any unchecked boxes
+  // Once ten checkboxes are checked, disable the dropdown and disable any unchecked boxes
   if (selected_count >= 10) {
     $comparison.find('.js-dropdown button')
     .prop('disabled', true)

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -1124,6 +1124,26 @@ export function initSpendingTables(className, pageContext, options) {
 
 function refreshTables(e, pageContext) {
   const $comparison = $('#comparison');
+  const selected_count = $('#comparison input[type="checkbox"]:checked').length;
+  // Once ten checkboxes are checked, disable the dropdown and disanle any unchecked boxes
+  if (selected_count >= 10) {
+    $comparison.find('.js-dropdown button')
+    .prop('disabled', true)
+    .removeClass('is-active')
+    .next('.dropdown__panel').attr('aria-hidden','true');
+    $comparison.find('input[type="checkbox"]:not(:checked)')
+    .prop('disabled', true)
+    .next('label').addClass('disabled')
+    .next('.dropdown__remove').prop('disabled', false);
+  // If fewer than 10 are checked, enable the dropdown and enable any unchecked boxes
+  } else {
+    $comparison.find('.js-dropdown button')
+    .prop('disabled', false);
+    $comparison.find('input[type="checkbox"]:not(:checked)')
+    .prop('disabled', false)
+    .next('label').removeClass('disabled');
+  }
+
   const selected = $comparison
     .find('input[type="checkbox"]:checked')
     .map(function(_, input) {

--- a/fec/fec/static/js/templates/comparison.hbs
+++ b/fec/fec/static/js/templates/comparison.hbs
@@ -10,7 +10,7 @@
       </li>
       {{/each}}
     </ul>
-    <div class="grid grid--3-wide">
+    <div class="grid grid--3-wide u-no-margin">
       <div class="dropdown grid__item">
         <button type="button" class="dropdown__button button--alt">More</button>
         <div class="dropdown__panel" aria-hidden="true">

--- a/fec/fec/static/js/templates/comparison.hbs
+++ b/fec/fec/static/js/templates/comparison.hbs
@@ -1,6 +1,7 @@
 <div class="content__section u-no-padding">
   <fieldset class="js-dropdown">
   <legend class="label" for="candidate-list">Candidates to compare (listed by amount raised):</legend>
+  <label class="label--help label--help u-negative--top--margin u-padding--bottom">Limit 10 candidates</label>
     <ul class="dropdown__selected list--3-columns">
       {{#each this.selected}}
       <li class="dropdown__item">

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -177,7 +177,7 @@
 
   li {
     input[type="checkbox"] + label.disabled {
-      cursor: not-allowed;
+      pointer-events:none;
       opacity: .5;
     }
 
@@ -193,11 +193,7 @@
         display: none;
       }
     }
-    input[type="checkbox"] + label.disabled {
-      border: 1px solid #aeb0b5 !important;
-      background-color: #aeb0b5 !important;
 
-    }
   }
 
   input {

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -177,7 +177,7 @@
 
   li {
     input[type="checkbox"] + label.disabled {
-      pointer-events:none;
+      pointer-events: none;
       opacity: .5;
     }
 
@@ -193,7 +193,6 @@
         display: none;
       }
     }
-
   }
 
   input {

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -176,6 +176,11 @@
   margin: u(.5rem 0);
 
   li {
+    input[type="checkbox"] + label.disabled {
+      cursor: not-allowed;
+      opacity: .5;
+    }
+
     @include animation(fadeIn .2s ease-in);
     position: relative;
 
@@ -187,6 +192,11 @@
       input[type="checkbox"]:not(:checked) + label.is-unsuccessful + .dropdown__remove {
         display: none;
       }
+    }
+    input[type="checkbox"] + label.disabled {
+      border: 1px solid #aeb0b5 !important;
+      background-color: #aeb0b5 !important;
+
     }
   }
 

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -177,7 +177,7 @@
 
   li {
     input[type="checkbox"] + label.disabled {
-      pointer-events: none;
+      cursor: default;
       opacity: .5;
     }
 
@@ -191,6 +191,10 @@
 
       input[type="checkbox"]:not(:checked) + label.is-unsuccessful + .dropdown__remove {
         display: none;
+      }
+      .disabled {
+        border: 1px solid #aeb0b5;
+        background-color: #aeb0b5
       }
     }
   }

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -179,6 +179,8 @@
     input[type="checkbox"] + label.disabled {
       cursor: default;
       opacity: .5;
+      border: 1px solid #aeb0b5 !important;
+      background-color: #aeb0b5 !important;
     }
 
     @include animation(fadeIn .2s ease-in);
@@ -191,10 +193,6 @@
 
       input[type="checkbox"]:not(:checked) + label.is-unsuccessful + .dropdown__remove {
         display: none;
-      }
-      .disabled {
-        border: 1px solid #aeb0b5;
-        background-color: #aeb0b5
       }
     }
   }

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -325,7 +325,6 @@ describe('data table', function() {
 
   });
 
-//////NEW
   describe('refreshTables', function() {
     before(function(done) {
       this.$fixture = $('<div id="fixtures"></div>');
@@ -466,11 +465,9 @@ describe('data table', function() {
       done();
     });
 
-    it('should start with 10 sekected boxes and dropdown disabled by defualt', function() {
+    it('should start with 10 selected boxes and dropdown disabled by default', function() {
       const dropdown_button = $('.dropdown__button')
       const selected_checkboxes =  $('.dropdown__selected input[type="checkbox"]:checked')
-      //expect(this.refreshTables).to.have.been.called;
-      //expect(this.drawComparison).to.have.been.called;
       expect(selected_checkboxes.length).to.equal(10);
       expect(dropdown_button.prop('disabled')).to.be.true
     });
@@ -491,40 +488,35 @@ describe('data table', function() {
     });
 
     it('re-enables unchecked box when checked-count becomes less than 10', function() {
-      // uncheck a checkbox
+      // Uncheck a checkbox
       this.checkbox = $('.js-dropdown input[data-id="S4FL00736"]')
       $(this.checkbox).prop('checked',false)
 
-      // check an item from the fropdown
+      // Check an item from the dropdown
       this.checkbox1 =  $('.js-dropdown input[data-id="S2FL00656"]')
       $(this.checkbox1).prop('checked',true)
 
-      // trigger a click on the previosly checked box to uncheck it and fire refreshTables()
+      // Trigger a click on the previously checked box to uncheck it and fire refreshTables()
       this.checkbox1.trigger('click').trigger('change')
     
       expect(this.checkbox.prop('disabled')).to.be.false
     });
 
-    it('it enables/allows removal of disabled checkboxes from dropdown', function() {
+    it('enables/allows removal of disabled checkboxes from dropdown', function() {
       new Dropdown('.js-dropdown');
-      // check one item from the dropdown
+      // Check one item from the dropdown
       this.checkbox =  $('.dropdown__list input[data-id="S2FL00656"]')
       $(this.checkbox).prop('checked',true)
 
-      //Uncheck the checkbox to make it disabled
+      // Uncheck the checkbox to make it disabled
       this.checkbox.trigger($.Event('click')).trigger($.Event('change'))
 
       this.rm=$('.dropdown__selected input[data-id="S2FL00656"]').nextAll('button.dropdown__remove')
 
       expect(this.checkbox.prop('disabled')).to.be.true
       expect(this.rm.prop('disabled')).to.be.false
-
     });
-
   });
-
-/////END NEW
-
 
   describe('initSpendingTables', function() {
     before(function(done) {

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -16,7 +16,7 @@ import { candidateColumn, committeeColumn, supportOpposeColumn } from '../../sta
 import { buildTotalLink } from '../../static/js/modules/column-helpers.js';
 import { buildUrl } from '../../static/js/modules/helpers.js';
 
-import { DataTable_FEC, drawComparison, refreshTables, getCycle, initSpendingTables, mapResponse, mapSort, yearRange } from '../../static/js/modules/tables.js';
+import { DataTable_FEC, drawComparison, getCycle, initSpendingTables, mapResponse, mapSort, refreshTables, yearRange } from '../../static/js/modules/tables.js';
 import { init as initTablist } from '../../static/js/vendor/tablist.js';
 import { default as Dropdown }  from '../../static/js/modules/dropdowns.js';
 

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -16,8 +16,9 @@ import { candidateColumn, committeeColumn, supportOpposeColumn } from '../../sta
 import { buildTotalLink } from '../../static/js/modules/column-helpers.js';
 import { buildUrl } from '../../static/js/modules/helpers.js';
 
-import { DataTable_FEC, drawComparison, getCycle, initSpendingTables, mapResponse, mapSort, yearRange } from '../../static/js/modules/tables.js';
+import { DataTable_FEC, drawComparison, refreshTables, getCycle, initSpendingTables, mapResponse, mapSort, yearRange } from '../../static/js/modules/tables.js';
 import { init as initTablist } from '../../static/js/vendor/tablist.js';
+import { default as Dropdown }  from '../../static/js/modules/dropdowns.js';
 
 import { default as context } from '../fixtures/context.js';
 import { default as houseResults } from '../fixtures/house-results.js';
@@ -321,7 +322,209 @@ describe('data table', function() {
       var tables = $('#fixtures');
       done();
     });
+
   });
+
+//////NEW
+  describe('refreshTables', function() {
+    before(function(done) {
+      this.$fixture = $('<div id="fixtures"></div>');
+      $('body')
+        .empty()
+        .append(this.$fixture);
+      done();
+    });
+
+    after(function(done) {
+      $('body').empty();
+      this.$fixture = null;
+      done();
+    });
+
+    beforeEach(function(done) {
+      this.$fixture
+        .empty()
+        .append(
+          '<div id="comparison">'+
+          '<fieldset class="js-dropdown">'+
+            '<legend class="label" for="candidate-list">Candidates to compare (listed by amount raised):</legend>'+
+            '<label class="label--help label--help u-negative--top--margin u-padding--bottom">Limit 10 candidates</label>'+
+              '<ul class="dropdown__selected list--3-columns">'+
+                '<li class="dropdown__item">'+
+                  '<input id="checkbox-S8FL00273" name="candidate-list" type="checkbox" data-id="S8FL00273" data-name="SCOTT, RICK SEN" checked>'+
+                  '<label class="dropdown__value" for="checkbox-S8FL00273">SCOTT, RICK SEN</label>'+
+                '</li>'+
+                '<li class="dropdown__item">'+
+                  '<input id="checkbox-S4FL00611" name="candidate-list" type="checkbox" data-id="S4FL00611" data-name="MUCARSEL-POWELL, DEBBIE" checked>'+
+                  '<label class="dropdown__value" for="checkbox-S4FL00611">MUCARSEL-POWELL, DEBBIE</label>'+
+                '</li>'+
+                '<li class="dropdown__item">'+
+                  '<input id="checkbox-S4FL00553" name="candidate-list" type="checkbox" data-id="S4FL00553" data-name="GROSS, KEITH" checked>'+
+                  '<label class="dropdown__value" for="checkbox-S4FL00553">GROSS, KEITH</label>'+
+                '</li>'+
+                '<li class="dropdown__item">'+
+                  '<input id="checkbox-S4FL00637" name="candidate-list" type="checkbox" data-id="S4FL00637" data-name="CAMPBELL, STANLEY" checked>'+
+                  '<label class="dropdown__value" for="checkbox-S4FL00637">CAMPBELL, STANLEY</label>'+
+                '</li>'+
+                '<li class="dropdown__item">'+
+                  '<input id="checkbox-S2FL00581" name="candidate-list" type="checkbox" data-id="S2FL00581" data-name="GRAYSON, ALAN MARK" checked>'+
+                  '<label class="dropdown__value" for="checkbox-S2FL00581">GRAYSON, ALAN MARK</label>'+
+                '</li>'+
+                '<li class="dropdown__item">'+
+                  '<input id="checkbox-S4FL00595" name="candidate-list" type="checkbox" data-id="S4FL00595" data-name="RUSH, BRIAN" checked>'+
+                  '<label class="dropdown__value" for="checkbox-S4FL00595">RUSH, BRIAN</label>'+
+                '</li>'+
+                '<li class="dropdown__item">'+
+                  '<input id="checkbox-S4FL00538" name="candidate-list" type="checkbox" data-id="S4FL00538" data-name="HORAN, DONALD" checked>'+
+                  '<label class="dropdown__value" for="checkbox-S4FL00538">HORAN, DONALD</label>'+
+                '</li>'+
+                '<li class="dropdown__item">'+
+                  '<input id="checkbox-S4FL00512" name="candidate-list" type="checkbox" data-id="S4FL00512" data-name="JOSEPH, ROD" checked>'+
+                  '<label class="dropdown__value" for="checkbox-S4FL00512">JOSEPH, ROD</label>'+
+                '</li>'+
+                '<li class="dropdown__item">'+
+                  '<input id="checkbox-S4FL00785" name="candidate-list" type="checkbox" data-id="S4FL00785" data-name="COLUMBUS, JOHN" checked>'+
+                  '<label class="dropdown__value" for="checkbox-S4FL00785">COLUMBUS, JOHN</label>'+
+                '</li>'+
+                '<li class="dropdown__item">'+
+                  '<input id="checkbox-S4FL00736" name="candidate-list" type="checkbox" data-id="S4FL00736" data-name="BONOAN, FEENA" checked>'+
+                  '<label class="dropdown__value disabled" for="checkbox-S4FL00736">BONOAN, FEENA</label>'+
+                '</li>'+
+              '</ul>'+
+              '<div class="grid grid--3-wide">'+
+                '<div class="dropdown grid__item">'+
+                  '<button type="button" class="dropdown__button button--alt" aria-haspopup="true">More</button>'+
+                  '<div class="dropdown__panel ps ps--active-y" aria-hidden="true" aria-label="More options">'+
+                    '<ul class="dropdown__list">'+
+                      '<li class="dropdown__item">'+
+                      '<input id="checkbox-S2FL00656" name="candidate-list" type="checkbox" data-id="S2FL00656" data-name="NGUYEN, QUOC TUAN MR." tabindex="0">'+
+                      '<label class="dropdown__value disabled" for="checkbox-S2FL00656">NGUYEN, QUOC TUAN MR.</label></li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00579" name="candidate-list" type="checkbox" data-id="S4FL00579" data-name="STERN, EVERETT" tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00579">STERN, EVERETT</label></li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00439" name="candidate-list" type="checkbox" data-id="S4FL00439" data-name="DAVIS, JAMES" tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00439">DAVIS, JAMES</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00454" name="candidate-list" type="checkbox" data-id="S4FL00454" data-name="BOSWELL, MATT" tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00454">BOSWELL, MATT</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00462" name="candidate-list" type="checkbox" data-id="S4FL00462" data-name="LAROSE, JOSUE DR." tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00462">LAROSE, JOSUE DR.</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00488" name="candidate-list" type="checkbox" data-id="S4FL00488" data-name="SANSCRAINTE, MATTHEW ALEXANDER MR" tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00488">SANSCRAINTE, MATTHEW ALEXANDER MR</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00520" name="candidate-list" type="checkbox" data-id="S4FL00520" data-name="TOULME, ALIX CHRISTOPHER MR. JR." tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00520">TOULME, ALIX CHRISTOPHER MR. JR.</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00561" name="candidate-list" type="checkbox" data-id="S4FL00561" data-name="ROMAGNANO, CHASE ANDERSON MR." tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00561">ROMAGNANO, CHASE ANDERSON MR.</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00629" name="candidate-list" type="checkbox" data-id="S4FL00629" data-name="SMITH, JOE" tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00629">SMITH, JOE</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00678" name="candidate-list" type="checkbox" data-id="S4FL00678" data-name="ODELL, SHANNON MAY" tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00678">ODELL, SHANNON MAY</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00686" name="candidate-list" type="checkbox" data-id="S4FL00686" data-name="SUN, KATY" tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00686">SUN, KATY</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00751" name="candidate-list" type="checkbox" data-id="S4FL00751" data-name="BENNETT, SHANTELE RENEE MS N/A" tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00751">BENNETT, SHANTELE RENEE MS N/A</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00769" name="candidate-list" type="checkbox" data-id="S4FL00769" data-name="TOULME, ALIX CHRISTOPHER MR. JR." tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00769">TOULME, ALIX CHRISTOPHER MR. JR.</label>'+
+                      '</li>'+
+                      '<li class="dropdown__item">'+
+                        '<input id="checkbox-S4FL00793" name="candidate-list" type="checkbox" data-id="S4FL00793" data-name="RAMSAROOP, JOEL" tabindex="0">'+
+                        '<label class="dropdown__value disabled" for="checkbox-S4FL00793">RAMSAROOP, JOEL</label>'+
+                      '</li>'+
+                    '</ul>'+
+                '</div>'+
+              '</div>'+
+            '</fieldset>'+
+          '</div>'     
+      );
+      this.refreshTables = sinon.spy(refreshTables(null, context));
+      this.drawComparison = sinon.spy(drawComparison);  
+      done();
+    });
+        
+    afterEach(function(done) {
+      this.$fixture.empty();
+      done();
+    });
+
+    it('should start with 10 sekected boxes and dropdown disabled by defualt', function() {
+      const dropdown_button = $('.dropdown__button')
+      const selected_checkboxes =  $('.dropdown__selected input[type="checkbox"]:checked')
+      //expect(this.refreshTables).to.have.been.called;
+      //expect(this.drawComparison).to.have.been.called;
+      expect(selected_checkboxes.length).to.equal(10);
+      expect(dropdown_button.prop('disabled')).to.be.true
+    });
+
+    it('should enable dropdown if less than 10 checkboxes are selected', function() {
+      $('.js-dropdown input[data-id="S4FL00736"]').prop('checked',false)
+      const dropdown_button = $('.dropdown__button')
+      refreshTables(null, context);
+      expect(dropdown_button.prop('disabled')).to.be.false
+    });
+
+    it('should disable unchecked box when another item is checked from dropdown', function() {
+      $('.js-dropdown input[data-id="S4FL00736"]').prop('checked',false)
+      $('.js-dropdown input[data-id="S2FL00656"]').prop('checked',true)
+      refreshTables(null, context);
+      const disabled_checkboxes =  $('.dropdown__selected input[type="checkbox"]:disabled')
+      expect(disabled_checkboxes.length).to.equal(1);
+    });
+
+    it('re-enables unchecked box when checked-count becomes less than 10', function() {
+      // uncheck a checkbox
+      this.checkbox = $('.js-dropdown input[data-id="S4FL00736"]')
+      $(this.checkbox).prop('checked',false)
+
+      // check an item from the fropdown
+      this.checkbox1 =  $('.js-dropdown input[data-id="S2FL00656"]')
+      $(this.checkbox1).prop('checked',true)
+
+      // trigger a click on the previosly checked box to uncheck it and fire refreshTables()
+      this.checkbox1.trigger('click').trigger('change')
+    
+      expect(this.checkbox.prop('disabled')).to.be.false
+    });
+
+    it('it enables/allows removal of disabled checkboxes from dropdown', function() {
+      new Dropdown('.js-dropdown');
+      // check one item from the dropdown
+      this.checkbox =  $('.dropdown__list input[data-id="S2FL00656"]')
+      $(this.checkbox).prop('checked',true)
+
+      //Uncheck the checkbox to make it disabled
+      this.checkbox.trigger($.Event('click')).trigger($.Event('change'))
+
+      this.rm=$('.dropdown__selected input[data-id="S2FL00656"]').nextAll('button.dropdown__remove')
+
+      expect(this.checkbox.prop('disabled')).to.be.true
+      expect(this.rm.prop('disabled')).to.be.false
+
+    });
+
+  });
+
+/////END NEW
+
 
   describe('initSpendingTables', function() {
     before(function(done) {

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -467,54 +467,54 @@ describe('data table', function() {
 
     it('should start with 10 selected boxes and dropdown disabled by default', function() {
       const dropdown_button = $('.dropdown__button')
-      const selected_checkboxes =  $('.dropdown__selected input[type="checkbox"]:checked')
+      const selected_checkboxes =  $('.dropdown__selected input[type="checkbox"]:checked');
       expect(selected_checkboxes.length).to.equal(10);
-      expect(dropdown_button.prop('disabled')).to.be.true
+      expect(dropdown_button.prop('disabled')).to.be.true;
     });
 
     it('should enable dropdown if less than 10 checkboxes are selected', function() {
-      $('.js-dropdown input[data-id="S4FL00736"]').prop('checked',false)
-      const dropdown_button = $('.dropdown__button')
+      $('.js-dropdown input[data-id="S4FL00736"]').prop('checked',false);
+      const dropdown_button = $('.dropdown__button');
       refreshTables(null, context);
-      expect(dropdown_button.prop('disabled')).to.be.false
+      expect(dropdown_button.prop('disabled')).to.be.false;
     });
 
     it('should disable unchecked box when another item is checked from dropdown', function() {
-      $('.js-dropdown input[data-id="S4FL00736"]').prop('checked',false)
-      $('.js-dropdown input[data-id="S2FL00656"]').prop('checked',true)
+      $('.js-dropdown input[data-id="S4FL00736"]').prop('checked',false);
+      $('.js-dropdown input[data-id="S2FL00656"]').prop('checked',true);
       refreshTables(null, context);
-      const disabled_checkboxes =  $('.dropdown__selected input[type="checkbox"]:disabled')
+      const disabled_checkboxes =  $('.dropdown__selected input[type="checkbox"]:disabled');
       expect(disabled_checkboxes.length).to.equal(1);
     });
 
     it('re-enables unchecked box when checked-count becomes less than 10', function() {
       // Uncheck a checkbox
-      this.checkbox = $('.js-dropdown input[data-id="S4FL00736"]')
-      $(this.checkbox).prop('checked',false)
+      this.checkbox = $('.js-dropdown input[data-id="S4FL00736"]');
+      $(this.checkbox).prop('checked',false);
 
       // Check an item from the dropdown
-      this.checkbox1 =  $('.js-dropdown input[data-id="S2FL00656"]')
-      $(this.checkbox1).prop('checked',true)
+      this.checkbox1 =  $('.js-dropdown input[data-id="S2FL00656"]');
+      $(this.checkbox1).prop('checked',true);
 
       // Trigger a click on the previously checked box to uncheck it and fire refreshTables()
-      this.checkbox1.trigger('click').trigger('change')
+      this.checkbox1.trigger('click').trigger('change');
     
-      expect(this.checkbox.prop('disabled')).to.be.false
+      expect(this.checkbox.prop('disabled')).to.be.false;
     });
 
     it('enables/allows removal of disabled checkboxes from dropdown', function() {
       new Dropdown('.js-dropdown');
       // Check one item from the dropdown
-      this.checkbox =  $('.dropdown__list input[data-id="S2FL00656"]')
-      $(this.checkbox).prop('checked',true)
+      this.checkbox =  $('.dropdown__list input[data-id="S2FL00656"]');
+      $(this.checkbox).prop('checked',true);
 
-      // Uncheck the checkbox to make it disabled
-      this.checkbox.trigger($.Event('click')).trigger($.Event('change'))
+      // Uncheck the checkbox to make it disabled and fire refreshTables()
+      this.checkbox.trigger('click').trigger('change');
 
-      this.rm=$('.dropdown__selected input[data-id="S2FL00656"]').nextAll('button.dropdown__remove')
+      this.rm=$('.dropdown__selected input[data-id="S2FL00656"]').nextAll('button.dropdown__remove');
 
-      expect(this.checkbox.prop('disabled')).to.be.true
-      expect(this.rm.prop('disabled')).to.be.false
+      expect(this.checkbox.prop('disabled')).to.be.true;
+      expect(this.rm.prop('disabled')).to.be.false;
     });
   });
 

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/6226-cont-by-state-filter-limit'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/6226-cont-by-state-filter-limit'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 


### PR DESCRIPTION
## Summary (required)
- Limit the candidates selected on contribution by size and state to 10
- As explained in this comment:
https://github.com/fecgov/fec-cms/issues/6186#issuecomment-2047690409

- Resolves #6226

### Required reviewers
One developer, One UX

## Impacted areas of the application
Election page, Contributions by size and state 
modified:   fec/static/js/modules/tables.js
modified:   fec/static/scss/components/_dropdowns.scss
 

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)


## How to test
- [ ] ****** Remove feature deploy task before merge ******
-  `npm run build`
- `npm run test-single`
- Go to an election profile page, individual contribution tab: Example: http://127.0.0.1:8000/data/elections/senate/FL/2024/#individual-contributions
- You should only be able to have 10 candidates' checkboxes checked 
- Checkboxes above 10 should be disabled 
- The dropdown should  be enabled only when there are less than 10 checked
- Only the candidates added from the dropdown, can be removed with the "x" next to the box whether they are checked, unchecked or disabled
- For reference, this comment describes the overall expected behavior for this interface.https://github.com/fecgov/fec-cms/issues/6186#issuecomment-2047690409
