### PR TITLE
6801-upgrade django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.1.9
+Django==5.1.10
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-libsass==0.7


### PR DESCRIPTION
## Summary (required)

- Resolves #6801 

Upgrades django to remove snyk vuln. Couldn't upgrade to LTS due to django-uaa needing <5.2

### Required reviewers

1-2 devs

## How to test

- `gh pr checkout `
-  activate your venv
-  `pip install -r requirements.txt`
- `snyk test --file=requirements.txt --package-manager=pip`
-  `cd fec`
-  `python manage.py runserver`

