### PR TITLE
4258 - Auto-size block-table table columns

### DIFF
--- a/fec/fec/static/scss/components/_articles.scss
+++ b/fec/fec/static/scss/components/_articles.scss
@@ -26,6 +26,7 @@
 }
 .block-table {
   table {
+    table-layout: auto;
     @extend .simple-table-cms;
   }
 }


### PR DESCRIPTION
## Summary

- Resolves #4258 

Letting block-table table columns autosize

### Required reviewers

- 1+ devs
- 1+ SMEs?
(I tagged way more than I needed)

## Impacted areas of the application

Added `table-layout: auto;` to `.block-table table`.

It won't affect any table that's not in a `block-table` class element, but it will affect _every_ table inside one.

**SMEs**: Are there places we do _not_ want this to happen—anyplace where this will break things?

## Screenshots

Production above, localhost below
![image](https://github.com/user-attachments/assets/82a968f2-c365-4edb-9a82-2c6b1f35baca)


## Related PRs

None

## How to test

- Pull the branch
- `npm run build`
- `./manage.py runserver`
- Check [the example page used for this ticket](http://127.0.0.1:8000/legal-resources/enforcement/audit-reports/authorized-committee-audit-reports/kelly-for-congress-2016/)
- Check other locations `.block-table table` is being used
   - Are they generally okay?
   - Any of them broken?

### How to test in Inspector
- In the browser
  - right-click on something in the table ("Description" is good one)
  - choose Inspector.
- In the Elements tab,
  - click the `<table>` element
- Over (or down) in the Styles panel/tab,
  - click the plus sign
  - paste in `.block-table table`
  - tab
  - type/choose `table-layout`
  - tab
  - type/choose `auto`
  - tab (or enter or click outside)
- It should update in real time