### PR TITLE
Remove rulemakings feature flag references

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -92,9 +92,6 @@ FEATURES = {
     'pac_party': bool(env.get_credential('FEC_FEATURE_PAC_PARTY', '')),
     'pac_snapshot': bool(env.get_credential('FEC_FEATURE_PAC_SNAPSHOT', '')),
     'presidential_map': bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL_MAP', '')),
-    'rulemakings': bool(env.get_credential('FEC_FEATURE_RULEMAKINGS', '')),
-    'rulemakings_single': bool(env.get_credential('FEC_FEATURE_RULEMAKINGS_SINGLE', '')),
-    'rulemakings_commenting': bool(env.get_credential('FEC_FEATURE_RULEMAKINGS_COMMENTING', '')),
 }
 
 # Set feature flags to True for Feature
@@ -125,9 +122,6 @@ if FEC_CMS_ENVIRONMENT == ENVIRONMENTS['local']:
     FEATURES['nat_party_acct_disbursements'] = True
     FEATURES['nat_party_acct_rec_single'] = True
     FEATURES['nat_party_acct_dis_single'] = True
-    FEATURES['rulemakings'] = True
-    FEATURES['rulemakings_single'] = True
-    FEATURES['rulemakings_commenting'] = True
 
 # Application definition
 INSTALLED_APPS = (

--- a/fec/fec/templates/partials/navigation/nav-legal.html
+++ b/fec/fec/templates/partials/navigation/nav-legal.html
@@ -10,16 +10,7 @@
             <li class="mega__item"><a href="/legal-resources/enforcement/">Enforcement</a></li>
             <li class="mega__item"><a href="/data/legal/statutes/">Statutes</a></li>
             <li class="mega__item"><a href="/legal-resources/legislation/">Legislation</a></li>
-            <li class="mega__item"><a href="/legal-resources/regulations/">Regulations
-            {% if settings %} 
-              {% if settings.FEATURES.rulemakings %}
-              and rulemakings
-              {% endif %}
-            {% else %}
-               {% if FEATURES.rulemakings %}
-              and rulemakings
-              {% endif %}
-            {% endif %}
+            <li class="mega__item"><a href="/legal-resources/regulations/">Regulations and rulemakings
             </a></li>
             <li class="mega__item"><a href="/legal-resources/court-cases/">Court cases</a></li>
             <li class="mega__item"><a href="/legal-resources/policy-other-guidance/">Policy and other guidance</a></li>

--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -29,9 +29,7 @@
                <option value="adrs">Alternative Dispute Resolutions</option>
                <option value="murs">Closed Matters Under Review</option>
                <option value="regulations">Regulations</option>
-               {% if settings.FEATURES.rulemakings %}
                <option value="rulemakings">Rulemakings</option>
-               {% endif %}
                <option value="statutes">Statutes</option>
             </select>
             <input type="text" name="search" class="combo__input" aria-label="Search">
@@ -52,9 +50,7 @@
           <!--<li><a href="/data/audit">Audits</a></li> -->
           <li><a href="/data/legal/search/enforcement/">Closed Matters Under Review</a></li>
           <li><a href="/data/legal/search/regulations/">Regulations</a></li>
-          {% if settings.FEATURES.rulemakings %}
           <li><a href="/legal/search/rulemakings/">Rulemakings</a></li>
-          {% endif %}
           <li><a href="/data/legal/search/statutes">Statutes</a></li>
         </ul>
       </div>

--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -31,9 +31,6 @@ Search legal resources
             {% set document_types = {'all': 'All','statutes': 'Statutes','regulations':
             'Regulations','advisory_opinions': 'Advisory opinions','murs': 'Closed Matters Under Review', 'adrs':
             'Alternative dispute resolutions', 'admin_fines': 'Administrative fines', 'rulemakings': 'Rulemakings'} %}
-            {% if not FEATURES['rulemakings'] %}
-              {% do document_types.pop('rulemakings', None) %}
-            {% endif %}
             {% for category in category_order %}
             {% set category_title = document_types[category] %}
             {% if result_type == category or result_type == 'all' %}

--- a/fec/legal/templates/macros/legal.jinja
+++ b/fec/legal/templates/macros/legal.jinja
@@ -94,9 +94,6 @@
   <div class="combo combo--search {{ size }}">
     {% set document_types = [('all', 'All'),('admin_fines', 'Administrative fines'), ('advisory_opinions', 'Advisory opinions'), ('adrs', 'Alternative dispute resolutions'), ('murs', 'Closed Matters Under Review'), ('regulations', 'Regulations'),  ('rulemakings', 'Rulemakings'), ('statutes', 'Statutes')] %}
     <select class="search__select {{select_class}}" name="search_type" aria-label="Select a document type">
-    {% if not FEATURES['rulemakings'] %}
-      {% set document_types = document_types  | rejectattr('0', 'equalto', 'rulemakings') | list %}
-    {% endif %}
       {% for value, name in document_types %}
       <option value="{{ value }}" {% if result_type == value %}selected{% endif %}>{{ name }}</option>
       {% endfor %}

--- a/fec/legal/templates/rulemaking.jinja
+++ b/fec/legal/templates/rulemaking.jinja
@@ -20,7 +20,6 @@
     </div>
   </div>
   <div class="embedded-pdf-list">
-    {% if FEATURES.rulemakings_commenting %}{# feature flag to hide the commenting block -#}
     {% if not docs_that_can_receive_comments -%}
     <div class="submit-comments">
       <div class="label">Not open for comment</div>
@@ -34,7 +33,6 @@
     </div>
       {% endfor -%}
     {% endif -%}{# end if docs can receive comments #}
-    {% endif -%}{# end feature flag to hide commenting block -#}
     {% if key_documents %}{# Include the Key Documents bits only if there are docs to include #}
     <h2>Key documents</h2>
     <table class="simple-table simple-table--display">

--- a/fec/legal/urls.py
+++ b/fec/legal/urls.py
@@ -80,26 +80,23 @@ if settings.FEATURES['afs']:
     ]
 
 # Rulemakings - datatables
-if settings.FEATURES['rulemakings']:
-    urlpatterns += [
-        re_path(r'^legal/search/rulemakings/$', views_datatables.rulemaking),  # datatables
-    ]
+urlpatterns += [
+    re_path(r'^legal/search/rulemakings/$', views_datatables.rulemaking),  # datatables
+]
 
 # Rulemakings - single
-if settings.FEATURES['rulemakings_single']:
-    urlpatterns += [
-        re_path(r'^legal/rulemakings/(?P<rm_no>[\w-]+)/$', views.rulemaking),  # single
-    ]
+urlpatterns += [
+    re_path(r'^legal/rulemakings/(?P<rm_no>[\w-]+)/$', views.rulemaking),  # single
+]
 
 # Rulemakings - commenting (commenting requires single, too)
-if settings.FEATURES['rulemakings_commenting'] and settings.FEATURES['rulemakings_single']:
-    urlpatterns += [
-        # comment on single:
-        re_path(r'^legal/rulemakings/(?P<rm_no>[\w-]+)/(?P<doc_id>[0-9]+)/add-comments/$',
-                views.rulemaking_add_comments),
-        # save comments:
-        re_path(r'^legal/rulemaking/save-comments/', views.save_rulemaking_comments, name='save_rulemaking_comments'),
-    ]
+urlpatterns += [
+    # comment on single:
+    re_path(r'^legal/rulemakings/(?P<rm_no>[\w-]+)/(?P<doc_id>[0-9]+)/add-comments/$',
+            views.rulemaking_add_comments),
+    # save comments:
+    re_path(r'^legal/rulemaking/save-comments/', views.save_rulemaking_comments, name='save_rulemaking_comments'),
+]
 
 # Legal document redirect endpoint
 urlpatterns += [

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -840,7 +840,7 @@ def legal_search(request):
                 results['regulations_returned'] = ('3' if results['total_regulations'] > 3
                                                    else results['total_regulations'])
 
-        if settings.FEATURES['rulemakings'] and (result_type == 'all' or result_type == 'rulemakings'):
+        if result_type == 'all' or result_type == 'rulemakings':
             filters = {}
             url = '/rulemaking/search/'
             filters['q'] = query
@@ -1393,8 +1393,6 @@ def get_legal_category_order(results, result_type):
         results to the end.
     """
     categories = ['admin_fines', 'advisory_opinions', 'adrs', 'murs', 'regulations', 'rulemakings', 'statutes']
-    if not settings.FEATURES['rulemakings']:
-        categories.remove('rulemakings')
     category_order = [x for x in categories if results.get('total_' + x, 0) > 0] + \
         [x for x in categories if results.get('total_' + x, 0) == 0]
 


### PR DESCRIPTION
## Summary (required)

Before, Rulemakings was behind a feature flag to expose the endpoint in lower environments. Now that Rulemakings went live on March 10, we should consider removing the feature flag from the openFEC and fec-cms codebase and also removing feature flag environment variables from the cloud.gov space across all three environments.

This PR removes the following three rulemaking feature flags that are currently referenced in the code:

1. FEC_FEATURE_RULEMAKINGS
2. FEC_FEATURE_RULEMAKINGS_SINGLE
3. FEC_FEATURE_RULEMAKINGS_COMMENTING

- Resolves #https://github.com/fecgov/openFEC/issues/6526


### Required reviewers

1-2 developers


## How to test
- unset rulemakings feature flags if already set in local workspace:
         - run: `unset FEC_FEATURE_RULEMAKINGS`
         - run: `unset FEC_FEATURE_RULEMAKINGS_SINGLE`
         - run: `unset FEC_FEATURE_RULEMAKINGS_COMMENTING`
- run: `git checkout feature/6526-remove-rulemakings-feature-flags`
- run: `pyenv activate <cms virtual env>`
- run: `pytest` (on `fec-cms` dir )
- run:  `cd fec` 
- run: `./manage.py runserver` 
- test rulemaking landing page, datatables, single rulemakings pages are loading OK (without rulemakings feature flags), search across legal resources dropdown menu includes rulemakings, search across legal resource landing page dropdown menu includes rulemakings