### PR TITLE
Add legal search guide to website

### DIFF
--- a/fec/data/templates/partials/audit-filter.jinja
+++ b/fec/data/templates/partials/audit-filter.jinja
@@ -5,6 +5,9 @@
 {% import 'macros/filters/years.jinja' as years %}
 
 {% block filters %}
+<div class="filters__aside">
+  <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+</div>
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <div class="filters__inner">
  {# category/subcategory filter #}

--- a/fec/data/templates/partials/audit-filter.jinja
+++ b/fec/data/templates/partials/audit-filter.jinja
@@ -6,7 +6,7 @@
 
 {% block filters %}
 <div class="filters__aside">
-  <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+  <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
 </div>
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <div class="filters__inner">

--- a/fec/data/templates/partials/audit-filter.jinja
+++ b/fec/data/templates/partials/audit-filter.jinja
@@ -6,7 +6,7 @@
 
 {% block filters %}
 <div class="filters__aside">
-  <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
+  <div class="button--notebook u-margin--top t-sans">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
 </div>
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <div class="filters__inner">

--- a/fec/fec/static/scss/components/_buttons.scss
+++ b/fec/fec/static/scss/components/_buttons.scss
@@ -541,6 +541,44 @@
   }
 }
 
+.button--notebook {
+  font-size: u(1.6rem);
+  line-height: u(2.1rem);
+  margin-left: u(3.7rem);
+  margin-top: u(2.5rem);
+  padding: 0;
+  position: relative;
+  text-align: left;
+
+
+  &::before {
+    content: '';
+    background-size: 100%;
+    display: block;
+    height: u(3.7rem);
+    left: u(-2.3em);
+    position: absolute;
+    top: u(.5rem);
+    width: u(2.7rem);
+    @include u-icon-bg($notebook, $primary);
+  }
+}
+
+.filters__aside .button--notebook {
+  font-size: u(1.09rem);
+  line-height: u(1.5rem);
+  margin-left: u(2.5rem);
+  margin-top: 0;
+  max-width: 260px;
+  padding-left: u(.3rem);
+  
+    &::before { 
+    height: u(3rem);
+    top: u(.4rem);
+    width: u(2rem);
+  }
+}
+
 //For internal/external button widgets in Wagtail
 .block-internal_button .button--primary,
 .block-external_button .button--primary {

--- a/fec/fec/static/scss/components/_filters.scss
+++ b/fec/fec/static/scss/components/_filters.scss
@@ -185,6 +185,12 @@ $filter-button-width: u(4.6rem);
   }
 }
 
+.filters__aside {
+  width: 100%;
+  border-bottom: 1px solid $gray;
+  padding: u(2rem);
+}
+
 .filter {
   border-bottom: 1px solid darken($neutral, 10%);
   margin-top: u(1.5rem);
@@ -232,6 +238,8 @@ $filter-button-width: u(4.6rem);
       background-position: 50%;
     }
   }
