### PR TITLE
6666 Fix icons for cards with alternating backgrounds

### DIFF
--- a/fec/fec/static/scss/components/_cards.scss
+++ b/fec/fec/static/scss/components/_cards.scss
@@ -219,9 +219,13 @@
   border: 2px solid transparent;
 
   .card__image__container {
-    float: none;
-    vertical-align: middle;
     @include span-columns(4, table-cell);
+
+    & { // Special one-off because putting span-columns after these breaks the cards' icons
+      display: table-cell;
+      float: none;
+      vertical-align: middle;
+    }
   }
 
   .card__image {


### PR DESCRIPTION
## Summary

- Resolves #6666 

Fixing the cards' icon images for the alternating-bg cards

### Required reviewers

- Dev or UX or Content?

## Impacted areas of the application

The CSS for cards with alternating backgrounds, only reverting the order with a special override to allow declarations to follow attributes/elements (e.g. `declaration: value;` after `& .child {`)

## Screenshots

<img width="391" alt="image" src="https://github.com/user-attachments/assets/36ba98fd-4387-4ee2-a0d1-eff1bd950292" />

## Related PRs

None

## How to test

- pull the branch
- `npm run build-sass`
- `./manage.py runserver`
- Check that [reporting cards' icon images](http://127.0.0.1:8000/help-candidates-and-committees/candidate-taking-receipts/questionable-contributions/) are correct (like the screenshot above, not like on www or Pattern Library)