### PR TITLE
Move from jQuery .focus, .blur

### DIFF
--- a/fec/fec/static/js/modules/calendar-tooltip.js
+++ b/fec/fec/static/js/modules/calendar-tooltip.js
@@ -34,6 +34,6 @@ CalendarTooltip.prototype.close = function() {
   this.$content.remove();
   this.exportDropdown.destroy();
   this.$container.removeClass('is-active');
-  this.$container.focus(); // TODO: jQuery deprecation
+  this.$container.trigger('focus');
   this.events.clear();
 };

--- a/fec/fec/static/js/modules/calendar.js
+++ b/fec/fec/static/js/modules/calendar.js
@@ -350,8 +350,8 @@ Calendar.prototype.managePopoverControl = function(e) {
   $popover
     .find('.fc-close')
     .attr('tabindex', '0')
-    .focus() // TODO: jQuery deprecation
+    .trigger('focus')
     .on('click', function() {
-      $target.focus(); // TODO: jQuery deprecation
+      $target.trigger('focus');
     });
 };

--- a/fec/fec/static/js/modules/download.js
+++ b/fec/fec/static/js/modules/download.js
@@ -36,7 +36,7 @@ export function download(url, init, focus) {
   }
 
   if (focus) {
-    item.$button.focus(); // TODO: jQuery deprecation
+    item.$button.trigger('focus');
   }
 
   return item;

--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -85,7 +85,7 @@ Dropdown.prototype.toggle = function(e) {
 Dropdown.prototype.show = function() {
   restoreTabindex(this.$panel);
   this.$panel.attr('aria-hidden', 'false');
-  this.$panel.find('input[type="checkbox"]:first').focus(); // TODO: jQuery deprecation (:first and .focus)
+  this.$panel.find('input[type="checkbox"]').first().trigger('focus');
   this.$button.addClass('is-active');
   this.isOpen = true;
 };
@@ -120,7 +120,7 @@ Dropdown.prototype.handleKeyup = function(e) {
   if (e.keyCode === KEYCODE_ESC) {
     if (this.isOpen) {
       this.hide();
-      this.$button.focus(); // TODO: jQuery deprecation
+      this.$button.trigger('focus');
     }
   }
 };
@@ -221,14 +221,14 @@ Dropdown.prototype.selectItem = function($input) {
     if (next.length) {
       $(next[0])
         .find('input[type="checkbox"]')
-        .focus(); // TODO: jQuery deprecation
+        .trigger('focus');
     } else if (prev.length) {
       $(prev[0])
         .find('input[type="checkbox"]')
-        .focus(); // TODO: jQuery deprecation
+        .trigger('focus');
     }
   } else {
-    this.$selected.find('input[type="checkbox"]').focus(); // TODO: jQuery deprecation
+    this.$selected.find('input[type="checkbox"]').trigger('focus');
   }
 };
 

--- a/fec/fec/static/js/modules/filters/date-filter.js
+++ b/fec/fec/static/js/modules/filters/date-filter.js
@@ -334,7 +334,7 @@ DateFilter.prototype.handleGridItemSelect = function(e) {
     this.$grid.find('li').unbind('mouseenter mouseleave'); // TODO: jQuery deprecation (.unbind())
     this.setValue(value);
     this.$grid.addClass('is-invalid');
-    $nextItem.focus(); // TODO: jQuery deprecation
+    $nextItem.trigger('focus');
   }
 };
 

--- a/fec/fec/static/js/modules/filters/filter-panel.js
+++ b/fec/fec/static/js/modules/filters/filter-panel.js
@@ -65,7 +65,7 @@ FilterPanel.prototype.show = function(focus) {
     this.$body
       .find('input, select, button:not(.js-filter-close)')
       .first()
-      .focus(); // TODO: jQuery deprecation
+      .trigger('focus');
   }
 };
 
@@ -76,7 +76,7 @@ FilterPanel.prototype.hide = function() {
   }
   this.$body.removeClass('is-open');
   this.$content.attr('aria-hidden', true);
-  this.$focus.focus(); // TODO: jQuery deprecation
+  this.$focus.trigger('focus');
   removeTabindex(this.$form);
   $('body').removeClass('is-showing-filters');
   this.isOpen = false;

