### PR TITLE
Rewrite AO legal citations to point to the eCFR

### DIFF
--- a/fec/legal/templates/legal-advisory-opinion.jinja
+++ b/fec/legal/templates/legal-advisory-opinion.jinja
@@ -111,7 +111,7 @@
                     {% if advisory_opinion.regulatory_citations %}
                     {% for citation in advisory_opinion.regulatory_citations %}
                     <div>
-                      <a href="{{ '/regulations/{0}-{1}/CURRENT#{0}-{1}'.format(citation.part, citation.section) }}">{{ citation.title }} CFR &sect;{{ citation.part }}.{{ citation.section }}</a>
+                      <a href="{{ 'https://www.ecfr.gov/current/title-{0}/section-{1}.{2}'.format(citation.title, citation.part, citation.section) }}">{{ citation.title }} CFR &sect;{{ citation.part }}.{{ citation.section }}</a>
                     </div><br>
                     {% endfor %}
                     {% else %}


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/fec-proxy/issues/414

For AO citations that are outside of the FEC's title 11 jurisdiction, we must reformat the URL to point directly to the eCFR with the title and section defined in the URL. This allows for the eCFR to correctly find the corresponding citation.

### Required reviewers

One engineer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Advisory opinion individual page

## How to test

- Go to an individual AO page that has legal citations that are outside of title 11. For example: http://localhost:8000/data/legal/advisory-opinions/2012-02/
- Try the URLs for citations that are outside of title 11, such as title 29. The link should go to the correct corresponding title and section inside the eCFR.
- Similarly, try the URLs or citations that are part of title 11. The link should go to the correct corresponding title 11 and section inside the eCFR.
