### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Change admin fines URL from admin_fines to admin-fines

### DIFF
--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -67,12 +67,8 @@
                 {% if results["total_" + category] %}
                     <div class="results-info__right">
                       <span class="results-info__details">1&ndash;{{ results[category + "_returned"] }} of 
-                        {% if category == 'admin_fines' %}
-                          <a href="/data/legal/search/{{ category }}/?search={{ query }}&search_type={{ category}}">
-                        {% else %}
-                          <a href="/data/legal/search/{{ category | replace('_', '-') }}/?search={{ query }}&search_type={{ category}}">
-                        {% endif %}
-                          <strong>{{ results["total_" + category] }}</strong> results
+                        <a href="/data/legal/search/{{ category | replace('_', '-') }}/?search={{ query }}&search_type={{ category}}">
+                        <strong>{{ results["total_" + category] }}</strong> results
                         </a>
                       </span>
                     </div>

--- a/fec/legal/urls.py
+++ b/fec/legal/urls.py
@@ -1,4 +1,5 @@
 from django.urls import re_path
+from django.views.generic.base import RedirectView
 from django.conf import settings
 
 from legal import views
@@ -31,6 +32,14 @@ if settings.FEATURES['adrs']:
     ),
 
 if settings.FEATURES['afs']:
-    urlpatterns += re_path(
-        r'^data/legal/search/admin_fines/$', views.legal_doc_search_af
-    ),
+    urlpatterns += [
+        # Redirect from `admin_fines` to `admin-fines`
+        re_path(
+            r'^data/legal/search/admin_fines/$',
+            RedirectView.as_view(url='/data/legal/search/admin-fines/', query_string=True)
+        ),
+        # The actual `admin-fines` view
+        re_path(
+            r'^data/legal/search/admin-fines/$', views.legal_doc_search_af
+        ),
+    ]


### PR DESCRIPTION
## Summary (required)

- Resolves #6566 

To remain consistent for our URLs, this updates the administrative fines search URL has been updated from `/data/legal/search/admin_fines/` to `/data/legal/search/admin-fines/` also preserving the query parameters.

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Administrative fines search

## How to test

- Go to http://localhost:8000/data/legal/search/admin-fines/. Do a submit on all the filters to make sure that it still works.
- Go to the old URL http://localhost:8000/data/legal/search/admin_fines/ and make sure it redirects
- Go to the old URL with query parameters passed and make sure that it still works: http://localhost:8000/data/legal/search/admin-fines/?search_type=admin_fines&search=&case_no=4774&af_name=Virginia
