### PR TITLE
Fix is-loading bug on Filings/Reports urls with existing querystring parameters

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -623,7 +623,7 @@ DataTable_FEC.prototype.checkFromQuery = function(){
          }
       });
 
-    // Put 0-second, set-timeout on receipts/disbursements datatables so checkoxes are availale to check...
+    // Put 0-second, set-timeout on datatables with processed/raw tabs so function can run...
     // ...after the two filter panels are loaded
     if ('data_type' in queryFields){
     setTimeout(function() {
@@ -634,6 +634,7 @@ DataTable_FEC.prototype.checkFromQuery = function(){
               $(box).prop('checked', true).change(); // TODO: jQuery deprecation
         }
        }
+      $('button.is-loading, label.is-loading').removeClass('is-loading');
       }, 0);
 
      // No Set-timeout needed on datatables without two filter panels...


### PR DESCRIPTION
## Summary (required)

- Resolves #6481

Fixes bug on for Filing or Reports datatables where the the loading gif (three dots) keeps animating  wen visiting a url with querystring parameters

### Required reviewers

one frontend

## Impacted areas of the application

Filings and Reports datatables


## How to test

- `npm run build-js`
- Go to this url  and then open the `Filing information` section of the filter panel:
    - **Local**: http://127.0.0.1:8000/data/filings/?data_type=processed&form_type=F1M&form_type=F3P
    - **Production**: https://www.fec.gov/data/filings/?data_type=processed&form_type=F1M&form_type=F3P
- confirm that the `is-loading` gif is not persisting

