### PR TITLE
2808 - Don't remove side padding for smallest $lg widths

### DIFF
--- a/fec/fec/static/scss/layout/_layout.scss
+++ b/fec/fec/static/scss/layout/_layout.scss
@@ -11,10 +11,14 @@
   padding: u(0 2rem);
   @include outer-container;
 
-  // There's a point early in $xl where we still want the side padding
-  // 20 px on each side
-  @media (min-width: calc(1088px + 2rem) ) {
+  @include media($lg) {
     padding: 0;
+  }
+}
+// Keep content off the side of the browser in these in-between widths as soon as we get into $lg
+@media screen and (min-width: 860px) and (max-width: 990px) {
+  .container {
+    max-width: calc(100vw - 4rem); // 2rem on each side
   }
 }
 

--- a/fec/fec/static/scss/layout/_layout.scss
+++ b/fec/fec/static/scss/layout/_layout.scss
@@ -11,7 +11,9 @@
   padding: u(0 2rem);
   @include outer-container;
 
-  @include media($lg) {
+  // There's a point early in $xl where we still want the side padding
+  // 20 px on each side
+  @media (min-width: calc(1088px + 2rem) ) {
     padding: 0;
   }
 }


### PR DESCRIPTION
## Summary

- Resolves #2808 

Visual tweak. We were removing the side padding for main content columns as soon as we got into the $lg range but that meant content was against the edge of the browser window. This change adds a media query for that column so the content in full-width .container is never closer to the edges than the padding shared among the other widths

### Required reviewers

- 1 dev for code & UX?
- 1 UX?

## Impacted areas of the application

The smallest widths of the $lg range for the `.container` selector

## Screenshots

Localhost/this PR above; www below
<img width="956" alt="image" src="https://github.com/user-attachments/assets/d3e3208f-42bf-4111-8f0b-475a7ecf1073" />

Localhost/this PR above; www below
<img width="955" alt="image" src="https://github.com/user-attachments/assets/d319dace-8c25-40f4-80ea-2dfbbddb2fce" />

Localhost/this PR above; www below
<img width="927" alt="image" src="https://github.com/user-attachments/assets/c3962aaa-8b21-4865-8e8a-13e02cb9a828" />


## Related PRs

None

## How to test

- Pull the branch
- `npm run build`
- `./manage.py runserver`
- Load the site in localhost
- Open inspector to more easily see the page widths. We're looking at widths 850px to 1000px (10px before the new media query starts and 10px after it ends)
- Check pages that use the .container class
  - The content in the top red or blue section for pages like [About](http://127.0.0.1:8000/about/) or [Legal Resources](http://127.0.0.1:8000/legal-resources/)
  - The page title and text directly under it for pages like [Mission and History](http://127.0.0.1:8000/about/mission-and-history/)
  - The main page content as a whole for pages like [H4CC Guides](http://127.0.0.1:8000/help-candidates-and-committees/guides/) or [Browse Data](http://127.0.0.1:8000/data/browse-data/?tab=raising)