### PR TITLE
Fix Admin fines penalty amounts

### DIFF
--- a/fec/legal/templates/legal-admin_fine.jinja
+++ b/fec/legal/templates/legal-admin_fine.jinja
@@ -79,7 +79,7 @@
               {% for item in admin_fine.disposition_items[item] %}
                 <tr class="{{ itemloop.cycle('row-color-normal', 'row-color-contrast') }}">
                   <td>{{ item.disposition_description | replace('RTB', 'Reason to believe')}}</td>
-                  <td>{{ item.amount  | currency or 'Not applicable' }}</td>
+                  <td>{{ item.penalty  | currency or 'Not applicable' }}</td>
                   <td>{{ item.disposition_date | date(fmt='%m/%d/%Y') }}</td>
                 </tr>
               {% endfor %}


### PR DESCRIPTION
## Summary (required)

- Resolves #6684 

Updates disposition rows to use `penalty` instead of `amount` for penalty values.

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

-  AF canonical pages

## Related PRs

Related PRs against other branches:

https://github.com/fecgov/openFEC/pull/6023/files#diff-dfe44ead3abda2c14d09833b0191cf66c3cad807fdd2c4b97cf5919e5fb16403R230

## How to test

- Try a few admin fine pages:
   - http://localhost:8000/data/legal/administrative-fine/4463/
   - http://localhost:8000/data/legal/administrative-fine/4245/
   - http://localhost:8000/data/legal/administrative-fine/4158/