+
+
 
   label {
     max-width: 90%;

--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -53,7 +53,7 @@
         </ul>
       </div>
      
-      <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
+      <div class="button--notebook u-margin--top t-sans">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
      
     </div>
     <div class="grid__item">

--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -52,6 +52,9 @@
           <li><a href="/data/legal/search/statutes">Statutes</a></li>
         </ul>
       </div>
+     
+      <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+     
     </div>
     <div class="grid__item">
       <div class="heading--section heading--with-action">

--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -53,7 +53,7 @@
         </ul>
       </div>
      
-      <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+      <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
      
     </div>
     <div class="grid__item">

--- a/fec/home/templates/partials/legal-keyword-modal.html
+++ b/fec/home/templates/partials/legal-keyword-modal.html
@@ -6,7 +6,7 @@
       <h2 id="spending-modal-title" class="heading--section">Find documents with&hellip;</h2>
       <div class="row u-padding--top">
         <form class="modal__form" action="/data/legal/search/">
-          <p>Use these search boxes to refine your search. Only words with letters, numbers, spaces, and hyphens (such as in-kind) are accepted:</p>
+          <p>Use these search boxes to refine your search. Only words with letters, numbers, spaces, and hyphens (such as in-kind) are accepted.  Learn more about boolean filters and other search functionality using our <a href="/legal-resources/how-to-use-fec-legal-search-systems/" target="_blank">legal search guide</a></p>
           <div class="filter">
             <label class="label" for="keywords-any">Any of these words</label>
             <input type="text" id="keywords-any" data-operator="or">

--- a/fec/legal/templates/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/legal-search-results-adrs.jinja
@@ -9,6 +9,9 @@
 {% endblock %}
 
 {% block filters %}
+  <div class="filters__aside">
+    <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+  </div>
   <div class="filters__inner">
     {{ legal.keyword_search(result_type, query) }}
     <div class="filter">

--- a/fec/legal/templates/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/legal-search-results-adrs.jinja
@@ -10,7 +10,7 @@
 
 {% block filters %}
   <div class="filters__aside">
-    <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+    <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
   </div>
   <div class="filters__inner">
     {{ legal.keyword_search(result_type, query) }}

--- a/fec/legal/templates/legal-search-results-adrs.jinja
+++ b/fec/legal/templates/legal-search-results-adrs.jinja
@@ -10,7 +10,7 @@
 
 {% block filters %}
   <div class="filters__aside">
-    <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
+    <div class="button--notebook u-margin--top t-sans">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
   </div>
   <div class="filters__inner">
     {{ legal.keyword_search(result_type, query) }}

--- a/fec/legal/templates/legal-search-results-advisory_opinions.jinja
+++ b/fec/legal/templates/legal-search-results-advisory_opinions.jinja
@@ -16,6 +16,9 @@
 
 {% block filters %}
 <input id="doc_type" type="hidden" name="doc_type" value="advisory_opinions">
+<div class="filters__aside">
+  <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+</div>
 <div class="filters__inner">
   {{ text.field('ao_no', 'AO number') }}
   {{ text.field('ao_requestor', 'Requestor name (or AO name)', select_qty='single') }}

--- a/fec/legal/templates/legal-search-results-advisory_opinions.jinja
+++ b/fec/legal/templates/legal-search-results-advisory_opinions.jinja
@@ -17,7 +17,7 @@
 {% block filters %}
 <input id="doc_type" type="hidden" name="doc_type" value="advisory_opinions">
 <div class="filters__aside">
-  <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
+  <div class="button--notebook u-margin--top t-sans">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
 </div>
 <div class="filters__inner">
   {{ text.field('ao_no', 'AO number') }}

--- a/fec/legal/templates/legal-search-results-advisory_opinions.jinja
+++ b/fec/legal/templates/legal-search-results-advisory_opinions.jinja
@@ -17,7 +17,7 @@
 {% block filters %}
 <input id="doc_type" type="hidden" name="doc_type" value="advisory_opinions">
 <div class="filters__aside">
-  <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+  <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
 </div>
 <div class="filters__inner">
   {{ text.field('ao_no', 'AO number') }}

--- a/fec/legal/templates/legal-search-results-afs.jinja
+++ b/fec/legal/templates/legal-search-results-afs.jinja
@@ -9,6 +9,9 @@
 {% endblock %}
 
 {% block filters %}
+<div class="filters__aside">
+  <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+</div>
 <div class="filters__inner">
   {{ legal.keyword_search(result_type, query) }}
   <div class="filter">

--- a/fec/legal/templates/legal-search-results-afs.jinja
+++ b/fec/legal/templates/legal-search-results-afs.jinja
@@ -10,7 +10,7 @@
 
 {% block filters %}
 <div class="filters__aside">
-  <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+  <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
 </div>
 <div class="filters__inner">
   {{ legal.keyword_search(result_type, query) }}

--- a/fec/legal/templates/legal-search-results-afs.jinja
+++ b/fec/legal/templates/legal-search-results-afs.jinja
@@ -10,7 +10,7 @@
 
 {% block filters %}
 <div class="filters__aside">
-  <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
+  <div class="button--notebook u-margin--top t-sans">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
 </div>
 <div class="filters__inner">
   {{ legal.keyword_search(result_type, query) }}

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -15,7 +15,7 @@
   <input id="sort" type="hidden" name="sort" value="{{ sort }}">
   <input id="doc_type" type="hidden" name="doc_type" value="murs">
   <div class="filters__aside">
-    <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
+    <div class="button--notebook u-margin--top t-sans">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
   </div>
   <div class="filters__inner">
     <div class="filter">

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -14,8 +14,10 @@
 {% block filters %}
   <input id="sort" type="hidden" name="sort" value="{{ sort }}">
   <input id="doc_type" type="hidden" name="doc_type" value="murs">
+  <div class="filters__aside">
+    <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+  </div>
   <div class="filters__inner">
-    
     <div class="filter">
       <label class="label" for="case_no">MUR number</label>
       <input id="case_no" name="case_no" type="text" value="{{ case_no }}">

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -15,7 +15,7 @@
   <input id="sort" type="hidden" name="sort" value="{{ sort }}">
   <input id="doc_type" type="hidden" name="doc_type" value="murs">
   <div class="filters__aside">
-    <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+    <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
   </div>
   <div class="filters__inner">
     <div class="filter">

--- a/fec/legal/templates/legal-search-results-regulations.jinja
+++ b/fec/legal/templates/legal-search-results-regulations.jinja
@@ -9,6 +9,9 @@
 {% endblock %}
 
 {% block filters %}
+  <div class="filters__aside">
+    <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems.</a></button>
+  </div>
     <div class="filters__inner">
       {{ legal.keyword_search(result_type, query) }}
     </div>

--- a/fec/legal/templates/legal-search-results-regulations.jinja
+++ b/fec/legal/templates/legal-search-results-regulations.jinja
@@ -10,7 +10,7 @@
 
 {% block filters %}
   <div class="filters__aside">
-    <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems.</a></button>
+    <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
   </div>
     <div class="filters__inner">
       {{ legal.keyword_search(result_type, query) }}

--- a/fec/legal/templates/legal-search-results-regulations.jinja
+++ b/fec/legal/templates/legal-search-results-regulations.jinja
@@ -10,7 +10,7 @@
 
 {% block filters %}
   <div class="filters__aside">
-    <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
+    <div class="button--notebook u-margin--top t-sans">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
   </div>
     <div class="filters__inner">
       {{ legal.keyword_search(result_type, query) }}

--- a/fec/legal/templates/legal-search-results-statutes.jinja
+++ b/fec/legal/templates/legal-search-results-statutes.jinja
@@ -9,6 +9,9 @@
 {% endblock %}
 
 {% block filters %}
+  <div class="filters__aside">
+    <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+  </div>
   <div class="filters__inner">
     {{ legal.keyword_search(result_type, query) }}
   </div>

--- a/fec/legal/templates/legal-search-results-statutes.jinja
+++ b/fec/legal/templates/legal-search-results-statutes.jinja
@@ -10,7 +10,7 @@
 
 {% block filters %}
   <div class="filters__aside">
-    <button type="button" class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</button>
+    <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
   </div>
   <div class="filters__inner">
     {{ legal.keyword_search(result_type, query) }}

--- a/fec/legal/templates/legal-search-results-statutes.jinja
+++ b/fec/legal/templates/legal-search-results-statutes.jinja
@@ -10,7 +10,7 @@
 
 {% block filters %}
   <div class="filters__aside">
-    <div class="button--notebook u-margin--top">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
+    <div class="button--notebook u-margin--top t-sans">Use the legal search guide to learn more about <a href="/legal-resources/how-to-use-fec-legal-search-systems/">how to use FEC legal search systems</a>.</div>
   </div>
   <div class="filters__inner">
     {{ legal.keyword_search(result_type, query) }}

--- a/fec/legal/templates/partials/legal-keyword-modal.jinja
+++ b/fec/legal/templates/partials/legal-keyword-modal.jinja
@@ -6,7 +6,7 @@
       <h2 id="spending-modal-title" class="heading--section">Find documents with...</h2>
       <div class="row u-padding--top">
         <form class="modal__form" action="">
-          <p>Use these search boxes to refine your search. Only words with letters, numbers, spaces, and hyphens (such as in-kind) are accepted:</p>
+          <p>Use these search boxes to refine your search. Only words with letters, numbers, spaces, and hyphens (such as in-kind) are accepted. Learn more about boolean filters and other search functionality using our <a href="/legal-resources/how-to-use-fec-legal-search-systems/" target="_blank">legal search guide</a>.</p>
           <div class="filter">
             <label class="label" for="keywords-any">Any of these words</label>
             <input type="text" id="keywords-any" data-operator="or">


### PR DESCRIPTION
## Summary (required)

- Resolves #6799

Add link to legal search guide on legal landing, legal datatables' filter panel and in keyword modal 

### Required reviewers

One UX or Content, One Dev

## Impacted areas of the application

A new link on all legal datatables' filter panel  and keyword modal (except audit search)
A new link on legal landing

-  

## Screenshots

<img width="299" alt="Screenshot 2025-07-07 at 11 07 34 AM" src="https://github.com/user-attachments/assets/61bcb42b-db04-4a99-950c-19fcb4171692" />
<hr>
<img width="523" alt="Screenshot 2025-07-07 at 11 08 14 AM" src="https://github.com/user-attachments/assets/a3caa6fe-048f-46e2-9488-800a1006f2d6" />

Related issue:
https://github.com/fecgov/fec-cms/issues/6773

## How to test
- `npm run build-sass`
- Go to legal landing, legal datatables and keyword modal to see the link and verify it goes to the correct place
- Link in keyword modal should open in new tab




