### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Add 5 second timeout to search.gov calls

### DIFF
--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -127,11 +127,13 @@ def search_site(query, limit=0, offset=0):
         'offset': offset
     }
     try:
-        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params)
+        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params, timeout=5)
         return process_site_results(r.json(), limit=limit, offset=offset)
+    except requests.exceptions.Timeout:
+        logger.error('search_site: Search.gov request timed out after 5 seconds for query: %s', query)
+        return None
     except (Exception) as ex:
-        logger.error('search_site:' + ex.__class__.__name__)
-
+        logger.error('search_site: %s - %s', ex.__class__.__name__, str(ex))
         return None
 
 
@@ -211,10 +213,13 @@ def policy_guidance_search_site(query, limit=0, offset=0):
     }
 
     try:
-        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params)
+        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params, timeout=5)
         return process_site_results(r.json(), limit=limit, offset=offset)
+    except requests.exceptions.Timeout:
+        logger.error('policy_guidance_search_site: Search.gov request timed out after 5 seconds for query: %s', query)
+        return None
     except (Exception) as ex:
-        logger.error('policy_guidance_search_site' + ex.__class__.__name__)
+        logger.error('policy_guidance_search_site: %s - %s', ex.__class__.__name__, str(ex))
         return None
 
 

--- a/fec/search/views.py
+++ b/fec/search/views.py
@@ -127,10 +127,10 @@ def search_site(query, limit=0, offset=0):
         'offset': offset
     }
     try:
-        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params, timeout=5)
+        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params, timeout=10)
         return process_site_results(r.json(), limit=limit, offset=offset)
     except requests.exceptions.Timeout:
-        logger.error('search_site: Search.gov request timed out after 5 seconds for query: %s', query)
+        logger.error('search_site: Search.gov request timed out after 10 seconds for query: %s', query)
         return None
     except (Exception) as ex:
         logger.error('search_site: %s - %s', ex.__class__.__name__, str(ex))
@@ -213,10 +213,10 @@ def policy_guidance_search_site(query, limit=0, offset=0):
     }
 
     try:
-        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params, timeout=5)
+        r = requests.get('https://api.gsa.gov/technology/searchgov/v2/results/i14y', params=params, timeout=10)
         return process_site_results(r.json(), limit=limit, offset=offset)
     except requests.exceptions.Timeout:
-        logger.error('policy_guidance_search_site: Search.gov request timed out after 5 seconds for query: %s', query)
+        logger.error('policy_guidance_search_site: Search.gov request timed out after 10 seconds for query: %s', query)
         return None
     except (Exception) as ex:
         logger.error('policy_guidance_search_site: %s - %s', ex.__class__.__name__, str(ex))


### PR DESCRIPTION
## Summary

Add a 5 second timeout for search.gov API calls so the page can still render other search results.

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

- Global website search
- Guidance search

## How to test

- Use the global legal search and enter any search string. After 5 seconds, the results page should render and if there's an issue with the "Other pages" that we use search.gov API for, it will render the "Something went wrong" error block. Ex: http://localhost:8000/search/?type=candidates&type=committees&type=site&query=contributions
- Use the guidance search and enter any search string. If the results do not come back in 5 seconds, it will render the "Something went wrong" error block. Ex: https://www.fec.gov/legal-resources/policy-and-other-guidance/guidance-documents/?query=rule
- The server error logs should also have this error message every time there's a timeout: "ERROR:search.views: search_site: Search.gov request timed out after 5 seconds for query: contributions" or  "ERROR:search.views: policy_guidance_search_site: Search.gov request timed out after 5 seconds for query: rule"