### PR TITLE
6510 Dropdowns Scrolling

### DIFF
--- a/fec/data/templates/macros/filters/checkbox.jinja
+++ b/fec/data/templates/macros/filters/checkbox.jinja
@@ -16,8 +16,10 @@
 {% macro checkbox_options(name, options, prefix='') %}
 <div class="dropdown">
   <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
-  <div class="dropdown__panel" aria-hidden="true">
-    {{ checkbox_list(name, options, prefix) }}
+  <div class="dropdown__panel{% if options.items()|length > 11%} dropdown-scrolling{% endif %}" aria-hidden="true">
+    <div class="dropdown__content">
+      {{ checkbox_list(name, options, prefix) }}
+    </div>
   </div>
 </div>
 {% endmacro %}

--- a/fec/data/templates/macros/filters/committee-types.jinja
+++ b/fec/data/templates/macros/filters/committee-types.jinja
@@ -80,16 +80,18 @@
       <div class="dropdown">
         <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>
         <div id="ie-dropdown" class="dropdown__panel" aria-hidden="true">
-          <ul class="dropdown__list">
-            <li class="dropdown__item">
-              <input id="committee-type-checkbox-U" type="checkbox" name="{{ committee_type }}" value="U">
-              <label class="dropdown__value" for="committee-type-checkbox-U">Single candidate independent expenditure</label>
-            </li>
-            <li class="dropdown__item">
-              <input id="committee-type-checkbox-I" type="checkbox" name="{{ committee_type }}" value="I">
-              <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditure filer (not a committee)</label>
-            </li>
-          </ul>
+          <div class="dropdown__content">
+            <ul class="dropdown__list">
+              <li class="dropdown__item">
+                <input id="committee-type-checkbox-U" type="checkbox" name="{{ committee_type }}" value="U">
+                <label class="dropdown__value" for="committee-type-checkbox-U">Single candidate independent expenditure</label>
+              </li>
+              <li class="dropdown__item">
+                <input id="committee-type-checkbox-I" type="checkbox" name="{{ committee_type }}" value="I">
+                <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditure filer (not a committee)</label>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </fieldset>
@@ -130,58 +132,60 @@
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>
-      <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
-      <ul class="dropdown__list">
-        <li class="dropdown__item">
-          <input id="designation-checkbox-B" type="checkbox" name="{{ designation }}" value="B">
-          <label class="dropdown__value" for="designation-checkbox-B">Lobbyist/Registrant PAC</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="designation-checkbox-D" type="checkbox" name="{{ designation }}" value="D">
-          <label class="dropdown__value" for="designation-checkbox-D">Leadership PAC</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-N" type="checkbox" name="{{ committee_type }}" value="N">
-          <label class="dropdown__value" for="committee-type-checkbox-N">PAC - nonqualified</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-Q" type="checkbox" name="{{ committee_type }}" value="Q">
-          <label class="dropdown__value" for="committee-type-checkbox-Q">PAC - qualified</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-V" type="checkbox" name="{{ committee_type }}" value="V">
-          <label class="dropdown__value" for="committee-type-checkbox-V">Hybrid PAC (with Non-Contribution Account) - Nonqualified</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-W" type="checkbox" name="{{ committee_type }}" value="W">
-          <label class="dropdown__value" for="committee-type-checkbox-W">Hybrid PAC (with Non-Contribution Account) - Qualified</label>
-        </li>
-        <li class="dropdown__subhead">Separate segregated funds</li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-C" name="{{ organization_type }}" type="checkbox" value="C">
-          <label class="dropdown__value" for="org-type-checkbox-C">Corporation</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-L" name="{{ organization_type }}" type="checkbox" value="L">
-          <label class="dropdown__value" for="org-type-checkbox-L">Labor organization</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-M" name="{{ organization_type }}"  type="checkbox" value="M">
-          <label class="dropdown__value" for="org-type-checkbox-M">Membership organization</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-T" name="{{ organization_type }}"  type="checkbox" value="T">
-          <label class="dropdown__value" for="org-type-checkbox-T">Trade association</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-V" name="{{ organization_type }}"  type="checkbox" value="V">
-          <label class="dropdown__value" for="org-type-checkbox-V">Cooperative</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="org-type-checkbox-W" name="{{ organization_type }}"  type="checkbox" value="W">
-          <label class="dropdown__value" for="org-type-checkbox-W">Corporation without capital stock</label>
-        </li>
-      </ul>
+      <div id="pac-dropdown" class="dropdown__panel dropdown-scrolling" aria-hidden="true">
+      <div class="dropdown__content">
+        <ul class="dropdown__list">
+          <li class="dropdown__item">
+            <input id="designation-checkbox-B" type="checkbox" name="{{ designation }}" value="B">
+            <label class="dropdown__value" for="designation-checkbox-B">Lobbyist/Registrant PAC</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="designation-checkbox-D" type="checkbox" name="{{ designation }}" value="D">
+            <label class="dropdown__value" for="designation-checkbox-D">Leadership PAC</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-N" type="checkbox" name="{{ committee_type }}" value="N">
+            <label class="dropdown__value" for="committee-type-checkbox-N">PAC - nonqualified</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-Q" type="checkbox" name="{{ committee_type }}" value="Q">
+            <label class="dropdown__value" for="committee-type-checkbox-Q">PAC - qualified</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-V" type="checkbox" name="{{ committee_type }}" value="V">
+            <label class="dropdown__value" for="committee-type-checkbox-V">Hybrid PAC (with Non-Contribution Account) - Nonqualified</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-W" type="checkbox" name="{{ committee_type }}" value="W">
+            <label class="dropdown__value" for="committee-type-checkbox-W">Hybrid PAC (with Non-Contribution Account) - Qualified</label>
+          </li>
+          <li class="dropdown__subhead">Separate segregated funds</li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-C" name="{{ organization_type }}" type="checkbox" value="C">
+            <label class="dropdown__value" for="org-type-checkbox-C">Corporation</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-L" name="{{ organization_type }}" type="checkbox" value="L">
+            <label class="dropdown__value" for="org-type-checkbox-L">Labor organization</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-M" name="{{ organization_type }}"  type="checkbox" value="M">
+            <label class="dropdown__value" for="org-type-checkbox-M">Membership organization</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-T" name="{{ organization_type }}"  type="checkbox" value="T">
+            <label class="dropdown__value" for="org-type-checkbox-T">Trade association</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-V" name="{{ organization_type }}"  type="checkbox" value="V">
+            <label class="dropdown__value" for="org-type-checkbox-V">Cooperative</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="org-type-checkbox-W" name="{{ organization_type }}"  type="checkbox" value="W">
+            <label class="dropdown__value" for="org-type-checkbox-W">Corporation without capital stock</label>
+          </li>
+        </ul>
+      </div>
     </div>
   </fieldset>
   {% if display_sponsor_candidate_filter %}
