### PR TITLE
[MERGE WITH GIT FLOW]Resolve server error on global legal search page

### DIFF
--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -208,6 +208,8 @@ def transform_ecfr_query_string(query_string):
 
 def legal_search(request):
     original_query = request.GET.get('search', '')
+    q_proximities = request.GET.get('q_proximity', '')
+    q_proximitys = request.GET.get('q_proximity', '')
     updated_ecfr_query_string = transform_ecfr_query_string(original_query)
     result_type = request.GET.get('search_type', 'all')
     results = {}
@@ -245,6 +247,8 @@ def legal_search(request):
     return render(request, 'legal-search-results.jinja', {
         'parent': 'legal',
         'query': original_query,
+        'q_proximities': q_proximities,
+        'q_proximitys': q_proximitys,
         'results': results,
         'result_type': result_type,
         'category_order': get_legal_category_order(results, result_type),


### PR DESCRIPTION
## Summary (required)

- Resolves #6825
- Add `q_proximitys` placeholder var to the global legal search view to resolve server error

### Required reviewers

one developer

## Impacted areas of the application

Global legal search
https://www.fec.gov/legal-resources/

## How to test
- checkout and run branch
- Perform a search from the search box on legal resources landing, with `All sources` chosen 
URL: http://127.0.0.1:8000/data/legal/search/?search_type=all&search=filings
