### PR TITLE
6564 - Fix canonical rel links

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -35,7 +35,6 @@
     END_YEAR = {{ constants.END_YEAR }};
     DISTRICT_MAP_CUTOFF = '{{ constants.DISTRICT_MAP_CUTOFF }}';
     WEBMANAGER_EMAIL = '{{ WEBMANAGER_EMAIL }}';
-    CANONICAL_BASE = '{{ CANONICAL_BASE }}';
     TRANSITION_URL = '{{ TRANSITION_URL }}';
     {% if election_year %}ELECTION_YEAR = '{{ election_year }}';{% endif %}
 

--- a/fec/data/templates/partials/meta-tags.jinja
+++ b/fec/data/templates/partials/meta-tags.jinja
@@ -30,7 +30,7 @@
 
   {# Google
   ================================================== -#}
-  <link rel="canonical" href="{{ CANONICAL_BASE }}">
+  <link rel="canonical" href="{{ CANONICAL_BASE }}{{ request.path }}">
 
   {# Favicons
   ================================================== -#}

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -160,7 +160,6 @@
       window.API_KEY_PUBLIC = '{{ API_KEY_PUBLIC }}';
       window.API_KEY_PUBLIC_CALENDAR = '{{ settings.FEC_API_KEY_PUBLIC_CALENDAR }}';
       window.CALENDAR_DOWNLOAD_PUBLIC_API_KEY = '{{ settings.FEC_CAL_DOWNLOAD_API_KEY }}';
-      window.CANONICAL_BASE = '{{ settings.CANONICAL_BASE }}'
     </script>
     <script>
       window.calcAdminFineJsPath = '{% path_for_js "calc-admin-fines.js" %}';

--- a/fec/fec/templates/home_base.html
+++ b/fec/fec/templates/home_base.html
@@ -158,7 +158,6 @@
       window.API_KEY_PUBLIC = '{{ API_KEY_PUBLIC }}';
       window.API_KEY_PUBLIC_CALENDAR = '{{ settings.FEC_API_KEY_PUBLIC_CALENDAR }}';
       window.CALENDAR_DOWNLOAD_PUBLIC_API_KEY = '{{ settings.FEC_CAL_DOWNLOAD_API_KEY }}';
-      window.CANONICAL_BASE = '{{ settings.CANONICAL_BASE }}'
     </script>
     {% tags_for_js_chunks 'global.js' '' %}
 


### PR DESCRIPTION
## Summary

- Resolves #6564 

(Include a summary of proposed changes and connect issue below)

### Required reviewers

- code review

## Impacted areas of the application

- Anywhere `CANONICAL_BASE` was being used on the front-end but I couldn't find it in the repo
- The `<link rel="canonical">` href values for every jinja template, so everything under `/data/`—everything not in Wagtail

## Screenshots

<img width="703" alt="image" src="https://github.com/user-attachments/assets/32847e8c-69cd-480d-86db-97b53a7e965e">


Removing `CANONICAL_BASE` from front-end:
![image](https://github.com/user-attachments/assets/c05488d5-fefd-41cc-b356-3c83d2911b5b)

## Related PRs

Related PRs against other branches:

None

## How to test

- pull the branch
- `npm run build`
- `./manage.py runserver`
- Review the `<link rel="canonical">` `href` values for
  - homepage
  - some Wagtail pages
  - several Jinja pages
  - several Jinja pages with query params (that shouldn't be included in the canonical tag)
- Are there places where `CANONICAL_BASE` was being used by the front-end?
