### PR TITLE
6763 ao_year filter

### DIFF
--- a/fec/data/templates/macros/filters/dropdown-json.jinja
+++ b/fec/data/templates/macros/filters/dropdown-json.jinja
@@ -62,12 +62,12 @@ data-validate="false" data-modifies-filter="{{ name }}" data-required-default="{
   @param {string} label - Used in <label>{label}</label> and <label>Limit 1 {label}</label>
   @param {list} options[] - The data used for <option value="{}">{}</option>
 #}
-{% macro select_single_flat_list(name, label, options={}) %}
+{% macro select_single_flat_list(name, label, options={}, hide_help=false, first_opt_no_value_label=false) %}
 <div class="filter js-filter js-filter-control" id="{{ name }}-field" data-filter="select" data-name="{{ name }}" data-validate="false" data-modifies-filter="{{ name }}">
   <label for="{{ name }}" class="label">{{ label }}</label>
   <label class="label--help u-margin--top">Limit 1 {{ label | lower }}</label>
   <select id="{{ name }}" name="{{ name }}" data-filter-change="true" data-removeable-filter="true" class="dropdown">
-    <option value=''>More</option>
+    {% if first_opt_no_value_label %}<option value=''>{{ first_opt_no_value_label }}</option>{% endif %}
     {% for itemValue, itemLabel in options.items() %}
       <option value={{itemValue}} data-line-type="">{{ itemLabel }}</option>
     {% endfor %}

--- a/fec/data/templates/macros/filters/dropdown-json.jinja
+++ b/fec/data/templates/macros/filters/dropdown-json.jinja
@@ -65,7 +65,9 @@ data-validate="false" data-modifies-filter="{{ name }}" data-required-default="{
 {% macro select_single_flat_list(name, label, options={}, hide_help=false, first_opt_no_value_label=false) %}
 <div class="filter js-filter js-filter-control" id="{{ name }}-field" data-filter="select" data-name="{{ name }}" data-validate="false" data-modifies-filter="{{ name }}">
   <label for="{{ name }}" class="label">{{ label }}</label>
+  {% if not hide_help -%}
   <label class="label--help u-margin--top">Limit 1 {{ label | lower }}</label>
+  {%- endif %}
   <select id="{{ name }}" name="{{ name }}" data-filter-change="true" data-removeable-filter="true" class="dropdown">
     {% if first_opt_no_value_label %}<option value=''>{{ first_opt_no_value_label }}</option>{% endif %}
     {% for itemValue, itemLabel in options.items() %}

--- a/fec/data/templates/partials/national-party-account-disbursements-filter.jinja
+++ b/fec/data/templates/partials/national-party-account-disbursements-filter.jinja
@@ -39,7 +39,7 @@ Filter national party account disbursements
   <div class="accordion__content">
     {{ range.amount('disbursement_amount', 'Disbursement amount') }}
     {{ dropdown.select_single( 'disbursement_type', 'National party account disbursement type', options=constants.national_party_account_dropdowns.disbursements_types, default='', title_prefix='' ) }}
-    {{ dropdown.select_single_flat_list( 'party_account_type', 'National party account', options=constants.national_party_account_dropdowns.account_types) }}
+    {{ dropdown.select_single_flat_list( 'party_account_type', 'National party account', options=constants.national_party_account_dropdowns.account_types, first_opt_no_value_label='More') }}
   </div>
 </div>
 {% endblock %}

--- a/fec/data/templates/partials/national-party-account-receipts-filter.jinja
+++ b/fec/data/templates/partials/national-party-account-receipts-filter.jinja
@@ -41,7 +41,7 @@ Filter national party account disbursements
   <div class="accordion__content">
     {{ range.amount('contribution_receipt_amount', 'Receipt amount') }}
     {{ dropdown.select_single( 'receipt_type', 'National party account receipt type', options=constants.national_party_account_dropdowns.receipt_types, default='', title_prefix='' ) }}
-    {{ dropdown.select_single_flat_list( 'party_account_type', 'National party account', options=constants.national_party_account_dropdowns.account_types) }}
+    {{ dropdown.select_single_flat_list( 'party_account_type', 'National party account', options=constants.national_party_account_dropdowns.account_types, first_opt_no_value_label='More') }}
   </div>
 </div>
 {% endblock %}

--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -101,16 +101,6 @@ LegalSearchAo.prototype.initFilters = function() {
     this.updatePagination(this.lastQueryResponse.total_advisory_opinions);
   }
 
