### PR TITLE
6561 AO Search Pagination and Page Offset

### DIFF
--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -604,7 +604,7 @@ LegalSearchAo.prototype.updatePagination = function(resultsCount) {
   if (totalNumberOfPages <= maxButtonsOnScreen) {
     // Yay! We can just use every button
     for (let i = 0; i < totalNumberOfPages; i++) {
-      pageNumbers.push(i + 1);
+      pageNumbers.push(i);
     }
   } else {
     const buttonsBeforeCurrent = Math.floor(maxButtonsOnScreen / 2);

--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -279,6 +279,9 @@ LegalSearchAo.prototype.getResults = function(e) {
   // Set the sort param value according to this.sortOrder
   serializedFilters.sort = this.sortOrder == 'asc' ? 'ao_no' : '-ao_no';
 
+  // If we're getting new results, let's reset the page offset (go back to page 1)
+  serializedFilters['offset'] = 0;
+
   // Then update the URL with currently params
   updateQuery(serializedFilters, filterFields);
 


### PR DESCRIPTION
## Summary

- Resolves #6561 

Fixing the pagination buttons for AOs and resetting the `offset` when filters change.

### Required reviewers

- 1 Front-end and/or UX?

## Impacted areas of the application

The AO search template, its pagination and its filters controls (all of them independent from the other legal search tools from datatables and those filters)

## Screenshots

<img width="415" alt="image" src="https://github.com/user-attachments/assets/816386c0-8954-44f6-9807-b4f70ddc8419">

## Related PRs

None

## How to test

- Pull the branch
- `npm run build`
- `manage.py runserver`
- Pagination - first & current page buttons ([sample url](http://127.0.0.1:8000/data/legal/search/advisory-opinions/?type=advisory_opinions&ao_citation_require_all=false&ao_min_issue_date=&ao_max_issue_date=&ao_min_request_date=&ao_max_request_date=&limit=20&search=testing&ao_doc_category_id=F&sort=-ao_no))
   - Should start on page 1
   - Should show the page 1 button (as opposed to being absent)
   - Should not offer a page 3
   - Clicking page 2 should go to page 2
- Pagination - end ([sample url](http://127.0.0.1:8000/data/legal/search/advisory-opinions/?type=advisory_opinions&ao_citation_require_all=false&ao_min_issue_date=&ao_max_issue_date=&ao_min_request_date=&ao_max_request_date=&limit=20&ao_doc_category_id=F&sort=-ao_no&offset=1940))
   - Shouldn't offer more pages than exist
- Resetting to offset 0 ([sample url](http://127.0.0.1:8000/data/legal/search/advisory-opinions/?type=advisory_opinions&ao_citation_require_all=false&ao_min_issue_date=&ao_max_issue_date=&ao_min_request_date=&ao_max_request_date=&offset=20&limit=20&search=testing&ao_doc_category_id=F&sort=-ao_no))
   - Should start on page 2
   - Clicking the x to remove the 'testing' tag at the top
   - Results should refresh and the
   - pagination should revert to page 1