### PR TITLE
6122 - Admin Fines Calc Visual Polish

### DIFF
--- a/fec/fec/static/js/modules/calc-admin-fines-logic.js
+++ b/fec/fec/static/js/modules/calc-admin-fines-logic.js
@@ -13,7 +13,7 @@ export const availableDates = [
   {
     value: 'latest',
     label: 'I haven’t been assessed a fine',
-    summary: 'I haven’t been assessed: using latest fine amounts'
+    summary: 'I haven’t been assessed'
   },
   {
     value: '2025',

--- a/fec/fec/static/scss/components/_calc-admin-fines.scss
+++ b/fec/fec/static/scss/components/_calc-admin-fines.scss
@@ -5,7 +5,7 @@
 
 // Toggled with calc-admin-fines-modal.js
 body.scroll-locked-for-modal {
-  overflow: hidden;
+  overflow: hidden !important;
 }
 
 // To let the help section left line touch the bottom of the area
@@ -254,7 +254,7 @@ body.scroll-locked-for-modal {
       background-image: url('data:image/svg+xml;charset=utf8, %3Csvg%20%20fill%3D%27%23212121%27%20width%3D%2212%22%20height%3D%2210%22%20viewBox%3D%220%200%2012%2010%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M.418%203.809L6.652.124a.851.851%200%200%201%201.294.727v7.382a.852.852%200%200%201-1.284.733L.418%205.276a.852.852%200%200%201%200-1.467z%22%2F%3E%3C%2Fsvg%3E');
     }
     &.tooltip__trigger {
-      margin: 0.5em 0 0.5rem 1rem;
+      margin: 0.5em 0 0.5rem;
       position: relative;
     }
     &.tooltip__trigger + p {
@@ -286,6 +286,7 @@ body.scroll-locked-for-modal {
     background-color: transparent;
     border-color: $inverse;
     float: left;
+    margin-right: 0;
     transition: border-color 0.5s;
   }
   [type='radio'] + label:hover {


### PR DESCRIPTION
## Summary

- Resolves #6122 

Changed a bit of text for haven't-been-accessed and polished the ⓘ icon margins

### Required reviewers

- bug filer (UX)
- a dev?

## Impacted areas of the application

- The language for that one item in the admin fines calculator
- CSS rules for those icons in the admin fines calculator
- Strengthened a CSS rule to prevent scrolling `<body>` while the calculator is open

## Screenshots

www above, localhost below
<img width="480" alt="image" src="https://github.com/user-attachments/assets/4242b883-6555-4237-8177-1ecd8dcfbe60" />


## Related PRs

None

## How to test

- pull the branch
- `npm run build`
- Check the [admin fines calculator](http://127.0.0.1:8000/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine)
- Open the calculator by clicking 'Calculate estimated fine'
- Click 'Start calculating'
- Choose 'I haven't been assessed a fine'
- Click 'Next'

To check

- [ ] Mouse wheel, trackpad, page up/down, etc outside the calculator no longer moves the `<body>`
- [ ] Breadcrumb text no longer includes "using latest fine amounts" and only reads "I haven't been assessed"
- [ ] All ⓘ (circled i) icons in the calculator follow their `<input>` and `<label>` by ~1 em of space
- [ ] Closing the calculator lets the `<body>` scroll again