@@ -199,20 +203,22 @@
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>
       <div id="other-dropdown" class="dropdown__panel" aria-hidden="true">
-      <ul class="dropdown__list">
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-X" type="checkbox" name="{{ committee_type }}" value="X">
-          <label class="dropdown__value" for="committee-type-checkbox-X">Party - nonqualified</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-Y" type="checkbox" name="{{ committee_type }}" value="Y">
-          <label class="dropdown__value" for="committee-type-checkbox-Y">Party - qualified</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-Z" type="checkbox" name="{{ committee_type }}" value="Z">
-          <label class="dropdown__value" for="committee-type-checkbox-Z">National party nonfederal account</label>
-        </li>
-      </ul>
+      <div class="dropdown__content">
+        <ul class="dropdown__list">
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-X" type="checkbox" name="{{ committee_type }}" value="X">
+            <label class="dropdown__value" for="committee-type-checkbox-X">Party - nonqualified</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-Y" type="checkbox" name="{{ committee_type }}" value="Y">
+            <label class="dropdown__value" for="committee-type-checkbox-Y">Party - qualified</label>
+          </li>
+          <li class="dropdown__item">
+            <input id="committee-type-checkbox-Z" type="checkbox" name="{{ committee_type }}" value="Z">
+            <label class="dropdown__value" for="committee-type-checkbox-Z">National party nonfederal account</label>
+          </li>
+        </ul>
+      </div>
     </div>
   </fieldset>
 </div>
@@ -231,12 +237,15 @@
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>
       <div id="other-dropdown" class="dropdown__panel" aria-hidden="true">
-      <ul class="dropdown__list">
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-D" type="checkbox" name="{{ committee_type }}" value="D">
-          <label class="dropdown__value" for="committee-type-checkbox-D">Delegate committee</label>
-        </li>
-      </ul>
+        <div class="dropdown__content">
+          <ul class="dropdown__list">
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-D" type="checkbox" name="{{ committee_type }}" value="D">
+              <label class="dropdown__value" for="committee-type-checkbox-D">Delegate committee</label>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
   </fieldset>
 </div>
@@ -255,32 +264,35 @@
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ committee_type }}">More</button>
       <div id="other-dropdown" class="dropdown__panel" aria-hidden="true">
-      <ul class="dropdown__list">
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-C" type="checkbox" name="{{ committee_type }}" value="C">
-          <label class="dropdown__value" for="committee-type-checkbox-C">Communication cost</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-D" type="checkbox" name="{{ committee_type }}" value="D">
-          <label class="dropdown__value" for="committee-type-checkbox-D">Delegate committee</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-E" type="checkbox" name="{{ committee_type }}" value="E">
-          <label class="dropdown__value" for="committee-type-checkbox-E">Electioneering communication</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-X" type="checkbox" name="{{ committee_type }}" value="X">
-          <label class="dropdown__value" for="committee-type-checkbox-X">Party - nonqualified</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-Y" type="checkbox" name="{{ committee_type }}" value="Y">
-          <label class="dropdown__value" for="committee-type-checkbox-Y">Party - qualified</label>
-        </li>
-        <li class="dropdown__item">
-          <input id="committee-type-checkbox-Z" type="checkbox" name="{{ committee_type }}" value="Z">
-          <label class="dropdown__value" for="committee-type-checkbox-Z">National party nonfederal account</label>
-        </li>
-      </ul>
+        <div class="dropdown__content">
+          <ul class="dropdown__list">
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-C" type="checkbox" name="{{ committee_type }}" value="C">
+              <label class="dropdown__value" for="committee-type-checkbox-C">Communication cost</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-D" type="checkbox" name="{{ committee_type }}" value="D">
+              <label class="dropdown__value" for="committee-type-checkbox-D">Delegate committee</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-E" type="checkbox" name="{{ committee_type }}" value="E">
+              <label class="dropdown__value" for="committee-type-checkbox-E">Electioneering communication</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-X" type="checkbox" name="{{ committee_type }}" value="X">
+              <label class="dropdown__value" for="committee-type-checkbox-X">Party - nonqualified</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-Y" type="checkbox" name="{{ committee_type }}" value="Y">
+              <label class="dropdown__value" for="committee-type-checkbox-Y">Party - qualified</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-Z" type="checkbox" name="{{ committee_type }}" value="Z">
+              <label class="dropdown__value" for="committee-type-checkbox-Z">National party nonfederal account</label>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
   </fieldset>
 </div>

--- a/fec/data/templates/macros/filters/contributor-states.jinja
+++ b/fec/data/templates/macros/filters/contributor-states.jinja
@@ -5,15 +5,17 @@
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
-      <div id="state-dropdown{{id_suffix}}" class="dropdown__panel" aria-hidden="true">
-        <ul class="dropdown__list">
-          {% for state in constants.contributor_states.items() %}
-            <li class="dropdown__item">
-              <input name="{{ name }}" id="state-checkbox-{{state[0]}}{{id_suffix}}" type="checkbox" value="{{ state[0] }}">
-              <label class="dropdown__value" for="state-checkbox-{{ state[0] }}{{id_suffix}}">{{ state[1] }}</label>
-            </li>
-          {% endfor %}
-        </ul>
+      <div id="state-dropdown{{id_suffix}}" class="dropdown__panel dropdown-scrolling" aria-hidden="true">
+        <div class="dropdown__content">
+          <ul class="dropdown__list">
+            {% for state in constants.contributor_states.items() %}
+              <li class="dropdown__item">
+                <input name="{{ name }}" id="state-checkbox-{{state[0]}}{{id_suffix}}" type="checkbox" value="{{ state[0] }}">
+                <label class="dropdown__value" for="state-checkbox-{{ state[0] }}{{id_suffix}}">{{ state[1] }}</label>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
       </div>
     </div>
   </fieldset>

