### PR TITLE
Add 503 middleware

### DIFF
--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -130,7 +130,7 @@ class PoolTimeouts(MiddlewareMixin):
                 # Check if alert was sent recently (1 hour)
                 last_sent = cache.get(self.SLACK_ALERT_CACHE_KEY)
                 if not last_sent:
-                    slack.post_to_slack("Django/Psycopg PoolTimeout", "#test-bot")
+                    slack.post_to_slack("Django/Psycopg PoolTimeout", "#alerts")
                     cache.set(self.SLACK_ALERT_CACHE_KEY, True, timeout=self.THROTTLE_SECONDS)
                 else:
                     pass

--- a/fec/fec/middleware.py
+++ b/fec/fec/middleware.py
@@ -1,6 +1,12 @@
 from django.utils.deprecation import MiddlewareMixin
 from django.conf import settings
 
+from psycopg_pool import PoolTimeout
+from django.db.utils import OperationalError
+from django.core.cache import cache
+from django.shortcuts import render
+from fec import slack
+
 
 class AddSecureHeaders(MiddlewareMixin):
     """Add secure headers to each response"""
@@ -109,3 +115,30 @@ class AddSecureHeaders(MiddlewareMixin):
         response["Expect-CT"] = expect_ct_string
 
         return response
+
+
+class PoolTimeouts(MiddlewareMixin):
+    SLACK_ALERT_CACHE_KEY = "slack_pooltimeout_alert_sent"
+    THROTTLE_SECONDS = 3600
+
+    def process_request(self, request):
+        request._pool_timeout_handled = False  # flag to not spam alerts
+
+    def process_exception(self, request, exception):
+        if isinstance(exception, OperationalError) and isinstance(exception.__cause__, PoolTimeout):
+            if not getattr(request, '_pool_timeout_handled', False):
+                # Check if alert was sent recently (1 hour)
+                last_sent = cache.get(self.SLACK_ALERT_CACHE_KEY)
+                if not last_sent:
+                    slack.post_to_slack("Django/Psycopg PoolTimeout", "#test-bot")
+                    cache.set(self.SLACK_ALERT_CACHE_KEY, True, timeout=self.THROTTLE_SECONDS)
+                else:
+                    pass
+                request._pool_timeout_handled = True
+
+            # Return 503
+            response = render(request, '503.html')
+            response.status_code = 503
+            return response
+
+        return None  # Unhandled exceptions

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -161,6 +161,7 @@ MIDDLEWARE = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     # custom response headers
     'fec.middleware.AddSecureHeaders',
+    'fec.middleware.PoolTimeouts',
     'uaa_client.middleware.UaaRefreshMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/fec/fec/slack.py
