### PR TITLE
6770 Inaugural Committee Export Buttons

### DIFF
--- a/fec/data/templates/partials/committee/raising.jinja
+++ b/fec/data/templates/partials/committee/raising.jinja
@@ -68,7 +68,8 @@
               <div class="tag__item">Coverage dates: {{totals.coverage_start_date|date}} to {{transaction_end|date}}</div>
             </div>
             {% endif %}
-            <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-donor">Export</button>
+            <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="inaugural-donations-by-donor">Export</button>
+            <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="inaugural-donations-by-donor" aria-hidden="true"></div>
           </div>
           <table
               class="data-table data-table--heading-borders"
@@ -91,8 +92,8 @@
             </div>
             {% endif %}
             <div class="u-float-right">
-              <button type="button" class="js-export button button--cta button--export" data-export-for="itemized-receipts">Export</button>
-              <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="itemized-receipts" aria-hidden="true"></div>
+              <button type="button" class="js-export button button--cta button--export" data-export-for="inaugural-donations">Export</button>
+              <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="inaugural-donations" aria-hidden="true"></div>
             </div>
           </div>
           <table

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -961,6 +961,12 @@ DataTable_FEC.prototype.isPending = function() {
   return isPending(url);
 };
 
+/**
+ * @param {*} data
+ * @param {boolean} paginate
+ * @param {boolean} download
+ * @returns {string}
+ */
 DataTable_FEC.prototype.buildUrl = function(data, paginate, download) {
   let query = _extend(
     { sort_hide_null: false, sort_nulls_last: true }, // eslint-disable-line camelcase


### PR DESCRIPTION
## Summary

- Resolves #6770 

Fixed the data-export-for attributes for the export buttons so the export/download code finds the relevant tables

### Required reviewers

1-2?

## Impacted areas of the application

The Export buttons for inaugural committees' single pages

## Screenshots

It works!
![image](https://github.com/user-attachments/assets/c1abd283-e2cf-4c06-a3ed-829dc12c1106)

## Related PRs

None

## How to test

- pull the branch
- `npm run build` (probably unnecessary)
- `./manage.py runserver`
- **FOR THIS TEST ONLY**
  1. Close Chrome
  2. Launch Chrome without CORS protection: `open /Applications/Google\ Chrome.app --args --user-data-dir="/var/tmp/chrome-dev-disabled-security" --disable-web-security --disable-site-isolation-trials`
- Load any inaugural committee ([site search for `inaugural` offers several](http://127.0.0.1:8000/search/?query=inaugural&type=committees))
- Click to the Raising tab, Donations table
- [ ] All transactions tab, clicking Export starts the export and proceeds to offer the Download button
- [ ] Donor tab, clicking Export starts the export and proceeds to offer the Download button
- Skip to the Spending tab, Refunds section
- [ ] Clicking Export starts the export and proceeds to offer the Download button
- Feel free to poke around more, like to make sure non-inaugural committee pages weren't affected
- **RESTART CHROME!**