--- a/fec/data/templates/macros/filters/districts.jinja
+++ b/fec/data/templates/macros/filters/districts.jinja
@@ -6,8 +6,9 @@
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
-      <div id="district-dropdown{{id_suffix}}" class="dropdown__panel" aria-hidden="true">
-        <ul class="dropdown__list">
+      <div id="district-dropdown{{id_suffix}}" class="dropdown__panel dropdown-scrolling" aria-hidden="true">
+        <div class="dropdown__content">
+          <ul class="dropdown__list">
             {% for district in range(100) %}
             {% with formatted = '{0:02d}'.format(district) %}
               <li class="dropdown__item">
@@ -16,7 +17,8 @@
               </li>
             {% endwith %}
             {% endfor %}
-        </ul>
+          </ul>
+        </div>
       </div>
     </div>
   </fieldset>

--- a/fec/data/templates/macros/filters/states.jinja
+++ b/fec/data/templates/macros/filters/states.jinja
@@ -5,15 +5,17 @@
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
-      <div id="state-dropdown{{id_suffix}}" class="dropdown__panel" aria-hidden="true">
-        <ul class="dropdown__list">
-          {% for state in constants.states.items() %}
-            <li class="dropdown__item">
-              <input name="{{ name }}" id="state-checkbox-{{state[0]}}{{id_suffix}}" type="checkbox" value="{{ state[0] }}">
-              <label class="dropdown__value" for="state-checkbox-{{ state[0] }}{{id_suffix}}">{{ state[1] }}</label>
-            </li>
-          {% endfor %}
-        </ul>
+      <div id="state-dropdown{{id_suffix}}" class="dropdown__panel dropdown-scrolling" aria-hidden="true">
+        <div class="dropdown__content">
+          <ul class="dropdown__list">
+            {% for state in constants.states.items() %}
+              <li class="dropdown__item">
+                <input name="{{ name }}" id="state-checkbox-{{state[0]}}{{id_suffix}}" type="checkbox" value="{{ state[0] }}">
+                <label class="dropdown__value" for="state-checkbox-{{ state[0] }}{{id_suffix}}">{{ state[1] }}</label>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
       </div>
     </div>
   </fieldset>

--- a/fec/data/templates/macros/filters/years.jinja
+++ b/fec/data/templates/macros/filters/years.jinja
@@ -12,15 +12,17 @@
   <ul class="dropdown__selected"></ul>
   <div class="dropdown">
     <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
-    <div id="{{ name }}-dropdown" class="dropdown__panel" aria-hidden="true">
-      <ul class="dropdown__list">
-      {% for year in range(end_year, start_year, -2) %}
-        <li class="dropdown__item">
-          <input id="{{ name }}-checkbox-{{ year }}" name="{{ name }}" type="checkbox" value="{{ year }}" />
-          <label class="dropdown__value" for="{{name}}-checkbox-{{ year }}">{{ year | fmt_year_range }}</label>
-        </li>
-      {% endfor %}
-      </ul>
+    <div id="{{ name }}-dropdown" class="dropdown__panel dropdown-scrolling" aria-hidden="true">
+      <div class="dropdown__content">
+        <ul class="dropdown__list">
+        {% for year in range(end_year, start_year, -2) %}
+          <li class="dropdown__item">
+            <input id="{{ name }}-checkbox-{{ year }}" name="{{ name }}" type="checkbox" value="{{ year }}" />
+            <label class="dropdown__value" for="{{name}}-checkbox-{{ year }}">{{ year | fmt_year_range }}</label>
+          </li>
+        {% endfor %}
+        </ul>
+      </div>
     </div>
     {% if multi_time_period_label %}
       <label class="label--help--filter u-margin--top">{{ multi_time_period_label }}</label>
@@ -36,15 +38,17 @@
   <ul class="dropdown__selected"></ul>
   <div class="dropdown">
     <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
-    <div id="{{ name }}-dropdown" class="dropdown__panel" aria-hidden="true">
-      <ul class="dropdown__list">
-      {% for year in range(end_year, start_year, -1) %}
-        <li class="dropdown__item">
-          <input id="{{ name }}-checkbox-{{ year }}" name="{{ name }}" type="checkbox" value="{{ year }}" />
-          <label class="dropdown__value" for="{{name}}-checkbox-{{ year }}">{{ year }}</label>
-        </li>
-      {% endfor %}
-      </ul>
+    <div id="{{ name }}-dropdown" class="dropdown__panel dropdown-scrolling" aria-hidden="true">
+      <div class="dropdown__content">
+        <ul class="dropdown__list">
+        {% for year in range(end_year, start_year, -1) %}
+          <li class="dropdown__item">
+            <input id="{{ name }}-checkbox-{{ year }}" name="{{ name }}" type="checkbox" value="{{ year }}" />
+            <label class="dropdown__value" for="{{name}}-checkbox-{{ year }}">{{ year }}</label>
+          </li>
+        {% endfor %}
+        </ul>
+      </div>
     </div>
   </div>
 </fieldset>

--- a/fec/data/templates/partials/filters/audit-committee-types.jinja
+++ b/fec/data/templates/partials/filters/audit-committee-types.jinja
@@ -25,16 +25,18 @@
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
       <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
-        <ul class="dropdown__list">
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-X" type="checkbox" name="committee_type" value="X">
-            <label class="dropdown__value" for="committee-type-checkbox-X">Party - nonqualified</label>
-          </li>
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-Y" type="checkbox" name="committee_type" value="Y">
-            <label class="dropdown__value" for="committee-type-checkbox-Y">Party - qualified</label>
-          </li>
-        </ul>
+        <div class="dropdown__content">
+          <ul class="dropdown__list">
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-X" type="checkbox" name="committee_type" value="X">
+              <label class="dropdown__value" for="committee-type-checkbox-X">Party - nonqualified</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-Y" type="checkbox" name="committee_type" value="Y">
+              <label class="dropdown__value" for="committee-type-checkbox-Y">Party - qualified</label>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </fieldset>
@@ -47,20 +49,22 @@
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
       <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
