### PR TITLE
6504 MURs Final Disposition Tooltip

### DIFF
--- a/fec/data/templates/macros/filters/checkbox.jinja
+++ b/fec/data/templates/macros/filters/checkbox.jinja
@@ -44,7 +44,7 @@
     <label for="{{ name }}" class="label t-inline-block">{{ label }}</label>
     <div class="tooltip__container">
       <button class="tooltip__trigger"><span class="u-visually-hidden">Learn more</span></button>
-      <div class="tooltip tooltip--left tooltip--under">
+      <div class="tooltip tooltip--left tooltip--above">
         <p class="tooltip__content tooltip__content">{{ show_tooltip_text }}</p>
       </div>
     </div>

--- a/fec/data/templates/macros/filters/checkbox.jinja
+++ b/fec/data/templates/macros/filters/checkbox.jinja
@@ -35,11 +35,19 @@
 {% endmacro %}
 
 <!-- Used when there are multiple dropdowns within a single filter -->
-{% macro checkbox_dropdown_multiple(name, label, selected={}, options={}, legend=True, prefix='') %}
+{% macro checkbox_dropdown_multiple(name, label, selected={}, options={}, legend=True, prefix='', show_tooltip_text='') %}
 <div class="filter" data-filter="checkbox">
   <div class="js-dropdown">
-    {% if legend %}
-    <span class="label" for="{{ name }}">{{ label }}</span>
+    {% if legend and show_tooltip_text == '' %}
+    <span for="{{ name }}" class="label">{{ label }}</span>
+    {% elif show_tooltip_text != '' %}
+    <label for="{{ name }}" class="label t-inline-block">{{ label }}</label>
+    <div class="tooltip__container">
+      <button class="tooltip__trigger"><span class="u-visually-hidden">Learn more</span></button>
+      <div class="tooltip tooltip--left tooltip--under">
+        <p class="tooltip__content tooltip__content">{{ show_tooltip_text }}</p>
+      </div>
+    </div>
     {% else %}
     <label for="{{ name }}">{{ label }}</label>
     {% endif %}

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -68,7 +68,8 @@
         selected=suggested_mur_disposition_category_ids,
         options=mur_disposition_category_ids_display,
         legend=True,
-        prefix='mur_disposition_category_id'
+        prefix='mur_disposition_category_id',
+        show_tooltip_text='Final disposition does not search archived cases'
         ) }}
     </div>
   </div>


### PR DESCRIPTION
## Summary (required)

- Resolves #6504 

Adding a tooltip for the MURs search Final disposition filter, but also had to create that option for checkbox.checkbox_dropdown_multiple()

### Required reviewers

- 1 Front-end
- optional: UX for appearance, content
- optional: Content

## Impacted areas of the application

-  Everywhere checkbox.checkbox_dropdown_multiple is being called, but the default shouldn't affect anything else
- [MURs search](http://127.0.0.1:8000/data/legal/search/enforcement/) Final disposition filter should now have a tooltip

## Screenshots

After:
<img width="518" alt="image" src="https://github.com/user-attachments/assets/11f6eb56-cff8-4e42-ae32-a97054fa19e2">

## Related PRs

None?

## How to test

**Note:** The Case details accordion must exist

- pull the branch
- `npm i` just in case
- `npm run build`
- `./manage.py runserver`
- [ ] Check the [MURs search](http://127.0.0.1:8000/data/legal/search/enforcement/)
   - [ ] Case details accordion section should exist
   - [ ] Final disposition tooltip should exist
   - [ ] Final disposition tooltip content should be correct
- [ ] Other checkbox.checkbox_dropdown_multiple shouldn't have a tooltip. Other filters using it:
   - report-type
      - Monthly Reports
      - Quarterly Reports
      - Semiannual Reports
      - Election Sensitive Reports
      - Bundling Reports
      - Other Reports
   - debts
      - form line number for House or Senate committees, Presidential committees, PACs or party committees