+++ b/fec/fec/slack.py
@@ -1,0 +1,24 @@
+import requests
+import json
+from fec.settings.env import env
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def post_to_slack(message, channel):
+    response = requests.post(
+        env.get_credential("SLACK_HOOK"),
+        data=json.dumps(
+            {
+                "text": message,
+                "channel": channel,
+                "link_names": 1,
+                "username": "Robot",
+                "icon_emoji": ":robot_face:",
+            }
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+    if response.status_code != 200:
+        logger.error("SLACK ERROR- Message failed to send:{0}".format(message))

--- a/fec/fec/templates/500-status.html
+++ b/fec/fec/templates/500-status.html
@@ -1,82 +1,31 @@
-{% load static compress wagtailuserbar %}
-{% load filters %}
-<!DOCTYPE html>
-<html lang="en-US">
-  <head>
-    {% include './partials/meta-tags.html' %}
+{% extends "base.html" %}
 
-    <title>Website status error | FEC</title>
+{% block title %}Website status error | FEC{% endblock %}
 
-    {% if not request.is_preview %}{% include 'partials/google-tag-manager-script.html' %}{% endif %}
+{% block content %}
+  <!-- Browser Warning (only shows if outdated) -->
+  <div id="browser_warning" style="display: none; background: #f8d7da; color: #721c24; padding: 1rem; margin: 1rem 0; border: 1px solid #f5c6cb;">
+    <h2>Your web browser is not supported</h2>
+    <p>This site uses features that are not supported by this browser. For a better experience, please switch to a modern browser.</p>
+  </div>
 
-    {% block css %}
-    <link rel="stylesheet" type="text/css" href="{% path_for_css 'base.css' %}">
-    {% endblock %}
-  </head>
-
-  <body class="status-mode {% block body_class %}{% endblock %}">
-    <div id="browser_warning" style="display: none;">
-      <h2>Your web browser is not supported</h2>
-      <p>This site uses features that are not supported by this browser. For a better experience, please switch to a modern browser.</p>
-    </div>
-    <script>{# Currently checking for window.fetch and Object.assign #}
+  <script>
+    (function () {
       var browserIsCapable = ('fetch' in window && 'assign' in Object);
       if (!browserIsCapable) {
-        var browserWarningElement = document.getElementById('browser_warning');
-        browserWarningElement.style.display = 'block';
+        var warning = document.getElementById('browser_warning');
+        if (warning) warning.style.display = 'block';
       }
-    </script>
+    })();
+  </script>
 
-    {% if not request.is_preview %}{% include 'partials/google-tag-manager-noscript.html' %}{% endif %}
-
-    {% wagtailuserbar %}
-    {# env-specific banner #} 
-    {% include 'partials/env-banner.html' %}
-    {# .gov banner #}
-    {% include 'partials/usa-banner.html' %}
-    <header class="site-header site-header--homepage">
-      <div class="masthead">
-        <div class="homepage-seal">
-          <img src="{% static 'img/seal.svg' %}" alt="FEC logo" width="160" height="160">
-        </div>
-        <div class="site-title--print"></div>
-        <a title="Home" href="/" class="site-title" rel="home"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
+  <section class="content--blank">
+    <div class="container">
+      <div class="message message--alert message--big">
+        <h1 class="message__title">Server error</h1>
+        <p>We are experiencing technical difficulties. We know this may interrupt your work and are working hard to restore FEC.gov to normal. Please check the <a href="https://secure-stats.pingdom.com/x0blqgj29ogg">FEC.gov status page</a> for current system status availability.</p>
+        <p>If you have any questions or feedback about the website, please contact us at <a href="mailto:webmanager@fec.gov">webmanager@fec.gov</a>. For assistance with questions about the FEC or the federal campaign finance law, please email <a href="mailto:info@fec.gov">info@fec.gov</a> or call 800-424-9530.</p>
       </div>
-    </header>
-
-    <main id="main">
-      {% block content %}
-      <div class="container" style="padding-top: 15rem;">
-        <ul class="grid grid--flex">
-            <li class="grid__item text-centered">
-                <p>We are experiencing technical difficulties. We know this may interrupt your work and are working hard to restore FEC.gov to normal. Please check the <a href="https://secure-stats.pingdom.com/x0blqgj29ogg">FEC.gov status page</a> for current system status availability.</p>
-                <p>If you have any questions or feedback about the website, please contact us at <a href="mailto:webmanager@fec.gov">webmanager@fec.gov</a>. For assistance with questions about the FEC or the federal campaign finance law, please email <a href="mailto:info@fec.gov">info@fec.gov</a> or call 800-424-9530.</p>
-            </li>
-        </ul>
-      </div>
-      {% endblock %}
-    </main>
-
-    {% include './partials/glossary.html' %}
-
-    {% csrf_token %}
-
-    <script>
-      window.BASE_PATH = '/';
-      window.FEC_APP_URL = '{{ settings.FEC_APP_URL }}';
-      window.API_LOCATION = '{{ settings.FEC_API_URL }}';
-    </script>
-
-    {% tags_for_js_chunks 'global.js' '' %}
-    {% tags_for_js_chunks 'init.js' '' %}
-
-    {% block extra_js %}
-    {# Override this in templates to add extra javascript #}
-    {% endblock %}
-
-    {# GSA DAP for Production #}
-    {% if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION' %}
-    <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
-    {% endif %}
-  </body>
-</html>
+    </div>
+  </section>
+{% endblock %}

--- a/fec/fec/templates/500.html
+++ b/fec/fec/templates/500.html
@@ -7,7 +7,7 @@
   <div class="container">
     <div class="message message--alert message--big">
       <h1 class="message__title">Server error</h1>
-      <p>Sorry, this page failed to load. Check the FEC’s <a href="https://www.fec.gov/status">API status page</a> to see if we are experiencing a temporary outage. If not, please try again, and thanks for your patience.</p>
+      <p>Sorry, this page failed to load. Please check the FEC’s <a href="https://www.fec.gov/status">API status page</a> for any temporary outages. If not, please try again, and thanks for your patience.</p>
       <p>If you'd like to contact our team, use the <a href="javascript:$('.js-feedback.feedback__toggle.button--cta-secondary').trigger('click');" style="text-decoration:none">feedback box</a> on the bottom of any page or <a href="https://www.fec.gov/contact/">contact the FEC</a>.</p>
     </div>
   </div>

--- a/fec/fec/templates/503.html
+++ b/fec/fec/templates/503.html
@@ -7,7 +7,7 @@
   <div class="container">
     <div class="message message--alert message--big">
       <h1 class="message__title">Service unavailable</h1>
-      <p>Sorry, this page failed to load. Check the FEC’s <a href="https://www.fec.gov/status">API status page</a> to see if we are experiencing a temporary outage. If not, please try again, and thanks for your patience.</p>
+      <p>Sorry, this page failed to load. Please check the FEC’s <a href="https://www.fec.gov/status">API status page</a> for any temporary outages. If not, please try again, and thanks for your patience.</p>
       <p>If you'd like to contact our team, use the <a href="javascript:$('.js-feedback.feedback__toggle.button--cta-secondary').trigger('click');" style="text-decoration:none">feedback box</a> on the bottom of any page or <a href="https://www.fec.gov/contact/">contact the FEC</a>.</p>
     </div>
   </div>

--- a/fec/fec/templates/503.html
+++ b/fec/fec/templates/503.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Service unavailable | FEC {% endblock %}
+
+{% block content %}
+<section class="content--blank">
+  <div class="container">
+    <div class="message message--alert message--big">
+      <h1 class="message__title">Service unavailable</h1>
+      <p>Sorry, this page failed to load. Check the FEC’s <a href="https://www.fec.gov/status">API status page</a> to see if we are experiencing a temporary outage. If not, please try again, and thanks for your patience.</p>
+      <p>If you'd like to contact our team, use the <a href="javascript:$('.js-feedback.feedback__toggle.button--cta-secondary').trigger('click');" style="text-decoration:none">feedback box</a> on the bottom of any page or <a href="https://www.fec.gov/contact/">contact the FEC</a>.</p>
+    </div>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary (required)

- Resolves #6843 

Adds 503 template when we are getting db driver pool timeout errors 
Posts to slack that we are getting these errors once an hour
Changes website status page to match formatting (the 500 template we can switch to with an env var) 

### Required reviewers

2 devs, at least 1 front end, 
1 design 

## Impacted areas of the application

General components of the application that this PR will affect:

-  Middleware and error templates 

## Screenshots

Current 500 page:
<img width="2644" height="1724" alt="image" src="https://github.com/user-attachments/assets/72fb4289-3c4d-4f8d-82ce-910e84d6eaf4" />

Current 500-status page:
<img width="2636" height="1280" alt="image" src="https://github.com/user-attachments/assets/d24ceede-d9d8-4edb-9672-71ebeff07cfb" />

New 500 page:
<img width="1194" height="662" alt="Screenshot 2025-08-18 at 4 32 36 PM" src="https://github.com/user-attachments/assets/c801b3ca-e0b8-4330-ab80-f730a2fb5eca" />

New 500-status page:
<img width="720" height="400" alt="image" src="https://github.com/user-attachments/assets/1c86159f-d194-4b8d-bcf2-2452bad8dc89" />

New 503 page:
<img width="1194" height="662" alt="Screenshot 2025-08-18 at 4 33 03 PM" src="https://github.com/user-attachments/assets/59ba8b56-99d3-47c7-8949-2314150771c7" />

## How to test

- git checkout test-pooltimeout. (This branch has the current changes, plus some changes that make it easier to test timeouts locally) 
- activate your pyenv

- In dev.py: change debug to false and allow hosts 
DEBUG = False
ALLOWED_HOSTS = ['*']

- `npm run build-js`
- Build assets using collectstatic so that scripts and styles will work on site: `./manage.py collectstatic --noinput -v 0`

- cd fec
- python manage.py runserver

- test a 404 
http://127.0.0.1:8000/about/leadership-and-structure/main/
Should throw a 'page not found'

- test 503 PoolTimeout by using the fake hold url 
open multiple tabs of this url:
http://127.0.0.1:8000/hold/
You should see the 503 error, and a message in slack alerts

- test a regular 500
navigate to the broken template, you should see the regular 500 status error page
http://127.0.0.1:8000/data/browse-data/?tab=bulk-data

stop the local server 
- `export FEC_FEATURE_WEBSITE_STATUS=true` (set to anything) 
- restart the server 
- navigate back to the broken template, you should see the other 500 status error page 
http://127.0.0.1:8000/data/browse-data/?tab=bulk-data
