### PR TITLE
5225 - Show HREF on Print-outs

### DIFF
--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -187,6 +187,12 @@
   .value-bar {
     margin-top: u(0.5rem);
     height: u(0.5rem);
+
+    @media print {
+      color-adjust: exact;
+      print-color-adjust: exact;
+      -webkit-print-color-adjust: exact; 
+    }
   }
 
   @include media($lg) {

--- a/fec/fec/static/scss/components/_site-header.scss
+++ b/fec/fec/static/scss/components/_site-header.scss
@@ -555,6 +555,7 @@
 
   .masthead {
     background: none;
+    border-bottom: none;
   }
 
   .site-title {
@@ -572,9 +573,17 @@
     display: block;
     height: 114px;
     width: 100%;
+
+    color-adjust: exact;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
   }
 
   .homepage-seal {
     display: none;
+  }
+
+  #hero-heading {
+    padding-top: 0;
   }
 }

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -490,6 +490,12 @@ h3 + .simple-table {
     &[data-party="REP"] {
       background-color: $red-data;
     }
+
+    @media print {
+      color-adjust: exact;
+      print-color-adjust: exact;
+      -webkit-print-color-adjust: exact; 
+    }
   }
 
   & + .results-info {

--- a/fec/fec/static/scss/elements/_elements.scss
+++ b/fec/fec/static/scss/elements/_elements.scss
@@ -57,27 +57,29 @@ time {
   footer {
     display: none;
   }
-  
+
   // Rules to make <a> elements' hrefs visible for those who print the page 
   // .print-url: class we can add to individual elements to show the URL for print media
   // .no-print-url: class to skip printing the URL when it would otherwise be printed
+  
   #main h2 a,
   #main h3 a,
+  #main li > a:first-child,
   #main p a,
+  #main a.button,
+  #main .message a,
   .footer-links a,
-  .message a,
   .print-url {
-    &:not(.no-print-url) {
+    &:not(.no-print-url):not([href^='#']) {
       border-bottom: none;
       text-decoration: underline; 
   
       &:after {
-        content: '[' attr(href) ']';
+        content: '\00a0[' attr(href) ']';
         border-bottom: none !important;
         display: inline-block;
         font-size: .9em;
         font-weight: normal;
-        margin-left: .5em;
         text-decoration: none !important;
         word-break: break-all;
       }

--- a/fec/fec/static/scss/elements/_elements.scss
+++ b/fec/fec/static/scss/elements/_elements.scss
@@ -68,9 +68,11 @@ time {
   #main p a,
   #main a.button,
   #main .message a,
+  #main .legal-search-result a,
+  #main .legal-search-results a,
   .footer-links a,
   .print-url {
-    &:not(.no-print-url):not([href^='#']) {
+    &:not(.no-print-url):not([href^='#']):not(.paginate_button) {
       border-bottom: none;
       text-decoration: underline; 
   

--- a/fec/fec/static/scss/elements/_elements.scss
+++ b/fec/fec/static/scss/elements/_elements.scss
@@ -57,4 +57,30 @@ time {
   footer {
     display: none;
   }
+  
+  // Rules to make <a> elements' hrefs visible for those who print the page 
+  // .print-url: class we can add to individual elements to show the URL for print media
+  // .no-print-url: class to skip printing the URL when it would otherwise be printed
+  #main h2 a,
+  #main h3 a,
+  #main p a,
+  .footer-links a,
+  .message a,
+  .print-url {
+    &:not(.no-print-url) {
+      border-bottom: none;
+      text-decoration: underline; 
+  
+      &:after {
+        content: '[' attr(href) ']';
+        border-bottom: none !important;
+        display: inline-block;
+        font-size: .9em;
+        font-weight: normal;
+        margin-left: .5em;
+        text-decoration: none !important;
+        word-break: break-all;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Resolves #5225 

Adding style rules to print href values when printing pages. Any affected elements will get their border-bottom removed, will get an underline (printing borders can be tricky) and will get its `href` value appended after it in the body of the page, inside brackets: `\00a0[href]` (`\00a0` is a space)


Then the rules are to include a link's href value if it's one of
- `#main a.button` (main content, any `<a>` with the `button` class)
- `#main h2 a` (main content, any `<a>` inside of `<h2>`)
- `#main h3 a` (main content, any `<a>` inside of `<h3>`)
- `#main li > a:first-child` (main content, `<li><a>` (first child directly inside the `<li>`))
- `#main p a` (main content, any `<a>` inside any `<p>`)
- `#main .message a` (main content, any `<a>` inside any `.message`)
- `.footer-links a` (the site footer links)
- any element with the new `print-url` class (in case we want to force showing it someplace

These will cancel the above selectors:
- an `href` starting with `#`
- if the new `no-print-url` class has been added to the element


### Required reviewers

- Front-end
- UX

## Impacted areas of the application

Any changes will only take effect for print media so nothing should appear on the screen

## Screenshots

About page, actual print preview
<img width="497" alt="image" src="https://github.com/user-attachments/assets/af9fa597-88cf-4e77-88cf-6d2b7c0b32ff">

H4CC
<img width="979" alt="image" src="https://github.com/user-attachments/assets/7ad552fd-9de2-4d21-957a-00520a9034b7">

Footer links
<img width="1102" alt="image" src="https://github.com/user-attachments/assets/1682384b-a853-47d5-afda-8ad3ead8faf5">


## Related PRs

None

## How to test

- pull the branch
- `npm run build-sass`
- `./manage.py runserver`
- Load a page ([About](http://127.0.0.1:8000/about/) is a decent sample)
- Look at the print preview
- Check several other types of pages
- To make things quicker and check specifically this work:
   1. edit fec/fec/static/scss/elements/_elements.scss
   1. near the bottom, close the `@media print {` before the `// Rules` line
   1. at the very bottom, comment out or remove the very last `}`
   1. `npm run build-sass`
   1. reload pages and browse that way—the various `href` should appear on the screen normally in the same places they would if they were printed (though the rest of the layout will not look like printed versions might)
