### PR TITLE
6731-upgrade gunicorn 23.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==4.2.20
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7
-gunicorn==22.0.0
+gunicorn==23.0.0
 gevent==24.11.1
 psycopg==3.1.20
 requests==2.32.3


### PR DESCRIPTION
## Summary (required)

- Resolves #6731

Upgrades gunicorn to remediate snyk vuln

[Breaking Changes ](https://docs.gunicorn.org/en/latest/news.html)
    refuse requests where the uri field is empty 
    refuse requests with invalid CR/LR/NUL in heade field values 
    remove temporary --tolerate-dangerous-framing switch from 22.0
### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

-  gunicorn servers


## Related PRs

Related PRs against other branches:

https://github.com/fecgov/openFEC/pull/6187
## How to test

Running gunicorn locally has issues for me for CMS
- Deploy to a space or you can rebuild [this test branch in dev](https://app.circleci.com/pipelines/github/fecgov/fec-cms/4158/workflows/f6e54270-38ea-4666-95a7-88abcd46ede3/jobs/7688) 



