### PR TITLE
upgrade cf cli 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=8.9.0" | tar xzv -C $HOME/bin
 
       - run:
           name: Deploy CMS

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
       },
       "engines": {
         "node": "22.1.0",
-        "npm": "10.9.2"
+        "npm": "10.7.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   "browserslist": "last 2 versions, > 1%, IE 10",
   "engines": {
     "node": "22.1.0",
-    "npm": "10.9.2"
+    "npm": "10.7.0"
   },
   "license": "CC0-1.0"
 }


### PR DESCRIPTION
## Summary 
The Cloud.gov v2 API for Cloud Foundry is reaching its end-of-life. CF CLI versions 6 and 7 still rely on Cloud Foundry API v2 and will no longer work at some point with foundations that have disabled it. However, CF CLI v8 no longer uses Cloud Foundry API v2. For more details, refer to this [link](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0032-cfapiv2-eol.md#impact-and-consequences).

1. circleci/config.yml, is upgraded to CF CLI v8.9.0. This version supports Cloud Foundry API v3. Deploying to a cloud.gov space should work smoothly with this update

2. Update node/npm combo to fix the node/npm inconsistencies in circleci.  node v22.1.0 uses nvm 10.7.0. 
3. fec-pattern-library repo is also upgraded to use node v22.1.0 and nvm 10.7.0.

- ## Resolves #https://github.com/fecgov/openFEC/issues/6110


### Required reviewers

1 developer

## Impacted areas of the application

- installs for deploy section
- deploy cms section (to cloud.gov space)

## Screenshots
**Before:**
[cf cli v7.0.1 circleci build](https://app.circleci.com/pipelines/github/fecgov/fec-cms/4013/workflows/9aa6d6a0-b222-4360-9844-0ee9949cdc92/jobs/7540):

<img width="1141" alt="Screenshot 2025-01-29 at 3 45 34 PM" src="https://github.com/user-attachments/assets/370c8d3f-0fec-4df4-adad-7718bd253546" />


**After:**
[cf cli v8.9.0. circleci build](https://app.circleci.com/pipelines/github/fecgov/fec-cms/4020/workflows/c963a274-10d8-415b-a28a-594287e974a7/jobs/7547):

<img width="959" alt="Screenshot 2025-01-29 at 3 43 47 PM" src="https://github.com/user-attachments/assets/6e91dd45-28ae-4a36-a17c-bec7044be824" />

<img width="805" alt="Screenshot 2025-01-29 at 3 43 01 PM" src="https://github.com/user-attachments/assets/00655d64-83f4-4ed8-bd43-d6c89b93a244" />


## Related PRs

Related PRs against other branches:

- openFEC: https://github.com/fecgov/openFEC/pull/6114
- fec-proxy-redirect: https://github.com/fecgov/fec-proxy-redirect/pull/20
- fec-pattern-library: https://github.com/fecgov/fec-pattern-library/pull/229
- fec-proxy - https://github.com/fecgov/fec-proxy/pull/416

## How to test

- Follow [these](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) instructions to install cf CLI v8 on your local terminal or  run: `brew install cloudfoundry/tap/cf-cli@8`
- verify cf cli version: run `cf version`

```
F612211M:~ pkasireddy$ cf version
cf version 8.9.0+c23186c.2024-12-02
```

- rerun [this](https://app.circleci.com/pipelines/github/fecgov/fec-cms/4020/workflows/c963a274-10d8-415b-a28a-594287e974a7/jobs/7547) build in circleci
- **OR** 
- create a test branch, update tasks.py(DEPLOY_RULES) with the test branch and deploy to dev space
- Observe the following in circleci: 
- 1. In `installs for deploy` section, verify that cf cli v8.9.0 is downloaded and no errors there
- 2. In `deploy cms` section,  verify that  cms app deployed to cloud.space successfully without any errors 
- 3. In`deploy cms` section` confirm that cms app is using [Cloud Foundry v3 API](https://v3-apidocs.cloudfoundry.org/version/3.185.0/):

```
API endpoint:   https://api.fr.cloud.gov
API version:    3.185.0
```
