### PR TITLE
  [PR TO RELEASE] Sort AO by issue_date,  fix toggle on ao_no sort btn icon

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -389,12 +389,12 @@ def _get_sorted_documents(ao):
     )
     sorted_documents = sorted(sorted_documents, key=itemgetter("date"), reverse=True)
 
-    # # Sort by document date unless it's a final opinion. Final opinion uses issue date.
-    # sorted_documents = sorted(
-    #     sorted_documents,
-    #     key=lambda doc: doc.get("date") if doc.get("ao_doc_category_id") != 'F' else ao.get("issue_date"),
-    #     reverse=True
-    # )
+    # Sort by document date unless it's a final opinion. Final opinion uses issue date.
+    sorted_documents = sorted(
+        sorted_documents,
+        key=lambda doc: doc.get("date") if doc.get("ao_doc_category_id") != 'F' else ao.get("issue_date"),
+        reverse=True
+    )
 
     return sorted_documents
 

--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -153,11 +153,9 @@ LegalSearchAo.prototype.initFilters = function() {
  * Assign event listeners to the sortable column
  */
 LegalSearchAo.prototype.initTable = function() {
-  // Add the functionality for the case (first column) sorting, but only if the table exists
-  const theThElement = document.querySelectorAll('#results th[data-sort]');
-  console.log("theThElement", theThElement)
-  theThElement.forEach(theThElement => 
-    {
+  // Update the functionality to sort by one or more columns
+  const theThElements = document.querySelectorAll('#results th[data-sort]');
+  theThElements.forEach(theThElement => {
   if (theThElement) {
     theThElement.setAttribute('aria-controls', 'results');
     theThElement.addEventListener('click', this.handleSortClick.bind(this));
@@ -173,9 +171,10 @@ LegalSearchAo.prototype.initTable = function() {
 LegalSearchAo.prototype.handleSortClick = function(e) {
   e.stopImmediatePropagation();
 
-  this.sortOrder = this.sortOrder == 'asc' ? 'desc' : 'asc';
+  this.sortType = e.target.dataset.sort
+  this.sortOrder =  e.target.classList.contains('sorting_asc') ? 'desc' : 'asc';
 
-  updateTableSortColumn(e.target, this.sortOrder == 'asc' ? 'desc' : 'asc');
+  updateTableSortColumn(e.target, this.sortOrder);
 
   this.lastFilterId = undefined;
   this.debounce(this.getResults.bind(this), 250);
@@ -274,27 +273,21 @@ LegalSearchAo.prototype.getResults = function(e) {
   // Get data from our filters
   const serializedFilters = this.filterSet.serialize();
   const filterFields = this.filterSet.fields;
-
+ 
   // Let's override any filters here
 
   // Make sure search and sort are allowed fields
   filterFields.push('search', 'sort');
 
-  // Set the sort param value according to this.sortOrder
-  // serializedFilters.sort = this.sortOrder == 'asc' ? 'ao_no' : '-ao_no';
-  console.log('Initial serializedFilters.sort:', serializedFilters.sort);
-  console.log('sortOrder:', this.sortOrder);
-  if (serializedFilters.sort == 'ao_no'){
+  // Set the sort param value according to this.sortType
+  if (this.sortType == 'ao_no'){
     serializedFilters.sort = this.sortOrder == 'asc' ? 'ao_no' : '-ao_no';
   } else {
     serializedFilters.sort = this.sortOrder == 'asc' ? 'issue_date' : '-issue_date';
-  // If we're getting new results, let's reset the page offset (go back to page 1)
-  serializedFilters['offset'] = 0;
   }
 
-  console.log("serializedFilters.sort", serializedFilters.sort)
-  // If we're getting new results, let's reset the page offset (go back to page 1)
-  serializedFilters['offset'] = 0;
+    // If we're getting new results, let's reset the page offset (go back to page 1)
+    serializedFilters['offset'] = 0;
 
   // Then update the URL with currently params
   updateQuery(serializedFilters, filterFields);

--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -154,12 +154,16 @@ LegalSearchAo.prototype.initFilters = function() {
  */
 LegalSearchAo.prototype.initTable = function() {
   // Add the functionality for the case (first column) sorting, but only if the table exists
-  const theTh = document.querySelector('#results th[data-sort]');
-  if (theTh) {
-    theTh.setAttribute('aria-controls', 'results');
-    theTh.addEventListener('click', this.handleSortClick.bind(this));
-    updateTableSortColumn(theTh, this.sortOrder);
+  const theThElement = document.querySelectorAll('#results th[data-sort]');
+  console.log("theThElement", theThElement)
+  theThElement.forEach(theThElement => 
+    {
+  if (theThElement) {
+    theThElement.setAttribute('aria-controls', 'results');
+    theThElement.addEventListener('click', this.handleSortClick.bind(this));
+    updateTableSortColumn(theThElement, this.sortOrder);
   }
+  })
 };
 
 /**
@@ -277,8 +281,18 @@ LegalSearchAo.prototype.getResults = function(e) {
   filterFields.push('search', 'sort');
 
   // Set the sort param value according to this.sortOrder
-  serializedFilters.sort = this.sortOrder == 'asc' ? 'ao_no' : '-ao_no';
+  // serializedFilters.sort = this.sortOrder == 'asc' ? 'ao_no' : '-ao_no';
+  console.log('Initial serializedFilters.sort:', serializedFilters.sort);
+  console.log('sortOrder:', this.sortOrder);
+  if (serializedFilters.sort == 'ao_no'){
+    serializedFilters.sort = this.sortOrder == 'asc' ? 'ao_no' : '-ao_no';
+  } else {
+    serializedFilters.sort = this.sortOrder == 'asc' ? 'issue_date' : '-issue_date';
+  // If we're getting new results, let's reset the page offset (go back to page 1)
+  serializedFilters['offset'] = 0;
+  }
 
+  console.log("serializedFilters.sort", serializedFilters.sort)
   // If we're getting new results, let's reset the page offset (go back to page 1)
   serializedFilters['offset'] = 0;
 
@@ -731,7 +745,7 @@ const template_no_table = `<div class="panel__main legal-search-results js-legal
     <thead>
       <tr class="simple-table__header">
         <th class="simple-table__header-cell cell--15 sorting_desc sorting" data-sort="ao_no" aria-controls="results" aria-sort="descending" aria-description="Case: Activate to sort column descending">Case</th>
-        <th class="simple-table__header-cell cell--15">Date issued</th>
+        <th class="simple-table__header-cell cell--15 sorting_desc sorting" data-sort="issue_date" aria-controls="results" aria-sort="descending" aria-description="Data issued: Activate to sort column descending">Date issued</th>
         <th class="simple-table__header-cell">Summary</th>
         <th class="simple-table__header-cell">This opinion is cited by these later opinions</th>
       </tr>

--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -33,6 +33,13 @@ export default function LegalSearchAo() {
   this.sortOrder = 'desc';
   this.tagList;
 
+  if (window.context.sort) {
+    this.sortOrder = window.context.sort.includes('-') ? 'desc' : 'asc'
+  }
+  else {
+    this.sortOrder = 'desc';
+  }
+
   this.widgetsElement = document.querySelector('.data-container__widgets');
   this.initPageParts();
   this.initFilters();

--- a/fec/legal/templates/legal-search-results-advisory_opinions.jinja
+++ b/fec/legal/templates/legal-search-results-advisory_opinions.jinja
@@ -94,6 +94,9 @@
 {% endblock %}
 
 {% block results %}
+  {% with results=results %}
+    {% include 'partials/legal-pagination.jinja' %}
+  {% endwith %}
   {% with advisory_opinions = results.advisory_opinions %}
     {% include 'partials/legal-search-results-advisory-opinion.jinja' %}
   {% endwith %}
@@ -104,4 +107,7 @@
 
 {% block scripts %}
   {{ tags_for_js_chunks('legal-search-ao.js', '')|safe }}
+  <script>
+  window.context = {{ context_vars|to_json|safe }};
+  </script>
 {% endblock %}

--- a/fec/legal/templates/partials/legal-pagination.jinja
+++ b/fec/legal/templates/partials/legal-pagination.jinja
@@ -76,6 +76,7 @@
         {%- if ao_representative %}ao_representative={{ ao_representative }}&{% endif -%}
         {%- if ao_regulatory_citation %}ao_regulatory_citation={{ ao_regulatory_citation }}&{% endif -%}
         {%- for category_id in selected_ao_doc_category_ids %}ao_doc_category_id={{ category_id }}&{% endfor -%}
+        {%- if sort %}sort={{ sort }}& -%}&{% endif -%}
         &offset={{ offset - limit }}&limit={{ limit }}#results-{{ result_type }}">Previous</a>
     {% else %}
       <span class="paginate_button previous is-disabled">Previous</span>
@@ -131,6 +132,7 @@
           {%- if ao_representative %}ao_representative={{ ao_representative }}&{% endif -%}
           {%- if ao_regulatory_citation %}ao_regulatory_citation={{ ao_regulatory_citation }}&{% endif -%}
           {%- for category_id in selected_ao_doc_category_ids %}ao_doc_category_id={{ category_id }}&{% endfor -%}
+          {%- if sort %}sort={{ sort }}& -%}&{% endif -%}
           &offset={{ page_offset }}&limit={{ limit }}#results-{{ result_type }}">{{ page }}</a>
       {% endif %}
     {% endfor %}
@@ -181,6 +183,7 @@
         {%- if ao_representative %}ao_representative={{ ao_representative }}&{% endif -%}
         {%- if ao_regulatory_citation %}ao_regulatory_citation={{ ao_regulatory_citation }}&{% endif -%}
         {%- for category_id in selected_ao_doc_category_ids %}ao_doc_category_id={{ category_id }}&{% endfor -%}
+        {%- if sort %}sort={{ sort }}& -%}&{% endif -%}
         &offset={{ offset + limit }}&limit={{ limit }}#results-{{ result_type }}">Next</a>
     {% else %}
       <span class="paginate_button next is-disabled">Next</span>

--- a/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
+++ b/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
@@ -4,7 +4,7 @@
     <thead>
       <tr class="simple-table__header">
         <th class="simple-table__header-cell cell--15" data-sort="ao_no">Case</th>
-        <th class="simple-table__header-cell cell--15">Date issued</th>
+        <th class="simple-table__header-cell cell--15" data-sort="issue_date">Date issued</th>
         <th class="simple-table__header-cell">Summary</th>
         <th class="simple-table__header-cell">This opinion is cited by these later opinions</th>
       </tr>
@@ -33,7 +33,7 @@
             {% elif advisory_opinion.issue_date != undefined %}
               {{ advisory_opinion.issue_date | date(fmt='%m/%d/%Y') }}
             {% endif %}
-          </div>
+          </div> 
         </td>
         <td class="simple-table__cell">
           <div class="t-sans">

--- a/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
+++ b/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
@@ -3,8 +3,8 @@
   <table id="results" class="simple-table simple-table--display">
     <thead>
       <tr class="simple-table__header">
-        <th class="simple-table__header-cell cell--15" data-sort="ao_no">Case</th>
-        <th class="simple-table__header-cell cell--15" data-sort="issue_date">Date issued</th>
+        <th class="simple-table__header-cell cell--15 sorting" data-sort="ao_no">Case</th>
+        <th class="simple-table__header-cell cell--15 sorting" data-sort="issue_date">Date issued</th>
         <th class="simple-table__header-cell">Summary</th>
         <th class="simple-table__header-cell">This opinion is cited by these later opinions</th>
       </tr>

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -261,6 +261,7 @@ def legal_doc_search_ao(request):
     original_query = request.GET.get('search', '')
     offset = request.GET.get('offset', 0)
     limit = request.GET.get('limit', 20)
+    sort = request.GET.get('sort', '')
     ao_no = request.GET.getlist('ao_no', [])
     ao_requestor = request.GET.get('ao_requestor', '')
     ao_is_pending = request.GET.get('ao_is_pending', '')
@@ -286,6 +287,7 @@ def legal_doc_search_ao(request):
         offset=offset,
         limit=limit,
         ao_no=ao_no,
+        sort=sort,
         ao_requestor=ao_requestor,
         ao_requestor_type=ao_requestor_type_ids,
         ao_is_pending=ao_is_pending,
@@ -339,12 +341,19 @@ def legal_doc_search_ao(request):
     # Return the selected requestor type name, when "Any" is selected, clear the value
     ao_requestor_type_names = [ao_requestor_types.get(id) for id in ao_requestor_type_ids if id != 0]
 
+    # For Javascript
+    context_vars = {
+        'sort': sort,
+    }
+
     return render(request, 'legal-search-results-advisory_opinions.jinja', {
         'parent': 'legal',
         'results': results,
         'ao_document_categories': ao_document_categories,
         'result_type': 'advisory_opinions',
         'ao_no': ao_no,
+        'sort': sort,
+        'context_vars': context_vars,
         'ao_requestor': ao_requestor,
         'ao_requestor_types': ao_requestor_types,
         'ao_is_pending': ao_is_pending,

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -344,6 +344,7 @@ def legal_doc_search_ao(request):
     # For Javascript
     context_vars = {
         'sort': sort,
+        'sortType':sort.replace('-','')
     }
 
     return render(request, 'legal-search-results-advisory_opinions.jinja', {


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/openFEC/issues/6167
- Add sort by issue_date to AO data table
- Change sort column header styles to match other datatables

### Required reviewers

one frontend, one backend

## Impacted areas of the application

AO datatable `Case(ao_no)` and `Date(issue_date)`  columns

## Screenshots

### Default when neither sort column has been clicked

<img width="1113" alt="Screenshot 2025-04-12 at 10 11 51 PM" src="https://github.com/user-attachments/assets/d2c1bff9-39ac-43e0-afa6-28cc50239567" />

### Sort-order  and  sort-type and are preserved when paginating

<img width="1124" alt="Screenshot 2025-04-12 at 10 19 57 PM" src="https://github.com/user-attachments/assets/6966430d-dfa7-4711-8a17-d15eae527385" />



## Related PRs

https://github.com/fecgov/openFEC/pull/6173

## How to test

- `npm run build`
- `export FEC_API_URL=https://api-stage.open.fec.gov`
- Test AO datatable sort columns - Case(ao_no) and Date(issue_date)
- Confirm the sort-type and sort-order in the url (i.e: `sort=-ao_no` or `ao_no` and  `sort=-issue_date` or `issue_date`)
- Confirm that the sort icon is always toggles to the correct direction for the current sort order
- Test pagination. The sort-type and sort-order should persist when paginating. 
   - Note: Changing the sort always takes you back to page one is expected behavior


