### PR TITLE
On committee profile pages, within the Filings tab, display RFAIs for “24/48” report types in the 24–48 hour section

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -988,7 +988,7 @@ $(function() {
                 cycle: cycle,
                 committee_id: committeeId,
                 form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11', 'RFAI'],
-                report_type: ['-Q1', '-Q2', '-Q3', '-YE', '24', '48'],
+                report_type: ['-Q1', '-Q2', '-Q3', '-YE', '-TER', '-30G'],
                 /* Performing an include would only show RFAI form types.
                 For this reason, excludes need to be used for request_type
 

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -987,7 +987,7 @@ $(function() {
               {
                 cycle: cycle,
                 committee_id: committeeId,
-                form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11', 'RFAI'],
+                form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11'],
                 report_type: ['-Q1', '-Q2', '-Q3', '-YE'],
                 /* Performing an include would only show RFAI form types.
                 For this reason, excludes need to be used for request_type

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -987,8 +987,8 @@ $(function() {
               {
                 cycle: cycle,
                 committee_id: committeeId,
-                form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11'],
-                report_type: ['-Q1', '-Q2', '-Q3', '-YE'],
+                form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11', 'RFAI'],
+                report_type: ['-Q1', '-Q2', '-Q3', '-YE', '24', '48'],
                 /* Performing an include would only show RFAI form types.
                 For this reason, excludes need to be used for request_type
 


### PR DESCRIPTION
## Summary (required)

- Resolves #7060 

This PR excludes the following `report types` from appearing in the 24–48 hour filings notices section.RFAI goes in the 24-48 hour section if the request type is "2" or "4" and the report type is "24" or "48," otherwise the RFAI goes in the regular report section.

1. 'TER',
2.  '12G',
3.  '12P',
4. '12R',
5. '12S',
6. '30D',
7.  '30G',
8.  '30P',
9.  '30R'

### Few examples of RFAIs that belong in the 24-48 hour section

RQ-2:
RFAI: 24 HOUR NOTIFICATION 2023
https://www.fec.gov/data/committee/C00207944/?cycle=2024&tab=filings#notices
	https://docquery.fec.gov/pdf/434/202302070300170434/202302070300170434.pdf


RFAI: 48 HOUR NOTIFICATION 2024
https://www.fec.gov/data/committee/C00540203/?cycle=2024&tab=filings#notices
	https://docquery.fec.gov/pdf/268/202408130300219268/202408130300219268.pdf


RQ-4
RFAI: 24 HOUR NOTIFICATION 2012
https://www.fec.gov/data/committee/C90012774/?tab=filings#notices
	https://docquery.fec.gov/pdf/840/12330003840/12330003840.pdf

RFAI: 48 HOUR NOTIFICATION 2010
https://www.fec.gov/data/committee/C90010604/?tab=filings#notices
	https://docquery.fec.gov/pdf/824/11330011824/11330011824.pdf



### Required reviewers

1-2 developers

## Impacted areas of the application


-  committee filings notices

## How to test

- run: git checkout feature/7060-exclude-rfai-request-type-2-from-filing-notices
- run: npm run build-js
- run: cd fec
- run: ./manage.py runserver 
- Compare the results from prod vs local url provided below

prod: https://www.fec.gov/data/committee/C00434563/?tab=filings&cycle=2024
local: http://localhost:8000/data/committee/C00434563/?tab=filings&cycle=2024

prod: https://www.fec.gov/data/committee/C00869750/?tab=filings&cycle=2024
local: http://localhost:8000/data/committee/C00869750/?tab=filings&cycle=2024

prod: https://www.fec.gov/data/committee/C90012774/?tab=filings#notices
local: http://localhost:8000/data/committee/C90012774/?tab=filings#notices

https://www.fec.gov/data/committee/C00784983/?tab=filings&cycle=2024
local: http://localhost:8000/data/committee/C00784983/?tab=filings&cycle=2024

prod: https://www.fec.gov/data/committee/C00207944/?cycle=2024&tab=filings#notices
local: http://localhost:8000/data/committee/C00207944/?cycle=2024&tab=filings#notices

prod: https://www.fec.gov/data/committee/C00540203/?cycle=2024&tab=filings#notices
local: http://localhost:8000/data/committee/C00540203/?cycle=2024&tab=filings#notices

prod: https://www.fec.gov/data/committee/C90010604/?cycle=2010&tab=filings#notices
local: http://localhost:8000/data/committee/C90010604/?cycle=2010&tab=filings#notices

