### PR TITLE
5353 - Add Donations Tables for Inaugural Committees

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -119,10 +119,11 @@
               href="#section-3">Raising</a>
               {% if committee_type not in ['C', 'E', 'I'] %}
               <ul>
-                <li><a href="#total-receipts">Total receipts</a></li>
                 {% if is_inaugural %}
+                <li><a href="#total-receipts">Total donations</a></li>
                 <li><a href="#donations">Donations</a></li>
                 {% else %}
+                <li><a href="#total-receipts">Total receipts</a></li>
                 <li><a href="#individual-contribution-transactions">Individual contribution transactions</a></li>
                 {% endif %}
                 {% if FEATURES.nat_party_acct_rec_single and totals_national_party %}

--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -69,7 +69,7 @@
             aria-controls="panel1"
             href="#section-1"
             aria-selected="true">Financial Summary</a>
-            {% if committee_type != 'I' %}
+            {% if committee_type != 'I' and not is_inaugural -%}
             <ul>
               {% if FEATURES.pac_snapshot %}<li><a href="#committee-snapshot">Committee snapshot</a></li>{% endif %}
               <li><a href="#total-raised">Total raised</a></li>
@@ -120,7 +120,9 @@
               {% if committee_type not in ['C', 'E', 'I'] %}
               <ul>
                 <li><a href="#total-receipts">Total receipts</a></li>
-                {% if not is_inaugural %}
+                {% if is_inaugural %}
+                <li><a href="#donations">Donations</a></li>
+                {% else %}
                 <li><a href="#individual-contribution-transactions">Individual contribution transactions</a></li>
                 {% endif %}
                 {% if FEATURES.nat_party_acct_rec_single and totals_national_party %}

--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -35,16 +35,87 @@
         </div>
       </div>
       <div class="content__section--ruled">
-      <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
-    </div>
+        <p class="t-small u-negative--top--margin"><i>Newly filed summary data may not appear for up to 48 hours.</i></p>
+      </div>
     </div>
   {% endif %}
