### PR TITLE
6836-add connection pooling via Django/psycopg

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -228,14 +228,18 @@ WSGI_APPLICATION = 'fec.wsgi.application'
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', get_random_string(50))
 
 
-# Database
-# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
-
 DATABASES = {
-    # Be sure to set the DATABASE_URL environment variable on your local
-    # development machine so that the local database can be connected to.
     'default': dj_database_url.config()
 }
+
+# Add or update OPTIONS after the config() call
+DATABASES['default'].setdefault('OPTIONS', {})
+DATABASES['default']['OPTIONS'].update({
+    'pool': {
+        'max_size': 50,  # total possible db conn = Workers x Instances x max_size (600, probably too high)
+        'max_idle': 400,  # default is 600 sec
+    }
+})
 
 
 # Internationalization

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dj-database-url==0.4.2
 django-libsass==0.7
 gunicorn==23.0.0
 gevent==25.5.1
-psycopg==3.1.20
+psycopg[pool]==3.1.20
 requests==2.32.4
 urllib3==2.2.2
 whitenoise==5.2.0


### PR DESCRIPTION
## Summary (required)

- Resolves #6836 

Adds connection pooling, [Django 5.1 added connection pooling using psycopg3's pool](https://docs.djangoproject.com/en/5.2/releases/5.1/#postgresql-connection-pools)
I set max_size at 50 which is 600 possible db connections
I lowered max_idle from 600 to 400 s

We should lower both eventually, but these are conservative estimates. Hoping we can ask cloud.gov for a month of PI db connections like we can do with the API. 

It seems that we regularly need <50 db connections, so for right now django's in built connection pooling should suffice. If this is not enough connections we can consider external pooling with pgbouncer later. 

Max CMS Application DB connections = the lowest of these two options :

     (num of workers) x (instances) x (limit of greenlets spawned) 

OR 

    max_connections in the DB (SHOW max_connections;)

LIMITS OF GREENLETS SPAWNED=

the lowest of these two options: 

    —worker-connections  (gunicorn gevent, default is 1000)

OR

    pool size (if enabled)

POOL SIZE:
```
DJANGO ORM
max_size
```

### Required reviewers

2-4 devs

## Impacted areas of the application

-  DB connections


## How to test

- Push to dev/stage
- I tested by SSHing into stage ([wiki](https://github.com/fecgov/fec-cms/wiki/Switch-Wagtail-page%E2%80%90type-while-keeping-existing-ID-and-Slug)) lowering the max_size to 5 and increasing the instances to 2. I was able to get to 20 connections and could see the ten extra connections when I increased the instances. 
- You can do this with your local db if you connect via dbeaver
NOTE: when testing, you will also see your own connections and background/system processes. 
