### PR TITLE
Legal pagination bug with keyword boolean queries

### DIFF
--- a/fec/legal/templates/partials/legal-pagination.jinja
+++ b/fec/legal/templates/partials/legal-pagination.jinja
@@ -32,10 +32,10 @@
 
     {#- Previous page button -#}
     {% if result_type != 'advisory_opinions' and current_page > 1 %}
-      <a class="paginate_button previous" href="/data/legal/search/{{ result_type }}/
+      <a class="paginate_button previous" href="/data/legal/search/{{ result_type }}/?
         {%- if offset %}offset={{ offset - limit }}&{% endif -%}
         {%- if limit %}limit={{ limit }}&{% endif -%}
-        {%- if query %}?search={{ query }}&{% endif -%}
+        {%- if query %}search={{ query|urlencode|replace('+','%2B') }}&{% endif -%}
         {%- if sort %}sort={{ sort }}& -%}&{% endif -%}
         {%- if case_respondents %}case_respondents={{ case_respondents }}&{% endif -%}
         {%- for category_id in selected_doc_category_ids -%}
@@ -99,7 +99,7 @@
         <a class="paginate_button" href="/data/legal/search/{{ result_type }}/?
         {%- if page_offset %}offset={{ page_offset }}&{% endif -%}
         {%- if limit %}limit={{ limit }}&{% endif -%}
-        {%- if query %}search={{ query }}&{% endif -%}
+        {%- if query %}search={{ query|urlencode|replace('+','%2B')}}&{% endif -%}
         {%- if sort %}sort={{ sort }}& -%}&{% endif -%}
         {%- if case_respondents %}case_respondents={{ case_respondents }}&{% endif -%}
         {%- for category_id in selected_doc_category_ids -%}
@@ -156,9 +156,9 @@
     {#- Next page button -#}
     {% if result_type != 'advisory_opinions' and offset + limit < total_all %}
       <a class="paginate_button next" href="/data/legal/search/{{ result_type }}/?
-      {%- if offset %}offset={{ offset + limit }}&{% endif -%}
+      {%- if offset %}offset={{ offset + limit }}&{% else %}offset={{ limit }}&{% endif -%}
       {%- if limit %}limit={{ limit }}&{% endif -%}
-      {%- if query %}search={{ query }}&{% endif -%}
+      {%- if query %}search={{ query|urlencode|replace('+','%2B') }}&{% endif -%}
       {%- if sort %}sort={{ sort }}& -%}&{% endif -%}
         {%- if case_respondents %}case_respondents={{ case_respondents }}&{% endif -%}
         {%- for category_id in selected_doc_category_ids -%}


### PR DESCRIPTION
## Summary (required)

- Resolves #6878

- Use urlEncode to Preserve  plus (+)  signs in keyword boolean queries for pagination button URLs 
- Fix bug where previous/next pagination buttons don't work from page 1.

### Required reviewers

one content, one dev

## Impacted areas of the application

Pagination buttons (previous/next and page-number) on MUR, ADR and AF datatables

## How to test

- Checkout and run branch
- Perform a boolean search using the keyword field or "boolean filters" modal 
    - Example: http://127.0.0.1:8000/data/legal/search/murs/?search=%28independent+%2B+expenditure+%2B+coordinated%29+%2B+%28%22independent+expenditure%22%29+-%22coordinated+-communication%22
     - This is the query from above:  `(independent + expenditure + coordinated) + ("independent expenditure") -"coordinated -communication"`
- Paginate using the `previous/next buttons` and the `numbered buttons` to confirm that the query is preserved, result count stays the same and the pagination works as expected.
- Change the per page, to confirm pagination works as expected when switching per page number
