### PR TITLE
Add signup button to feedback panel

### DIFF
--- a/fec/fec/static/js/templates/feedback.hbs
+++ b/fec/fec/static/js/templates/feedback.hbs
@@ -12,7 +12,7 @@
     <form id="feedback-form" class="container">
       <fieldset>
         <h2>Help us improve FEC.gov</h2>
-        <h3 class="t-sans">Test new website features with our design team</h3>
+        <h3 class="t-sans u-no-margin">Test new website features with our design team</h3>
         <div class="card--feedback">
           <div class="card__left">
             <a class="button--cta" href="">Sign up</a>

--- a/fec/fec/static/js/templates/feedback.hbs
+++ b/fec/fec/static/js/templates/feedback.hbs
@@ -11,7 +11,18 @@
     </div>
     <form id="feedback-form" class="container">
       <fieldset>
-        <h3 class="t-sans">Post public feedback about the FEC.gov website anonymously</h3>
+        <h2>Help us improve FEC.gov</h2>
+        <h3 class="t-sans">Test new website features with our design team</h3>
+        <div class="card--feedback">
+          <div class="card__left">
+            <a class="button--cta" href="">Sign up</a>
+          </div>
+          <div class="card__right">
+            <p class="t-sans t-note">Sign up for a 30-minute video call to help us test new website features.</p>
+          </div>
+        </div>
+        <hr>
+        <h3 class="t-sans">Or post public feedback about the FEC.gov website anonymously</h3>
         <p class="t-sans t-note">How can we improve FEC.gov? Your feedback, browser information and the URL of the page you were viewing at the time of submission will be posted publicly - so don't include sensitive information like your name, contact information or Social Security number.</p>
         <label for="feedback-1" class="label">What were you trying to do on fec.gov, and how can we improve it? <span class="label--help">(required)</span></label>
         <textarea id="feedback-1" name="action"></textarea>

--- a/fec/fec/static/scss/components/_feedback.scss
+++ b/fec/fec/static/scss/components/_feedback.scss
@@ -36,7 +36,7 @@
 
   hr {
     border-bottom: 1px dotted $gray-dark;
-    margin: u(0 0 1rem 0);
+    margin: u(2rem 0);
   }
 
   .t-note {
@@ -58,10 +58,8 @@
     border-color: $base;
   }
 
-  h3 {
-    &:first-of-type {
-      margin-top: u(2rem);
-    }
+  h3:first-of-type {
+    margin-top: u(2rem);
   }
 
   .feedback__close {
@@ -75,13 +73,13 @@
     flex-direction: row;
 
     .card__left {
-      padding: 1rem 1rem 1rem 0;
+      padding: 1rem 1rem 0 0;
       a {
         white-space: nowrap;
       }
     }
     .card__right {
-      padding: 1rem 0 1rem 1rem;
+      padding: 1rem 0 0 1rem;
 
       p {
         margin-bottom: 0;

--- a/fec/fec/static/scss/components/_feedback.scss
+++ b/fec/fec/static/scss/components/_feedback.scss
@@ -35,7 +35,7 @@
   }
 
   hr {
-    border-top: 1px dotted $gray-dark;
+    border-bottom: 1px dotted $gray-dark;
     margin: u(0 0 1rem 0);
   }
 
@@ -68,6 +68,25 @@
     position: absolute;
     right: u(1rem);
     top: u(1rem);
+  }
+
+  .card--feedback {
+    display: flex;
+    flex-direction: row;
+
+    .card__left {
+      padding: 1rem 1rem 1rem 0;
+      a {
+        white-space: nowrap;
+      }
+    }
+    .card__right {
+      padding: 1rem 0 1rem 1rem;
+
+      p {
+        margin-bottom: 0;
+      }
+    }
   }
 
   @include media($lg) {

--- a/fec/home/templates/purgecss-homepage/full.html
+++ b/fec/home/templates/purgecss-homepage/full.html
@@ -941,6 +941,17 @@
         </div>
         <form id="feedback-form" class="container">
           <fieldset>
+            <h2>Help us improve FEC.gov</h2>
+            <h3 class="t-sans">Test new website features with our design team</h3>
+            <div class="card--feedback">
+              <div class="card__left">
+                <a class="button--cta" href="https://ethn.io/12085">Sign up</a>
+              </div>
+              <div class="card__right">
+                <p class="t-sans t-note">Sign up for a 30-minute video call to help us test new website features.</p>
+              </div>
+            </div>
+            <hr>
             <h3 class="t-sans">Post public feedback about the FEC.gov website anonymously</h3>
             <p class="t-sans t-note">How can we improve FEC.gov? Your feedback, browser information and the URL of the page you were viewing at the time of submission will be posted publicly - so don't include sensitive information like your name, contact information or Social Security number.</p>
             <label for="feedback-1" class="label">What were you trying to do on fec.gov, and how can we improve it? <span class="label--help">(required)</span></label>

--- a/fec/home/templates/purgecss-homepage/toggled.html
+++ b/fec/home/templates/purgecss-homepage/toggled.html
@@ -67,6 +67,17 @@
         </div>
         <form id="feedback-form" class="container">
           <fieldset>
+            <h2>Help us improve FEC.gov</h2>
+            <h3 class="t-sans">Test new website features with our design team</h3>
+            <div class="card--feedback">
+              <div class="card__left">
+                <a class="button--cta" href="">Sign up</a>
+              </div>
+              <div class="card__right">
+                <p class="t-sans t-note">Sign up for a 30-minute video call to help us test new website features.</p>
+              </div>
+            </div>
+            <hr>
             <h3 class="t-sans">Post public feedback about the FEC.gov website anonymously</h3>
             <p class="t-sans t-note">How can we improve FEC.gov? Your feedback, browser information and the URL of the page you were viewing at the time of submission will be posted publicly - so don't include sensitive information like your name, contact information or Social Security number.</p>
             <label for="feedback-1" class="label">What were you trying to do on fec.gov, and how can we improve it? <span class="label--help">(required)</span></label>


### PR DESCRIPTION
## Summary

- Resolves #6497 

Adding a new section to the Feedback panel

### Required reviewers

- UX/design
- 1 front-end

## Impacted areas of the application

The feedback panel on the homepage and site-wide

## Screenshots

<img width="596" alt="image" src="https://github.com/user-attachments/assets/25a6e7f3-b214-4890-a3da-9fc34086dd4d">

## Related PRs

None

## How to test

- Pull the branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- At different widths, open the feedback box and click the signup form on
  - Homepage
  - Wagtail page
  - Data page