### PR TITLE
6829 Update Default Election Years

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -12,10 +12,10 @@ from data import utils
 
 START_YEAR = 1979
 END_YEAR = 2026  # Change at the beginning of the year
-DEFAULT_TIME_PERIOD = 2024  # Change after the April quarterly report (4/15/25)
+DEFAULT_TIME_PERIOD = 2026  # Change after the April quarterly report (4/15/27)
 DEFAULT_ELECTION_YEAR = 2026  # Change after election day (11/3/26)
-DEFAULT_PRESIDENTIAL_YEAR = 2024  # Change after April quarterly after mid-terms (4/15/25)
-DISTRICT_MAP_CUTOFF = 2026  # The year we show district maps for on election pages. Change at the beginning of the year.
+DEFAULT_PRESIDENTIAL_YEAR = 2028  # Change after April quarterly after mid-terms (4/15/29)
+DISTRICT_MAP_CUTOFF = 2026  # The year we show district maps for on election pages. Change at the beginning of the year
 
 states = OrderedDict([
     ('AL', 'Alabama'),


### PR DESCRIPTION
## Summary

- Resolves #6829 

Updating `DEFAULT_TIME_PERIOD` and `DEFAULT_PRESIDENTIAL_YEAR` from 2024 to 2026

### Required reviewers

- Dev

## Impacted areas of the application

- Everywhere that uses the defaults

## Screenshots

Updated defaults
<img width="638" height="306" alt="image" src="https://github.com/user-attachments/assets/9a31cbe2-5f3a-4b11-8793-88e0f80bb883" />


## Related PRs

None

## How to test

- Pull the branch
- `./manage.py runserver`
- Check pages (mostly data tables) that use default years