### PR TITLE
6540 Add Disclaimers to National Party Datatables

### DIFF
--- a/fec/data/templates/datatable.jinja
+++ b/fec/data/templates/datatable.jinja
@@ -54,15 +54,6 @@
           {% endif %}
           </noscript>
         </table>
-        {% if result_type == 'national_party_account_disbursements' %}
-        <div class="datatable__note">
-          <p class="t-note">Total spent is not a summary total disclosed by the committee.</p>
-        </div>
-        {% elif result_type == 'national_party_account_receipts' %}
-        <div class="datatable__note">
-          <p class="t-note">Total raised is not a summary total disclosed by the committee. It may include contributions that did not meet the itemization threshold.</p>
-        </div>
-        {% endif %}
       </div>
     </div>
   </div>

--- a/fec/data/templates/datatable.jinja
+++ b/fec/data/templates/datatable.jinja
@@ -41,21 +41,31 @@
               {{ datatables.committees(data) }}
             {% endif %}
           </noscript>
-        </table>
-        <noscript>
+          <noscript>
           {% if query %}
-          <div class="results-info">
-            <div class="dataTables_paginate paging_simple">
-              {% if query['page']|int > 1 %}
-                <a href="?page={{query['page']|int - 1}}" class="button button--previous button--standard"></a>
-              {% endif %}
-                <a href="?page={{query['page']|int + 1}}" class="button button--next button--standard"></a>
+            <div class="results-info">
+              <div class="dataTables_paginate paging_simple">
+                {% if query['page']|int > 1 %}
+                  <a href="?page={{query['page']|int - 1}}" class="button button--previous button--standard"></a>
+                {% endif %}
+                  <a href="?page={{query['page']|int + 1}}" class="button button--next button--standard"></a>
+              </div>
             </div>
-          </div>
           {% endif %}
-        </noscript>
+          </noscript>
+        </table>
+        {% if result_type == 'national_party_account_disbursements' %}
+        <div class="datatable__note">
+          <p class="t-note">Total spent is not a summary total disclosed by the committee.</p>
+        </div>
+        {% elif result_type == 'national_party_account_receipts' %}
+        <div class="datatable__note">
+          <p class="t-note">Total raised is not a summary total disclosed by the committee. It may include contributions that did not meet the itemization threshold.</p>
+        </div>
+        {% endif %}
       </div>
     </div>
+  </div>
 </section>
 
 {% include 'partials/datatable-modal.jinja' %}

--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -247,6 +247,9 @@
           </tr>
         </thead>
       </table>
+      <div class="datatable__note">
+        <p class="t-note">Total raised is not a summary total disclosed by the committee. It may include contributions that did not meet the itemization threshold.</p>
+      </div>
     </div>
   {% endif %}{#- /NATIONAL PARTY -#}
   </div>

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -393,6 +393,9 @@
           </tr>
         </thead>
       </table>
+      <div class="datatable__note">
+        <p class="t-note">Total spent is not a summary total disclosed by the committee.</p>
+      </div>
     </div>
   {% endif %}{#- /NATIONAL PARTY -#}
 </section>

--- a/fec/data/views_datatables.py
+++ b/fec/data/views_datatables.py
@@ -217,7 +217,7 @@ def national_party_account_receipts(request):
 def national_party_account_disbursements(request):
     return render(request, 'datatable.jinja', {
         'parent': 'data',
-        'result_type': 'national_party_account_receipts',
+        'result_type': 'national_party_account_disbursements',
         'slug': 'national-party-account-disbursements',
         'title': 'National party account disbursements',
         'columns': constants.table_columns['national-party-account-disbursements'],

--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -342,6 +342,9 @@
     @include span-columns(9);
   }
 }
+#results_wrapper + .datatable__note {
+  padding: u(1rem);
+}
 
 // Datatable cell widths
 //


### PR DESCRIPTION
## Summary (required)

- Resolves #6540 

Adding disclaimers under the datatables for the national party accounts raising & spending

### Required reviewers

- UX/design
- 1 front-end

## Impacted areas of the application

Technically every datatable page would be affected but the only visible differences should be for national party disbursement and receipts.

## Screenshots

Disbursements
<img width="604" alt="image" src="https://github.com/user-attachments/assets/26659103-ff93-4da1-80e9-88e80a286c9f">

Receipts
<img width="709" alt="image" src="https://github.com/user-attachments/assets/3a69f3e0-b9e3-412a-8b76-3257020cd349">

## Related PRs

None

## How to test

- Pull the branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- The disclaimer should appear for [disbursements](http://127.0.0.1:8000/data/national-party-account-disbursements/)
- The disclaimer should appear for [receipts](http://127.0.0.1:8000/data/national-party-account-receipts/)
- Disclaimers should not appear for any other datatable page (candidate and committee single pages still have their own disclaimers under their smaller tables)