### PR TITLE
Handle null `issue_date` for final opinion document and legal search results

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -389,12 +389,15 @@ def _get_sorted_documents(ao):
     )
     sorted_documents = sorted(sorted_documents, key=itemgetter("date"), reverse=True)
 
-    # # Sort by document date unless it's a final opinion. Final opinion uses issue date.
-    # sorted_documents = sorted(
-    #     sorted_documents,
-    #     key=lambda doc: doc.get("date") if doc.get("ao_doc_category_id") != 'F' else ao.get("issue_date"),
-    #     reverse=True
-    # )
+    # Sort by document date unless it's a final opinion. Final opinion uses issue date.
+    sorted_documents = sorted(
+        sorted_documents,
+        key=lambda doc: (
+            # Make it blank for null issue_date when ao_doc_category_id is 'F'
+            doc.get("issue_date") or "" if doc.get("ao_doc_category_id") == 'F' else doc.get("date")
+        ),
+        reverse=True
+    )
 
     return sorted_documents
 

--- a/fec/data/templatetags/filters.py
+++ b/fec/data/templatetags/filters.py
@@ -139,7 +139,7 @@ def date_filter(value, fmt='%m/%d/%Y'):
 @library.filter
 def ao_document_date(value):
     date = date_filter(value)
-    return 'Not dated' if date == '01/01/1900' else date
+    return '' if date is None else date
 
 
 @library.filter

--- a/fec/legal/templates/legal-advisory-opinion.jinja
+++ b/fec/legal/templates/legal-advisory-opinion.jinja
@@ -43,7 +43,7 @@
           <h2>Documents</h2>
           {% if final_opinion %}
             <div class="content__section">
-              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final opinion</a> <span class="t-sans u-padding--left">{{ final_opinion.date | date(fmt='%B %d, %Y') }}</span>
+              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final opinion</a>{% if advisory_opinion.issue_date %}<span class="t-sans u-padding--left">{{ advisory_opinion.issue_date | date(fmt='%B %d, %Y') }}</span>{% endif %}
             </div>
           {% endif %}
           <table class="data-table simple-table" style="table-layout: auto;">
@@ -57,7 +57,12 @@
             <tbody>
               {% for document in advisory_opinion.sorted_documents %}
                 <tr>
-                  <td>{{ document.date | ao_document_date }}</td>
+                  <td>
+                  {% if document.ao_doc_category_id == 'F' %}
+                    {{ advisory_opinion.issue_date | ao_document_date }}
+                  {% else %}
+                    {{ document.date | ao_document_date }}
+                  {% endif %}</td>
                   <td><a href="{{ document.url }}">{{ document.description }}</a></td>
                   <td>{{ document.category }}</td>
                 </tr>

--- a/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
+++ b/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
@@ -30,7 +30,8 @@
               Pending
             {% elif advisory_opinion.status == "Withdrawn"%}
               Withdrawn
-            {% elif advisory_opinion.issue_date != undefined %}
+            {% elif advisory_opinion.issue_date is not none %}
+              {# When issue date is null, leave it blank #}
               {{ advisory_opinion.issue_date | date(fmt='%m/%d/%Y') }}
             {% endif %}
           </div>


### PR DESCRIPTION
## Summary

- Resolves #6601 

Handle null `issue_date` for final opinion document and legal search results table

### Required reviewers

1 front end engineer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Advisory opinions search results table
- Advisory opinions individual page

## Screenshots

<img width="1334" alt="Screenshot 2024-12-19 at 12 59 47 PM" src="https://github.com/user-attachments/assets/84a048be-c79f-4c6e-a701-57b3954f75c1" />

<img width="808" alt="Screenshot 2024-12-19 at 11 57 55 AM" src="https://github.com/user-attachments/assets/69d70daa-44ff-422e-9604-03e4198c4719" />


## Related PRs

branch | PR
------ | ------
feature/6487-update-final-opinion-date | [link](https://github.com/fecgov/fec-cms/pull/6541)

## How to test

- Pull down this PR
- Hook up your local API to the dev environment as we've reproduced the error there
- Load the [advisory opinions search page](http://localhost:8000/data/legal/search/advisory-opinions/?ao_doc_category_id=F) and ensure the issue date for AO 2024-15 has a blank issue date column
- Load the [AO 2024-15](http://localhost:8000/data/legal/advisory-opinions/2024-14/) page and ensure page still loads with the final opinion document with a blank date and no date shown next to the advisory opinions button.