### PR TITLE
Add a11y modal dialog to global.js

### DIFF
--- a/fec/fec/static/js/data-init.js
+++ b/fec/fec/static/js/data-init.js
@@ -5,7 +5,7 @@
 // Implementing a polyfill for js native WeakMap
 // in order to patch functionality in an included library
 // require('es6-weak-map/implement');
-import { default as A11yDialog } from 'a11y-dialog';
+
 import { Accordion } from 'aria-accordion/src/accordion.js';
 import { default as Sticky } from 'component-sticky/index.js';
 
@@ -67,16 +67,6 @@ $(function() {
   // Initialize search
   $('.js-search').each(function() {
     new Search($(this));
-  });
-
-  $('.js-modal').each(function() {
-    new A11yDialog(this);
-    this.addEventListener('dialog:show', function() {
-      $('body').css('overflow', 'hidden');
-    });
-    this.addEventListener('dialog:hide', function() {
-      $('body').css('overflow', 'scroll');
-    });
   });
 
   // Initialize cycle selects

--- a/fec/fec/static/js/global.js
+++ b/fec/fec/static/js/global.js
@@ -3,6 +3,7 @@
  */
 import Glossary from 'glossary-panel/src/glossary.js';
 
+import { default as A11yDialog } from 'a11y-dialog';
 import { default as terms } from './data/terms.json' assert { type: 'json' };
 import Feedback from './modules/feedback.js';
 import SiteNav from './modules/site-nav.js';
@@ -56,4 +57,14 @@ $(function() {
   window.submitFeedback = function(token) {
     feedbackWidget.submit(token);
   };
+
+  $('.js-modal').each(function() {
+    new A11yDialog(this);
+    this.addEventListener('dialog:show', function() {
+      $('body').css('overflow', 'hidden');
+      });
+    this.addEventListener('dialog:hide', function() {
+      $('body').css('overflow', 'scroll');
+      });
+    });
 });

--- a/fec/fec/static/js/init.js
+++ b/fec/fec/static/js/init.js
@@ -3,7 +3,7 @@
  * If present, this file initializes…
  * .js-accordion, .js-dropdown, .js-form-nav, .js-post-content, .js-scroll, .js-sticky-side
  */
-import { default as A11yDialog } from 'a11y-dialog';
+
 import { Accordion } from 'aria-accordion/src/accordion.js';
 import { default as Sticky } from 'component-sticky/index.js';
 
@@ -74,16 +74,5 @@ $(function() {
     }
     $p.nextAll().remove();
   });
-
-  $('.js-modal').each(function() {
-  new A11yDialog(this);
-  this.addEventListener('dialog:show', function() {
-    $('body').css('overflow', 'hidden');
-    });
-  this.addEventListener('dialog:hide', function() {
-    $('body').css('overflow', 'scroll');
-    });
-  });
-
 });
 

--- a/fec/fec/static/js/init.js
+++ b/fec/fec/static/js/init.js
@@ -3,6 +3,7 @@
  * If present, this file initializes…
  * .js-accordion, .js-dropdown, .js-form-nav, .js-post-content, .js-scroll, .js-sticky-side
  */
+import { default as A11yDialog } from 'a11y-dialog';
 import { Accordion } from 'aria-accordion/src/accordion.js';
 import { default as Sticky } from 'component-sticky/index.js';
 
@@ -73,4 +74,16 @@ $(function() {
     }
     $p.nextAll().remove();
   });
+
+  $('.js-modal').each(function() {
+  new A11yDialog(this);
+  this.addEventListener('dialog:show', function() {
+    $('body').css('overflow', 'hidden');
+    });
+  this.addEventListener('dialog:hide', function() {
+    $('body').css('overflow', 'scroll');
+    });
+  });
+
 });
+

--- a/fec/home/templates/home/full_width_page.html
+++ b/fec/home/templates/home/full_width_page.html
@@ -56,6 +56,5 @@
 
 {% block extra_js %}
   <script> window.BASE_PATH = '/data' </script>
-  {% tags_for_js_chunks 'data-init.js' '' %}
   {% tags_for_js_chunks 'reporting-dates-tables.js' '' %}
 {% endblock %}

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/6493-add-a11y-modal-to-init-js'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/6493-add-a11y-modal-to-init-js'),
 )
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #6493

- Add `a11y-dialog.js` to `global.js` to fix inoperable modal windows on new reporting dates tables. 
- Remove `a11y-dialog.js` from `init.js` and `data-init.js`

### Required reviewers

one frontend

## Impacted areas of the application

- New reporting dates tables that use `reporting_dates_table.html`
- Legacy reporting dates tables that use `full_width_page.html`
- methodology buttons on any page that now gets the a11y JS from global.js 

## Screenshots

![modals](https://github.com/user-attachments/assets/811824a0-c1bc-4917-8084-45862595c5bd)


## Related PRs

https://github.com/fecgov/fec-cms/pull/5798

## How to test

- Checkout and `npm run build-js`
- `npm run test-single`
- Test a new reporting dates table page and verify that the header modals work as in the gif above.:
    - **Local** (might need to be published from draft to test):  http://127.0.0.1:8000/help-candidates-and-committees/dates-and-deadlines/dates-2024-reporting-dates-and-deadlines/congressional-pre-election-reporting-dates-2024
    - **Feature:** https://fec-feature-cms.app.cloud.gov/help-candidates-and-committees/dates-and-deadlines/2024-reporting-dates/congressional-pre-election-reporting-dates-2024/
- Test a `full_width_page.html` to verify header modals work:
    - **Local:** http://127.0.0.1:8000/help-candidates-and-committees/dates-and-deadlines/2020-reporting-dates/congressional-pre-election-reporting-dates-2020/
    - **Feature:** https://fec-feature-cms.app.cloud.gov/help-candidates-and-committees/dates-and-deadlines/2020-reporting-dates/congressional-pre-election-reporting-dates-2020/
- Test pages that use the methodology modal:
    - **Local:** http://127.0.0.1:8000/data/elections/house/
    - **Feature:** https://fec-feature-cms.app.cloud.gov/data/elections/house/
- Any other non-legal  pages use a11y-dialog.js for modals window popups?
    - NOTE: Legal pages do not  apply here as they get the a11y functionality from `legal.js`
  
    
