### PR TITLE
Create legal document redirect endpoint

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -117,7 +117,7 @@ def find_legal_document_by_filename(filename):
         filename = filename[:-4]
 
     # Search for the document using the legal search API
-    results = _call_api("legal", "search", filename=f"{filename}.pdf")
+    results = _call_api("legal", "search", filename=filename)
 
     if not results:
         return None

--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -99,6 +99,51 @@ def load_legal_search_results(query, query_exclude="", query_type="all", offset=
     return results
 
 
+def find_legal_document_by_filename(filename):
+    """
+    Find a legal document by its filename and return the document URL.
+
+    Args:
+        filename (str): The document filename
+
+    Returns:
+        str: The full URL to the document, or None if not found
+
+    Raises:
+        Exception: If there's an API error
+    """
+    # Remove .pdf extension if provided
+    if filename.endswith('.pdf'):
+        filename = filename[:-4]
+
+    # Search for the document using the legal search API
+    results = _call_api("legal", "search", filename=f"{filename}.pdf")
+
+    if not results:
+        return None
+
+    # Search through all document types for a matching filename
+    document_types = ['advisory_opinions', 'murs', 'adrs', 'admin_fines']
+
+    for doc_type in document_types:
+        if doc_type in results and results[doc_type]:
+            for item in results[doc_type]:
+                if 'documents' in item:
+                    for doc in item['documents']:
+                        doc_filename = doc.get('filename', '')
+                        if doc_filename == filename or doc_filename == f"{filename}.pdf":
+                            document_url = doc.get('url')
+                            if document_url:
+                                if document_url.startswith('/'):
+                                    # Convert relative URL to absolute URL using CANONICAL_BASE
+                                    canonical_base = getattr(settings, 'CANONICAL_BASE', 'https://www.fec.gov')
+                                    return f"{canonical_base}{document_url}"
+                                else:
+                                    return document_url
+
+    return None
+
+
 def load_legal_advisory_opinion(ao_no):
     url = "/legal/docs/advisory_opinions/"
     results = _call_api(url, parse.quote(ao_no))

--- a/fec/legal/tests.py
+++ b/fec/legal/tests.py
@@ -2,7 +2,11 @@ import unittest
 from collections import OrderedDict
 from unittest import mock
 
+from django.test import TestCase, RequestFactory
+from django.http import Http404
+
 from data import api_caller
+from legal import views
 
 
 class TestLegal(unittest.TestCase):
@@ -52,3 +56,108 @@ class TestLegal(unittest.TestCase):
                 (0.0, [{'penalty': 0.0, 'disposition': 'Conciliation-PC'}])
             ]))
         ])
