### PR TITLE
[PR TO RELEASE 04/07/26 ] Reduce redundancy in rulemaking single page document listings

### DIFF
--- a/fec/data/templatetags/filters.py
+++ b/fec/data/templatetags/filters.py
@@ -185,6 +185,21 @@ def compare(string, string_1):
         return True
 
 
+@library.filter
+def compare_commenter(string, string_1):
+    """Convert `string_1` from "LastName, FirstName" format to "FirstName LastName" 
+    Returns False if `converted_string_1` is in `string`. Else returns True.
+    """
+
+    # Convert name from "LastName, FirstName" format to "FirstName LastName"
+    converted_string_1 = ' '.join(reversed(string_1.split(', ')))
+
+    if converted_string_1 in string:
+        return False
+    else:
+        return True
+
+
 @library.global_function
 def path_for_css(key):
     """Looks up the hashed asset key in rev-manifest-css.json

--- a/fec/data/templatetags/filters.py
+++ b/fec/data/templatetags/filters.py
@@ -188,13 +188,15 @@ def compare(string, string_1):
 @library.filter
 def compare_commenter(string, string_1):
     """Convert `string_1` from "LastName, FirstName" format to "FirstName LastName" 
-    Returns False if `converted_string_1` is in `string`. Else returns True.
+    Returns False if `converted_string_1` is in `string`.
+    Returns False if `string` == 'Comment'.
+    Else returns True.
     """
 
     # Convert name from "LastName, FirstName" format to "FirstName LastName"
     converted_string_1 = ' '.join(reversed(string_1.split(', ')))
 
-    if converted_string_1 in string:
+    if converted_string_1 in string or string == 'Comment':
         return False
     else:
         return True

--- a/fec/data/templatetags/filters.py
+++ b/fec/data/templatetags/filters.py
@@ -4,6 +4,7 @@ import locale
 import re
 
 from dateutil.parser import parse as parse_date
+from difflib import SequenceMatcher
 
 from django.conf import settings
 from django_jinja import library
@@ -162,6 +163,26 @@ def filesize(value):
         unit += 1
 
     return '%d %s' % (value, units[unit])
+
+
+@library.filter
+def compare(string, string_1):
+    """Compares two strings to determine if they are nearly identical or semantically similar. 
+    Returns False if `string` is >= than 50% similar to `string_1`. Else returns True.
+    Uses difflib.SequenceMatcher: https://docs.python.org/3/library/difflib.html
+    """
+
+    # Calculate the similarity ratio
+    similarity_ratio = SequenceMatcher(None, string, string_1).ratio()
+
+    # Define a threshold for redundancy (e.g., 50% similar)
+    threshold = .5
+
+    if similarity_ratio >= threshold:
+        return False
+        
+    else:
+        return True
 
 
 @library.global_function

--- a/fec/legal/templates/rulemaking.jinja
+++ b/fec/legal/templates/rulemaking.jinja
@@ -106,7 +106,7 @@
               {% if doc.label == 'Hearing Schedule' %}
                <li><a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ doc.url }}" data-doc_id="{{ doc.doc_id }}" target="_blank">{{ doc.label }}</a></li>
                 {% for entity in doc.doc_entities %}
-                  <li class="indent">{{ entity.name }}, {{ entity.role }}</li>
+                  <li class="indent">{{ entity.name }} | {{ entity.role }}</li>
                 {% endfor %}
               {% else %}
                 {# Check commenters count to determine display #}
@@ -119,7 +119,7 @@
                     {% endif %}
                   </li>
                   {% for entity in doc.doc_entities if entity.role != 'Commenter' %}
-                    <li class="indent">{{ entity.name }}, {{ entity.role }}</li>
+                    <li class="indent">{{ entity.name }} | {{ entity.role }}</li>
                   {% endfor %}
                 {% else %}
                   {# Multiple commenters: show "Joint comment" #}
@@ -129,7 +129,7 @@
                     {% endif %}
                   </li>
                   {% for entity in doc.doc_entities %}
-                    <li class="indent">{{ entity.name }}, {{ entity.role }}</li>
+                    <li class="indent">{{ entity.name }} | {{ entity.role }}</li>
                   {% endfor %}
                 {% endif %}
               {% endif %}

--- a/fec/legal/templates/rulemaking.jinja
+++ b/fec/legal/templates/rulemaking.jinja
@@ -114,7 +114,7 @@
                   {# Single commenter: show commenter name #}
                   <li>
                     <a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ doc.url }}" data-doc_id="{{ doc.doc_id }}" target="_blank">{{ doc.commenters[0].name }} | {{ doc.commenters[0].role }}</a>
-                    {% if doc.doc_description and 'pdf' not in doc.doc_description.lower() and doc.doc_description | compare(doc.label)  %}
+                    {% if doc.doc_description and 'pdf' not in doc.doc_description.lower() and doc.doc_description | compare_commenter(doc.commenters[0].name)  %}
                      <br>{{ doc.doc_description }} 
                     {% endif %}
                   </li>
@@ -124,7 +124,7 @@
                 {% else %}
                   {# Multiple commenters: show "Joint comment" #}
                   <li><a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ doc.url }}" data-doc_id="{{ doc.doc_id }}" target="_blank">Joint comment</a>
-                    {% if doc.doc_description and 'pdf' not in doc.doc_description.lower() and doc.doc_description | compare(doc.label) %}
+                    {% if doc.doc_description and 'pdf' not in doc.doc_description.lower() %}
                       <br>{{ doc.doc_description }} 
                     {% endif %}
                   </li>

--- a/fec/legal/templates/rulemaking.jinja
+++ b/fec/legal/templates/rulemaking.jinja
@@ -71,16 +71,15 @@
       <ul>
         <li>
           {%- if docL1.url -%}
-          <a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ docL1.url }}" data-doc_id="{{ docL1.doc_id }}" target="_blank">{{ docL1.label }}</a>
+           <a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ docL1.url }}" data-doc_id="{{ docL1.doc_id }}" target="_blank">{{ docL1.label }}</a>
           {%- else -%}
-          {{ docL1.label }}
+           {{ docL1.label }}
           {%- endif -%}
-          {%- if docL1.doc_description and 'pdf' not in docL1.doc_description.lower() -%}
-            <br>{{ docL1.doc_description }}
+          {%- if docL1.doc_description and 'pdf' not in docL1.doc_description.lower() and docL1.doc_description | compare(docL1.label) -%}
+           <br>{{ docL1.doc_description }}
           {%- endif -%}
         </li>
           {%- if docL1.doc_entities -%}
-
                 {%- for entity in docL1.doc_entities -%}
                   <li class="indent">{{ entity.name }}, {{ entity.role }}</li>
                 {%- endfor -%}
@@ -105,7 +104,7 @@
           <ul>
             {% if (doc.label == 'Comments' or doc.label == 'Hearing Schedule') and doc.doc_entities %}
               {% if doc.label == 'Hearing Schedule' %}
-                <li><a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ doc.url }}" data-doc_id="{{ doc.doc_id }}" target="_blank">{{ doc.label }}</a></li>
+               <li><a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ doc.url }}" data-doc_id="{{ doc.doc_id }}" target="_blank">{{ doc.label }}</a></li>
                 {% for entity in doc.doc_entities %}
                   <li class="indent">{{ entity.name }}, {{ entity.role }}</li>
                 {% endfor %}
@@ -114,8 +113,10 @@
                 {% if doc.commenters|length == 1 %}
                   {# Single commenter: show commenter name #}
                   <li>
-                  <a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ doc.url }}" data-doc_id="{{ doc.doc_id }}" target="_blank">{{ doc.commenters[0].name }} | {{ doc.commenters[0].role }}</a>
-                  {% if doc.doc_description and 'pdf' not in doc.doc_description.lower() %}<br>{{ doc.doc_description }}{% endif %}
+                    <a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ doc.url }}" data-doc_id="{{ doc.doc_id }}" target="_blank">{{ doc.commenters[0].name }} | {{ doc.commenters[0].role }}</a>
+                    {% if doc.doc_description and 'pdf' not in doc.doc_description.lower() and doc.doc_description | compare(doc.label)  %}
+                     <br>{{ doc.doc_description }} 
+                    {% endif %}
                   </li>
                   {% for entity in doc.doc_entities %}
                     <li class="indent">{{ entity.name }}, {{ entity.role }}</li>
@@ -123,7 +124,10 @@
                 {% else %}
                   {# Multiple commenters: show "Joint comment" #}
                   <li><a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ doc.url }}" data-doc_id="{{ doc.doc_id }}" target="_blank">Joint comment</a>
-                  {% if doc.doc_description and 'pdf' not in doc.doc_description.lower() %}<br>{{ doc.doc_description }}{% endif %}</li>
+                    {% if doc.doc_description and 'pdf' not in doc.doc_description.lower() and doc.doc_description | compare(doc.label) %}
+                      <br>{{ doc.doc_description }} 
+                    {% endif %}
+                  </li>
                   {% for entity in doc.doc_entities %}
                     <li class="indent">{{ entity.name }}, {{ entity.role }}</li>
                   {% endfor %}
@@ -131,8 +135,8 @@
               {% endif %}
             {% else %}
               <a class="embed-pdf" href="{{ CANONICAL_BASE }}{{ doc.url }}" data-doc_id="{{ doc.doc_id }}" target="_blank">{{ doc.label }}</a>
-              {% if doc.doc_description and 'pdf' not in doc.doc_description.lower() %}
-                <br>{{ doc.doc_description }}
+              {% if doc.doc_description and 'pdf' not in doc.doc_description.lower() and doc.doc_description | compare(doc.label)  %}
+               <br>{{ doc.doc_description }} 
               {% endif %}
             {% endif %}
           </ul>

--- a/fec/legal/templates/rulemaking.jinja
+++ b/fec/legal/templates/rulemaking.jinja
@@ -118,7 +118,7 @@
                      <br>{{ doc.doc_description }} 
                     {% endif %}
                   </li>
-                  {% for entity in doc.doc_entities %}
+                  {% for entity in doc.doc_entities if entity.role != 'Commenter' %}
                     <li class="indent">{{ entity.name }}, {{ entity.role }}</li>
                   {% endfor %}
                 {% else %}

--- a/fec/legal/templates/rulemaking.jinja
+++ b/fec/legal/templates/rulemaking.jinja
@@ -118,7 +118,7 @@
                      <br>{{ doc.doc_description }} 
                     {% endif %}
                   </li>
-                  {% for entity in doc.doc_entities if entity.role != 'Commenter' %}
+                  {% for entity in doc.doc_entities %}
                     <li class="indent">{{ entity.name }} | {{ entity.role }}</li>
                   {% endfor %}
                 {% else %}


### PR DESCRIPTION
## Summary (required)

- Resolves #7041 

-  **compare library filter** : Compares two strings to determine if they are nearly identical or semantically similar using Python's built in  [difflib.SequenceMatcher](https://docs.python.org/3/library/difflib.html):   
    - This seems to work well for our document descriptions/labels with a `similarity_ratio of threshold of .5`.  Meaning if the description and the label are  >= 50% similar, we don't show it.
- **compare_commenter filter** :  compare the `commenter name` to `doc_description`  when one is  "lastname, firstname" and the other is  "firstname lastname."
- Avoid repeating `commenter.name | commenter.role` in the entity listing for single commenter comments where it is already shown  as the pdf link text above.

### Required reviewers

one or two devs

## Impacted areas of the application

Rulemaking single pages
new filters in filters.py

## Screenshots
### BEFORE:
<img width="756" height="704" alt="2022-06-BEFORE" src="https://github.com/user-attachments/assets/a94dabc8-21ac-48c1-af78-8b80cafdb879" />
<hr>
### AFTER:
<img width="757" height="422" alt="2022-06-AFTER" src="https://github.com/user-attachments/assets/1826e886-c525-42d3-b70a-b8536ba6afe0" />


## Related PRs

https://github.com/fecgov/fec-cms/pull/7054

## How to test
 - Test pages confirm document description, labels and commenter names are not repeated verbatim or redundantly 
 - On dev.fec.gov, you can see the item removed by filters in red and items retained by filter in green
 - Examples 2022-06, 2024-01, 2023-02