--- a/fec/fec/static/js/modules/filters/filter-typeahead.js
+++ b/fec/fec/static/js/modules/filters/filter-typeahead.js
@@ -161,7 +161,7 @@ FilterTypeahead.prototype.handleSelected = function(e, datum) {
 
   this.$elm.find('label[for="' + id + '"]').addClass('is-loading');
 
-  this.$button.focus().addClass('is-loading');
+  this.$button.trigger('focus').addClass('is-loading');
 };
 
 FilterTypeahead.prototype.handleAutocomplete = function(e, datum) {

--- a/fec/fec/static/js/modules/filters/text-filter.js
+++ b/fec/fec/static/js/modules/filters/text-filter.js
@@ -63,7 +63,7 @@ TextFilter.prototype.handleChange = function() {
   // set the button focus within a timeout
   // to prevent change event from firing twice
   setTimeout(function() {
-    button.focus(); // TODO: jQuery deprecation
+    button.trigger('focus');
   }, 0);
 
   if (value.length > 0) {

--- a/fec/fec/static/js/modules/search.js
+++ b/fec/fec/static/js/modules/search.js
@@ -32,7 +32,7 @@ export default function Search($el, opts) {
   $(document.body).on('keyup', function(e) {
     // Focus search on "/"
     if (e.keyCode === KEYCODE_SLASH) {
-      $input.first().focus(); // TODO: jQuery deprecation
+      $input.first().trigger('focus');
     }
   });
 }

--- a/fec/fec/static/js/modules/skip-nav.js
+++ b/fec/fec/static/js/modules/skip-nav.js
@@ -28,6 +28,6 @@ Skipnav.prototype.focusOnTarget = function(e) {
 
   if (e.keyCode === 13 || e.type === 'click') {
     this.$target.attr('tabindex', '0');
-    this.$target.focus(); // TODO: jQuery deprecation
+    this.$target.trigger('focus');
   }
 };

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -235,7 +235,7 @@ export function modalRenderFactory(template, fetch) {
               $modal.find('.js-pdf_url').remove();
             }
             // Set focus on the close button
-            $('.js-hide').focus(); // TODO: jQuery deprecation
+            $('.js-hide').trigger('focus');
 
             // When under $large-screen
             // TODO figure way to share these values with CSS.
@@ -260,7 +260,7 @@ export function modalRenderFactory(template, fetch) {
 }
 
 function hidePanel(api, $modal) {
-  $('.row-active .js-panel-button').focus(); // TODO: jQuery deprecation
+  $('.row-active .js-panel-button').trigger('focus');
   $('.js-panel-toggle tr').toggleClass('row-active', false);
   $('body').toggleClass('panel-active', false);
   $modal.attr('aria-hidden', 'true');

--- a/fec/fec/static/js/pages/contact-form.js
+++ b/fec/fec/static/js/pages/contact-form.js
@@ -43,7 +43,7 @@ ContactForm.prototype.initTypeahead = function() {
     //focus away to prompt removal of error state, if present. Could only focus into...
     //...another field, Attempts to focusout, or focus onto body, did not work.
     $('#id_u_contact_title')
-      .focus() // TODO: jQuery deprecation
+      .trigger('focus')
       .trigger('blur');
   });
 };

--- a/fec/fec/static/js/pages/contact-form.js
+++ b/fec/fec/static/js/pages/contact-form.js
@@ -44,7 +44,7 @@ ContactForm.prototype.initTypeahead = function() {
     //...another field, Attempts to focusout, or focus onto body, did not work.
     $('#id_u_contact_title')
       .focus() // TODO: jQuery deprecation
-      .blur(); // TODO: jQuery deprecation
+      .trigger('blur');
   });
 };
 

--- a/fec/fec/static/js/pages/reporting-dates-tables.js
+++ b/fec/fec/static/js/pages/reporting-dates-tables.js
@@ -367,7 +367,7 @@ ReportingDates.prototype.mediaQueryResponse = function(mql) {
       for (const close of jsmodalClose) {
         close.addEventListener('click', () => {
           jsmodal[0].setAttribute('aria-hidden', 'true');
-          close.focus(); // TODO: jQuery deprecation
+          close.trigger('focus');
         });
       }
     });


### PR DESCRIPTION
## Summary

- Resolves # (if we set this to 6410, will this one PR close that whole ticket? It'll have other PRs, too.)

Resolving the jQuery deprecations has been a burden so let's break https://github.com/fecgov/fec-cms/pull/6411 into much smaller pieces

### Required reviewers

- front-end for code
- anyone for functionality

## Impacted areas of the application

