### PR TITLE
Add 2023-2024 links for bulk datasets

### DIFF
--- a/fec/data/templates/partials/browse-data/bulk-data.jinja
+++ b/fec/data/templates/partials/browse-data/bulk-data.jinja
@@ -8,6 +8,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2026/weball26.zip">2025–2026</a></li>
             <li><a href="/files/bulk-downloads/2024/weball24.zip">2023–2024</a></li>          
             <li><a href="/files/bulk-downloads/2022/weball22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/weball20.zip">2019–2020</a></li>
@@ -42,6 +43,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2026/cn26.zip">2025–2026</a></li>
             <li><a href="/files/bulk-downloads/2024/cn24.zip">2023–2024</a></li>          
             <li><a href="/files/bulk-downloads/2022/cn22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/cn20.zip">2019–2020</a></li>
@@ -76,6 +78,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2026/ccl26.zip">2025–2026</a></li>
             <li><a href="/files/bulk-downloads/2024/ccl24.zip">2023–2024</a></li>            
             <li><a href="/files/bulk-downloads/2022/ccl22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/ccl20.zip">2019–2020</a></li>
@@ -100,6 +103,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2026/webl26.zip">2025–2026</a></li>
             <li><a href="/files/bulk-downloads/2024/webl24.zip">2023–2024</a></li>            
             <li><a href="/files/bulk-downloads/2022/webl22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/webl20.zip">2019–2020</a></li>
@@ -125,6 +129,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2026/cm26.zip">2025–2026</a></li>
             <li><a href="/files/bulk-downloads/2024/cm24.zip">2023–2024</a></li>
             <li><a href="/files/bulk-downloads/2022/cm22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/cm20.zip">2019–2020</a></li>
@@ -159,7 +164,8 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
-            <li><a href="/files/bulk-downloads/2024/webk24.zip">2023–2024</a></li>            
+            <li><a href="/files/bulk-downloads/2026/webk26.zip">2025–2026</a></li>
+            <li><a href="/files/bulk-downloads/2024/webk24.zip">2023–2024</a></li>       
             <li><a href="/files/bulk-downloads/2022/webk22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/webk20.zip">2019–2020</a></li>
             <li><a href="/files/bulk-downloads/2018/webk18.zip">2017–2018</a></li>
@@ -184,6 +190,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2026/indiv26.zip">2025–2026</a></li>
             <li><a href="/files/bulk-downloads/2024/indiv24.zip">2023–2024</a></li>
             <li><a href="/files/bulk-downloads/2022/indiv22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/indiv20.zip">2019–2020</a></li>
@@ -218,6 +225,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2026/pas226.zip">2025–2026</a></li>
             <li><a href="/files/bulk-downloads/2024/pas224.zip">2023–2024</a></li>          
             <li><a href="/files/bulk-downloads/2022/pas222.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/pas220.zip">2019–2020</a></li>
@@ -252,6 +260,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered u-margin--bottom">
+            <li><a href="/files/bulk-downloads/2026/oth26.zip">2025–2026</a></li>
             <li><a href="/files/bulk-downloads/2024/oth24.zip">2023–2024</a></li>            
             <li><a href="/files/bulk-downloads/2022/oth22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/oth20.zip">2019–2020</a></li>
@@ -286,6 +295,7 @@
         <i class="icon i-download icon--absolute--left"></i>
         <div class="content__section--indent-left">
           <ul class="list--flat-bordered">
+            <li><a href="/files/bulk-downloads/2026/oppexp26.zip">2025–2026</a></li> 
             <li><a href="/files/bulk-downloads/2024/oppexp24.zip">2023–2024</a></li>            
             <li><a href="/files/bulk-downloads/2022/oppexp22.zip">2021–2022</a></li>
             <li><a href="/files/bulk-downloads/2020/oppexp20.zip">2019–2020</a></li>

--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -181,6 +181,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2026/Form2Filer_2026.csv">2025–2026</a></li>
                   <li><a href="/files/bulk-downloads/2024/Form2Filer_2024.csv">2023–2024</a></li>
                   <li><a href="/files/bulk-downloads/2022/Form2Filer_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/Form2Filer_2020.csv">2019–2020</a></li>

--- a/fec/data/templates/partials/browse-data/committees.jinja
+++ b/fec/data/templates/partials/browse-data/committees.jinja
@@ -16,7 +16,8 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/2024/committee_summary_2024.csv">2023–2024</a></li>                  
+                  <li><a href="/files/bulk-downloads/2026/committee_summary_2026.csv">2025–2026</a></li>
+                  <li><a href="/files/bulk-downloads/2024/committee_summary_2024.csv">2023–2024</a></li>              
                   <li><a href="/files/bulk-downloads/2022/committee_summary_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/committee_summary_2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/2018/committee_summary_2018.csv">2017–2018</a></li>
