### PR TITLE
6841-switch template status to 500

### DIFF
--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -465,13 +465,18 @@ def guides(request):
 # Custom handle 500 error for website status
 def error_500(request, template_name="500.html"):
     cms_env = request.GET.get("FEC_CMS_ENVIRONMENT", "")
+    context = {'FEC_CMS_ENVIRONMENT': cms_env}
     if settings.FEATURES.get('website_status'):
         return render(
             request,
             '500-status.html',
-            {'FEC_CMS_ENVIRONMENT': cms_env})
+            context,
+            status=500
+        )
 
     return render(
         request,
         template_name,
-        {'FEC_CMS_ENVIRONMENT': cms_env})
+        context,
+        status=500
+    )


### PR DESCRIPTION
## Summary (required)

- Resolves #6841 

Changes template statuses to 500, so that Pingdom will alert us with server errors. I don't think we should build an alternative template for DB connection errors, I think we should keep this information exclusive to our logging/alerts

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  CMS server errors


## How to test

**DO NOT TRY TO PUSH TO DEV/STAGE**

- Pull down the branch
- Set the feature flag `export FEC_FEATURE_WEBSITE_STATUS=true`. This will turn on the alternative 500 error messaging (see screenshot above for what that looks like).
- Turn off DEBUG mode inside of the dev.py file. Change to `DEBUG = False`. Also add `ALLOWED_HOSTS = ['*']`. These will be temporary changes to test out the 500 error messaging.
- `npm run build-js`
- Build assets using collectstatic so that scripts and styles will work on site: `./manage.py collectstatic --noinput -v 0`
- Pick a jinja template or a HTML template (our templates all use jinja as the framework even though the extension is .html). 
- Modify that chosen jinja template's extends to reference an invalid file name. Example: `{% extends 'layouts/invalid_name.jinja' %}`
- Run the server `./manage.py runserver`
- Go to the page that uses that modified jinja template. You should see the custom 500 server error message. If you curl you should get a 500
'curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8000/{template you chose}'
- Test turning off the alternative 500 error message by 
    - Turn off your CMS server
    - Unset the flag: `unset FEC_FEATURE_WEBSITE_STATUS`
- Run the server `./manage.py runserver`
- Refresh the page with the modified jinja template and you should now see the normal/default 500 error message and receive a 500 if you inspect or curl
'curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8000/{template you chose}'

You can also run these tests on current develop branch locally to confirm that currently render sends a 200

I didn't test this in an environment with Pingdom because it's a security risk to allow hosts. 