### PR TITLE
Update downloadable photo text

### DIFF
--- a/fec/home/templates/home/commissioner_page.html
+++ b/fec/home/templates/home/commissioner_page.html
@@ -15,7 +15,7 @@
 
     {% if self.picture %}
       {% image self.picture original as commissioner_picture %}
-      <img src="{{ commissioner_picture.url }}" alt="Headshot of {{ self.title }}">
+      <img src="{{ commissioner_picture.url }}" alt="Official photo of {{ self.title }}">
     {% endif %}
 
       <div class="u-padding--top u-padding--bottom">
@@ -37,7 +37,7 @@
         </div>
         {% if self.picture_download %}
         {% image self.picture_download original as commissioner_picture_download %}
-            <a class="button button--standard button--download u-margin--top" href="{{ commissioner_picture_download.url }}" download>Download headshot</a>
+            <a class="button button--standard button--download u-margin--top" href="{{ commissioner_picture_download.url }}" download>Download official photo</a>
         {% endif %}
       </div>
 


### PR DESCRIPTION
## Summary (required)

- Resolves #6630 

Update Commissioner downloadable photo to be "Download official photo"

### Required reviewers

1 front-end

## Impacted areas of the application

General components of the application that this PR will affect:

-  Commissioner pages

## Screenshots

<img width="242" alt="Screenshot 2025-01-13 at 11 36 48 AM" src="https://github.com/user-attachments/assets/0aa77aac-2435-4ea2-b523-f8fd32b242d0" />

## How to test

- Go to a commissioner page that contains a downloadable photo and check the button to make sure it has the correct text