+
+
+class TestLegalDocumentRedirect(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @mock.patch('data.api_caller.find_legal_document_by_filename')
+    def test_legal_document_redirect_success(self, mock_find_document):
+        """Test successful redirect for legal document by filename"""
+        # Mock the api_caller function to return a document URL
+        mock_find_document.return_value = 'https://www.fec.gov/files/legal/aos/1997-01/1069112.pdf'
+
+        request = self.factory.get('/legal/search/documents/?filename=1069112')
+        response = views.legal_document_redirect(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, 'https://www.fec.gov/files/legal/aos/1997-01/1069112.pdf')
+        mock_find_document.assert_called_once_with('1069112')
+
+    @mock.patch('requests.get')
+    def test_legal_document_redirect_with_pdf_extension(self, mock_get):
+        """Test successful redirect when filename includes .pdf extension"""
+        # Mock API response with document found
+        mock_response = mock.Mock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'murs': [{
+                'documents': [{
+                    'filename': '00000182',
+                    'url': '/files/legal/murs/4735/00000182.pdf',
+                    'category': 'General Counsel Reports'
+                }]
+            }]
+        }
+        mock_get.return_value = mock_response
+
+        request = self.factory.get('/legal/search/documents/?filename=00000182.pdf')
+        response = views.legal_document_redirect(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, 'https://www.fec.gov/files/legal/murs/4735/00000182.pdf')
+
+    @mock.patch('requests.get')
+    def test_legal_document_redirect_not_found(self, mock_get):
+        """Test 404 when document is not found"""
+        # Mock API response with no documents found
+        mock_response = mock.Mock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'advisory_opinions': [],
+            'murs': [],
+            'adrs': [],
+            'admin_fines': []
+        }
+        mock_get.return_value = mock_response
+
+        request = self.factory.get('/legal/search/documents/?filename=nonexistent')
+
+        with self.assertRaises(Http404):
+            views.legal_document_redirect(request)
+
+    @mock.patch('data.api_caller.find_legal_document_by_filename')
+    def test_legal_document_redirect_api_error(self, mock_find_document):
+        """Test 404 when API returns an error"""
+        # Mock the api_caller function to raise an exception
+        mock_find_document.side_effect = Exception('API Error')
+
+        request = self.factory.get('/legal/search/documents/?filename=1069112')
+
+        with self.assertRaises(Http404):
+            views.legal_document_redirect(request)
+        mock_find_document.assert_called_once_with('1069112')
+
+    def test_legal_document_redirect_no_filename(self):
+        """Test 404 when no filename parameter is provided"""
+        request = self.factory.get('/legal/search/documents/')
+
+        with self.assertRaises(Http404):
+            views.legal_document_redirect(request)
+
+    @mock.patch('data.api_caller.find_legal_document_by_filename')
+    def test_legal_document_redirect_url_routing(self, mock_find_document):
+        """Test that the /legal/search/documents/ URL correctly routes to the redirect function"""
+        # Mock the api_caller function to return a document URL
+        mock_find_document.return_value = 'https://www.fec.gov/files/legal/aos/1997-01/1069112.pdf'
+
+        # Test the /legal/search/documents/ endpoint
+        response = self.client.get('/legal/search/documents/?filename=1069112')
+        # Should redirect (302) not give 404
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, 'https://www.fec.gov/files/legal/aos/1997-01/1069112.pdf')
+        mock_find_document.assert_called_once_with('1069112')
+
+    @mock.patch('data.api_caller.find_legal_document_by_filename')
+    def test_legal_document_redirect_uses_canonical_base(self, mock_find_document):
+        """Test that redirect uses CANONICAL_BASE setting"""
+        # Mock the api_caller function to return a document URL with env base
+        mock_find_document.return_value = 'https://env.fec.gov/files/legal/aos/1997-01/1069112.pdf'
+
+        request = self.factory.get('/legal/search/documents/?filename=1069112')
+        response = views.legal_document_redirect(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, 'https://env.fec.gov/files/legal/aos/1997-01/1069112.pdf')
+        mock_find_document.assert_called_once_with('1069112')

--- a/fec/legal/urls.py
+++ b/fec/legal/urls.py
@@ -43,3 +43,8 @@ if settings.FEATURES['afs']:
             r'^data/legal/search/admin-fines/$', views.legal_doc_search_af
         ),
     ]
+
+# Legal document redirect endpoint
+urlpatterns += [
+    re_path(r'^legal/search/documents/$', views.legal_document_redirect, name='legal_document_redirect'),
+]


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/fec-proxy/issues/425

Creates new redirect endpoint `/legal/search/documents/` to look up document filename redirect paths.

This PR should be merged along with the proxy PR https://github.com/fecgov/fec-proxy/pull/429, so that the legacy legal documents paths will redirect to this new endpoint to look up the filename.

### Required reviewers

1 engineer

## Impacted areas of the application

-  Legal documents path /legal/search/documents/

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/425-redirect-to-legaldocs-endpoint | [link](https://github.com/fecgov/fec-proxy/pull/429)

## How to test

- Pass a filename to query the endpoint to see if it will redirect. Examples: 
   - http://localhost:8000/legal/search/documents/?filename=1069112
   - http://localhost:8000/legal/search/documents/?filename=8332_13
   - http://localhost:8000/legal/search/documents/?filename=456
   - http://localhost:8000/legal/search/documents/?filename=00005412
   - https://www.fec.gov/files/legal/admin_fines/20/21092501233.pdf