@@ -52,6 +53,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/data.fec.gov/leadership2026.csv">2025–2026</a></li>
                   <li><a href="/files/bulk-downloads/data.fec.gov/leadership2024.csv">2023–2024</a></li>
                   <li><a href="/files/bulk-downloads/data.fec.gov/leadership2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/data.fec.gov/leadership2020.csv">2019–2020</a></li>
@@ -78,7 +80,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/data.fec.gov/lobbyist.csv">2007–2024</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/lobbyist.csv">2007–2026</a></li>
                 </ul>
                 <p class="u-margin--top"><a href="/campaign-finance-data/lobbyistregistrant-committees-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
               </div>
@@ -99,6 +101,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2026/Form1Filer_2026.csv">2025-2026</a></li>
                   <li><a href="/files/bulk-downloads/2024/Form1Filer_2024.csv">2023-2024</a></li>
                   <li><a href="/files/bulk-downloads/2022/Form1Filer_2022.csv">2021-2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/Form1Filer_2020.csv">2019–2020</a></li>

--- a/fec/data/templates/partials/browse-data/filings-reports.jinja
+++ b/fec/data/templates/partials/browse-data/filings-reports.jinja
@@ -69,7 +69,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/data.fec.gov/FalseFictitiousFilings.csv">2016–2024</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/FalseFictitiousFilings.csv">2016–2026</a></li>
                 </ul>
                 <p class="u-margin--top"><a href="/campaign-finance-data/false-fictitious-filings-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
               </div>

--- a/fec/data/templates/partials/browse-data/raising.jinja
+++ b/fec/data/templates/partials/browse-data/raising.jinja
@@ -39,7 +39,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                  <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/data.fec.gov/lobbyist_bundle.csv">2009–2024</a></li>
+                  <li><a href="/files/bulk-downloads/data.fec.gov/lobbyist_bundle.csv">2009–2026</a></li>
                 </ul>
                 <p class="u-margin--top"><a href="/campaign-finance-data/lobbyist-bundled-contributions-file-description/">Data description for this file</a><i class="icon icon--small i-arrow-right icon--inline--right"></i></p>
               </div>

--- a/fec/data/templates/partials/browse-data/spending.jinja
+++ b/fec/data/templates/partials/browse-data/spending.jinja
@@ -25,7 +25,8 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
-                  <li><a href="/files/bulk-downloads/2024/independent_expenditure_2024.csv">2023–2024</a></li>                  
+                  <li><a href="/files/bulk-downloads/2026/independent_expenditure_2026.csv">2025–2026</a></li>
+                  <li><a href="/files/bulk-downloads/2024/independent_expenditure_2024.csv">2023–2024</a></li>                 
                   <li><a href="/files/bulk-downloads/2022/independent_expenditure_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/independent_expenditure_2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/2018/independent_expenditure_2018.csv">2017–2018</a></li>
@@ -78,6 +79,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2026/ElectioneeringComm_2026.csv">2025–2026</a></li>
                   <li><a href="/files/bulk-downloads/2024/ElectioneeringComm_2024.csv">2023–2024</a></li>
                   <li><a href="/files/bulk-downloads/2022/ElectioneeringComm_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/ElectioneeringComm_2020.csv">2019–2020</a></li>
@@ -106,8 +108,9 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2026/CommunicationCosts_2026.csv">2025–2026</a></li>
                   <li><a href="/files/bulk-downloads/2024/CommunicationCosts_2024.csv">2023–2024</a></li>
-                  <li><a href="/files/bulk-downloads/2022/CommunicationCosts_2022.csv">2021–2022</a></li>
+                  <li><a href="/files/bulk-downloads/2022/CommunicationCosts_2022.csv">2021–2022</a></li>   
                   <li><a href="/files/bulk-downloads/2020/CommunicationCosts_2020.csv">2019–2020</a></li>
                   <li><a href="/files/bulk-downloads/2018/CommunicationCosts_2018.csv">2017–2018</a></li>
                   <li><a href="/files/bulk-downloads/2016/CommunicationCosts_2016.csv">2015–2016</a></li>


### PR DESCRIPTION
## Summary (required)

Add 2023-2024 links for bulk datasets

- Resolves #6645 

(Include a summary of proposed changes and connect issue below)

### Required reviewers

1 developer

## Impacted areas of the application

-  [Download bulk data](https://www.fec.gov/data/browse-data/?tab=bulk-data)

## Screenshots

**Before:** 
<img width="1243" alt="Screenshot 2025-01-22 at 11 30 19 AM" src="https://github.com/user-attachments/assets/e43fc85c-5437-41cb-ac15-1e64a8dcebda" />

**After:**
<img width="1222" alt="Screenshot 2025-01-22 at 11 32 16 AM" src="https://github.com/user-attachments/assets/6e93f4d8-0dcf-4fee-a90f-b54e8b7dff2b" />


## How to test

-  run `git checkout feature/6645-add-bulk-data-links`
- run `pyenv activate <cms virtualenv>`
- run ` cd fec`
- run `./manage.py runserver`
-  Verify newly setup 2025-2026 links are available under [Download bulk data](http://localhost:8000/data/browse-data/?tab=bulk-data)
