### PR TITLE
6517 MURS Filters Tooltips

### DIFF
--- a/fec/data/templates/macros/filters/typeahead-filter.jinja
+++ b/fec/data/templates/macros/filters/typeahead-filter.jinja
@@ -1,11 +1,19 @@
-{% macro field(name, title, instructions=False, dataset='committees', allow_text=False, id_suffix='', minor_label_text=False, helper_text=False) %}
+{% macro field(name, title, instructions=False, dataset='committees', allow_text=False, id_suffix='', minor_label_text=False, helper_text=False, show_tooltip_text='') %}
 <div
   class="filter js-filter typeahead-filter"
   data-filter="typeahead"
   data-name="{{ name }}"
   id="{{ name }}-field{{id_suffix}}"
   data-dataset="{{ dataset }}" {% if allow_text %}data-allow-text{% endif %}>
-  {% if minor_label_text %}
+  {% if show_tooltip_text != '' %}
+    <label class="label t-inline-block" for="{{ name }}{{id_suffix}}">{{ title }}</label>
+    <div class="tooltip__container" tabindex="0">
+      <button class="tooltip__trigger" tabindex="0"><span class="u-visually-hidden">Learn more</span></button>
+      <div class="tooltip tooltip--left tooltip--above">
+        <p class="tooltip__content tooltip__content">{{show_tooltip_text}}</p>
+      </div>
+    </div>
+  {% elif minor_label_text %}
     <label for="{{ name }}{{id_suffix}}">{{ title }}</label>
   {% else %}
     <label class="label" for="{{ name }}{{id_suffix}}">{{ title }}</label>

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -147,9 +147,10 @@
       <label for="case_citation_require_all_false">Show cases citing any of them</label>
       <input type="radio" id="case_citation_require_all_true" name="case_citation_require_all" value="true"{% if case_citation_require_all == 'true' %} checked{% endif %}>
       <label for="case_citation_require_all_true">Show cases citing all of them</label>
-      {{ typeahead.field('case_regulatory_citation', 'Regulatory citation', False, dataset='caseRegulatoryCitations', allow_text=False) }}
-      {{ typeahead.field('case_statutory_citation', 'Statutory citation', False, dataset='caseStatutoryCitations', allow_text=False) }}
-      
+      {{ typeahead.field('case_regulatory_citation', 'Regulatory citation', False, dataset='caseRegulatoryCitations',
+        allow_text=False, show_tooltip_text='Regulatory citation does not search archived cases') }}
+      {{ typeahead.field('case_statutory_citation', 'Statutory citation', False, dataset='caseStatutoryCitations',
+        allow_text=False, show_tooltip_text='Statutory citation does not search archived cases') }}
     </div>
   </div>
   <div class="filters__inner">


### PR DESCRIPTION
## Summary

- Resolves #6517 

Adding tooltips for typeahead filters and giving them content for regulatory and statutory citations for MURs filters

### Required reviewers

- UX
- A dev

## Impacted areas of the application

Technically every typeahead filter on the site, but should only be a visible change where we've also added `show_tooltip_text`

-  

## Screenshots

Typeahead with no tooltip - local
<img width="472" alt="image" src="https://github.com/user-attachments/assets/ea6622c5-d5d2-458e-815e-5427463c365f" />

Typeahead with no tooltip - Production
![image](https://github.com/user-attachments/assets/ec7f505e-8cb7-4005-8f5d-3a2ebcf9771c)


Typeahead with new tooltip - local
<img width="521" alt="image" src="https://github.com/user-attachments/assets/612139bd-5277-4a33-89f6-6fbc0adcbaec" />

Typeahead pre-tooltip - Production
![image](https://github.com/user-attachments/assets/94b52803-295b-4d0d-aed8-87b779ce2f0e)


## Related PRs

None

## How to test

- Pull the branch
- `npm run build`
- `./manage.py runserver`
- Check that the [citation filters for MURs](http://127.0.0.1:8000/data/legal/search/murs/) have the tooltips
- Check that other datatables' typeaheads haven't changed
