### PR TITLE
6686 Site Search Pagination

### DIFF
--- a/fec/fec/static/scss/components/_buttons.scss
+++ b/fec/fec/static/scss/components/_buttons.scss
@@ -402,7 +402,7 @@
 }
 
 .button--previous {
-  @include u-icon-button($arrow-left, left, 1rem, background-position 50% 50%);
+  @include u-icon-button($arrow-left, left, 1rem, background-position 50% 50% !important);
 }
 
 .button--next {

--- a/fec/fec/static/scss/components/_buttons.scss
+++ b/fec/fec/static/scss/components/_buttons.scss
@@ -406,7 +406,7 @@
 }
 
 .button--next {
-  @include u-icon-button($arrow-right, right, 1rem, background-position 50% 50%);
+  @include u-icon-button($arrow-right, right, 1rem, background-position 50% 50% !important);
 }
 
 .button--close--base {

--- a/fec/search/templates/search/search.html
+++ b/fec/search/templates/search/search.html
@@ -170,9 +170,9 @@
                 {% endfor %}
               </ul>
               <div class="results-info">
-                <span class="t-sans">{{ results.site.meta.count }} results</span>
+                <span class="t-sans">Showing {{results.site.meta.results_range}} of {{ results.site.meta.count }} results</span>
                 <div class="u-float-right">
-                  {% if results.site.meta.prev_offset %}
+                  {% if results.site.meta.current_offset > 0 %}
                     <a class="button button--standard button--previous" href="{% url 'search' %}?query={{ search_query|urlencode }}&amp;offset={{ results.site.meta.prev_offset }}"><span class="u-visually-hidden">Previous</span></a>
                   {% endif %}
                   {% if results.site.meta.next_offset %}

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -39,6 +39,19 @@ def prev_offset(limit, next_offset):
         return 0
 
 
+def results_range(current_offset, next_offset, total_results):
+    """
+    Helper function to return "x-xx" results count messages.
+    current_offset is 0-based, i.e. a current_offset of 0 is the first result, current_offset 10 is the eleventh
+    """
+    first_result_num = int(current_offset) + 1
+    if next_offset:
+        last_result_num = max(first_result_num, int(next_offset))
+    else:
+        last_result_num = total_results
+    return '-'.join([str(first_result_num), str(last_result_num)])
+
+
 def parse_icon(path):
     """
     Parse which icon to show by checking if the URL is at /data/
@@ -76,8 +89,10 @@ def process_site_results(results, limit=0, offset=0):
         },
         'meta': {
             'count': web_results['total'],
+            'current_offset': int(offset),
             'next_offset': web_results['next_offset'],
-            'prev_offset': prev_offset(limit, int(offset))
+            'prev_offset': prev_offset(limit, int(offset)),
+            'results_range': results_range(offset, web_results['next_offset'], web_results['total']),
         }
     }
 


### PR DESCRIPTION
## Summary

- Resolves #6686 

Updating the site search results pagination

### Required reviewers

- 1 dev for code
- UX for UX?

## Impacted areas of the application

Site search results footer–the message, the back button, and both buttons' icons icon position

**and every button across the site that uses `button--next` or `button--previous` classes** (though only their icons' background position may be centered if it wasn't already for some reason)

BONUS: New "Showing #-## of" message for results count. I added it for my own debugging and decided to keep it, moving us a little closer to search results across the rest of the site.

## Screenshots

Production above, this PR below
![image](https://github.com/user-attachments/assets/b3239c5d-6410-495d-85a2-7cb9530020c4)


## Related PRs

None

## How to test

- Pull the branch
- `npm run build`
- `./manage.py runserver`
- Go to site search ([link directly](http://127.0.0.1:8000/search/) or use the header nav search and choose the "Other pages" option near the bottom of the suggestions)
- NEW: I added "Showing #-## of" text before the current "### results" text.
- [ ] Page one of results should still show no ⬅️ button—only the ➡️
- [ ] Page 2 should offer both ⬅️ & ➡️
- [ ] Clicking ⬅️ should step back to the previous 10 results
- [ ] Clicking ➡️ should still skip forward by 10 (if there are 10 more)
- [ ] The icons for ⬅️ and ➡️ should be centered
- Jump forward to a page or two from the end of your results (editing the URL is easiest)
- [ ] The "Showing #-##" text should be correct
- [ ] The ⬅️ button should display anytime there are previous results (i.e. we're starting with an offset > 0)
- [ ] The ➡️ button should appear anytime there are more results to show
- [ ] SITEWIDE: Other ⬅️ and ➡️ icons shouldn't be broken because of the new centering background-position