### PR TITLE
Change Citations filters labels for AO & MURs

### DIFF
--- a/fec/legal/templates/legal-search-results-advisory_opinions.jinja
+++ b/fec/legal/templates/legal-search-results-advisory_opinions.jinja
@@ -47,7 +47,7 @@
     </div>
     {{ date.field('document_date', 'Document date', id_prefix='ao_') }}
   </div>
-  <button type="button" class="js-accordion-trigger accordion__button">Citations</button>
+  <button type="button" class="js-accordion-trigger accordion__button">Final opinion footnote citations</button>
   <div class="accordion__content">
     <label>If more than one citation is entered:</label>
     <input type="radio" id="ao_citation_require_all_false" name="ao_citation_require_all" value="false"{% if ao_citation_require_all != 'true' %} checked{% endif %}>

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -139,7 +139,7 @@
 
   {# </div> #}
   {# <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false"> #}
-    <button type="button" class="js-accordion-trigger accordion__button">Citations</button>
+    <button type="button" class="js-accordion-trigger accordion__button">Disposition citations</button>
 
     <div class="accordion__content">
       <label>If more than one citation is entered:</label>


### PR DESCRIPTION
## Summary

- Resolves #6692 

Changing the labels for the "Citations" filters for AOs and MURs

### Required reviewers

- one

## Impacted areas of the application

AOs & MURs filters but only those for Citations 

## Screenshots

AOs
<img width="599" alt="image" src="https://github.com/user-attachments/assets/5099f364-8ad6-496d-b0c2-7bbc8f0fd0f4" />

MURs
<img width="525" alt="image" src="https://github.com/user-attachments/assets/01011c71-bf67-47ce-bf7b-e33f699b008c" />


## Related PRs

None

## How to test

- Pull the branch
- Test [MURs](http://127.0.0.1:8000/data/legal/search/murs/)
- Test [AOs](http://127.0.0.1:8000/data/legal/search/advisory-opinions/)
- approve, merge