### PR TITLE
remove payment_amount from individual admin fine case pages

### DIFF
--- a/fec/legal/templates/legal-admin_fine.jinja
+++ b/fec/legal/templates/legal-admin_fine.jinja
@@ -53,8 +53,7 @@
             {% if admin_fine.final_determination_amount != 0 %}
               <tr>
                 <th scope="row" class="u-padding--right"><p class="u-margin--bottom t-bold t-low-height">Civil penalty due date:</p></td>
-                <td><p class="u-margin--bottom t-low-height">{{ admin_fine.civil_penalty_due_date | date(fmt='%m/%d/%Y') or 'No date available' }}, {{ admin_fine.civil_penalty_payment_status | replace('Did Not Pay', 'Not paid') | capitalize or 'No status available' }}
-                {% if admin_fine.civil_penalty_payment_status == 'Partially Paid' %} {{ admin_fine.payment_amount | currency or '' }}{% endif %}</p>
+                <td><p class="u-margin--bottom t-low-height">{{ admin_fine.civil_penalty_due_date | date(fmt='%m/%d/%Y') or 'No date available' }}, {{ admin_fine.civil_penalty_payment_status | replace('Did Not Pay', 'Not paid') | capitalize or 'No status available' }}</p>
                 </td>
               </tr>
             {% endif %}


### PR DESCRIPTION
## Summary (required)

- Resolves #6867 

Remove `payment_amount` field next to partially paid statuses for all individual admin fine case pages.

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

-  Admin fine individual pages

## Screenshots

### Before
<img width="733" height="348" alt="Screenshot 2025-09-09 at 10 26 48 AM" src="https://github.com/user-attachments/assets/b218ab57-07d8-448c-9243-8fad535604cb" />


### After
<img width="799" height="353" alt="Screenshot 2025-09-09 at 10 26 34 AM" src="https://github.com/user-attachments/assets/8a2fc5f4-7bff-448a-8712-ed06c139df8a" />

## How to test

- Take a look at a couple of admin fine cases that have a `payment_amount` in the record. Here's some examples:
   - http://localhost:8000/data/legal/administrative-fine/3374/
   - http://localhost:8000/data/legal/administrative-fine/2451/
   - http://localhost:8000/data/legal/administrative-fine/1082/