-        <ul class="dropdown__list">
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-O" type="checkbox" name="committee_type" value="O">
-            <label class="dropdown__value" for="committee-type-checkbox-O">Super PAC (independent expenditure only)</label>
-          </li>
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-I" type="checkbox" name="committee_type" value="I">
-            <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditure filer (not a committee)</label>
-          </li>
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-U" type="checkbox" name="committee_type" value="U">
-            <label class="dropdown__value" for="committee-type-checkbox-U">Single candidate independent expenditure committee</label>
-          </li>
-        </ul>
+        <div class="dropdown__content">
+          <ul class="dropdown__list">
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-O" type="checkbox" name="committee_type" value="O">
+              <label class="dropdown__value" for="committee-type-checkbox-O">Super PAC (independent expenditure only)</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-I" type="checkbox" name="committee_type" value="I">
+              <label class="dropdown__value" for="committee-type-checkbox-I">Independent expenditure filer (not a committee)</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-U" type="checkbox" name="committee_type" value="U">
+              <label class="dropdown__value" for="committee-type-checkbox-U">Single candidate independent expenditure committee</label>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </fieldset>
@@ -73,24 +77,26 @@
     <div class="dropdown">
       <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
       <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
-        <ul class="dropdown__list">
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-N" type="checkbox" name="committee_type" value="N">
-            <label class="dropdown__value" for="committee-type-checkbox-N">PAC - nonqualified</label>
-          </li>
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-Q" type="checkbox" name="committee_type" value="Q">
-            <label class="dropdown__value" for="committee-type-checkbox-Q">PAC - qualified</label>
-          </li>
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-V" type="checkbox" name="committee_type" value="V">
-            <label class="dropdown__value" for="committee-type-checkbox-V">Hybrid PAC (with Non-Contribution Account) - Nonqualified</label>
-          </li>
-          <li class="dropdown__item">
-            <input id="committee-type-checkbox-W" type="checkbox" name="committee_type" value="W">
-            <label class="dropdown__value" for="committee-type-checkbox-W">Hybrid PAC (with Non-Contribution Account) - Qualified</label>
-          </li>
-        </ul>
+        <div class="dropdown__content">
+          <ul class="dropdown__list">
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-N" type="checkbox" name="committee_type" value="N">
+              <label class="dropdown__value" for="committee-type-checkbox-N">PAC - nonqualified</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-Q" type="checkbox" name="committee_type" value="Q">
+              <label class="dropdown__value" for="committee-type-checkbox-Q">PAC - qualified</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-V" type="checkbox" name="committee_type" value="V">
+              <label class="dropdown__value" for="committee-type-checkbox-V">Hybrid PAC (with Non-Contribution Account) - Nonqualified</label>
+            </li>
+            <li class="dropdown__item">
+              <input id="committee-type-checkbox-W" type="checkbox" name="committee_type" value="W">
+              <label class="dropdown__value" for="committee-type-checkbox-W">Hybrid PAC (with Non-Contribution Account) - Qualified</label>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </fieldset>

--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -1,8 +1,6 @@
 /**
  *
  */
-import PerfectScrollbar from 'perfect-scrollbar';
-
 import { removeTabindex, restoreTabindex } from './accessibility.js';
 import Listeners from './listeners.js';
 
