### PR TITLE
[MERGE WITH GIT FLOW] Temporarily revert final opinion issue date changes

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -387,13 +387,14 @@ def _get_sorted_documents(ao):
     sorted_documents = sorted(
         ao["documents"], key=itemgetter("description", "document_id"), reverse=False
     )
+    sorted_documents = sorted(sorted_documents, key=itemgetter("date"), reverse=True)
 
-    # Sort by document date unless it's a final opinion. Final opinion uses issue date.
-    sorted_documents = sorted(
-        sorted_documents,
-        key=lambda doc: doc.get("date") if doc.get("ao_doc_category_id") != 'F' else ao.get("issue_date"),
-        reverse=True
-    )
+    # # Sort by document date unless it's a final opinion. Final opinion uses issue date.
+    # sorted_documents = sorted(
+    #     sorted_documents,
+    #     key=lambda doc: doc.get("date") if doc.get("ao_doc_category_id") != 'F' else ao.get("issue_date"),
+    #     reverse=True
+    # )
 
     return sorted_documents
 

--- a/fec/legal/templates/legal-advisory-opinion.jinja
+++ b/fec/legal/templates/legal-advisory-opinion.jinja
@@ -43,7 +43,7 @@
           <h2>Documents</h2>
           {% if final_opinion %}
             <div class="content__section">
-              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final opinion</a> <span class="t-sans u-padding--left">{{ advisory_opinion.issue_date | date(fmt='%B %d, %Y') }}</span>
+              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final opinion</a> <span class="t-sans u-padding--left">{{ final_opinion.date | date(fmt='%B %d, %Y') }}</span>
             </div>
           {% endif %}
           <table class="data-table simple-table" style="table-layout: auto;">
@@ -57,12 +57,7 @@
             <tbody>
               {% for document in advisory_opinion.sorted_documents %}
                 <tr>
-                  <td>
-                  {% if document.ao_doc_category_id == 'F' %}
-                    {{ advisory_opinion.issue_date | ao_document_date }}
-                  {% else %}
-                    {{ document.date | ao_document_date }}
-                  {% endif %}</td>
+                  <td>{{ document.date | ao_document_date }}</td>
                   <td><a href="{{ document.url }}">{{ document.description }}</a></td>
                   <td>{{ document.category }}</td>
                 </tr>


### PR DESCRIPTION
## Summary (required)


Revert recent changes for final opinion issue date so recent AO-2024-15 can render correctly on site
PR: https://github.com/fecgov/fec-cms/pull/6541
### Required reviewers

one developer

## Impacted areas of the application

General components of the application that this PR will affect:

## How to test

- Checkout and run branch
- Make sure the link to page for AO-2024-15 from AO datatable works and that is shows and links properly to final opinion document


