### PR TITLE
AO datatable consistent pagination

### DIFF
--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -30,7 +30,7 @@ export default function LegalSearchAo() {
   this.noResultsMessage;
   this.paginationElement;
   this.resultsTable;
-  this.sortOrder = 'desc';
+  this.sortOrder;
   this.sortType;
   this.tagList;
 
@@ -730,6 +730,12 @@ LegalSearchAo.prototype.updatePagination = function(resultsCount) {
     );
   }
   buttonsParent.appendChild(newNextButton);
+
+  // Clone the updated pagination element into div.pagination_holder after the table
+  const paginationClone = this.paginationElement.cloneNode(true);
+  const paginationHolder = document.querySelector('.pagination_holder')
+  paginationHolder.replaceChildren(paginationClone);
+
 };
 
 // The bare-minimum html for the results table

--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -184,7 +184,15 @@ LegalSearchAo.prototype.handleSortClick = function(e) {
   e.stopImmediatePropagation();
 
   this.sortType = e.target.dataset.sort
+
+  // Only toggle the sort direction when existing sort direction exists on the column
+  if (e.target.classList.contains('sorting_asc') || e.target.classList.contains('sorting_desc')) {
   this.sortOrder =  e.target.classList.contains('sorting_asc') ? 'desc' : 'asc';
+  }
+  // Otherwise always start descending by default. When activating the column for sort.
+  else {
+    this.sortOrder = 'desc'
+  }
 
   updateTableSortColumn(e.target, this.sortOrder, this.sortType );
 

--- a/fec/legal/templates/legal-search-results-advisory_opinions.jinja
+++ b/fec/legal/templates/legal-search-results-advisory_opinions.jinja
@@ -100,9 +100,7 @@
   {% with advisory_opinions = results.advisory_opinions %}
     {% include 'partials/legal-search-results-advisory-opinion.jinja' %}
   {% endwith %}
-  {% with results=results %}
-    {% include 'partials/legal-pagination.jinja' %}
-  {% endwith %}
+  <div class="pagination_holder"></div>
 {% endblock %}
 
 {% block scripts %}

--- a/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
+++ b/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
@@ -3,7 +3,7 @@
   <table id="results" class="simple-table simple-table--display">
     <thead>
       <tr class="simple-table__header">
-        <th class="simple-table__header-cell cell--15 sorting" data-sort="ao_no">Case</th>
+        <th class="simple-table__header-cell cell--15 sorting sorting_desc" data-sort="ao_no">Case</th>
         <th class="simple-table__header-cell cell--15 sorting" data-sort="issue_date">Date issued</th>
         <th class="simple-table__header-cell">Summary</th>
         <th class="simple-table__header-cell">This opinion is cited by these later opinions</th>


### PR DESCRIPTION
## Summary (required)
- After deploying [recent sort changes](https://github.com/fecgov/fec-cms/pull/6742) for AO datatables, we noticed that the top and bottom paginations  do not match when you change sort-order or sort-type
- Also, to match other datatables, fix the initial view on load  to  show the first column (ao-no) as being sorted descending with the icon pointing down. 

- Resolves #issue_number

### Required reviewers

one frontend, one backend

## Impacted areas of the application

AO datatables sort and pagination functionality

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## Related PRs
https://github.com/fecgov/fec-cms/pull/6742

## How to test
- `npm run build`
- Confirm that the default, on first page load, shows the first column sorted descending 
- Confirm that switching sort-type (from one column to the other), it defaults to descending first.
- Test that the top and bottom pagination and meta data ("Showing 1-20 of etc") always match and that they both go back to page one when you change the sort-order or sort-type when you are paginating.

