### PR TITLE
Increase z-index of search dropdown to cover navigation

### DIFF
--- a/fec/fec/static/scss/components/_search-bar.scss
+++ b/fec/fec/static/scss/components/_search-bar.scss
@@ -219,7 +219,7 @@ $search-button-width: u(5.6rem);
   top: u(3.5rem) !important;
   width: 100%;
   // z-index is being set on the element through a node_modules JS so adding an !important to fight that:
-  z-index: $z-dropdowns !important;
+  z-index: $z-max !important;
 }
 
 .tt-suggestion {


### PR DESCRIPTION
## Summary

- Resolves #7046

- Increase `z-index` of search dropdown to use variable, `$z-max `to avoid navigation showing through
- This obscure visual bug was inadvertently introduced by changes to the `navigation` SCSS variable,  `$z-navigation,  in  [this PR ](https://github.com/fecgov/fec-cms/pull/6422) to "Bring site nav above leaflet zoom" 

### Required reviewers

one dev

## Impacted areas of the application

Global site search dropdown

## Screenshots
<img width="467" height="298" alt="Screenshot 2026-03-30 at 8 55 09 PM" src="https://github.com/user-attachments/assets/b43ff0f5-ec9c-4a3f-9f47-df6c1d5f338b" />

## Related PRs

https://github.com/fecgov/fec-cms/pull/6422


## How to test

- `npm run build-sass`
- Verify that navigation does not show through dropdown for global site-search