### PR TITLE
Move from jQuery.change

### DIFF
--- a/fec/fec/static/js/modules/audit-category-sub-category.js
+++ b/fec/fec/static/js/modules/audit-category-sub-category.js
@@ -7,7 +7,7 @@
 import { buildUrl } from './helpers.js';
 
 export function auditCategorySubcategory() {
-  $('#primary_category_id').change(function() { // TODO: jQuery deprecation
+  $('#primary_category_id').on('change', function() {
     var $select = $('#sub_category_id');
     $.getJSON(
       buildUrl(['audit-category'], {

--- a/fec/fec/static/js/modules/audit_tags.js
+++ b/fec/fec/static/js/modules/audit_tags.js
@@ -6,7 +6,7 @@ import { default as auditCategoryTemplate } from '../templates/audit_tags.hbs';
 export default function auditTags() {
   $('.data-container__tags').prepend(auditCategoryTemplate);
   $('.tag__category.sub').css('visibility', 'hidden');
-  $('#primary_category_id').change(function() { // TODO: jQuery deprecation
+  $('#primary_category_id').on('change', function() {
     const current_category = $('#primary_category_id option:selected').text();
     $('.tag__category.sub').css('visibility', 'hidden');
     $('.tag__item.primary').contents()[0].nodeValue = `Findings and issue category: ${current_category}`;
@@ -15,7 +15,7 @@ export default function auditTags() {
       : $('.tag__item.primary button').show();
   });
 
-  $('#sub_category_id').change(function() { // TODO: jQuery deprecation
+  $('#sub_category_id').on('change', function() {
     const current_sub = $('#sub_category_id option:selected').text();
     $('.tag__item.sub').contents()[0].nodeValue = `Sub Category: ${current_sub}`;
   });

--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -129,7 +129,7 @@ Dropdown.prototype.handleCheckKeyup = function(e) {
   if (e.keyCode === KEYCODE_ENTER) {
     $(e.target)
       .prop('checked', true)
-      .change(); // TODO: jQuery deprecation
+      .trigger('change');
   }
 };
 

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -220,7 +220,7 @@ ElectionSearch.prototype.getUpcomingElections = function() {
  * Handle a change event on the zip code fields
  */
 ElectionSearch.prototype.handleZipChange = function() {
-  this.$state.val('').change(); // TODO: jQuery deprecation
+  this.$state.val('').trigger('change');
   this.$district.val('');
 };
 

--- a/fec/fec/static/js/modules/filters/date-filter.js
+++ b/fec/fec/static/js/modules/filters/date-filter.js
@@ -136,8 +136,8 @@ DateFilter.prototype.fromQuery = function(query) {
 
 DateFilter.prototype.setValue = function(value) {
   value = ensureArray(value);
-  this.$minDate.val(value[0]).change(); // TODO: jQuery deprecation
-  this.$maxDate.val(value[1]).change(); // TODO: jQuery deprecation
+  this.$minDate.val(value[0]).trigger('change');
+  this.$maxDate.val(value[1]).trigger('change');
 };
 
 DateFilter.prototype.handleModifyEvent = function(e, opts) {
@@ -146,12 +146,12 @@ DateFilter.prototype.handleModifyEvent = function(e, opts) {
   if (opts.filterName === this.name) {
     this.maxYear = parseInt(opts.filterValue);
     this.minYear = this.maxYear - 1;
-    this.$minDate.val('01/01/' + this.minYear.toString()).change(); // TODO: jQuery deprecation
+    this.$minDate.val('01/01/' + this.minYear.toString()).trigger('change');
     if (this.maxYear === today.getFullYear()) {
       today = moment(today).format('MM/DD/YYYY');
-      this.$maxDate.val(today).change(); // TODO: jQuery deprecation
+      this.$maxDate.val(today).trigger('change');
     } else {
-      this.$maxDate.val('12/31/' + this.maxYear.toString()).change(); // TODO: jQuery deprecation
+      this.$maxDate.val('12/31/' + this.maxYear.toString()).trigger('change');
     }
     this.validate();
   }

--- a/fec/fec/static/js/modules/filters/election-filter.js
+++ b/fec/fec/static/js/modules/filters/election-filter.js
@@ -43,7 +43,7 @@ ElectionFilter.prototype.fromQuery = function(query) {
     this.$cycles
       .find('input[value="' + cycle + ':' + full + '"]')
       .prop('checked', true)
-      .change(); // TODO: jQuery deprecation
+      .trigger('change');
   }
   return this;
 };
@@ -80,7 +80,7 @@ ElectionFilter.prototype.handleElectionChange = function(e) {
     .find('input')
     .eq(0)
     .prop('checked', true)
-    .change(); // TODO: jQuery deprecation
+    .trigger('change');
 };
 
 ElectionFilter.prototype.handleCycleChange = function(e) {
@@ -89,9 +89,9 @@ ElectionFilter.prototype.handleCycleChange = function(e) {
     .split(':');
   this.$cycle
     .val(selected[0])
-    .change() // TODO: jQuery deprecation
+    .trigger('change')
     .attr('checked', true);
-  this.$full.val(selected[1]).change(); // TODO: jQuery deprecation
+  this.$full.val(selected[1]).trigger('change');
   this.setTag();
 };
 

--- a/fec/fec/static/js/modules/filters/filter-base.js
+++ b/fec/fec/static/js/modules/filters/filter-base.js
@@ -84,7 +84,7 @@ Filter.prototype.setValue = function(value) {
   const $input = this.$input.data('temp')
     ? this.$elm.find('#' + this.$input.data('temp'))
     : this.$input;
-  $input.val(prepareValue($input, value)).change(); // TODO: jQuery deprecation
+  $input.val(prepareValue($input, value)).trigger('change');
   return this;
 };
 

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -276,7 +276,7 @@ FilterTypeahead.prototype.appendCheckbox = function(opts) {
   } else {
     const checkbox = $(template_checkbox(data));
     checkbox.appendTo(this.$selected);
-    checkbox.find('input').change(); // TODO: jQuery deprecation
+    checkbox.find('input').trigger('change');
     this.clearInput();
   }
 };

--- a/fec/fec/static/js/modules/filters/select-filter.js
+++ b/fec/fec/static/js/modules/filters/select-filter.js
@@ -29,7 +29,7 @@ SelectFilter.prototype.fromQuery = function(query) {
 SelectFilter.prototype.setValue = function(value) {
   this.$input.find('option[selected]').prop('selected', false);
   this.$input.find('option[value="' + value + '"]').prop('selected', true);
-  this.$input.change(); // TODO: jQuery deprecation
+  this.$input.trigger('change');
 };
 
 SelectFilter.prototype.handleChange = function(e) {

--- a/fec/fec/static/js/modules/filters/text-filter.js
+++ b/fec/fec/static/js/modules/filters/text-filter.js
@@ -145,7 +145,7 @@ TextFilter.prototype.appendCheckbox = function(value) {
   };
   const checkbox = $(template_checkbox(opts));
   checkbox.appendTo(this.checkboxList.$elm);
-  checkbox.find('input').change();
+  checkbox.find('input').trigger('change');
   this.$input.val('');
   this.checkboxIndex++;
 };

--- a/fec/fec/static/js/modules/filters/toggle-filter.js
+++ b/fec/fec/static/js/modules/filters/toggle-filter.js
@@ -16,7 +16,7 @@ ToggleFilter.prototype.fromQuery = function(query) {
   this.$elm
     .find('input[value="' + query[this.name] + '"]')
     .prop('checked', true)
-    .change(); // TODO: jQuery deprecation
+    .trigger('change');
 };
 
 ToggleFilter.prototype.handleChange = function(e) {

--- a/fec/fec/static/js/modules/filters/validate-date-filters.js
+++ b/fec/fec/static/js/modules/filters/validate-date-filters.js
@@ -121,8 +121,8 @@ ValidateDateFilter.prototype.fromQuery = function(query) {
     ? query['min_' + this.name]
     : defaultStart;
   var maxDate = query['max_' + this.name] ? query['max_' + this.name] : now;
-  this.$minDate.val(minDate).change(); // TODO: jQuery deprecation
-  this.$maxDate.val(maxDate).change(); // TODO: jQuery deprecation
+  this.$minDate.val(minDate).trigger('change');
+  this.$maxDate.val(maxDate).trigger('change');
   return this;
 };
 

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -660,7 +660,7 @@ DataTable_FEC.prototype.checkFromQuery = function() {
       // …if they are not already checked
       for (let box of queryBoxes) {
         if (!($(box).is(':checked'))) {
-          $(box).prop('checked', true).change(); // TODO: jQuery deprecation
+          $(box).prop('checked', true).trigger('change');
         }
        }
       $('button.is-loading, label.is-loading').removeClass('is-loading');
@@ -673,7 +673,7 @@ DataTable_FEC.prototype.checkFromQuery = function() {
     // …if they are not already checked
     for (let box of queryBoxes) {
       if (!($(box).is(':checked'))) {
-        $(box).prop('checked', true).change(); // TODO: jQuery deprecation
+        $(box).prop('checked', true).trigger('change');
       }
     }
   }

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -119,7 +119,7 @@ TopEntities.prototype.updateElectionYearOptions = function(office) {
     if (currentOption.css('display') == 'none') {
       $('#election-year')
         .val(minFutureYear)
-        .change(); // TODO: jQuery deprecation
+        .trigger('change');
     }
   } else {
     // show all options/enable for Safari!

--- a/fec/fec/tests/js/checkbox-filter.js
+++ b/fec/fec/tests/js/checkbox-filter.js
@@ -79,19 +79,19 @@ describe('checkbox filters', function() {
     });
 
     it('sets loaded-once on the input after loading', function() {
-      this.$input.prop('checked', true).change(); // TODO: jQuery deprecation
+      this.$input.prop('checked', true).trigger('change');
       expect(this.$input.data('loaded-once')).to.be.true;
       expect(this.$label.attr('class')).to.not.equal('is-loading');
     });
 
     it('adds the loading class if it has loaded once', function() {
-      this.$input.prop('checked', true).change(); // TODO: jQuery deprecation
-      this.$input.prop('checked', false).change(); // TODO: jQuery deprecation
+      this.$input.prop('checked', true).trigger('change');
+      this.$input.prop('checked', false).trigger('change');
       expect(this.$label.attr('class')).to.equal('is-loading');
     });
 
     it('triggers the add event on checking a checkbox', function() {
-      this.$input.prop('checked', true).change(); // TODO: jQuery deprecation
+      this.$input.prop('checked', true).trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:added', [
         {
           key: 'president',
@@ -104,7 +104,7 @@ describe('checkbox filters', function() {
     });
 
     it('triggers remove event on unchecking a checkbox', function() {
-      this.$input.prop('checked', false).change(); // TODO: jQuery deprecation
+      this.$input.prop('checked', false).trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:removed', [
         {
           key: 'president',

--- a/fec/fec/tests/js/contact-form.js
+++ b/fec/fec/tests/js/contact-form.js
@@ -69,12 +69,12 @@ describe('Contact form', function() {
   });
 
   it('shows the other reason box when other is selected', function() {
-    this.form.category.val('other').change(); // TODO: jQuery deprecation
+    this.form.category.val('other').trigger('change');
     expect(this.form.otherReason.is(':visible')).to.be.true;
   });
 
   it('hides the other reason box when another value is selected', function() {
-    this.form.category.val('option-1').change(); // TODO: jQuery deprecation
+    this.form.category.val('option-1').trigger('change');
     expect(this.form.otherReason.is(':visible')).to.be.false;
   });
 

--- a/fec/fec/tests/js/cycle-select.js
+++ b/fec/fec/tests/js/cycle-select.js
@@ -59,7 +59,7 @@ describe('cycle select', function() {
     });
 
     it('changes the query string on change', function() {
-      this.cycleSelect.$elm.val('2014').change(); // TODO: jQuery deprecation
+      this.cycleSelect.$elm.val('2014').trigger('change');
       expect(CycleSelect.prototype.setUrl).to.have.been.calledWith(window.location.href + '?cycle=2014');
     });
   });
@@ -88,7 +88,7 @@ describe('cycle select', function() {
     });
 
     it('changes the query string on change', function() {
-      this.cycleSelect.$cycles.find('[name="cycle-toggle-cycle-1"]').val('2014').change(); // TODO: jQuery deprecation
+      this.cycleSelect.$cycles.find('[name="cycle-toggle-cycle-1"]').val('2014').trigger('change');
       expect(
         CycleSelect.prototype.setUrl
       ).to.have.been.calledWith(
@@ -128,7 +128,7 @@ describe('cycle select', function() {
     });
 
     it('changes the query string on change', function() {
-      this.cycleSelect.$elm.val('2014').change(); // TODO: jQuery deprecation
+      this.cycleSelect.$elm.val('2014').trigger('change');
       var url = URI(window.location.href);
       url.path('2014/');
       expect(CycleSelect.prototype.setUrl).to.have.been.calledWith(url.toString());

--- a/fec/fec/tests/js/date-filter.js
+++ b/fec/fec/tests/js/date-filter.js
@@ -122,7 +122,7 @@ describe('date filter', function() {
     });
 
     it('triggers an add event with all the right properties', function() {
-      this.filter.$minDate.val('01/01/2015').change(); // TODO: jQuery deprecation
+      this.filter.$minDate.val('01/01/2015').trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:added', [
         {
           key: 'min_date',
@@ -139,14 +139,14 @@ describe('date filter', function() {
 
     it('triggers a remove event if the field has no value', function() {
       this.filter.$minDate.val('01/01/2015');
-      this.filter.$minDate.val('').change(); // TODO: jQuery deprecation
+      this.filter.$minDate.val('').trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:removed');
     });
 
     it('triggers a rename event if the field had a value', function() {
       this.filter.$minDate.val('01/01/2015');
       this.filter.$minDate.data('had-value', true);
-      this.filter.$minDate.val('02/01/2015').change(); // TODO: jQuery deprecation
+      this.filter.$minDate.val('02/01/2015').trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:renamed');
       expect(this.filter.$minDate.data('loaded-once')).to.be.true;
     });

--- a/fec/fec/tests/js/election-search.js
+++ b/fec/fec/tests/js/election-search.js
@@ -67,22 +67,22 @@ describe('election search', function() {
   });
 
   it('should disable the district select when state is not set', function() {
-    this.el.$state.val('').change(); // TODO: jQuery deprecation
+    this.el.$state.val('').trigger('change');
     expect(this.el.$district.prop('disabled')).to.be.true;
   });
 
   it('should disable the district select when state is set and the state does not have districts', function() {
-    this.el.$state.val('AS').change(); // TODO: jQuery deprecation
+    this.el.$state.val('AS').trigger('change');
     expect(this.el.$district.prop('disabled')).to.be.true;
   });
 
   it('should enable the district select when state is set and the state has districts', function() {
-    this.el.$state.val('VA').change(); // TODO: jQuery deprecation
+    this.el.$state.val('VA').trigger('change');
     expect(this.el.$district.prop('disabled')).to.be.false;
   });
 
   it('should clear the state select and disable the district select when the zip select is set', function() {
-    this.el.$zip.val('19041').change(); // TODO: jQuery deprecation
+    this.el.$zip.val('19041').trigger('change');
     expect(this.el.$state.val()).to.equal('');
     expect(this.el.$district.prop('disabled')).to.be.true;
   });
@@ -93,7 +93,7 @@ describe('election search', function() {
   });
 
   it('should serialize state and district inputs', function() {
-    this.el.$state.val('VA').change(); // TODO: jQuery deprecation
+    this.el.$state.val('VA').trigger('change');
     this.el.$district.val('01');
     expect(this.el.serialize()).to.deep.equal({
       cycle: '2016',

--- a/fec/fec/tests/js/statistical-summary-archive.js
+++ b/fec/fec/tests/js/statistical-summary-archive.js
@@ -83,8 +83,8 @@ describe('Tablefilter', function() {
     describe('disableNonPresYears', function() {
         beforeEach(function() {
             this.disableNonPresYears = spy(Tablefilter.prototype, 'disableNonPresYears');
-            this.chooseYear.val('1982').change(); // TODO: jQuery deprecation
-            this.chooseFiler.val('presidential').change(); // TODO: jQuery deprecation
+            this.chooseYear.val('1982').trigger('change');
+            this.chooseFiler.val('presidential').trigger('change');
             this.filter.showTable();
 
         });

--- a/fec/fec/tests/js/toggle-filter.js
+++ b/fec/fec/tests/js/toggle-filter.js
@@ -60,7 +60,7 @@ describe('toggle filters', function() {
   });
 
   it('calls handleChange() on change', function() {
-    this.filter.$elm.find('#efiling').prop('checked', true).change(); // TODO: jQuery deprecation
+    this.filter.$elm.find('#efiling').prop('checked', true).trigger('change');
     expect(this.handleChange).to.have.been.called;
   });
 
@@ -94,7 +94,7 @@ describe('toggle filters', function() {
     });
 
     it('triggers rename event on changing the toggle', function() {
-      this.$fixture.find('#efiling').prop('checked', true).change(); // TODO: jQuery deprecation
+      this.$fixture.find('#efiling').prop('checked', true).trigger('change');
       expect(this.trigger).to.have.been.calledWith('filter:renamed', [
         {
           key: 'data_type-toggle',

--- a/fec/fec/tests/js/typeahead-filter.js
+++ b/fec/fec/tests/js/typeahead-filter.js
@@ -121,10 +121,10 @@ describe('FilterTypeahead', function() {
     var enableButton = spy(this.FilterTypeahead, 'enableButton');
     var disableButton = spy(this.FilterTypeahead, 'disableButton');
 
-    // this.FilterTypeahead.$field.typeahead('val', 'FAKE CANDIDATE').change(); // TODO: jQuery deprecation
+    // this.FilterTypeahead.$field.typeahead('val', 'FAKE CANDIDATE').trigger('change');
     // expect(enableButton).to.have.been.called;
 
-    // this.FilterTypeahead.$field.typeahead('val', '').change(); // TODO: jQuery deprecation
+    // this.FilterTypeahead.$field.typeahead('val', '').trigger('change');
     // expect(disableButton).to.have.been.called;
 
     // this.FilterTypeahead.enableButton.restore();

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -378,7 +378,7 @@
     // ...if they are not already checked
     for (let box of queryBoxes) {
       if (!($(box).is(':checked'))) {
-            $(box).trigger('click');   
+        $(box).prop('checked', true).trigger('change') 
       }
     }
    })();


### PR DESCRIPTION
## Summary

- Resolves # (if we set this to 6410, will this one PR close that whole ticket? It'll have other PRs, too.)

Resolving the jQuery deprecations has been a burden so let's break https://github.com/fecgov/fec-cms/pull/6411 into much smaller pieces

### Required reviewers

- front-end for code
- anyone for functionality

## Impacted areas of the application

General components of the application that this PR will affect:

`change()` and `.change(𝑓)` on/in:
- Audit category sub category
- Audit tags
- Dropdowns
- Election search
- All filters, especially
  - Date
  - Election
  - Select
  - Text
  - Typeahead
- Tables
- Top entities

## Screenshots

No changes

## Related PRs

Related PRs against other branches:

PR | Branch | Deprecated features
------ | ------ | ------
#6750 | feature/jquery-deprecation-click | `.click`
#6751‡ | feature/jquery-deprecation-change | `.change`
#6753 | feature/jquery-migrations-focus-blur | `.focus`, `.blur`
#6752 | feature/jquery-deprecations | `.bind`, `:first`, `.hover`, `.keyCode`, `:last`, `.submit`, `.trim`

‡you are here

## How to test

- Pull the branch
- `npm i`
- [ ] `npm run test-single` should be clear
- `npm run build`
- `./manage.py runserver`
- For this PR we're checking the `change` actions and handlers:
  - [Audit search](http://127.0.0.1:8000/legal-resources/enforcement/audit-search/)
    - [ ] Selecting a Primary filter should add that filter (those under 'Findings and issue categories')
    - [ ] Changing the Primary filter should update the tag
    - [ ] Selecting a Secondary filter should work (those under 'Sub categories')
    - [ ] Changing the Secondary filter should update the tag
  - Dropdowns ([Calendar](http://127.0.0.1:8000) is an easy place))
    - Tab to any of the dropdowns (Subscribe, Download, any of the events' dropdowns)
    - [ ] The Enter key should open the dropdown
    - Tab through an option or two
    - [ ] The Enter key should do the action that's highlighted
  - [Election search](http://127.0.0.1:8000/data/elections/)
    - Choose a state
    - Enter a ZIP Code (Enter, Tab, or click the 🔍)
    - [ ] The State drop-down should have reverted to blank
  - Date filters ([Receipts with two dates](http://127.0.0.1:8000/data/receipts/?data_type=processed&two_year_transaction_period=2014&min_date=01%2F01%2F2014&max_date=12%2F31%2F2014))
    - [ ] On page load, the date filters should apply correctly
  - Election filter ([Candidates for president](http://127.0.0.1:8000/data/candidates/president/?election_year=2012))
    - [ ] The election year and time period filters should work correctly (initially setting and then changing values)
  - Filter base
    - Go to a datatables page with multiple types of filters ([Receipts](http://127.0.0.1:8000/data/receipts/) works)
    - Apply several filters of different types
    - [ ] Text filter should have added a checkbox for your value(s)
    - Reload the page
    - [ ] Your filters should have been applied correctly (This tests filter-base.js and tables.js)
    - Especially:
    - [ ] Date filters
    - [ ] Select filters
    - [ ] Toggle filters
  - Top entities ([Homepage](Who is raising and spending the most))
    - Scroll down to "Who is raising and spending the most"
    - Make sure it's not showing president or a presidential election year
    - Change the office to president
    - [ ] The "Running in" `<select>` should have updated to a presidential election year 
- [ ] Celebrate!
