### PR TITLE
Toggle Election Search Map

### DIFF
--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -32,9 +32,8 @@
               <label for="zip" class="label">Find by ZIP code</label>
               <input type="text" inputmode="numeric" id="zip" name="zip" class="combo__input">
               <button class="combo__button button--search button--standard" type="submit">
-                  <span class="u-visually-hidden">Search</span>
+                <span class="u-visually-hidden">Search</span>
               </button>
-
               <span class="t-note t-sans search__example">Example: 90210</span>
             </div>
           </div>
@@ -61,7 +60,7 @@
               </select>
             </div>
             <div class="search-controls__submit">
-                <button type="submit" class="button--search--text button--standard">Search</button>
+              <button type="submit" class="button--search--text button--standard">Search</button>
             </div>
           </fieldset>
         </div>
@@ -73,8 +72,8 @@
       <div class="usa-width-one-half">
         <div class="js-accordion accordion--neutral u-padding--bottom" data-content-prefix="2022-redistricting">
           <button type="button" class="js-accordion-trigger accordion__button" aria-controls="2022-redistricting-content-0" aria-expanded="false">Information about redistricting and the 2020 Decennial Census</button>
-            <div class="accordion__content" id="2022-redistricting-content-0" aria-hidden="true">
-              <p>Following the 2020 Census, some states have redrawn their district maps. The FEC has updated its map to reflect the new congressional districts and boundaries.</p>
+          <div class="accordion__content" id="2022-redistricting-content-0" aria-hidden="true">
+            <p>Following the 2020 Census, some states have redrawn their district maps. The FEC has updated its map to reflect the new congressional districts and boundaries.</p>
           </div>
         </div>
         <div class="heading--section js-results-heading">
@@ -82,9 +81,9 @@
         {% if FEATURES.house_senate_overview %}
         </div>
         <div class="u-padding--top">
-         <span class="heading__subtitle">All Elections</span>
-           <h3  class="u-no-margin-bottom u-margin--top"><span class="icon i-star icon--inline--left"></span><a href="/data/elections/senate/">All Senate elections</a></h3>
-           <h3><span class="icon i-star icon--inline--left"></span><a href="/data/elections/house/">All House elections</a></h3>
+          <span class="heading__subtitle">All Elections</span>
+          <h3 class="u-no-margin-bottom u-margin--top"><span class="icon i-star icon--inline--left"></span><a href="/data/elections/senate/">All Senate elections</a></h3>
+          <h3><span class="icon i-star icon--inline--left"></span><a href="/data/elections/house/">All House elections</a></h3>
         </div>
         <div class="result u-padding--bottom--small u-negative--bottom--margin">
         {% endif %}
@@ -94,8 +93,8 @@
           <div class="js-accordion accordion--neutral pa-message" data-content-prefix="pa-redistricting">
             <button type="button" class="js-accordion-trigger accordion__button" aria-controls="pa-redistricting-content-0" aria-expanded="false">Information about 2018 Pennsylvania redistricting</button>
             <div class="accordion__content" id="pa-redistricting-content-0" aria-hidden="true">
-                <p>On February 19, 2018, Pennsylvania's Supreme Court released a new congressional map for Pennsylvania. Some candidates subsequently amended their registration forms to reflect new district numbers. Candidates are listed using
-                    information from their registration forms and may be running in different districts than in the past.</p>
+              <p>On February 19, 2018, Pennsylvania's Supreme Court released a new congressional map for Pennsylvania. Some candidates subsequently amended their registration forms to reflect new district numbers. Candidates are listed using
+                information from their registration forms and may be running in different districts than in the past.</p>
             </div>
           </div>
         </div>
@@ -103,13 +102,30 @@
           <div class="js-results-items"></div>
         </div>
       </div>