@@ -87,7 +85,6 @@ Dropdown.prototype.toggle = function(e) {
 Dropdown.prototype.show = function() {
   restoreTabindex(this.$panel);
   this.$panel.attr('aria-hidden', 'false');
-  new PerfectScrollbar(this.$panel.get(0), { suppressScrollX: true });
   this.$panel.find('input[type="checkbox"]:first').focus(); // TODO: jQuery deprecation (:first and .focus)
   this.$button.addClass('is-active');
   this.isOpen = true;

--- a/fec/fec/static/js/templates/comparison.hbs
+++ b/fec/fec/static/js/templates/comparison.hbs
@@ -13,15 +13,17 @@
     <div class="grid grid--3-wide u-no-margin">
       <div class="dropdown grid__item">
         <button type="button" class="dropdown__button button--alt">More</button>
-        <div class="dropdown__panel" aria-hidden="true">
-          <ul class="dropdown__list">
-            {{#each this.options}}
-            <li class="dropdown__item">
-              <input id="checkbox-{{ this.candidate_id }}" name="candidate-list" type="checkbox" data-id="{{this.candidate_id}}" data-name="{{this.candidate_name}}">
-              <label class="dropdown__value" for="checkbox-{{ this.candidate_id }}">{{this.candidate_name}}</label>
-            </li>
-            {{/each}}
-          </ul>
+        <div class="dropdown__panel dropdown-scrolling" aria-hidden="true">
+          <div class="dropdown__content">
+            <ul class="dropdown__list">
+              {{#each this.options}}
+              <li class="dropdown__item">
+                <input id="checkbox-{{ this.candidate_id }}" name="candidate-list" type="checkbox" data-id="{{this.candidate_id}}" data-name="{{this.candidate_name}}">
+                <label class="dropdown__value" for="checkbox-{{ this.candidate_id }}">{{this.candidate_name}}</label>
+              </li>
+              {{/each}}
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -40,7 +40,7 @@
     padding: u(1rem 2rem 1rem 1rem);
     position: absolute;
     right: u(1.5rem);
-    top: u(.5rem);
+    top: u(0.5rem);
   }
 
   &.is-active::after {
@@ -75,8 +75,8 @@
 
 .dropdown__button--mini {
   &::after {
-    padding: u(1rem .5rem 1rem 1.5rem);
-    right: u(.5rem);
+    padding: u(1rem 0.5rem 1rem 1.5rem);
+    right: u(0.5rem);
   }
 
   & + .dropdown__panel {
@@ -92,7 +92,6 @@
   border-top: none;
   margin-top: -1px;
   max-height: u(30rem);
-  overflow: hidden;
   text-align: left;
   top: u(3.4rem);
   z-index: $z-dropdowns;
@@ -135,7 +134,7 @@
     color: $base;
     display: block;
     margin: 0;
-    padding: u(.5rem 1rem .5rem 1.5rem);
+    padding: u(0.5rem 1rem 0.5rem 1.5rem);
     max-width: 100%;
     white-space: nowrap;
 
@@ -154,7 +153,7 @@
       border: 1px solid $gray;
       display: block;
       font-size: u(1.4rem);
-      padding: u(.5rem 1rem .5rem 1.5rem);
+      padding: u(0.5rem 1rem 0.5rem 1.5rem);
       text-align: left;
       width: 100%;
 
@@ -165,13 +164,13 @@
       &.is-checked {
         @include u-icon-bg($check, $gray);
         background-color: $gray-light;
-        background-position: right u(.5rem) top 50%;
+        background-position: right u(0.5rem) top 50%;
         padding-right: u(1.5rem);
         cursor: default;
       }
-      
-      &[data-label*="mur_disposition_category_id-"] {
-        pointer-events: none; 
+
+      &[data-label*='mur_disposition_category_id-'] {
+        pointer-events: none;
       }
     }
 
@@ -188,7 +187,7 @@
     border-bottom: 1px solid $gray-dark;
     font-size: u(1.4rem);
     font-weight: bold;
-    padding-left: u(.75rem);
+    padding-left: u(0.75rem);
 
     &:hover {
       background-color: $inverse;
@@ -210,25 +209,29 @@
 }
 
 .dropdown__selected {
-  margin: u(.5rem 0);
+  margin: u(0.5rem 0);
 
   li {
-    input[type="checkbox"] + label.disabled {
+    input[type='checkbox'] + label.disabled {
       cursor: default;
-      opacity: .5;
+      opacity: 0.5;
       border: 1px solid #aeb0b5 !important;
       background-color: #aeb0b5 !important;
     }
 
-    @include animation(fadeIn .2s ease-in);
+    @include animation(fadeIn 0.2s ease-in);
     position: relative;
 
     &:hover {
-      input[type="checkbox"]:not(:checked) + label:not(.is-loading) + .dropdown__remove {
+      input[type='checkbox']:not(:checked)
+        + label:not(.is-loading)
+        + .dropdown__remove {
         display: inline-block;
       }
 
-      input[type="checkbox"]:not(:checked) + label.is-unsuccessful + .dropdown__remove {
+      input[type='checkbox']:not(:checked)
+        + label.is-unsuccessful
+        + .dropdown__remove {
         display: none;
       }
     }
@@ -238,14 +241,14 @@
     margin-left: 0;
   }
 
-  [type="checkbox"] + label {
+  [type='checkbox'] + label {
     max-width: min(18em, 90%);
     word-wrap: break-word;
   }
 
   .dropdown__remove {
     @include u-icon-button($x, $gray-dark);
-    background-position: u(.75rem) 50%;
+    background-position: u(0.75rem) 50%;
     background-size: 18px;
     display: none;
     top: 0;

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -4,13 +4,15 @@
 //
 // <div class="dropdown">
 //   <button type="button" class="dropdown__button button--alt" data-name="name">More</button>
-//   <div id="name-dropdown" class="dropdown__panel" aria-hidden="true">
-//     <ul class="dropdown__list">
-//       <li class="dropdown__item">
-//         <input id="name-checkbox-2016" name="name" type="checkbox" value="2016" />
-//         <label class="dropdown__value" for="name-checkbox-2016">2016</label>
-//       </li>
-//     </ul>
+//   <div id="name-dropdown" class="dropdown__panel dropdown__panel" aria-hidden="true">
+//     <div class="dropdown__content">
+//       <ul class="dropdown__list">
+//         <li class="dropdown__item">
+//           <input id="name-checkbox-2016" name="name" type="checkbox" value="2016" />
+//           <label class="dropdown__value" for="name-checkbox-2016">2016</label>
+//         </li>
+//       </ul>
+//     </div>
 //   </div>
 // </div>
 //
@@ -94,6 +96,37 @@
   text-align: left;
   top: u(3.4rem);
   z-index: $z-dropdowns;
+
+  .dropdown__content {
+    position: relative;
+    width: 100%;
+  }
+
+  // For scrolling dropdowns, force the scrollbars to appear,
+  // flip its x to move the scroll to the left, then flip its content back
+  &.dropdown-scrolling {
+    overflow-x: hidden;
+    overflow-y: scroll;
+    // scrollbar-color: $gray-dark $gray-medium; // For Firefox but it breaks Chrome on Mac OS
+    // scrollbar-width: thin; // For Firefox but it breaks Chrome on Mac OS
+    transform: scaleX(-1);
+
+    .dropdown__content {
+      overflow: hidden;
+      transform: scaleX(-1);
+    }
+
+    &::-webkit-scrollbar {
+      -webkit-appearance: none !important;
+      background: $gray-medium !important;
+      width: 4px !important;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: $gray-dark !important;
+      border-radius: 4px !important;
+      width: 4px !important;
+    }
+  }
 
   .dropdown__value,
   label.dropdown__value {
@@ -226,6 +259,4 @@
       width: 30%;
     }
   }
-}
-  width: 4px;
 }

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -227,20 +227,5 @@
     }
   }
 }
-
-.ps-scrollbar-y-rail {
-  background: $gray-medium;
-  border-left: 1px solid $gray-dark;
-  position: absolute;
-  left: 0;
-  right: auto;
-  width: 4px;
-}
-
-.ps-scrollbar-y {
-  background: $gray-dark;
-  left: 0;
-  position: absolute;
-  right: auto;
   width: 4px;
 }

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -18,11 +18,10 @@ import { buildUrl } from '../../static/js/modules/helpers.js';
 
 import { DataTable_FEC, drawComparison, getCycle, initSpendingTables, mapResponse, mapSort, refreshTables, yearRange } from '../../static/js/modules/tables.js';
 import { init as initTablist } from '../../static/js/vendor/tablist.js';
-import { default as Dropdown }  from '../../static/js/modules/dropdowns.js';
+import { default as Dropdown } from '../../static/js/modules/dropdowns.js';
 
 import { default as context } from '../fixtures/context.js';
 import { default as houseResults } from '../fixtures/house-results.js';
-// const DataTable = DataTable_FEC;
 
 describe('data table', function() {
   before(function() {
@@ -200,7 +199,7 @@ describe('data table', function() {
           results: [],
           pagination: { count: 1000000 }
         };
-        this.table.fetch({}, function() {});
+        this.table.fetch({}, function() {}); // eslint-disable-line no-empty-function
         this.deferred.resolve(resp);
         expect(this.table.disableExport).to.have.been.called;
         expect(this.table.enableExport).not.to.have.been.called;
@@ -220,7 +219,7 @@ describe('data table', function() {
         fields: ['name', 'office', 'party']
       };
       this.table.filterSet.isValid = true;
-      this.table.fetch({}, function() {});
+      this.table.fetch({}, function() {}); // eslint-disable-line no-empty-function
       expect(this.table.filters).to.deep.equal(serialized);
       var params = URI.parseQuery(window.location.search);
       expect(params.name).to.equal('bartlet');
@@ -228,7 +227,7 @@ describe('data table', function() {
 
     it('terminates ongoing ajax requests', function() {
       var xhr = (this.table.xhr = { abort: stub() });
-      this.table.fetch({}, function() {});
+      this.table.fetch({}, function() {}); // eslint-disable-line no-empty-function
       expect(xhr.abort).to.have.been.called;
     });
   });
@@ -245,7 +244,7 @@ describe('data table', function() {
     it('calls fetch on reload', function() {
       var serialized = { name: 'bartlet' };
       this.table.filterSet = {
-        activateAll: function() {},
+        activateAll: function() {}, // eslint-disable-line no-empty-function
         serialize: function() {
           return serialized;
         }
@@ -258,7 +257,7 @@ describe('data table', function() {
     it('does not call fetch on reload when state is unchanged', function() {
       var serialized = { name: 'bartlet' };
       this.table.filterSet = {
-        activateAll: function() {},
+        activateAll: function() {}, // eslint-disable-line no-empty-function
         serialize: function() {
           return serialized;
         }
@@ -319,7 +318,6 @@ describe('data table', function() {
     });
 
     it('should draw tables for comparison and show by-size by default', function(done) {
-      var tables = $('#fixtures');
       done();
     });
 
@@ -345,9 +343,9 @@ describe('data table', function() {
         .empty()
         .append(
           '<div id="comparison">'+
-          '<fieldset class="js-dropdown">'+
-            '<legend class="label" for="candidate-list">Candidates to compare (listed by amount raised):</legend>'+
-            '<label class="label--help label--help u-negative--top--margin u-padding--bottom">Limit 10 candidates</label>'+
+            '<fieldset class="js-dropdown">'+
+              '<legend class="label" for="candidate-list">Candidates to compare (listed by amount raised):</legend>'+
+              '<label class="label--help label--help u-negative--top--margin u-padding--bottom">Limit 10 candidates</label>'+
               '<ul class="dropdown__selected list--3-columns">'+
                 '<li class="dropdown__item">'+
                   '<input id="checkbox-S8FL00273" name="candidate-list" type="checkbox" data-id="S8FL00273" data-name="SCOTT, RICK SEN" checked>'+
@@ -393,81 +391,84 @@ describe('data table', function() {
               '<div class="grid grid--3-wide">'+
                 '<div class="dropdown grid__item">'+
                   '<button type="button" class="dropdown__button button--alt" aria-haspopup="true">More</button>'+
-                    '<ul class="dropdown__list">'+
-                      '<li class="dropdown__item">'+
-                      '<input id="checkbox-S2FL00656" name="candidate-list" type="checkbox" data-id="S2FL00656" data-name="NGUYEN, QUOC TUAN MR." tabindex="0">'+
-                      '<label class="dropdown__value disabled" for="checkbox-S2FL00656">NGUYEN, QUOC TUAN MR.</label></li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00579" name="candidate-list" type="checkbox" data-id="S4FL00579" data-name="STERN, EVERETT" tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00579">STERN, EVERETT</label></li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00439" name="candidate-list" type="checkbox" data-id="S4FL00439" data-name="DAVIS, JAMES" tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00439">DAVIS, JAMES</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00454" name="candidate-list" type="checkbox" data-id="S4FL00454" data-name="BOSWELL, MATT" tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00454">BOSWELL, MATT</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00462" name="candidate-list" type="checkbox" data-id="S4FL00462" data-name="LAROSE, JOSUE DR." tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00462">LAROSE, JOSUE DR.</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00488" name="candidate-list" type="checkbox" data-id="S4FL00488" data-name="SANSCRAINTE, MATTHEW ALEXANDER MR" tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00488">SANSCRAINTE, MATTHEW ALEXANDER MR</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00520" name="candidate-list" type="checkbox" data-id="S4FL00520" data-name="TOULME, ALIX CHRISTOPHER MR. JR." tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00520">TOULME, ALIX CHRISTOPHER MR. JR.</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00561" name="candidate-list" type="checkbox" data-id="S4FL00561" data-name="ROMAGNANO, CHASE ANDERSON MR." tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00561">ROMAGNANO, CHASE ANDERSON MR.</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00629" name="candidate-list" type="checkbox" data-id="S4FL00629" data-name="SMITH, JOE" tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00629">SMITH, JOE</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00678" name="candidate-list" type="checkbox" data-id="S4FL00678" data-name="ODELL, SHANNON MAY" tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00678">ODELL, SHANNON MAY</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00686" name="candidate-list" type="checkbox" data-id="S4FL00686" data-name="SUN, KATY" tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00686">SUN, KATY</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00751" name="candidate-list" type="checkbox" data-id="S4FL00751" data-name="BENNETT, SHANTELE RENEE MS N/A" tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00751">BENNETT, SHANTELE RENEE MS N/A</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00769" name="candidate-list" type="checkbox" data-id="S4FL00769" data-name="TOULME, ALIX CHRISTOPHER MR. JR." tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00769">TOULME, ALIX CHRISTOPHER MR. JR.</label>'+
-                      '</li>'+
-                      '<li class="dropdown__item">'+
-                        '<input id="checkbox-S4FL00793" name="candidate-list" type="checkbox" data-id="S4FL00793" data-name="RAMSAROOP, JOEL" tabindex="0">'+
-                        '<label class="dropdown__value disabled" for="checkbox-S4FL00793">RAMSAROOP, JOEL</label>'+
-                      '</li>'+
-                    '</ul>'+
                   '<div class="dropdown__panel dropdown-scrolling" aria-hidden="true" aria-label="More options">'+
+                    '<div class="dropdown__content">'+
+                      '<ul class="dropdown__list">'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S2FL00656" name="candidate-list" type="checkbox" data-id="S2FL00656" data-name="NGUYEN, QUOC TUAN MR." tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S2FL00656">NGUYEN, QUOC TUAN MR.</label></li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00579" name="candidate-list" type="checkbox" data-id="S4FL00579" data-name="STERN, EVERETT" tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00579">STERN, EVERETT</label></li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00439" name="candidate-list" type="checkbox" data-id="S4FL00439" data-name="DAVIS, JAMES" tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00439">DAVIS, JAMES</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00454" name="candidate-list" type="checkbox" data-id="S4FL00454" data-name="BOSWELL, MATT" tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00454">BOSWELL, MATT</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00462" name="candidate-list" type="checkbox" data-id="S4FL00462" data-name="LAROSE, JOSUE DR." tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00462">LAROSE, JOSUE DR.</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00488" name="candidate-list" type="checkbox" data-id="S4FL00488" data-name="SANSCRAINTE, MATTHEW ALEXANDER MR" tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00488">SANSCRAINTE, MATTHEW ALEXANDER MR</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00520" name="candidate-list" type="checkbox" data-id="S4FL00520" data-name="TOULME, ALIX CHRISTOPHER MR. JR." tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00520">TOULME, ALIX CHRISTOPHER MR. JR.</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00561" name="candidate-list" type="checkbox" data-id="S4FL00561" data-name="ROMAGNANO, CHASE ANDERSON MR." tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00561">ROMAGNANO, CHASE ANDERSON MR.</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00629" name="candidate-list" type="checkbox" data-id="S4FL00629" data-name="SMITH, JOE" tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00629">SMITH, JOE</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00678" name="candidate-list" type="checkbox" data-id="S4FL00678" data-name="ODELL, SHANNON MAY" tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00678">ODELL, SHANNON MAY</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00686" name="candidate-list" type="checkbox" data-id="S4FL00686" data-name="SUN, KATY" tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00686">SUN, KATY</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00751" name="candidate-list" type="checkbox" data-id="S4FL00751" data-name="BENNETT, SHANTELE RENEE MS N/A" tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00751">BENNETT, SHANTELE RENEE MS N/A</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00769" name="candidate-list" type="checkbox" data-id="S4FL00769" data-name="TOULME, ALIX CHRISTOPHER MR. JR." tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00769">TOULME, ALIX CHRISTOPHER MR. JR.</label>'+
+                        '</li>'+
+                        '<li class="dropdown__item">'+
+                          '<input id="checkbox-S4FL00793" name="candidate-list" type="checkbox" data-id="S4FL00793" data-name="RAMSAROOP, JOEL" tabindex="0">'+
+                          '<label class="dropdown__value disabled" for="checkbox-S4FL00793">RAMSAROOP, JOEL</label>'+
+                        '</li>'+
+                      '</ul>'+
+                    '</div>'+
+                  '</div>'+
                 '</div>'+
               '</div>'+
             '</fieldset>'+
-          '</div>'     
+          '</div>'
       );
-      this.refreshTables = sinon.spy(refreshTables(null, context));
-      this.drawComparison = sinon.spy(drawComparison);  
+      this.refreshTables = sinon.spy(refreshTables(null, context)); // eslint-disable-line no-undef
+      this.drawComparison = sinon.spy(drawComparison); // eslint-disable-line no-undef
       done();
     });
-        
+
     afterEach(function(done) {
       this.$fixture.empty();
       done();
     });
 
     it('should start with 10 selected boxes and dropdown disabled by default', function() {
-      const dropdown_button = $('.dropdown__button')
-      const selected_checkboxes =  $('.dropdown__selected input[type="checkbox"]:checked');
+      const dropdown_button = $('.dropdown__button');
+      const selected_checkboxes = $('.dropdown__selected input[type="checkbox"]:checked');
       expect(selected_checkboxes.length).to.equal(10);
       expect(dropdown_button.prop('disabled')).to.be.true;
     });
@@ -483,7 +484,7 @@ describe('data table', function() {
       $('.js-dropdown input[data-id="S4FL00736"]').prop('checked',false);
       $('.js-dropdown input[data-id="S2FL00656"]').prop('checked',true);
       refreshTables(null, context);
-      const disabled_checkboxes =  $('.dropdown__selected input[type="checkbox"]:disabled');
+      const disabled_checkboxes = $('.dropdown__selected input[type="checkbox"]:disabled');
       expect(disabled_checkboxes.length).to.equal(1);
     });
 
@@ -493,19 +494,19 @@ describe('data table', function() {
       $(this.checkbox).prop('checked',false);
 
       // Check an item from the dropdown
-      this.checkbox1 =  $('.js-dropdown input[data-id="S2FL00656"]');
+      this.checkbox1 = $('.js-dropdown input[data-id="S2FL00656"]');
       $(this.checkbox1).prop('checked',true);
 
       // Trigger a click on the previously checked box to uncheck it and fire refreshTables()
       this.checkbox1.trigger('click').trigger('change');
-    
+
       expect(this.checkbox.prop('disabled')).to.be.false;
     });
 
     it('enables/allows removal of disabled checkboxes from dropdown', function() {
       new Dropdown('.js-dropdown');
       // Check one item from the dropdown
-      this.checkbox =  $('.dropdown__list input[data-id="S2FL00656"]');
+      this.checkbox = $('.dropdown__list input[data-id="S2FL00656"]');
       $(this.checkbox).prop('checked',true);
 
       // Uncheck the checkbox to make it disabled and fire refreshTables()
@@ -536,7 +537,7 @@ describe('data table', function() {
           orderSequence: ['desc', 'asc'],
           render: buildTotalLink(
             ['independent-expenditures'],
-            function(data, type, row, meta) {
+            function(data, type, row) {
               return {
                 data_type: 'processed',
                 is_notice: 'false',
@@ -617,8 +618,6 @@ describe('data table', function() {
     });
 
     it('should return an object when no table available', function() {
-      var meta = { settings: { sTableId: 'notable' } };
-      var results = this.spy(null, meta);
       this.spy.calledOnce;
       this.spy.returned({});
     });

--- a/fec/fec/tests/js/tables.js
+++ b/fec/fec/tests/js/tables.js
@@ -393,7 +393,6 @@ describe('data table', function() {
               '<div class="grid grid--3-wide">'+
                 '<div class="dropdown grid__item">'+
                   '<button type="button" class="dropdown__button button--alt" aria-haspopup="true">More</button>'+
-                  '<div class="dropdown__panel ps ps--active-y" aria-hidden="true" aria-label="More options">'+
                     '<ul class="dropdown__list">'+
                       '<li class="dropdown__item">'+
                       '<input id="checkbox-S2FL00656" name="candidate-list" type="checkbox" data-id="S2FL00656" data-name="NGUYEN, QUOC TUAN MR." tabindex="0">'+
@@ -450,6 +449,7 @@ describe('data table', function() {
                         '<label class="dropdown__value disabled" for="checkbox-S4FL00793">RAMSAROOP, JOEL</label>'+
                       '</li>'+
                     '</ul>'+
+                  '<div class="dropdown__panel dropdown-scrolling" aria-hidden="true" aria-label="More options">'+
                 '</div>'+
               '</div>'+
             '</fieldset>'+

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,6 @@
         "moment": "^2.29.4",
         "npm-watch": "^0.13.0",
         "numeral": "^1.5.6",
-        "perfect-scrollbar": "^1.5.5",
         "puppeteer-core": "^21.11.0",
         "sass": "^1.77.6",
         "scrollmonitor": "^1.2.11",
@@ -19076,13 +19075,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/perfect-scrollbar": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz",
-      "integrity": "sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "moment": "^2.29.4",
     "npm-watch": "^0.13.0",
     "numeral": "^1.5.6",
-    "perfect-scrollbar": "^1.5.5",
     "puppeteer-core": "^21.11.0",
     "sass": "^1.77.6",
     "scrollmonitor": "^1.2.11",


### PR DESCRIPTION
## Summary

- Resolves #6510 

Bringing back the longer dropdowns' scrolling handles but doing so by moving to a native solution, away from a JavaScript package (perfect-scrollbar)

### Required reviewers

- UX/Design
- Front-end

## Impacted areas of the application

- Every `.dropdown__panel` across the site e.g. filters, Calendar, Legal

## Screenshots

| Production  | Pattern library | This PR | 
| ------------- | ------------- | ------------- |
| <img width="297" alt="image" src="https://github.com/user-attachments/assets/4cb7b620-1375-42e1-afcc-f62ff0f33b36">  | <img width="298" alt="image" src="https://github.com/user-attachments/assets/627f5959-3623-4846-a711-1d914dba3d31">  | <img width="296" alt="image" src="https://github.com/user-attachments/assets/5aadedcf-294d-4ffd-8166-ceb196109a9c">  |

## Related PRs

Related PRs against other branches:

None

## How to test

### Are there any other places we should test?

**Known issue**: Firefox doesn't like changing scrollbars so it's swapped to the left but will behave as the OS dictates. Trying to adjust for Firefox deactivated the changes for everyone else

- Pull the branch
- `npm i`
- `./manage.py runserver`
- `npm run test-single` (should be zero errors)
- `npm run build`
- **Should always show scroll bars:**
  - [Receipts](http://127.0.0.1:8000/data/receipts/)
    - Report time period (cycles filter)
    - State or territory (states filter)
    - PACS
    - Receipt type (it's a native `<select>` so should scroll by itself)
  - [National party account receipts](http://127.0.0.1:8000/data/national-party-account-receipts/)
    - Report time period (it's a years filter so it'll have the scrollbars but won't have anything to scroll)
    - National party account receipt type (it's a native `<select>` so should scroll by itself)
    - National party account (it's a native `<select>` so should scroll by itself)
  - [Disbursements](http://127.0.0.1:8000/data/disbursements)
    - Disbursement type (it's a native `<select>` so should scroll by itself)
  - [Independent expenditures](http://127.0.0.1:8000/data/independent-expenditures)
    - Political party
    - District
  - [Filings](http://127.0.0.1:8000/data/filings)
    - Form type
  - [Political action and party committees](http://127.0.0.1:8000/data/committees/pac-party/)
    - Time period (it's a native `<select>` so should scroll by itself)
    - Other committees?
  - [Presidential committee reports](http://127.0.0.1:8000/data/reports/presidential)
    - Election sensitive reports
  - Legal 
    - [Advisory opinions](http://127.0.0.1:8000/data/legal/search/advisory-opinions)
        - Requestor type (it's a native `<select>` so should scroll by itself)
    - [MURS](http://127.0.0.1:8000/data/legal/search/murs/?search_type=murs) - Disposition filter
- **Should not be changed - should not try to scroll:**
  - [Calendar](http://127.0.0.1:8000/calendar/)
    - Subscribe
    - Download
    - Add to calendar (to the right of every event)
  - [Receipts](http://127.0.0.1:8000/data/receipts/)
    - Independent expenditure committees
    - Other committees and filers
  - [Debts](http://127.0.0.1:8000/data/debts/)
    - Debt type * 3
  - [Political action and party committees](http://127.0.0.1:8000/data/committees/pac-party/)
    - Parties
    - Other committees?
  - [Presidential committee reports](http://127.0.0.1:8000/data/reports/presidential)
    - Monthly reports
    - Quarterly reports
    - Other reports