### PR TITLE
[HOTFIX - merge with gitflow] hotfix/6558 6559 ao keyword search

### DIFF
--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -365,7 +365,7 @@ LegalSearchAo.prototype.refreshTable = function(response) {
             <div class="t-sans">`;
     if (advisory_opinion.aos_cited_by.length > 0) {
       advisory_opinion.aos_cited_by.forEach(citation => {
-        newRow += `<div><a href="${citation.no}">${citation.no}</a></div>`;
+        newRow += `<div><a href="/data/legal/advisory-opinions/${citation.no}/">${citation.no}</a></div>`;
       });
     } else {
       newRow += `This advisory opinion is not cited by other advisory opinions`;

--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -125,6 +125,21 @@ LegalSearchAo.prototype.initFilters = function() {
   const categoryFiltersFormElement = document.querySelector('#category-filters');
   categoryFiltersFormElement.addEventListener('change', this.handleFiltersChanged.bind(this));
 
+  // Add a null submit button at the top of the form to prevent Enter submits
+  const submitBlocker = document.createElement('input');
+  submitBlocker.setAttribute('type', 'submit');
+  submitBlocker.setAttribute('disabled', 'disabled');
+  submitBlocker.setAttribute('style', 'display:none');
+  submitBlocker.setAttribute('aria-hidden', 'true');
+  categoryFiltersFormElement.prepend(submitBlocker);
+
+  // Change the keyword search button from submit to a regular button since JS will be handling it
+  const searchInputField = document.querySelector('#search-input');
+  if (searchInputField) {
+    const searchInputSubmitButton = searchInputField.parentNode.querySelector('[type="submit"]');
+    if (searchInputSubmitButton) searchInputSubmitButton.setAttribute('type', 'button');
+  }
+
   const filterTagsElement = document.querySelector('.js-filter-tags');
   filterTagsElement.addEventListener('click', this.handleRemovingRequestorTypeTag.bind(this));
 
@@ -209,7 +224,7 @@ LegalSearchAo.prototype.handleKeywordSearchChange = function(e) {
   if (currentTag.length >= 1) {
     currentTag.forEach((tag, i) => {
       // We only want to keep one filter tag for keywords, so change its label
-      // but only if it has a value to show 
+      // but only if it has a value to show
       if (i === 0 && newVal.length > 0)
         tag.textContent = newVal;
       // Otherwise, if it's after the first one, click its X button

--- a/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
+++ b/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
@@ -43,15 +43,13 @@
         <td class="simple-table__cell">
           <div class="t-sans">
             {% if advisory_opinion.aos_cited_by|length > 0 %}
-                {% for citation in advisory_opinion.aos_cited_by %}
-                    <div>
-                        <a href="{{ citation.no }}">
-                            {{ citation.no }}
-                        </a>
-                    </div>
-                {% endfor %}
+              {% for citation in advisory_opinion.aos_cited_by %}
+                <div>
+                  <a href="/data/legal/advisory-opinions/{{ citation.no }}/">{{ citation.no }}</a>
+                </div>
+              {% endfor %}
             {% else %}
-                This advisory opinion is not cited by other advisory opinions
+              This advisory opinion is not cited by other advisory opinions
             {% endif %}
           </div>
         </td>


### PR DESCRIPTION
## Summary
- Resolves #6558 
- Resolves #6559 

Fixing the AO keyword search functionality.

### Required reviewers

- SME
- Front-end

## Impacted areas of the application

The AO search page and its filters

## Screenshots

None

## Related PRs

None

## How to test
- **Other filters should be unaffected**
- Keyword search should work as expected whether one uses
   - the More Keyword Options pop-up
   - the Enter button while typing in the field
   - the magnifying button while typing in the field
   - the Tab button while typing in the field
- In the right column, the AO number links should work correctly
   - on first load (testing the Jinja template)
   - after filters have been changed (testing the JavaScript fetching results)