### PR TITLE
Remove symbols from more keywords and update keyword tooltip

### DIFF
--- a/fec/fec/static/scss/components/_search-controls.scss
+++ b/fec/fec/static/scss/components/_search-controls.scss
@@ -307,7 +307,7 @@
   .keyword-modal{
     .modal__tips, .modal__form {
       display:table-cell;
-      width:44%;
+      width:100%;
     }
     .modal__tips {
       margin-left: u(1rem);

--- a/fec/home/templates/partials/legal-keyword-modal.html
+++ b/fec/home/templates/partials/legal-keyword-modal.html
@@ -5,8 +5,8 @@
       <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide title="Close this dialog window"></button>
       <h2 id="spending-modal-title" class="heading--section">Find documents with...</h2>
       <div class="row u-padding--top">
-        <form class="modal__form  search-controls__either" action="/data/legal/search/">
-          <p>Use these search boxes to refine your search:</p>
+        <form class="modal__form" action="/data/legal/search/">
+          <p>Use these search boxes to refine your search. Only letters, numbers, and spaces are accepted:</p>
           <div class="filter">
             <label class="label" for="keywords-any">Any of these words</label>
             <input type="text" id="keywords-any" data-operator="or">
@@ -27,40 +27,11 @@
             <input type="text" id="keywords-none" data-operator="exclude">
             <span class="t-note t-sans">Entering <span class="t-underline">text message</span> will exclude <span class="t-underline">text</span> and <span class="t-underline">message</span></span>
             <input type="hidden" name="search">
-            <button class="u-margin--top button button--cta button--search--text" type="submit">Search</button>
+            <div>
+              <button class="u-margin--top button button--cta button--search--text" type="submit">Search</button>
+            </div>
           </div>
         </form>
-        <div class="search-controls__or search-controls__or--vertical">or</div>
-
-        <div class="modal__tips search-controls__either">
-          <p>Use these symbols in the main search box:</p>
-          <table class="simple-table">
-            <thead class="simple-table__header">
-              <tr>
-                <th>Symbol</th>
-                <th>Meaning</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="simple-table__row">
-                <td class="simple-table__cell">|</td>
-                <td class="simple-table__cell">or</td>
-              </tr>
-              <tr class="simple-table__row">
-                <td class="simple-table__cell">+</td>
-                <td class="simple-table__cell">and</td>
-              </tr>
-              <tr class="simple-table__row">
-                <td class="simple-table__cell">&ldquo; &rdquo;</td>
-                <td class="simple-table__cell">exact phrase</td>
-              </tr>
-              <tr class="simple-table__row">
-                <td class="simple-table__cell">-</td>
-                <td class="simple-table__cell">but not</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
       </div>
     </div>
   </div>

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -4,7 +4,7 @@
   <div class="tooltip__container">
    <button class="tooltip__trigger"><span class="u-visually-hidden">Learn more</span></button>
    <div class="tooltip tooltip--left tooltip--under">
-      <p class="tooltip__content tooltip__content">Refine a keyword search by using +, |, “ ”, -, to expand or limit results.</p>
+      <p class="tooltip__content tooltip__content">Refine a keyword search by using + (and), | (or), " " (exact phrase), - (but not), to expand or limit results.</p>
    </div>
   </div>
   <div class="combo combo--search--mini no-mar-b">

--- a/fec/legal/templates/partials/legal-keyword-modal.jinja
+++ b/fec/legal/templates/partials/legal-keyword-modal.jinja
@@ -5,8 +5,8 @@
       <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide title="Close this dialog window"></button>
       <h2 id="spending-modal-title" class="heading--section">Find documents with...</h2>
       <div class="row u-padding--top">
-        <form class="modal__form  search-controls__either" action="">
-          <p>Use these search boxes to refine your search:</p>
+        <form class="modal__form" action="">
+          <p>Use these search boxes to refine your search. Only letters, numbers, and spaces are accepted:</p>
           <div class="filter">
             <label class="label" for="keywords-any">Any of these words</label>
             <input type="text" id="keywords-any" data-operator="or">
@@ -26,41 +26,11 @@
             <label class="label" for="keywords-none">None of these words</label>
             <input type="text" id="keywords-none" data-operator="exclude">
             <span class="t-note t-sans">Entering <span class="t-underline">text message</span> will exclude <span class="t-underline">text</span> and <span class="t-underline">message</span></span>
-            <button class="u-margin--top button button--cta button--search--text" type="submit">Search</button>
+            <div>
+              <button class="u-margin--top button button--cta button--search--text" type="submit">Search</button>
+            </div>
           </div>
         </form>
-
-        <div class="search-controls__or search-controls__or--vertical">or</div>
-
-        <div class="modal__tips search-controls__either">
-          <p>Use these symbols in the main search box:</p>
-          <table class="simple-table">
-            <thead class="simple-table__header">
-              <tr>
-                <th>Symbol</th>
-                <th>Meaning</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="simple-table__row">
-                <td class="simple-table__cell">|</td>
-                <td class="simple-table__cell">or</td>
-              </tr>
-              <tr class="simple-table__row">
-                <td class="simple-table__cell">+</td>
-                <td class="simple-table__cell">and</td>
-              </tr>
-              <tr class="simple-table__row">
-                <td class="simple-table__cell">&ldquo; &rdquo;</td>
-                <td class="simple-table__cell">exact phrase</td>
-              </tr>
-              <tr class="simple-table__row">
-                <td class="simple-table__cell">-</td>
-                <td class="simple-table__cell">but not</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Resolves #6466 

Removed symbols from the more keywords box and updated the keyword tooltip.

### Required reviewers

1 UX
1 front-end

## Impacted areas of the application

General components of the application that this PR will affect:

- MURs
- ADRs
- AFs
- AOs
- Statutes

## Screenshots

<img width="1343" alt="Screenshot 2024-09-24 at 11 31 14 AM" src="https://github.com/user-attachments/assets/171f9fa9-7eaf-426a-9c50-6a77cce2f63f">

<img width="447" alt="Screenshot 2024-09-24 at 11 31 26 AM" src="https://github.com/user-attachments/assets/aa2cc5e0-7ca8-469b-a195-cb28d717944e">

## How to test
- Checkout this branch
- `npm run build-sass`
- Hover over "Search keywords `i`" to see the updated tooltip
- Click on the "More keyword options" link to open the keyword modal and check layout and updated language
- Pages to check
   - MURs http://localhost:8000/data/legal/search/murs/
   - ADRs http://localhost:8000/data/legal/search/adrs/
   - AFs http://localhost:8000/data/legal/search/admin_fines/
   - AOs http://localhost:8000/data/legal/search/advisory-opinions/
   - Statutes http://localhost:8000/data/legal/search/statutes/