-      <div class="usa-width-one-half">
-        <div class="election-map"></div>
-        <div class="t-italic js-map-approx-message">
-            <p>District maps on this page are approximate.</p>
+      <div class="usa-width-one-half toggle-election-search-map">
+      {% if FEATURES.hide_election_search_map %}
+      {# When this flag goes away, remove the toggle-* class from the div above, and remove the tabindex="-1" here #}
+        <style>
+          .toggle-election-search-map {
+            .election-map, .js-map-approx-message, .message--info {
+              border: 0;
+              height: 0;
+              margin: 0 !important;
+              opacity: 0;
+              padding: 0 !important;
+            }
+            .js-upcoming-presidential .slab--inline {
+              margin-top: 0;
+            }
+          }
+        </style>
+      {% endif %}
+        <div class="election-map" tabindex="-1"></div>
+        <div class="t-italic js-map-approx-message" tabindex="-1">
+          <p>District maps on this page are approximate.</p>
         </div>
-        <div class="message message--info js-map-message" aria-hidden="true">
-            Election maps and ZIP code search are only available for elections in {{ constants.DISTRICT_MAP_CUTOFF }} and future election years.
+        <div class="message message--info js-map-message" aria-hidden="true" tabindex="-1">
+          Election maps and ZIP code search are only available for elections in {{ constants.DISTRICT_MAP_CUTOFF }} and future election years.
         </div>
         <div class="js-upcoming-presidential"></div>
       </div>

--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -21,6 +21,19 @@
     <div class="grid--2-wide grid--flex">
       <div class="grid__item">
         <h2>Compare candidates</h2>
+        {% if FEATURES.hide_election_search_map %}
+        <div class="card card--neutral">
+          <a href="/data/raising-bythenumbers/" title="Raising: by the numbers">
+            <div class="card__image__container">
+              <span class="card__icon i-graph-horizontal-ordered"><span class="u-visually-hidden">Icon of a graph</span></span>
+            </div>
+            <div class="card__content">
+              <h3>Raising &raquo;</h3>
+              <p>Discover which candidates are raising the most</p>
+            </div>
+          </a>
+        </div>
+        {% else %}
         <div id="election-lookup" class="search--election-mini">
           <div class="usa-width-one-half">
             <form action="/data/elections/" class="content__section">
@@ -54,7 +67,24 @@
           </div>
           <div class="election-map dormant election-map--small usa-width-one-half" title="click to activate the interactive map"></div>
         </div>
+        {% endif %}
       </div>
+      {% if FEATURES.hide_election_search_map %}
+      <div class="grid__item">
+        <h2>&nbsp;</h2>
+        <div class="card card--neutral">
+          <a href="/data/spending-bythenumbers/" title="Spending: by the numbers">
+            <div class="card__image__container">
+              <span class="card__icon i-graph-horizontal-ordered"><span class="u-visually-hidden">Icon of a graph</span></span>
+            </div>
+            <div class="card__content">
+              <h3>Spending &raquo;</h3>
+              <p>Discover which candidates are spending the most</p>
+            </div>
+          </a>
+        </div>
+      </div>
+      {% else %}
       <div class="grid__item example--primary callout-holder">
         <h2>&nbsp;</h2>
         <div class="grid grid--2-wide">  
@@ -86,6 +116,7 @@
           </div>
         </div>
       </div>
+      {% endif %}
     </div>
   </section>
 

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -71,6 +71,7 @@ FEATURES = {
     'barcharts': bool(env.get_credential('FEC_FEATURE_HOME_BARCHARTS', '')),
     'contributionsbystate': bool(env.get_credential('FEC_FEATURE_CONTRIBUTIONS_BY_STATE', '')),
     'debts': bool(env.get_credential('FEC_FEATURE_DEBTS', '')),
+    'hide_election_search_map': bool(env.get_credential('FEC_HIDE_ELECTION_SEARCH_MAP', '')),
     'h4_allocated_disbursements': bool(env.get_credential('FEC_FEATURE_H4_ALLOCATED_DISBURSEMENTS', True)),
     'house_senate_overview': bool(env.get_credential('FEC_FEATURE_HOUSE_SENATE_OVERVIEW', '')),
     'house_senate_overview_methodology': bool(env.get_credential('FEC_FEATURE_HOUSE_SENATE_OVERVIEW_METHODOLOGY', '')),


### PR DESCRIPTION
## Summary

- Resolves #

Created and applied an env var to hide the election search map, currently only hiding for the data landing page.

### Required reviewers

a dev

## Impacted areas of the application

Currently, only `/data/`

## Screenshots

Production:
<img width="970" alt="image" src="https://github.com/user-attachments/assets/0f0f03e8-fa8e-4896-8b09-8bc2d346a017" />

This PR:
<img width="969" alt="image" src="https://github.com/user-attachments/assets/b05b136f-3473-4a62-b3e9-ff8ec5609d64" />


## Related PRs

None

## How to test

- Pull the branch
- `./manage.py runserver`
- Check the [data landing page](http://127.0.0.1:8000/data/) (Should have the map search and the Raising/Spending cards combo)
- Cancel run server
- `export FEC_HIDE_ELECTION_SEARCH_MAP=True`
- `./manage.py runserver`
- Check the data landing page again. (The map should be gone, replaced with a larger Raising card, and a larger Spending card)
- (reject, comment, approve, merge)
- Revert the env var to nothing: `unset FEC_HIDE_ELECTION_SEARCH_MAP`
