### PR TITLE
[PR TO 05/13/25 RELEASE] Error handling and logging for global and policy searches

### DIFF
--- a/fec/fec/static/scss/components/_messages.scss
+++ b/fec/fec/static/scss/components/_messages.scss
@@ -100,7 +100,7 @@ p {
 //
 
 .message--small {
-  background-position: u(1rem 1rem);
+  background-position: u(1rem 1.5rem);
   padding: u(4rem 1rem 1rem 1rem);
 
   &.message {
@@ -187,7 +187,7 @@ p {
 
   .message--small {
     background-size: u(2rem);
-    background-position: u(1rem 1rem);
+    background-position: u(1rem 1.5rem);
     padding: u(1rem 1rem 1rem 4rem);
   }
 

--- a/fec/fec/static/scss/components/_messages.scss
+++ b/fec/fec/static/scss/components/_messages.scss
@@ -14,6 +14,10 @@
   margin: u(2rem 0);
   padding: u(5rem 2rem 2rem 2rem);
 
+  .message--white {
+    background-color: #fff
+  }
+
   p:last-child {
     margin-bottom: 0;
   }

--- a/fec/search/templates/search/policy_guidance_search_page.html
+++ b/fec/search/templates/search/policy_guidance_search_page.html
@@ -72,8 +72,8 @@
           <p>Try changing your search term.</p>
         </div>
       {% elif policy_search_error %}
-      <div class="message message--alert">
-         <p>{{policy_search_error | safe }}</p>
+      <div class="message message--small message--alert">
+         {{policy_search_error | safe }}
          </div>
       {% endif %}
     </div>

--- a/fec/search/templates/search/policy_guidance_search_page.html
+++ b/fec/search/templates/search/policy_guidance_search_page.html
@@ -29,7 +29,7 @@
 {% block feed %}
   <div class="row" id="results-container">
     <div class="main">
-      {% if results.results %}
+      {% if results.meta.count > 0  %}
         <section id="site">
           <div class="heading--section" class="row">
             <h2 class="u-float-left u-no-margin">Results</h2>
@@ -65,12 +65,16 @@
             {% endif %}
           </div>
         </section>
-      {% elif results.meta.count == 0 %}
+      {% elif results.meta.count == 0 and not policy_search_error %}
         <div class="message message--info">
           <h2>No results</h2>
           <p>We didn’t find any results matching <strong>&ldquo;{{search_query}}&rdquo;</strong>.</p>
           <p>Try changing your search term.</p>
         </div>
+      {% elif policy_search_error %}
+      <div class="message message--alert">
+         <p>{{policy_search_error | safe }}</p>
+         </div>
       {% endif %}
     </div>
   </div>

--- a/fec/search/templates/search/search.html
+++ b/fec/search/templates/search/search.html
@@ -228,6 +228,8 @@
                 <p>{{ comm_search_error | safe }}</p>
                 </div>
               {% endif %}
+            {% else %}
+              <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong></p>
             {% endif %}
             <div class="message--alert__bottom">
               <p>Think this was a mistake?<br>Try one of the other search tools or submit feedback.</p>

--- a/fec/search/templates/search/search.html
+++ b/fec/search/templates/search/search.html
@@ -183,7 +183,7 @@
             </section>
           {% endif %}
           {% if site_search_error %}
-          <div class="messag message--small message--alert">
+          <div class="message message--small message--alert">
             <p>{{ site_search_error | safe }} </p>
             </div>
           {% endif %}
@@ -204,7 +204,6 @@
               <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong> in:</p>
                <ul  class="list--bulleted">
               {% if 'candidates' in type and not cand_search_error %}
-              <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong> in:</p>
                 <li><strong>Candidates</strong></li>
               {% endif %}
               {% if 'committees' in type and not comm_search_error %}

--- a/fec/search/templates/search/search.html
+++ b/fec/search/templates/search/search.html
@@ -203,46 +203,49 @@
         {% elif results.count == 0 %}
           <div class="message message--info">
             <h2>No results</h2>
-            {% if site_search_error or cand_search_error or comm_search_error %}
-              <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong> in:</p>
-               
-              {% if 'candidates' in type and not cand_search_error %}
-              <h2 class="u-border-top-base u-padding--top">Candidates</h2>
+            <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong>
+              {% if site_search_error or cand_search_error or comm_search_error %}
+                for
+                {% if 'candidates' in type and not cand_search_error %}
+                  Candidates
+                {% endif %}
+                {% if 'committees' in type and not comm_search_error %}
+                  {% if not cand_search_error %}
+                    or
+                  {% endif %}
+                  Committees
+                {% endif %}
+                {% if 'site' in type and not site_search_error %}
+                  {% if not comm_search_error or not cand_search_error  %}
+                    or
+                  {% endif %}
+                  Other pages
+                {% endif %}
               {% endif %}
-              {% if 'committees' in type and not comm_search_error %}
-              <h2 class="u-border-top-base u-padding--top">Committees</h2>
-              {% endif %}
-              {% if 'site' in type and not site_search_error %}
-              <h2 class="u-border-top-base u-padding--top">Other pages</h2>
-              {% endif %}
-              {% if cand_search_error %}
-              <h2 class="u-border-top-base u-padding--top">Candidates</h2>
-                <div class="message message--white message--small message--alert">
-                  {{ cand_search_error | safe }}
-                </div>
-              {% endif %}
-              {% if comm_search_error %}
-              <h2 class="u-border-top-base u-padding--top">Committees</h2>
-                <div class="message message--white message--small message--alert">
-                 {{ comm_search_error | safe }}
-                </div>
-              {% endif %}
-              {% if site_search_error %}
-              <h2 class="u-border-top-base u-padding--top">Other pages</h2>
+            </p>
+            <p class="u-border-top-base u-padding--top">Think this was a mistake?<br>Please let us know.</p>
+            <p>
+              <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}" class="button--standard">Email our team</a>&nbsp;&nbsp; <a href="https://github.com/fecgov/fec/issues/new" class="button--standard">File an issue</a></p>
+            </p>
+          </div>
+          {% if cand_search_error %}
+            <h2 class="u-border-top-base u-padding--top">Candidates</h2>
               <div class="message message--white message--small message--alert">
-               {{ site_search_error | safe }}
+                {{ cand_search_error | safe }}
               </div>
             {% endif %}
-            {% else %}
-              <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong></p>
+            {% if comm_search_error %}
+            <h2 class="u-border-top-base u-padding--top">Committees</h2>
+              <div class="message message--white message--small message--alert">
+                {{ comm_search_error | safe }}
+              </div>
             {% endif %}
-            <div class="message--alert__bottom">
-              <p>Think this was a mistake?<br>Try one of the other search tools or submit feedback.</p>
-              <p>
-                <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}" class="button--standard">Email our team</a>&nbsp;&nbsp; <a href="https://github.com/fecgov/fec/issues/new" class="button--standard">File an issue</a></p>
-              </p>
+            {% if site_search_error %}
+            <h2 class="u-border-top-base u-padding--top">Other pages</h2>
+            <div class="message message--white message--small message--alert">
+              {{ site_search_error | safe }}
             </div>
-          </div>
+          {% endif %}
         {% endif %}
       </div>
     </div>

--- a/fec/search/templates/search/search.html
+++ b/fec/search/templates/search/search.html
@@ -58,7 +58,7 @@
               {% endif %}
             </ul>
           </nav>
-          <aside class="sidebar sidebar--primary">
+          <aside class="sidebar sidebar--primary sidebar--left side-nav">
             <h4 class="sidebar__title">Other search tools</h4>
               <div class="sidebar__content">
                 <ul class="sidebar__related-links">
@@ -182,19 +182,22 @@
               </div>
             </section>
           {% endif %}
-          {% if site_search_error %}
-          <div class="message message--small message--alert">
-            <p>{{ site_search_error | safe }} </p>
-            </div>
-          {% endif %}
           {% if cand_search_error %}
-          <div class="message message--small message--alert">
-            <p>{{ cand_search_error | safe }} </p>
+            <h2 class="u-border-top-base u-padding--top">Candidates</h2>
+            <div class="message message--small message--alert">
+              <p>{{ cand_search_error | safe }} </p>
             </div>
           {% endif %}
           {% if comm_search_error %}
-          <div class="message message--small message--alert">
-            <p>{{ comm_search_error | safe }} </p>
+            <h2 class="u-border-top-base u-padding--top">Committees</h2>
+            <div class="message message--small message--alert">
+             <p>{{ comm_search_error | safe }} </p>
+            </div>
+          {% endif %}
+          {% if site_search_error %}
+          <h2 class="u-border-top-base u-padding--top">Other pages</h2>
+            <div class="message message--small message--alert">
+              {{ site_search_error | safe }}
             </div>
           {% endif %}
         {% elif results.count == 0 %}
@@ -202,32 +205,34 @@
             <h2>No results</h2>
             {% if site_search_error or cand_search_error or comm_search_error %}
               <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong> in:</p>
-               <ul  class="list--bulleted">
+               
               {% if 'candidates' in type and not cand_search_error %}
-                <li><strong>Candidates</strong></li>
+              <h2 class="u-border-top-base u-padding--top">Candidates</h2>
               {% endif %}
               {% if 'committees' in type and not comm_search_error %}
-                <li><strong>Committees</strong></li>
+              <h2 class="u-border-top-base u-padding--top">Committees</h2>
               {% endif %}
               {% if 'site' in type and not site_search_error %}
-                <li><strong>Other pages</strong></li>
-              {% endif %}
-              </ul>
-              {% if site_search_error %}
-              <div class="message message--white message--small message--alert">
-                <p>{{ site_search_error | safe }} </p>
-                </div>
+              <h2 class="u-border-top-base u-padding--top">Other pages</h2>
               {% endif %}
               {% if cand_search_error %}
-              <div class="message message--white message--small message--alert">
-                <p>{{ cand_search_error | safe }}</p>
+              <h2 class="u-border-top-base u-padding--top">Candidates</h2>
+                <div class="message message--white message--small message--alert">
+                  {{ cand_search_error | safe }}
                 </div>
               {% endif %}
               {% if comm_search_error %}
-              <div class="message message--white message--small message--alert">
-                <p>{{ comm_search_error | safe }}</p>
+              <h2 class="u-border-top-base u-padding--top">Committees</h2>
+                <div class="message message--white message--small message--alert">
+                 {{ comm_search_error | safe }}
                 </div>
               {% endif %}
+              {% if site_search_error %}
+              <h2 class="u-border-top-base u-padding--top">Other pages</h2>
+              <div class="message message--white message--small message--alert">
+               {{ site_search_error | safe }}
+              </div>
+            {% endif %}
             {% else %}
               <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong></p>
             {% endif %}

--- a/fec/search/templates/search/search.html
+++ b/fec/search/templates/search/search.html
@@ -182,10 +182,54 @@
               </div>
             </section>
           {% endif %}
-        {% else %}
+          {% if site_search_error %}
+          <div class="messag message--small message--alert">
+            <p>{{ site_search_error | safe }} </p>
+            </div>
+          {% endif %}
+          {% if cand_search_error %}
+          <div class="message message--small message--alert">
+            <p>{{ cand_search_error | safe }} </p>
+            </div>
+          {% endif %}
+          {% if comm_search_error %}
+          <div class="message message--small message--alert">
+            <p>{{ comm_search_error | safe }} </p>
+            </div>
+          {% endif %}
+        {% elif results.count == 0 %}
           <div class="message message--info">
             <h2>No results</h2>
-            <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong>.</p>
+            {% if site_search_error or cand_search_error or comm_search_error %}
+              <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong> in:</p>
+               <ul  class="list--bulleted">
+              {% if 'candidates' in type and not cand_search_error %}
+              <p>We didn’t find any pages matching <strong>&ldquo;{{search_query}}&rdquo;</strong> in:</p>
+                <li><strong>Candidates</strong></li>
+              {% endif %}
+              {% if 'committees' in type and not comm_search_error %}
+                <li><strong>Committees</strong></li>
+              {% endif %}
+              {% if 'site' in type and not site_search_error %}
+                <li><strong>Other pages</strong></li>
+              {% endif %}
+              </ul>
+              {% if site_search_error %}
+              <div class="message message--white message--small message--alert">
+                <p>{{ site_search_error | safe }} </p>
+                </div>
+              {% endif %}
+              {% if cand_search_error %}
+              <div class="message message--white message--small message--alert">
+                <p>{{ cand_search_error | safe }}</p>
+                </div>
+              {% endif %}
+              {% if comm_search_error %}
+              <div class="message message--white message--small message--alert">
+                <p>{{ comm_search_error | safe }}</p>
+                </div>
+              {% endif %}
+            {% endif %}
             <div class="message--alert__bottom">
               <p>Think this was a mistake?<br>Try one of the other search tools or submit feedback.</p>
               <p>

--- a/fec/search/templates/search/search.html
+++ b/fec/search/templates/search/search.html
@@ -184,19 +184,19 @@
           {% endif %}
           {% if cand_search_error %}
             <h2 class="u-border-top-base u-padding--top">Candidates</h2>
-            <div class="message message--small message--alert">
+            <div class="message  message--alert">
               <p>{{ cand_search_error | safe }} </p>
             </div>
           {% endif %}
           {% if comm_search_error %}
             <h2 class="u-border-top-base u-padding--top">Committees</h2>
-            <div class="message message--small message--alert">
+            <div class="message message--alert">
              <p>{{ comm_search_error | safe }} </p>
             </div>
           {% endif %}
           {% if site_search_error %}
           <h2 class="u-border-top-base u-padding--top">Other pages</h2>
-            <div class="message message--small message--alert">
+            <div class="message message--alert">
               {{ site_search_error | safe }}
             </div>
           {% endif %}
@@ -230,19 +230,19 @@
           </div>
           {% if cand_search_error %}
             <h2 class="u-border-top-base u-padding--top">Candidates</h2>
-              <div class="message message--white message--small message--alert">
+              <div class="message message--alert">
                 {{ cand_search_error | safe }}
               </div>
             {% endif %}
             {% if comm_search_error %}
             <h2 class="u-border-top-base u-padding--top">Committees</h2>
-              <div class="message message--white message--small message--alert">
+              <div class="message  message--alert">
                 {{ comm_search_error | safe }}
               </div>
             {% endif %}
             {% if site_search_error %}
             <h2 class="u-border-top-base u-padding--top">Other pages</h2>
-            <div class="message message--white message--small message--alert">
+            <div class="message  message--alert">
               {{ site_search_error | safe }}
             </div>
           {% endif %}

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -134,7 +134,7 @@ def search(request):
 
     search_error_message = """
         <h2>Something went wrong</h2>
-        <p>This section failed to load. Check FEC.gov status page to see if we are experiencing a temporary outage.
+        <p class="u-negative--top--margin">This section failed to load. Check FEC.gov status page to see if we are experiencing a temporary outage.
         If not, please try again and thanks for your patience.</p>
         <p class="u-border-top-base u-padding--top">Need to contact our team? Use the feedback box at the bottom of any page to report this issue or visit our Contact page to find more ways to reach us.</p>
         <p class="u-padding--bottom">

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -136,6 +136,7 @@ def search(request):
         <h3>Something went wrong</h3>
         <p>This section failed to load. Check FEC.gov status page to see if we are experiencing a temporary outage.
         If not, please try again and thanks for you patience.</p>
+        <p class="u-border-top-base u-padding--top">Need to contact our team? Use the feedback box at the bottom of any page to report this issue or visit our Contact page to find more ways to reach us.</p>
         <p class="u-padding--bottom">
             <a href="https://www.fec.gov" class="button--standard button--cta">Return home</a>&nbsp;&nbsp;
             <a href="https://fecgov.statuspage.io" class="button--standard">FEC.gov status page</a>&nbsp;&nbsp;

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -114,6 +114,7 @@ def search_site(query, limit=0, offset=0):
         return process_site_results(r.json(), limit=limit, offset=offset)
     except (Exception) as ex:
         logger.error('search_site:' + ex.__class__.__name__)
+
         return None
 
 
@@ -130,6 +131,17 @@ def search(request):
     results = {}
     results['count'] = 0
 
+
+    search_error_message = """
+        <h3>Something went wrong</h3>
+        <p>This section failed to load. Check FEC.gov status page to see if we are experiencing a temporary outage.
+        If not, please try again and thanks for you patience.</p>
+        <p class="u-padding--bottom">
+            <a href="https://www.fec.gov" class="button--standard button--cta">Return home</a>&nbsp;&nbsp;
+            <a href="https://fecgov.statuspage.io" class="button--standard">FEC.gov status page</a>&nbsp;&nbsp;
+            <a href="https://www.fec.gov/contact" class="button--standard">Contact us</a>
+        </p>
+        """
     site_search_error = ''
     cand_search_error = ''
     comm_search_error = ''
@@ -139,21 +151,21 @@ def search(request):
         if results['candidates']:
             results['count'] += len(results['candidates']['results'])
         else:
-            cand_search_error = 'We were unable to search <strong>Candidates</strong> because that FEC API endpoint is currently not responding. Please try again later.'
-
+            cand_search_error = search_error_message
+          
     if 'committees' in search_type and search_query:
         results['committees'] = search_committees(search_query)
         if results['committees']:
             results['count'] += len(results['committees']['results'])
         else:
-            comm_search_error = 'We were unable to search <strong>Committees</strong> because that FEC API endpoint is currently not responding. Please try again later.'
+            comm_search_error = search_error_message
 
     if 'site' in search_type and search_query:
         results['site'] = search_site(search_query, limit=limit, offset=offset)
         if results['site']:
             results['count'] += len(results['site']['results'])
         else:
-            site_search_error = 'We were unable to search <strong>Other pages</strong> because search.gov is currently not responding. Please try again later.'
+            site_search_error = search_error_message
 
     return render(request, 'search/search.html', {
         'search_query': search_query,
@@ -209,7 +221,17 @@ def policy_guidance_search(request):
             num_pages = math.ceil(int(results['meta']['count']) / limit)
             total_count = results['meta']['count'] + results['best_bets']['count']
         else:
-            policy_search_error = 'We were unable to search <strong>Policy and Other Guidance</strong> because search.gov is currently not responding. Please try again later.'
+            policy_search_error =  """
+            <h3>Something went wrong</h3>
+            <p>This section failed to load. Check FEC.gov status page to see if we are experiencing a temporary outage.
+            If not, please try again and thanks for you patience.</p>
+            <p class="u-padding--bottom">
+                <a href="https://www.fec.gov" class="button--standard button--cta">Return home</a>&nbsp;&nbsp;
+                <a href="https://fecgov.statuspage.io" class="button--standard">FEC.gov status page</a>&nbsp;&nbsp;
+                <a href="https://www.fec.gov/contact" class="button--standard">Contact us</a>
+            </p>
+            """
+            
 
     resultset = {}
     resultset['search_query'] = search_query

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -21,7 +21,7 @@ def search_candidates(query):
         r = requests.get(url, params={'q': query, 'sort': '-receipts', 'per_page': 3, 'api_key': settings.FEC_API_KEY_PRIVATE})
         return r.json()
     except (Exception) as ex:
-        logger.error('search_canndidates:' + ex.__class__.__name__)
+        logger.error('search_candidates:' + ex.__class__.__name__)
         return None
 
 
@@ -110,7 +110,7 @@ def search_site(query, limit=0, offset=0):
         'offset': offset
     }
     try:
-        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14yX', params=params)
+        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params)
         return process_site_results(r.json(), limit=limit, offset=offset)
     except (Exception) as ex:
         logger.error('search_site:' + ex.__class__.__name__)
@@ -134,7 +134,7 @@ def search(request):
 
     search_error_message = """
         <h2>Something went wrong</h2>
-        <p class="u-negative--top--margin">This section failed to load. Check FEC.gov status page to see if we are experiencing a temporary outage.
+        <p class="u-negative--top--margin">This section failed to load. Check FEC.gov status page to check if we are experiencing a temporary outage.
         If not, please try again and thanks for your patience.</p>
         <p class="u-border-top-base u-padding--top">Need to contact our team? Use the feedback box at the bottom of any page to report this issue or visit our Contact page to find more ways to reach us.</p>
         <p class="u-padding--bottom">
@@ -224,8 +224,8 @@ def policy_guidance_search(request):
         else:
             policy_search_error =  """
             <h3>Something went wrong</h3>
-            <p>This section failed to load. Check FEC.gov status page to see if we are experiencing a temporary outage.
-            If not, please try again and thanks for you patience.</p>
+            <p>This section failed to load. Check FEC.gov status page to check if we are experiencing a temporary outage.
+            If not, please try again and thanks for your patience.</p>
             <p class="u-padding--bottom">
                 <a href="https://www.fec.gov" class="button--standard button--cta">Return home</a>&nbsp;&nbsp;
                 <a href="https://fecgov.statuspage.io" class="button--standard">FEC.gov status page</a>&nbsp;&nbsp;

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -181,7 +181,7 @@ def policy_guidance_search_site(query, limit=0, offset=0):
     }
 
     try:
-        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14yX', params=params)
+        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params)
         return process_site_results(r.json(), limit=limit, offset=offset)
     except (Exception) as ex:
         logger.error('policy_guidance_search_site' + ex.__class__.__name__)

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -110,7 +110,7 @@ def search_site(query, limit=0, offset=0):
         'offset': offset
     }
     try:
-        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params)
+        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14yX', params=params)
         return process_site_results(r.json(), limit=limit, offset=offset)
     except (Exception) as ex:
         logger.error('search_site:' + ex.__class__.__name__)
@@ -135,7 +135,7 @@ def search(request):
     search_error_message = """
         <h2>Something went wrong</h2>
         <p>This section failed to load. Check FEC.gov status page to see if we are experiencing a temporary outage.
-        If not, please try again and thanks for you patience.</p>
+        If not, please try again and thanks for your patience.</p>
         <p class="u-border-top-base u-padding--top">Need to contact our team? Use the feedback box at the bottom of any page to report this issue or visit our Contact page to find more ways to reach us.</p>
         <p class="u-padding--bottom">
             <a href="https://www.fec.gov" class="button--standard button--cta">Return home</a>&nbsp;&nbsp;

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -133,7 +133,7 @@ def search(request):
 
 
     search_error_message = """
-        <h3>Something went wrong</h3>
+        <h2>Something went wrong</h2>
         <p>This section failed to load. Check FEC.gov status page to see if we are experiencing a temporary outage.
         If not, please try again and thanks for you patience.</p>
         <p class="u-border-top-base u-padding--top">Need to contact our team? Use the feedback box at the bottom of any page to report this issue or visit our Contact page to find more ways to reach us.</p>


### PR DESCRIPTION
## Summary

- Resolves #6525

Revised designs: https://github.com/fecgov/fec-cms/issues/6557

- Handle errors for the global site search and Policy Guidance search when the FEC API or search.gov API  do not return search-result data
- Use a catch-all  `Try/Except` block to handle:
    -   `Connection Errors` when the FEC API  endpoints (Candidtes or Committees) or search.gov  API  are not responding. 
    - `Key Error`, `JSON Decode Error` or any other error that arises when the data returned is not processable, search-result json.
- Render an error message to the search-result page and log errors in server logs.

### Required reviewers
One developer, One UX

## Impacted areas of the application

General components of the application that this PR will affect:

 - Global site search 
 - Policy Guidance search

	modified:   fec/static/scss/components/_messages.scss
	modified:   search/templates/search/policy_guidance_search_page.html
	modified:   search/templates/search/search.html
	modified:   search/views.py

## Screenshot

<img width="776" alt="Screenshot 2025-04-25 at 10 00 32 PM" src="https://github.com/user-attachments/assets/a01b2879-ab00-4daf-b990-39715f64cf4f" />



## How to test

-  Export the `SEARCHGOV_API_ACCESS_KEY` and `SEARCHGOV_POLICY_GUIDANCE_KEY` in terminal or add to `bash_profile` or `zsh profile` and source the profile in terminal.
-  `npm  run build-sass`
- Using the global site search box or [Policy Guidance search  box](http://127.0.0.1:8000/legal-resources/policy-and-other-guidance/guidance-documents/):
    - **Trigger a `JSON Decode Error`** : Change a character in the URL in `search/views.py` line 113 or 196.
    - **Trigger a `Key Error`:** Export the  wrong access key for search.gov, like `export SEARCHGOV_API_ACCESS_KEY=1234` (Note: this is not a "key" error because the access key is invalid, it's because the expected json key/value pairs were not returned)
    - **Trigger  a `Connection Error`:**  Change the url on line 113 or 196 of `search/views.py` to a site that does not exist like: https://www.doesnotexist.com
- You can test`Candidates` or `Committees` errors by changing 'candidates' to 'candidatesX' in line 17 or changing  'committees' to 'committeesX' in line 30 of `search/views.py`
- See the error messages on the results page
- See the errors logged in your terminal
- `No-results-message`: You can search this string `"tkts"`  (which has  consistently returned no results) 
    - The `no-results-message` is the same as it was before except when there no results AND also an error