-  // Do a quick edit for the Requestor Type field
-  /** @property {HTMLSelectElement} */
-  const requestorSelect = document.querySelector('#ao_requestor_type');
-  // The Jinja template element includes a <option>More</option> that we want to remove
-  // The Python list doesn't like assigning an empty string as its value so we'll do that here
-  if (requestorSelect.options[1].textContent == 'Any') {
-    requestorSelect.removeChild(requestorSelect.options[1]);
-    requestorSelect.options[0].textContent = 'Any';
-  }
-
   this.tagList = new TagList({
     resultType: 'results',
     showResultCount: true,
@@ -147,9 +137,6 @@ LegalSearchAo.prototype.initFilters = function() {
     const searchInputSubmitButton = searchInputField.parentNode.querySelector('[type="submit"]');
     if (searchInputSubmitButton) searchInputSubmitButton.setAttribute('type', 'button');
   }
-
-  const filterTagsElement = document.querySelector('.js-filter-tags');
-  filterTagsElement.addEventListener('click', this.handleRemovingRequestorTypeTag.bind(this));
 
   // Update the window.location based on filters, in case this special template is setting values
   updateQuery(this.filterSet.serialize(), this.filterSet.fields);
@@ -259,18 +246,6 @@ LegalSearchAo.prototype.handleKeywordSearchChange = function(e) {
   } else {
     this.tagList.addTag(null, { key: 'search-input', name: 'search', value: newVal });
   }
-};
-
-/**
- * TODO: FIX THE NEED FOR THIS
- * Removing the filter tag for ao_requestor_type was resetting its <select>,
- * but its 'change' and 'select' events weren't bubbling.
- * This sets getResults to a delay when this single filter tag is removed.
- * @param {PointerEvent} e
- */
-LegalSearchAo.prototype.handleRemovingRequestorTypeTag = function(e) {
-  if (e.target.closest('[data-id="ao_requestor_type"]'))
-    this.debounce(this.getResults.bind(this), 250);
 };
 
 /**

--- a/fec/fec/static/js/modules/filters/filter-base.js
+++ b/fec/fec/static/js/modules/filters/filter-base.js
@@ -111,7 +111,7 @@ Filter.prototype.formatValue = function($input, value) {
 };
 
 /**
- * @param {jQuery.event} e
+ * @param {jQuery.Event} e
  * @param {Object} opts
  * @returns {Null} Return if irrelevant (opts.name != this.name)
  */
@@ -133,7 +133,7 @@ Filter.prototype.handleAddEvent = function(e, opts) {
 };
 
 /**
- * @param {jQuery.event} e
+ * @param {jQuery.Event} e
  * @param {Object} opts
  * @returns {Null} Return if irrelevant (opts.name != this.name || opts.loadedOnce !== true)
  */

--- a/fec/fec/static/js/modules/filters/filter-set.js
+++ b/fec/fec/static/js/modules/filters/filter-set.js
@@ -154,9 +154,9 @@ FilterSet.prototype.clear = function() {
 };
 
 /**
- * Removes the checkboxes in the panel that show whats been selected when you remove the tag from
- * the tags panel at the top of the table
- * @param {jQuery.event} e
+ * Removes the checkboxes in the panel that show what's been selected when you remove the tag from
+ * the tags panel above the table
+ * @param {jQuery.Event} e
  * @param {Object} opts - settings object like { key: value } where value is the clicked tag's data-id
  */
 FilterSet.prototype.handleTagRemoved = function(e, opts) {
@@ -167,13 +167,9 @@ FilterSet.prototype.handleTagRemoved = function(e, opts) {
 
     if (type === 'checkbox' || type === 'radio') {
       $input.click(); // TODO: jQuery deprecation
-    } else if (type === 'text') {
+    } else if (type === 'text' || type === 'select-one') {
       $input.val('');
       $input.get(0).dispatchEvent(new Event('change', { bubbles: true }));
-    } else if (type === 'select-one') {
-      // Find the option with no value and set it to selected
-      $input.find('option[value=""]').attr('selected', true);
-      $input.trigger('change');
     }
   }
 };

--- a/fec/legal/templates/legal-search-results-advisory_opinions.jinja
+++ b/fec/legal/templates/legal-search-results-advisory_opinions.jinja
@@ -19,7 +19,7 @@
 <div class="filters__inner">
   {{ text.field('ao_no', 'AO number') }}
   {{ text.field('ao_requestor', 'Requestor name (or AO name)', select_qty='single') }}
-  {{ dropdown.select_single_flat_list('ao_requestor_type', 'Requestor Type', options=ao_requestor_types )}}
+  {{ dropdown.select_single_flat_list('ao_requestor_type', 'Requestor Type', options=ao_requestor_types, first_opt_no_value_label='Any' )}}
 </div>
 <div class="js-accordion accordion--neutral restricted-fields" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Documents</button>

--- a/fec/legal/templates/legal-search-results-advisory_opinions.jinja
+++ b/fec/legal/templates/legal-search-results-advisory_opinions.jinja
@@ -20,6 +20,7 @@
   {{ text.field('ao_no', 'AO number') }}
   {{ text.field('ao_requestor', 'Requestor name (or AO name)', select_qty='single') }}
   {{ dropdown.select_single_flat_list('ao_requestor_type', 'Requestor Type', options=ao_requestor_types, first_opt_no_value_label='Any' )}}
+  {{ dropdown.select_single_flat_list('ao_year', 'AO year', options=ao_year_opts, hide_help=true, first_opt_no_value_label='Any' )}}
 </div>
 <div class="js-accordion accordion--neutral restricted-fields" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Documents</button>

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -318,7 +318,7 @@ def legal_doc_search_ao(request):
 
     # Define AO requestor types dictionary
     ao_requestor_types = {
-        "0": "Any",
+        # "0": "Any",
         "1": "Federal candidate/candidate committee/officeholder",
         "2": "Publicly funded candidates/committees",
         "3": "Party committee, national",

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -276,6 +276,7 @@ def legal_doc_search_ao(request):
     ao_regulatory_citation = request.GET.get('ao_regulatory_citation', '')
     ao_statutory_citation = request.GET.get('ao_statutory_citation', '')
     ao_citation_require_all = request.GET.get('ao_citation_require_all', '')
+    ao_year = request.GET.get('ao_year', '')
 
     query, query_exclude = parse_query(original_query)
 
@@ -301,6 +302,7 @@ def legal_doc_search_ao(request):
         ao_regulatory_citation=ao_regulatory_citation,
         ao_statutory_citation=ao_statutory_citation,
         ao_citation_require_all=ao_citation_require_all,
+        ao_year=ao_year,
     )
 
     # Define AO document categories dictionary
@@ -334,6 +336,13 @@ def legal_doc_search_ao(request):
         "15": "Individual",
         "16": "Other",
     }
