### PR TITLE
Update Django to a minor patch version to fix the snyk vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.17
+Django==4.2.18
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary 

Update Django to a minor patch version to resolve snyk vulnerabilities:

https://app.snyk.io/vuln/SNYK-PYTHON-DJANGO-8623541
https://app.snyk.io/vuln/SNYK-PYTHON-DJANGO-8623542

- Resolves #6643

### Required reviewers

1 Developer

## Screenshots

**Before:** 
<img width="1172" alt="Screenshot 2025-02-05 at 12 08 03 PM" src="https://github.com/user-attachments/assets/53dbcdb2-77cf-4fe7-8280-7aa88c73d6ff" />


**After:**
<img width="1189" alt="Screenshot 2025-02-05 at 12 15 12 PM" src="https://github.com/user-attachments/assets/170910bf-250c-452e-8d7c-30b63228dc36" />
## Related PRs


## How to test

- run `git checkout develop`
- run `pyenv activate <cms virtualenv>`
- run `snyk test --file=requirements.tx`t (Snyk flags django v4.1.17 as vulnerable)
- run `git checkout feature/6643-upgrade-django`
- run `pyenv activate < new cms virtualenv>`
- run `pip install -r requirements.txt`
- run `pip install -r requirements-dev.txt`
- run `snyk test --file=requirements.txt` (Snyk NO longer flags django as vulnerable)
- cd fec
- ./manage.py runserver (test cms app)
