### PR TITLE
Add q_exclude to statutes

### DIFF
--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -686,7 +686,6 @@ def legal_doc_search_regulations(request):
 def legal_doc_search_statutes(request):
     original_query = request.GET.get('search', '')
     results = {}
-    query = request.GET.get('search', '')
     offset = request.GET.get('offset', 0)
 
     query, query_exclude = parse_query(original_query)

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -684,18 +684,25 @@ def legal_doc_search_regulations(request):
 
 
 def legal_doc_search_statutes(request):
+    original_query = request.GET.get('search', '')
     results = {}
     query = request.GET.get('search', '')
     offset = request.GET.get('offset', 0)
 
-    results = api_caller.load_legal_search_results(query, '', 'statutes',
-                                                   offset=offset)
+    query, query_exclude = parse_query(original_query)
+
+    results = api_caller.load_legal_search_results(
+            query,
+            query_exclude,
+            'statutes',
+            offset=offset,
+        )
 
     return render(request, 'legal-search-results-statutes.jinja', {
         'parent': 'legal',
         'results': results,
         'result_type': 'statutes',
-        'query': query,
+        'query': original_query,
         'social_image_identifier': 'legal',
     })
 


### PR DESCRIPTION
## Summary (required)

- Resolves #6679 

Add q_exclude to statues API query

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Statutes search

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/6133-fix-q_exclude-for-statutes (API) | [link](https://github.com/fecgov/openFEC/pull/6137)
feature/bool-ops-simple-query-string-v2 (CMS) | [link](https://github.com/fecgov/fec-cms/pull/6405)

## How to test

- Go to the statutes search and perform a search with exclude in the statement. The exclude should be split out into it's own `q_exclude` parameter.
   - Example of one result 
      CMS: http://localhost:8000/data/legal/search/statutes/?search=federal%20-activities&search_type=statutes
      API call: https://api.open.fec.gov/v1/legal/search?type=statutes&hits_returned=20&from_hit=0&q=federal&q_exclude=activities&api_key=DEMO_KEY
   - Example of no results 
      CMS: http://localhost:8000/data/legal/search/statutes/?search_type=statutes&search=federal+-election
      API call: https://api.open.fec.gov/v1/legal/search?type=statutes&hits_returned=20&from_hit=0&q=federal&q_exclude=election&api_key=DEMO_KEY
  