### PR TITLE
6045 - Dropdown Filters Arrow Size Hiccup

### DIFF
--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -56,12 +56,12 @@
     }
   }
 
-  &.is-successful {
-    &::after {
-      right: 0;
-      @include u-icon-button($check, left, 1.5rem, background-position u(1.25rem) 50%, background-size 18px, padding-left u(2.5rem));
-    }
-  }
+  // &.is-successful {
+  //   &::after {
+  //     right: 0;
+  //     @include u-icon-button($check, left, 1.5rem, background-position u(1.25rem) 50%, background-size 18px, padding-left u(2.5rem));
+  //   }
+  // }
 
   &.button--alt-primary::after,
   &.button--alt-secondary::after {


### PR DESCRIPTION
## Summary

- Resolves #6045 

Multi-select dropdown filters were visually glitching while in their is-successful state

### Required reviewers

- reporter
- a dev?
- an SME for dropdown filter locations?

## Impacted areas of the application

All dropdown filters, particularly those who could be switched to an is-successful state

## Screenshots

No visual changes—when working correctly, the down arrow doesn't change size

## Related PRs

None

## How to test

- pull the branch
- `npm run build-sass`
- `./manage.py runserver`
- Check the multi-select dropdown filters (check and uncheck the choices). The dropdown's icon should change to the loading ellipsis but then change back to the same-sized down arrow as it started
- Some pages that use the multi-select dropdown filters
  - http://127.0.0.1:8000/data/receipts/?data_type=processed&two_year_transaction_period=2024&min_date=01%2F01%2F2023&max_date=12%2F31%2F2024&contributor_state=AS&contributor_state=AK
  - http://127.0.0.1:8000/data/party-coordinated-expenditures/?cycle=2024
  - http://127.0.0.1:8000/data/filings/?data_type=processed&candidate_id=P80001571&state=AS&form_type=F2&form_type=F3&form_type=RFAI
- Some other places that use the dropdown is-successful filter
  - [ ] Where else could this affect?