### PR TITLE
6532 - Remove Tag Manager from Pages in Preview

### DIFF
--- a/fec/fec/templates/500-status.html
+++ b/fec/fec/templates/500-status.html
@@ -7,7 +7,7 @@
 
     <title>Website status error | FEC</title>
 
-    {% include 'partials/google-tag-manager-script.html' %}
+    {% if not request.is_preview %}{% include 'partials/google-tag-manager-script.html' %}{% endif %}
 
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% path_for_css 'base.css' %}">
@@ -27,7 +27,7 @@
       }
     </script>
 
-    {% include 'partials/google-tag-manager-noscript.html' %}
+    {% if not request.is_preview %}{% include 'partials/google-tag-manager-noscript.html' %}{% endif %}
 
     {% wagtailuserbar %}
     {# env-specific banner #} 

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -11,7 +11,7 @@
 
     <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }} | FEC {% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
 
-    {% include 'partials/google-tag-manager-script.html' %}
+    {% if not request.is_preview %}{% include 'partials/google-tag-manager-script.html' %}{% endif %}
 
     {% block css %}
     <link rel="stylesheet" type="text/css" href="{% path_for_css 'base.css' %}">
@@ -31,7 +31,7 @@
       }
     </script>
 
-    {% include 'partials/google-tag-manager-noscript.html' %}
+    {% if not request.is_preview %}{% include 'partials/google-tag-manager-noscript.html' %}{% endif %}
 
     {% wagtailuserbar %}
     <a href="#main" class="skip-nav">skip navigation</a>

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -12,7 +12,8 @@
 
     <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }} | FEC {% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
 
-    {% include 'partials/google-tag-manager-script.html' %}
+    {% if not request.is_preview %}{% include 'partials/google-tag-manager-script.html' %}{% endif %}
+
     {% block css %}
     <link defer rel="stylesheet" type="text/css" href="{% path_for_css 'home.css' %}">
     {% endblock %}
@@ -31,7 +32,7 @@
       }
     </script>
 
-    {% include 'partials/google-tag-manager-noscript.html' %}
+    {% if not request.is_preview %}{% include 'partials/google-tag-manager-noscript.html' %}{% endif %}
 
     {% wagtailuserbar %}
     <a href="#main" class="skip-nav">skip navigation</a>


### PR DESCRIPTION
## Summary

- Resolves #6532 

Doesn't add Tag Manager to pages if request.is_preview. 

(Only edited the .html templates because the .jinja templates aren't in Wagtail so won't appear in the content editor's preview panel.)

### Required reviewers

- One or two who can log in to the Wagtail editor on localhost

## Impacted areas of the application

- The home base template
- The base template for other Wagtail pages
- The 500 template (for consistency)

## Screenshots

No visual changes

## Related PRs

None

## How to test

- Pull, build, and run develop (or any branch but this one)
- Log in to the localhost content editor
- Start to edit any page that gives you a preview (all/any of them?) (No reason to make any edits or save anything)
- Check inspector for that preview
- cmd-f for "tagmanager"; there should be at least two occurrences
- Switch to _this_ branch (the one for this PR)
- Log in to the localhost content editor
- Start to edit any page that gives you a preview
- Check inspector for that preview
- Editor, preview, and browser should all behave as expected (no errors, no strange content)
- cmd-f for "tagmanager"; _there should be zero occurrences_
- If it's good:
   - **Remove other reviewers from this PR**
   - Approve
   - Merge
