### PR TITLE
Add 2025-2026 links for bulk datasets

### DIFF
--- a/fec/data/templates/partials/browse-data/candidates.jinja
+++ b/fec/data/templates/partials/browse-data/candidates.jinja
@@ -16,6 +16,7 @@
               <i class="icon i-download icon--absolute--left"></i>
               <div class="content__section--indent-left">
                 <ul class="list--flat-bordered u-no-margin">
+                  <li><a href="/files/bulk-downloads/2026/candidate_summary_2026.csv">2025–2026</a></li>
                   <li><a href="/files/bulk-downloads/2024/candidate_summary_2024.csv">2023–2024</a></li>                  
                   <li><a href="/files/bulk-downloads/2022/candidate_summary_2022.csv">2021–2022</a></li>
                   <li><a href="/files/bulk-downloads/2020/candidate_summary_2020.csv">2019–2020</a></li>


### PR DESCRIPTION
## Summary (required)

Add 2025-2026 bulk datasets links  under  **candidates/all candidates** section
- Related #6645 

(Include a summary of proposed changes and connect issue below)

### Required reviewers

1 developer

### Related PRs

https://github.com/fecgov/fec-cms/pull/6647

## Impacted areas of the application

-  [Browse data Candidates](https://www.fec.gov/data/browse-data/?tab=candidates)

## Screenshots

**Before: In Production** 
<img width="1234" alt="Screenshot 2025-02-18 at 7 35 24 AM" src="https://github.com/user-attachments/assets/2ed83cb8-c087-44bb-bdc2-f7f111256fff" />

**After: In local branch**

<img width="1238" alt="Screenshot 2025-02-18 at 7 36 39 AM" src="https://github.com/user-attachments/assets/7cdbf343-eec8-4a71-ba13-81258a3dad11" />



## How to test

-  run `git checkout feature/add-all-candidates-bulk-downloads-link`
- run `pyenv activate <cms virtualenv>`
- run ` cd fec`
- run `./manage.py runserver`
-  Verify newly setup 2025-2026 links are available under [Candidates/All candidates ](http://127.0.0.1:8000/data/browse-data/?tab=candidates)
