### PR TITLE
[DONT MERGE YET] 6651-switch gunicorn worker type

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -11,4 +11,4 @@ cd fec
 ./manage.py migrate --noinput
 
 # Run application
-gunicorn -k gevent -w 2 fec.wsgi:application
+gunicorn -k gthread --threads 2 -w 2 fec.wsgi:application


### PR DESCRIPTION
## Summary (required)

- Resolves #6651 

A great breakdown of the worker types and their uses [here](https://dev.to/lsena/gunicorn-worker-types-how-to-choose-the-right-one-4n2c)

Switches to gunicorn to gthread worker type, we are switching to this type because of the difficulty in configuration with gevent--but can switch back if we find this is not performant enough. 

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  gunicorn servers 
This will effect our connections to the CMS db 

## Related PRs
https://github.com/fecgov/openFEC/pull/6112

## How to test
- currently on [feature](https://app.circleci.com/pipelines/github/fecgov/fec-cms/3996/workflows/b3f0e81a-d830-4ffa-a7ba-e5c139c77bdb/jobs/7518)
- try out different page requests 
- check your cms db connections (I don't want to put the sql here, because of our recent conversation with the db team but you can message me if you are connected to the cms db and can't find it in slack) 

You could load test, but there's limitations there since it's not sending requests to the db
Load testing [has happened on openFEC](https://docs.google.com/spreadsheets/d/1caYXmuuIFXVTzz0i8z1zS6-fBG1l7KgDPxCJH-TGsho/edit?gid=228893973#gid=228893973) and will be happening during the testing of the above PR as well