### PR TITLE
6505 - Remove right border from entity_type:last-child

### DIFF
--- a/fec/fec/static/scss/components/_entity-header.scss
+++ b/fec/fec/static/scss/components/_entity-header.scss
@@ -170,6 +170,10 @@
     margin-right: u(1rem);
     padding-right: u(1rem);
     border-right: 1px solid;
+
+    &:last-child {
+      border-right: none;
+    }
   }
 
   // Specific to admin fine pages for now. In the future, we should refine the entity type last of type dividers for other pages.


### PR DESCRIPTION
## Summary

- Resolves #6505 

There's an extra visual separator after the last item in entity headers. This removes that right border when the element is the last-child (i.e. it's the last html element in its html element parent)

### Required reviewers

- design
- code approach

## Impacted areas of the application

Anywhere .entity__type is used but it seems like it's only here inside entity-header

## Screenshots

<img width="365" alt="image" src="https://github.com/user-attachments/assets/e2731121-993a-48d9-8cdd-18e2051969ee">

## Related PRs

None

## How to test

- pull the branch
- `npm i` just in case
- `npm run build`
- `./manage.py runserver`
- Open a [candidate](http://127.0.0.1:8000/data/committee/C00431445/) and check the entity_type items (e.g. active/terminated, registration date)
- Across widths, the final item should not have the following visual separator (which was a border-right)

**Are we using this anywhere else?**