### PR TITLE
Use issue_date for final opinion date

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -383,7 +383,14 @@ def _get_sorted_documents(ao):
     sorted_documents = sorted(
         ao["documents"], key=itemgetter("description", "document_id"), reverse=False
     )
-    sorted_documents = sorted(sorted_documents, key=itemgetter("date"), reverse=True)
+
+    # Sort by document date unless it's a final opinion. Final opinion uses issue date.
+    sorted_documents = sorted(
+        sorted_documents,
+        key=lambda doc: doc.get("date") if doc.get("ao_doc_category_id") != 'F' else ao.get("issue_date"),
+        reverse=True
+    )
+
     return sorted_documents
 
 

--- a/fec/legal/templates/legal-advisory-opinion.jinja
+++ b/fec/legal/templates/legal-advisory-opinion.jinja
@@ -43,7 +43,7 @@
           <h2>Documents</h2>
           {% if final_opinion %}
             <div class="content__section">
-              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final opinion</a> <span class="t-sans u-padding--left">{{ final_opinion.date | date(fmt='%B %d, %Y') }}</span>
+              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final opinion</a> <span class="t-sans u-padding--left">{{ advisory_opinion.issue_date | date(fmt='%B %d, %Y') }}</span>
             </div>
           {% endif %}
           <table class="data-table simple-table" style="table-layout: auto;">
@@ -57,7 +57,12 @@
             <tbody>
               {% for document in advisory_opinion.sorted_documents %}
                 <tr>
-                  <td>{{ document.date | ao_document_date }}</td>
+                  <td>
+                  {% if document.ao_doc_category_id == 'F' %}
+                    {{ advisory_opinion.issue_date | ao_document_date }}
+                  {% else %}
+                    {{ document.date | ao_document_date }}
+                  {% endif %}</td>
                   <td><a href="{{ document.url }}">{{ document.description }}</a></td>
                   <td>{{ document.category }}</td>
                 </tr>


### PR DESCRIPTION
## Summary (required)

- Resolves #6487 

Final opinion date should now be using `issue_date` rather than `document.date`.

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Advisor opinions canonical page

## How to test

- Look at this [spreadsheet](https://docs.google.com/spreadsheets/d/1fKNeBEgEWppeuxDjb_cF6pMlCFzonWN6kRWdCa-x9qY/edit?gid=0#gid=0) to check that the AOs with incorrect final opinion dates. They should now all be using the issue_date.
- Check any AO individual canonical page to make sure that the final opinions are also using issue_date.
