### PR TITLE
Remove legacy search.gov env vars from code and cloud environments

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -35,8 +35,8 @@ FEC_GITHUB_TOKEN = env.get_credential('FEC_GITHUB_TOKEN')
 FEC_SERVICE_NOW_API = env.get_credential('FEC_SERVICE_NOW_API')
 FEC_SERVICE_NOW_USERNAME = env.get_credential('FEC_SERVICE_NOW_USERNAME')
 FEC_SERVICE_NOW_PASSWORD = env.get_credential('FEC_SERVICE_NOW_PASSWORD')
-# Search.gov website keys
-SEARCHGOV_BASE_API_URL = env.get_credential('SEARCHGOV_BASE_API_URL', '')
+
+# Search.gov API keys
 SEARCHGOV_API_ACCESS_KEY = env.get_credential('SEARCHGOV_API_ACCESS_KEY')
 SEARCHGOV_POLICY_GUIDANCE_KEY = env.get_credential('SEARCHGOV_POLICY_GUIDANCE_KEY')
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5923

Remove all  SEARCHGOV env vars from `all cloud environments` and `app code(base.py)`,  except these two:
        SEARCHGOV_API_ACCESS_KEY
        SEARCHGOV_POLICY_GUIDANCE_KEY

### Required reviewers

one frontend OR one backend

## Impacted areas of the application

modified: fec/fec/settings/base.py
`fec-creds-*`  on all cloud environments were edited accordingly


## Related PRs

https://github.com/fecgov/fec-cms/pull/5925

## How to test

- There is not really a way to test this except to confirm that search results still work on prod
- Or you could check the `fec-creds-*`  dictionaries on cloud environments to make sure only the only remaining searchgov vars are:
    - SEARCHGOV_API_ACCESS_KEY
    - SEARCHGOV_POLICY_GUIDANCE_KEY

