### PR TITLE
Handle URL for archived MUR 3620

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -112,15 +112,19 @@ def load_legal_advisory_opinion(ao_no):
     return ao
 
 
-def load_legal_mur(mur_no):
+def load_legal_mur(mur_no, requested_mur_type='current'):
 
     url = "/legal/docs/murs/"
-    mur = _call_api(url, parse.quote(mur_no))
+    murs = _call_api(url, parse.quote(mur_no))
 
-    if not mur:
+    if not murs:
         raise Http404
 
-    mur = mur["docs"][0]
+    # get matching doc by mur_type, else use the first
+    if constants.ARCHIVED_MUR_EXCEPTION == mur_no:
+        mur = next((doc for doc in murs["docs"] if doc['mur_type'] == requested_mur_type), murs["docs"][0])
+    else:
+        mur = murs["docs"][0]
 
     if mur["mur_type"] == "current":
         complainants = []

--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -982,3 +982,6 @@ SENATE_CLASSES = {
         ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'MD',
             'MO', 'NV', 'NH', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'SC', 'SD', 'UT', 'VT', 'WA', 'WI']
 }
+
+# Archived MUR that has the same number as the current MUR
+ARCHIVED_MUR_EXCEPTION = "3620"

--- a/fec/legal/templates/partials/legal-search-results-mur.jinja
+++ b/fec/legal/templates/partials/legal-search-results-mur.jinja
@@ -23,6 +23,9 @@
               <a title="{{ mur.name }}" href="/data/legal/matter-under-review/{{ mur.no }}">
                 {{ mur.name|upper }}
               </a>
+            {% elif mur.no == ARCHIVED_MUR_EXCEPTION and mur.mur_type == 'archived'%}
+              <a title="{{ mur.mur_name }}" href="/data/legal/matter-under-review/{{ mur.no }}?mur_type=archived">
+                {{ mur.mur_name|upper }}
             {% else %}
               <a title="{{ mur.mur_name }}" href="/data/legal/matter-under-review/{{ mur.no }}">
                 {{ mur.mur_name|upper }}

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -140,7 +140,8 @@ def process_mur_subjects(mur):
 
 
 def mur_page(request, mur_no):
-    mur = api_caller.load_legal_mur(mur_no)
+    requested_mur_type = request.GET.get('mur_type', 'current')
+    mur = api_caller.load_legal_mur(mur_no, requested_mur_type)
 
     if not mur:
         raise Http404()
@@ -347,6 +348,7 @@ def legal_doc_search_mur(request):
         'case_min_close_date': case_min_close_date,
         'case_max_close_date': case_max_close_date,
         'query': original_query,
+        'ARCHIVED_MUR_EXCEPTION': constants.ARCHIVED_MUR_EXCEPTION,
         'social_image_identifier': 'legal',
         'selected_doc_category_ids': case_doc_category_ids,
         'selected_doc_category_names': mur_document_category_names,


### PR DESCRIPTION
## Summary (required)

- Resolves #6508 

Archived MUR 3620 has a rare case where it was reopened without creating a different MUR number. Therefore, it will have 2 separate MUR cases attached to it, one is the current case and the other is the archived case. This PR will handle the particular URL depending on which case you are interested in seeing.

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

-  MUR 3620

## Screenshots

<img width="1322" alt="Screenshot 2024-11-04 at 9 12 20 PM" src="https://github.com/user-attachments/assets/d7faed13-b1ca-4674-9fec-861ae218053e">

## How to test

- Go to http://localhost:8000/data/legal/search/murs/?search_type=murs&case_no=3620 and see the results for MUR number 3620. There should be 2, one archived case, and one current case.
   - Archived case should have this URL: http://localhost:8000/data/legal/matter-under-review/3620?mur_type=archived
   - Current case should have this URL: http://localhost:8000/data/legal/matter-under-review/3620
- Make sure that this does not effect other archived MUR or current MUR cases. Go to a random archived MUR case or random current MUR case to test.