General components of the application that this PR will affect:

`focus()` and `.blur()` on/in

- Calendar
- Contact form
- Download
- Dropdowns
- Date filters
- Filter panel
- Reporting dates table
- Search
- SkipNav
- Tables
- Text filter
- Typeahead filter

## Screenshots

No changes

## Related PRs

Related PRs against other branches:

PR | Branch | Deprecated features
------ | ------ | ------
#6750 | feature/jquery-deprecation-click | `.click`
#6751 | feature/jquery-deprecation-change | `.change`
#6753‡ | feature/jquery-migrations-focus-blur | `.focus`, `.blur`
#6752 | feature/jquery-deprecations | `.bind`, `:first`, `.hover`, `.keyCode`, `:last`, `.submit`, `.trim`

‡you are here


## How to test

- Pull the branch
- `npm i`
- [ ] `npm run test-single` should be clear
- `npm run build`
- `./manage.py runserver`
- For the `blur` triggers:
  - Load the [RAD Contact form](http://127.0.0.1:8000/help-candidates-and-committees/question-rad/)
  - [ ] The focus isn't on the "Your position or title (optional)" text
- For the `focus` triggers:
  - [Calendar](http://127.0.0.1:8000/calendar/)
    - Switch to grid view
    - Click an event
    - Click the X/close
    - Press the tab key
    - [x] Focus shifted to the next(ish) event, rather than someplace outside of the calendar grid
    - Click another event to open its popup (leave it open)
    - Click the next/prev month buttons
    - [x] The open popup closed
  - Downloads
    - *Will need to test on not-localhost*
    - Go to a datatables page ([National party](http://127.0.0.1:8000/data/national-party-account-receipts/) works)
    - Click the Export button
    - [x] Focus shifted to the new Download button in the downloads panel
  - Dropdowns (not the native `<select>` elements
    - Load a page with dropdown filters ([National party](http://127.0.0.1:8000/data/national-party-account-receipts/) works)
    - Change the Report time period filter
    - [x] When selecting the first option, the next is focused
    - [x] When selecting the last option, the previous is focused
    - [x] When all options have been selected, focus moves to the last checkbox for that filter
  - Date filter
    - Go to a page with date filters with the grid ([PAC and party committee reports](http://127.0.0.1:8000/data/reports/pac-party/) works)
    - Expand the Date filter panel
    - Click into the Beginning field for Transaction time period
    - Click a date from the grid
    - [x] Focused moved to the Ending field
  - Filter panel
    - Go to any datatables page with the left-side filters panel (all of them?)
    - Click into the first field or so
    - Click the < at the top to close that filter panel
    - [x] The tab key tabbed to the table right away, rather than tabbing through the fields in the collapsed filter panel
    - Open the filter panel again
    - [x] The tab key (within 1-2 presses) is back to tabbing through the filter panel elements
  - Typeahead filter
    - Go to any page with a Typeahead filter (Any candidate or committee name?)
    - In a Typeahead filter, start typing to find a candidate, committee, etc
    - Choose one
    - [x] The focus went to that Typeahead filter's 🔍 button
  - Text filter
    - Go to any datatables page with text field filters ([Receipts](http://127.0.0.1:8000/data/receipts/?) has city name)
      - Type a value into the text field
      - *do not tab or click out of it*
      - Press Enter
      - [x] The focus moved to that field's ▶︎ button
  - Search
    - ISSUE: I can't find where to test the focus for inside search.js. Are we still using .js-search anywhere? (#6752 had the same issue)
  - SkipNav
    - Load any page
    - Press the tab key
    - [x] The skip nav element should appear at the top left of the screen and it should be focused
  - Tables
    - Load any page with a details panel ([Receipts](http://127.0.0.1:8000/data/receipts/) does)
    - Click one of the ➲ to open the details side panel
    - [x] Pressing enter closes the panel
    - [x] Pressing enter again re-opens the same panel
    - (repeat)
  - Reporting Dates Table
    - Go to a [Reporting dates table](http://127.0.0.1:8000/help-candidates-and-committees/dates-and-deadlines/2024-reporting-dates/coordinated-communications-periods-congressional-primaries-2024/)
    - Shrink your browser width so it's more like phone size
    - Click any of the * in the "State & type of election" column, or any of the footnote numbers in "Election date" column
    - That should open a kind of sub row for that entry
    - [x] The Enter key closes that content
- [x] Celebrate!