+
+    # Possible values for the ao_year filter
+    # We want 1975+ but not the future, so limit the range to > 1974
+    all_ao_years = list(range(datetime.datetime.now().year, 1974, -1))
+    ao_year_opts = {}
+    for year in all_ao_years:
+        ao_year_opts[year] = year
 
     # Return the selected document category name
     ao_document_category_names = [ao_document_categories.get(id) for id in ao_doc_category_ids]
@@ -374,6 +383,8 @@ def legal_doc_search_ao(request):
         'selected_ao_doc_category_names': ao_document_category_names,
         'selected_ao_requestor_type_ids': ao_requestor_type_ids,
         'selected_ao_requestor_type_names': ao_requestor_type_names,
+        'ao_year': ao_year,
+        'ao_year_opts': ao_year_opts,
         'is_loading': True,  # Indicate that the page is loading initially
     })
 

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -344,7 +344,7 @@ def legal_doc_search_ao(request):
     # For Javascript
     context_vars = {
         'sort': sort,
-        'sortType':sort.replace('-','')
+        'sortType': sort.replace('-', '')
     }
 
     return render(request, 'legal-search-results-advisory_opinions.jinja', {


### PR DESCRIPTION
## Summary

- Resolves #6763 

Adding the ao_year filter for AO search. Also fixing a filter for national party accounts

### Required reviewers

- UX
- dev

## Impacted areas of the application

AO search and one of the filters for national party accounts datatables, both raising and spending.

## Screenshots

<img width="667" alt="image" src="https://github.com/user-attachments/assets/fc40be74-d39d-4f35-9b7b-0ae03d2c981b" />

## Related PRs

None

## How to test

- pull the branch
- `npm run build`
- `./manage.py runserver`
- Go to [AO search](http://127.0.0.1:8000/data/legal/search/advisory-opinions/)
- We're comparing both the 'Requestor type' filter _and_ the 'AO year' filters
- 'Requestor type' has had a tweak but should behave exactly as it does on Production (add one, change the pulldown to a different value, change it to null, add another, remove its tag, add another…)
- 'AO year' should behave properly and offer 1975-[the current year]
- Be sure to check AO year fully. e.g. add one, change it, clear it, remove its tag
- For National party [receipts](http://127.0.0.1:8000/data/national-party-account-receipts/) and [disbursements](http://127.0.0.1:8000/data/national-party-account-disbursements/), we're checking the very last filter, 'National party account'. Specifically, we want to set a value, remove its tag, set a different value, remove its tag, set any value (yes, three times), and try to remove its tag. That's where Production was breaking, when removing the tag a third time