### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Hotfix/calendar event time style fix

### DIFF
--- a/fec/fec/static/scss/components/_calendar.scss
+++ b/fec/fec/static/scss/components/_calendar.scss
@@ -468,9 +468,11 @@
 }
 
 .cal-list__time {
-  margin-right: 0 !important; // overriding omega()
   @include span-columns(4 of 8);
   @include omega;
+  & {
+    margin-right: 0; // overriding omega()
+  }
 }
 
 .cal-list__info {


### PR DESCRIPTION
## Summary

- Resolves #6719 

Adjusting the layout after the Sass upgrade a little while ago, we'd added an `!important` for the `margin-right` but that wasn't being overridden when we needed it to be.

This change removes the `!important` and changes the way that bit of sass is structured (i.e. moves the `margin-right` into a `& { … }` so we don't get deprecation warnings)

### Required reviewers

- 1 Dev

## Impacted areas of the application

The right margin of calendar event dates in the list view and only widths >= 860px

## Screenshots

The right margin is back
<img width="300" alt="image" src="https://github.com/user-attachments/assets/213a429d-af28-43f6-a662-c6ada221351b" />

## Related PRs

None

## How to test

- Pull
- `npm run build-sass`
- `./manage.py runserver`
- Check the [Calendar page](http://127.0.0.1:8000/calendar/)
- Make sure the calendar stays in the list view and the left menu should be closed
- Check the events' time columns from 860px and up