-  {% if not is_inaugural %}
+  {% if is_inaugural %}
+    <div id="donations" class="entity__figure row">
+      <div class="heading--section heading--with-action">
+        <h3 class="heading__left">Donations</h3>
+        <a class="heading__right button--alt button--browse"
+          href="/data/receipts/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}">Filter this data</a>
+      </div>
+      {#- Toggles for the individual tables -#}
+      <fieldset class="row toggles js-toggles">
+        <legend class="label">Group by:</legend>
+        <label for="toggle-itemized">
+          <input id="toggle-itemized" type="radio" class="js-panel-toggle-control" name="donations-group" value="donations-itemized" checked>
+          <span class="button--alt">All transactions</span>
+        </label>
+        <label for="toggle-state">
+          <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="donations-group" value="donations-by-donor">
+          <span class="button--alt">Donor</span>
+        </label>
+      </fieldset>
+      {#- The tables that will be toggled -#}
+      <div class="row">
+        <div id="donations-by-donor" class="panel-toggle-element" aria-hidden="true">
+          <div class="results-info results-info--simple">
+            {% if totals %}
+            <div class="u-float-left tag__category">
+              <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
+            </div>
+            {% endif %}
+            <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-donor">Export</button>
+          </div>
+          <table
+              class="data-table data-table--heading-borders"
+              data-type="inaugural-donations-by-donor"
+              data-committee="{{ committee.committee_id }}"
+              data-cycle="{{ cycle }}"
+            >
+            <thead>
+              <th scope="col">Employer</th>
+              <th scope="col">Total contributed</th>
+            </thead>
+          </table>
+          {{ disclaimer.disclaimer('receipts', committee.committee_id, cycle) }}
+        </div>
+        <div id="donations-itemized" class="panel-toggle-element">
+          <div class="results-info results-info--simple">
+            {% if totals %}
+            <div class="u-float-left tag__category">
+              <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
+            </div>
+            {% endif %}
+            <div class="u-float-right">
+              <button type="button" class="js-export button button--cta button--export" data-export-for="itemized-receipts">Export</button>
+              <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="itemized-receipts" aria-hidden="true"></div>
+            </div>
+          </div>
+          <table
+              class="data-table data-table--heading-borders"
+              data-type="inaugural-donations"
+              data-committee="{{ committee.committee_id }}"
+              data-cycle="{{ cycle }}"
+            >
+            <thead>
+              <th scope="col">Donor name</th>
+              <th scope="col">State</th>
+              <th scope="col">Date</th>
+              <th scope="col">Amount</th>
+            </thead>
+          </table>
+        </div>
+      </div>
+    </div>
+  {% else %}{#- ends if is_inaugural #}
   <div class="entity__figure" id="individual-contribution-transactions">
     <div class="heading--section heading--with-action">
       <h3 class="heading__left">Individual contributions</h3>
       <a class="heading__right button--alt button--browse"
-          href="/data/individual-contributions/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}">Filter this data</a>
+        href="/data/individual-contributions/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}">Filter this data</a>
     </div>
     <fieldset class="row toggles js-toggles">
       <legend class="label">Group by:</legend>

--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -17,9 +17,10 @@
   {% if totals and committee_type not in ['C', 'E', 'I'] %}
     <div id="total-receipts" class="entity__figure row">
       <div class="heading--section heading--with-action">
-        <h3 class="heading__left">Total receipts</h3>
+        <h3 class="heading__left">Total {% if is_inaugural %}donations{% else %}receipts{% endif %}</h3>
         <a class="heading__right button--alt button--browse"
-          href="/data/receipts/?two_year_transaction_period={{ cycle }}&committee_id={{ committee_id }}">Filter all receipts</a>
+          href="/data/receipts/?two_year_transaction_period={{ cycle }}&committee_id={{ committee_id }}">Filter all
+          {% if is_inaugural %}donations{% else %}receipts{% endif %}</a>
       </div>
       <div class="content__section--narrow">
         <div class="row u-margin-bottom">
@@ -28,9 +29,9 @@
           </div>
         </div>
         <div class="row">
-          <span class="usa-width-one-half t-block t-sans">raised in total receipts by this committee from <strong>{{totals.coverage_start_date|date_full(time_tag=True)}} to {{totals.coverage_end_date|date_full(time_tag=True)}}.</strong></span>
+          <span class="usa-width-one-half t-block t-sans">raised in total {% if is_inaugural %}donations{% else %}receipts{% endif %} by this committee from <strong>{{totals.coverage_start_date|date_full(time_tag=True)}} to {{totals.coverage_end_date|date_full(time_tag=True)}}.</strong></span>
           <div class="usa-width-one-half">
-            <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of receipt.</span>
+            <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of {% if is_inaugural %}donation{% else %}receipt{% endif %}.</span>
           </div>
         </div>
       </div>

--- a/fec/data/templates/partials/committee/spending.jinja
+++ b/fec/data/templates/partials/committee/spending.jinja
@@ -24,7 +24,8 @@
           <h3 class="heading__left">Total refunds</h3>
           {% endif %}
           <a class="heading__right button--alt button--browse"
-              href="/data/disbursements/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}">Filter all disbursements
+              href="/data/disbursements/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}"
+              >Filter all {% if is_inaugural %}refunds{% else %}disbursements{% endif %}
           </a>
         </div>
         <div class="content__section--narrow">

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -669,8 +669,8 @@ DataTable_FEC.prototype.checkFromQuery = function() {
     // No Set-timeout needed on datatables without two filter panels…
     // …Also it causes a noticeable intermittent time-lag while populating table on these pages
     } else {
-    // Iterate the array of matching checkboxes(queryBoxes), check them and fire change()...
-    // ...if they are not already checked
+    // Iterate the array of matching checkboxes(queryBoxes), check them and fire change()…
+    // …if they are not already checked
     for (let box of queryBoxes) {
       if (!($(box).is(':checked'))) {
         $(box).prop('checked', true).change(); // TODO: jQuery deprecation
@@ -1091,6 +1091,10 @@ DataTable_FEC.prototype.hideEmpty = function(response) {
 
 DataTable_FEC.registry = {};
 
+/**
+ * @param {JQuery} $table
+ * @param {Object} opts
+ */
 DataTable_FEC.defer = function($table, opts) {
   tabsOnShow($table, function() {
     new DataTable_FEC($table, opts);

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -160,9 +160,9 @@ const disbursementRecipientColumns = [
     className: 'all',
     orderable: false,
     render: function ( data ) {
-      if(data) {
+      if (data) {
         return data + '%';
-      } else{
+      } else {
         return 'Could not calculate';
       }
     }
@@ -412,6 +412,18 @@ const nationalPartySpendingColumns = [
   })
 ];
 
+const inauguralTotalsByDonorsColumns = [
+  {
+    data: 'contributor_name',
+    className: 'all',
+    orderable: false
+  },
+  currencyColumn({
+    data: 'total_donation',
+    className: 'min-desktop hide-panel column--number t-mono'
+  })
+];
+
 const aggregateCallbacks = {
   afterRender: barsAfterRender.bind(undefined, undefined)
 };
@@ -607,6 +619,58 @@ $(function() {
           })
         );
         break;
+      case 'inaugural-donations':
+        path = ['schedules', 'schedule_a'];
+        // For raising/spending tabs, use previous cycle if provided
+        cycle = window.context.cycle || $table.attr('data-cycle');
+        DataTable_FEC.defer(
+          $table,
+          _extend({}, tableOpts, {
+            path: path,
+            query: {
+              committee_id: committeeId,
+              two_year_transaction_period: cycle
+              // is_individual: true
+            },
+            columns: individualContributionsColumns,
+            callbacks: aggregateCallbacks,
+            order: [[3, 'desc']],
+            useExport: true,
+            singleEntityItemizedExport: true,
+            paginator: SeekPaginator,
+            hideEmptyOpts: {
+              dataType: 'inaugural donations', // helps build `We don't have ${dataType} for ${cycle}`
+              name: window.context.name,
+              timePeriod: window.context.timePeriod,
+              reason: missingDataReason('contributions')
+            }
+          })
+        );
+        break;
+        case 'inaugural-donations-by-donor':
+          path = ['totals', 'inaugural_committees', 'by_contributor'];
+          // For raising/spending tabs, use previous cycle if provided
+          cycle = window.context.cycle || $table.attr('data-cycle');
+          DataTable_FEC.defer(
+            $table,
+            _extend({}, tableOpts, {
+              path: path,
+              query: _extend(query, {
+                committee_id: committeeId,
+                cycle: cycle
+              }),
+              columns: inauguralTotalsByDonorsColumns,
+              callbacks: aggregateCallbacks,
+              order: [[1, 'desc']],
+              hideEmptyOpts: {
+                dataType: 'inaugural donations',
+                name: window.context.name,
+                timePeriod: window.context.timePeriod,
+                reason: missingDataReason('contributions')
+              }
+            })
+          );
+          break;
       case 'disbursements-by-recipient':
         path = ['schedules', 'schedule_b', 'by_recipient'];
         // For raising/spending tabs, use previous cycle if provided


### PR DESCRIPTION
## Summary

- Resolves #5353 

Adding the donations tables for inaugural committees

### Required reviewers

- dev
- UX
- SME(s)? (Tricia?)

## Impacted areas of the application

The left column for single committee pages but, because of the if, we should check other non-inaugural committees' pages to make sure they haven't changed.  

## Screenshots

| Before / Production  | After / this PR |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/e18bf01b-b375-4bf0-ade5-fb89391c8c23)  | ![image](https://github.com/user-attachments/assets/5ecc88c0-7955-4bf4-81c9-6867a0b3b761)  |

## Related PRs

None

## How to test

- Pull the branch
- `npm run build`
- `./manage.py runserver`
- Some inaugural committees to test (these types of committees are limited)
  - [2009](http://127.0.0.1:8000/data/committee/C00458166/)
  - [2013](http://127.0.0.1:8000/data/committee/C00540005/)
- Review
  - Raising section functions as expected
  - sub items/anchors moved the page
  - "All" and "donor" tabs function
  - "All" and "donor" table sorting works and the information is correct
  - "Filter this data" buttons work as expected
  - "Export" buttons work as expected (which can't be tested on localhost, right?)
  - Other committee pages' raising Financial Summary and Raising sections are unaffected