### PR TITLE
.gov Banner on Homepage, Datatables

### DIFF
--- a/fec/fec/static/js/data-init.js
+++ b/fec/fec/static/js/data-init.js
@@ -40,30 +40,6 @@ $(function() {
     .detach()
     .appendTo('body');
 
-  // Initialize new accordions
-  $('.js-accordion').each(function() {
-    const contentPrefix = $(this).data('content-prefix') || 'accordion';
-    const openFirst = $(this).data('open-first');
-    const reflectStatic = $(this).data('reflect-static');
-    const selectors = {
-      trigger: '.js-accordion-trigger'
-    };
-    const opts = {
-      contentPrefix: contentPrefix,
-      openFirst: openFirst,
-      reflectStatic: reflectStatic,
-      collapseOthers:
-        window.location.href.indexOf('president/presidential-map') > 0
-          ? true
-          : false,
-      customHiding:
-        window.location.href.indexOf('president/presidential-map') > 0
-          ? true
-          : false
-    };
-    new Accordion(this, selectors, opts);
-  });
-
   // Initialize search
   $('.js-search').each(function() {
     new Search($(this));

--- a/fec/fec/static/js/global.js
+++ b/fec/fec/static/js/global.js
@@ -1,9 +1,10 @@
 /**
  * Scripts used on every page of the site e.g. main nav, search, feedback
  */
+import { default as A11yDialog } from 'a11y-dialog';
+import { Accordion } from 'aria-accordion';
 import Glossary from 'glossary-panel/src/glossary.js';
 
-import { default as A11yDialog } from 'a11y-dialog';
 import { default as terms } from './data/terms.json' assert { type: 'json' };
 import Feedback from './modules/feedback.js';
 import SiteNav from './modules/site-nav.js';
@@ -12,6 +13,30 @@ import TOC from './modules/toc.js';
 import Typeahead from './modules/typeahead.js';
 
 $(function() {
+  // Initialize new accordions, including the .gov ribbon at the top of every page
+  $('.js-accordion').each(function() {
+    const contentPrefix = $(this).data('content-prefix') || 'accordion';
+    const openFirst = $(this).data('open-first');
+    const reflectStatic = $(this).data('reflect-static');
+    const selectors = {
+      trigger: '.js-accordion-trigger'
+    };
+    const opts = {
+      contentPrefix: contentPrefix,
+      openFirst: openFirst,
+      reflectStatic: reflectStatic,
+      collapseOthers:
+        window.location.href.indexOf('president/presidential-map') > 0
+          ? true
+          : false,
+      customHiding:
+        window.location.href.indexOf('president/presidential-map') > 0
+          ? true
+          : false
+    };
+    new Accordion(this, selectors, opts);
+  });
+
   /**
    * Glossary and "Table of Contents"
    */

--- a/fec/fec/static/js/init.js
+++ b/fec/fec/static/js/init.js
@@ -1,10 +1,9 @@
 /**
  * Initializes things common to many pages, but not universal (the truly universal are inside global.js)
  * If present, this file initializes…
- * .js-accordion, .js-dropdown, .js-form-nav, .js-post-content, .js-scroll, .js-sticky-side
+ * .js-dropdown, .js-form-nav, .js-post-content, .js-scroll, .js-sticky-side
  */
 
-import { Accordion } from 'aria-accordion/src/accordion.js';
 import { default as Sticky } from 'component-sticky/index.js';
 
 import Dropdown from './modules/dropdowns.js';
@@ -17,20 +16,6 @@ import './modules/calc-admin-fines-modal.js';
 tablistInit();
 
 $(function() {
-  // Initialize new accordions
-  $('.js-accordion').each(function() {
-    const contentPrefix = $(this).data('content-prefix') || 'accordion';
-    const openFirst = $(this).data('open-first') || false;
-    const selectors = {
-      trigger: '.js-accordion-trigger'
-    };
-    const opts = {
-      contentPrefix: contentPrefix,
-      openFirst: openFirst
-    };
-    new Accordion(this, selectors, opts);
-  });
-
   // Initialize sticky elements
   $('.js-sticky-side').each(function() {
     const container = $(this).data('sticky-container');
@@ -75,4 +60,3 @@ $(function() {
     $p.nextAll().remove();
   });
 });
-

--- a/fec/fec/static/scss/components/_site-header.scss
+++ b/fec/fec/static/scss/components/_site-header.scss
@@ -124,7 +124,7 @@
   padding-top: 0;
   padding-bottom: 0;
   font-size: u(1.2rem);
-  font-weight: 400;
+  font-weight: 400 !important;
 }
 
 .usa-banner-header {


### PR DESCRIPTION
## Summary

- Resolves #6536 
- Resolves #6516 

Moving the accordion initialization to global.js because it didn't exist in home.js but was duped in both init.js and data-init.js. Since we need it on every page, we're moving it to global

Digging in to the .gov banner, I unbolded the datatables version (its font-weight was being overridden by accordion styles).

### Required reviewers

- front-end

## Impacted areas of the application

The .gov banner but also every accordion. We should check a few templates.

## Screenshots

Not bold
<img width="758" alt="image" src="https://github.com/user-attachments/assets/d99fc94e-57ca-4a7f-97cb-2c6e00a7a1ab">

It opens again
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/c6515026-30cb-4af4-8e75-e50b521db385">


## Related PRs

None

## How to test

- pull the branch
- `npm run build`
- `./manage.py runserver`
- Check that the homepage .gov banner opens and closes as expected.
- Check a few other styles of templates to make sure there are no errors with accordions otherwise (calendar, cms, data, legal, 404?)
- Check that the datatable pages' version of the .gov banner isn't bold