### PR TITLE
Update year and office constants

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -4,11 +4,11 @@ import operator
 from data import utils
 
 START_YEAR = 1979
-END_YEAR = 2024
+END_YEAR = 2026  # Change at the beginning of the year
 DEFAULT_TIME_PERIOD = 2024  # Change after the April quarterly report (4/15/25)
-DEFAULT_ELECTION_YEAR = 2024  # Change after election day (11/5/24)
+DEFAULT_ELECTION_YEAR = 2026  # Change after election day (11/3/26)
 DEFAULT_PRESIDENTIAL_YEAR = 2024  # Change after April quarterly after mid-terms (4/15/25)
-DISTRICT_MAP_CUTOFF = 2024  # The year we show district maps for on election pages
+DISTRICT_MAP_CUTOFF = 2026  # The year we show district maps for on election pages. Change at the beginning of the year.
 
 states = OrderedDict([
     ('AL', 'Alabama'),

--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -3,6 +3,13 @@ import operator
 
 from data import utils
 
+# Updating END_YEAR, DEFAULT_ELECTION_YEAR, or DISTRICT_MAP_CUTOFF
+# affects transaction tables and raising/spending visualizations.
+# Also update related visualization logic in:
+#   - fec/data/views.py: def raising, office; def spending, office
+#   - home/templatetags/top_entities.py: def raising_spending, office
+#   - homes/templates/home/home_page.html: officeSelector.value; yearSelector.value
+
 START_YEAR = 1979
 END_YEAR = 2026  # Change at the beginning of the year
 DEFAULT_TIME_PERIOD = 2024  # Change after the April quarterly report (4/15/25)

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -933,7 +933,7 @@ def house_senate_overview(request, office, cycle=None):
 
 
 def raising(request):
-    office = request.GET.get("office", "P")  # The default for features like Who is raising the most
+    office = request.GET.get("office", "S")  # The default for features like Who is raising the most
 
     election_year = int(
         request.GET.get("election_year", constants.DEFAULT_ELECTION_YEAR)
@@ -957,7 +957,7 @@ def raising(request):
 
 
 def spending(request):
-    office = request.GET.get("office", "P")  # The default for features like Who is spending the most
+    office = request.GET.get("office", "S")  # The default for features like Who is spending the most
 
     election_year = int(
         request.GET.get("election_year", constants.DEFAULT_ELECTION_YEAR)

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -121,12 +121,12 @@
     });
     {# Handle Chrome inconsistency with History API #}
     const officeSelector = document.querySelector('.js-office');
-    if (officeSelector) officeSelector.value = 'P';
+    if (officeSelector) officeSelector.value = 'S';
     // $('.js-office').val('P');
     {# This should be changed with /fec/home/templates_tags/top_entites.py #}
     {# TODO: make this more elegant #}
     const yearSelector = document.querySelector('.js-election-year');
-    if (yearSelector) yearSelector.value = '2024';
+    if (yearSelector) yearSelector.value = '2026';
     // $('.js-election-year').val('2024');
     const chartToggleReceipts = document.querySelector('.js-chart-toggle [value=receipts]');
     if (chartToggleReceipts) chartToggleReceipts.setAttribute('checked', true);

--- a/fec/home/templatetags/top_entities.py
+++ b/fec/home/templatetags/top_entities.py
@@ -9,7 +9,7 @@ register = template.Library()
 
 @register.inclusion_tag('partials/raising-spending.html')
 def raising_spending(request):
-    office = request.GET.get('office', 'P')  # Sets the default office for the homepage feature
+    office = request.GET.get('office', 'S')  # Sets the default office for the homepage feature
     # If changing this, look at line 130 in /fec/home/templates/home/home_page.html
     # TODO: make this more elegant
 


### PR DESCRIPTION
## Summary

- Resolves #6689 

Updated the default constants for `END_YEAR`, `DEFAULT_ELECTION_YEAR`, and `DISTRICT_MAP_CUTOFF` to 2026 for the new year. Also updated visualizations to default to Senate 2026 for the new election two-year-period.

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

- Homepage, Who's raising/spending the most visualization: http://localhost:8000/
- Raising by the numbers: http://localhost:8000/data/raising-bythenumbers/
- Spending by the numbers: http://localhost:8000/data/spending-bythenumbers/
- Elections district map: http://localhost:8000/data/elections/
- Transaction and reports datatables should now show 2025-2026 as a year option. Try http://localhost:8000/data/filings/?data_type=processed and http://localhost:8000/data/receipts/. May want to try disbursements as well.

## How to test

- Pull down this branch
- `npm run build-js`
- `cd fec && manage.py runsserver`
- Check each of the pages in the impacted areas of this application section. Ensure that the years are defaulting to 2026 and Senate where appropriate. 
- Ensure that the 2026 option is available for transactions and report datatables and visualizations.