### PR TITLE
upgrade gevent v24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7
 gunicorn==22.0.0
-gevent==23.9.1
+gevent==24.11.1
 psycopg==3.1.8
 requests==2.32.3
 urllib3==2.2.2


### PR DESCRIPTION
## Summary (required)

- Resolves #6544 

### Required reviewers - 1 dev

## How to test

- run `snyk test --file=requirements.txt --package-manager=pip` (Terminal output will show gevent as vulnerable package)
-  checkout this branch
- run `pyenv activate`  your virtual env
- run `pip install -r requirements.txt` 
- run `snyk test --file=requirements.txt --package-manager=pip` (Terminal output no longer shows gevent as vulnerable package)
