### PR TITLE
Redirect legacy rulemaking documents

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -145,6 +145,46 @@ def find_legal_document_by_filename(filename):
     return None
 
 
+def find_rulemaking_document_by_doc_id(doc_id):
+    """
+    Find a rulemaking document by doc_id and return the document URL.
+
+    Args:
+        doc_id (int): The rulemaking document ID
+
+    Returns:
+        str: The full URL to the document, or None if not found
+    """
+    results = _call_api("/rulemaking/search/", doc_id=doc_id)
+
+    if not results:
+        return None
+
+    canonical_base = getattr(settings, 'CANONICAL_BASE', 'https://www.fec.gov')
+
+    for rulemaking in results.get("rulemakings", []):
+        for doc in rulemaking.get("documents", []):
+            if doc.get("doc_id") == doc_id:
+                document_url = doc.get("url")
+                if document_url:
+                    return f"{canonical_base}{document_url}" if document_url.startswith('/') else document_url
+
+            for level_2 in doc.get("level_2_labels", []):
+                for nested_doc in level_2.get("level_2_docs", []):
+                    if nested_doc.get("doc_id") == doc_id:
+                        document_url = nested_doc.get("url")
+                        if document_url:
+                            return f"{canonical_base}{document_url}" if document_url.startswith('/') else document_url
+
+        for no_tier_doc in rulemaking.get("no_tier_documents", []):
+            if no_tier_doc.get("doc_id") == doc_id:
+                document_url = no_tier_doc.get("url")
+                if document_url:
+                    return f"{canonical_base}{document_url}" if document_url.startswith('/') else document_url
+
+    return None
+
+
 def load_legal_advisory_opinion(ao_no):
     url = "/legal/docs/advisory_opinions/"
     results = _call_api(url, parse.quote(ao_no))

--- a/fec/legal/tests/test_legal.py
+++ b/fec/legal/tests/test_legal.py
@@ -157,3 +157,118 @@ class TestLegalDocumentRedirect(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, 'https://env.fec.gov/files/legal/aos/1997-01/1069112.pdf')
         mock_find_document.assert_called_once_with('1069112')
+
+
+class TestRulemakingDocumentRedirect(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @mock.patch('data.api_caller.find_rulemaking_document_by_doc_id')
+    def test_rulemaking_document_redirect_success(self, mock_find_document):
+        mock_find_document.return_value = 'https://www.fec.gov/files/legal/rulemakings/2011-02/420899/test.pdf'
+
+        request = self.factory.get('/legal/search/rulemakings/documents/?doc_id=420899')
+        response = views.rulemaking_document_redirect(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, 'https://www.fec.gov/files/legal/rulemakings/2011-02/420899/test.pdf')
+        mock_find_document.assert_called_once_with(420899)
+
+    @mock.patch.object(api_caller, '_call_api')
+    def test_find_rulemaking_document_redirect_nested_doc_success(self, mock_call_api):
+        mock_call_api.return_value = {
+            'rulemakings': [{
+                'documents': [{
+                    'doc_id': 421096,
+                    'url': '/files/legal/rulemakings/2011-02/421096/Final-Rule.pdf',
+                    'level_2_labels': [{
+                        'level_2_docs': [{
+                            'doc_id': 420899,
+                            'url': '/files/legal/rulemakings/2011-02/420899/test.pdf'
+                        }]
+                    }]
+                }],
+                'no_tier_documents': []
+            }]
+        }
+
+        request = self.factory.get('/legal/search/rulemakings/documents/?doc_id=420899')
+        response = views.rulemaking_document_redirect(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, f"{settings.CANONICAL_BASE}/files/legal/rulemakings/2011-02/420899/test.pdf")
+
+    @mock.patch.object(api_caller, '_call_api')
+    def test_find_rulemaking_document_redirect_no_tier_success(self, mock_call_api):
+        mock_call_api.return_value = {
+            'rulemakings': [{
+                'documents': [],
+                'no_tier_documents': [{
+                    'doc_id': 22006,
+                    'url': '/files/legal/rulemakings/2009-03/22006/Debt-Consolidation-Act.pdf'
+                }]
+            }]
+        }
+
+        request = self.factory.get('/legal/search/rulemakings/documents/?doc_id=22006')
+        response = views.rulemaking_document_redirect(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url,
+            f"{settings.CANONICAL_BASE}/files/legal/rulemakings/2009-03/22006/Debt-Consolidation-Act.pdf"
+        )
+
+    @mock.patch('data.api_caller.find_rulemaking_document_by_doc_id')
+    def test_rulemaking_document_redirect_api_error(self, mock_find_document):
+        mock_find_document.side_effect = Exception('API Error')
+
+        request = self.factory.get('/legal/search/rulemakings/documents/?doc_id=420899')
+
+        with self.assertRaises(Http404):
+            views.rulemaking_document_redirect(request)
+        mock_find_document.assert_called_once_with(420899)
+
+    @mock.patch.object(api_caller, '_call_api')
+    def test_rulemaking_document_redirect_not_found(self, mock_call_api):
+        mock_call_api.return_value = {
+            'rulemakings': []
+        }
+
+        request = self.factory.get('/legal/search/rulemakings/documents/?doc_id=999999')
+
+        with self.assertRaises(Http404):
+            views.rulemaking_document_redirect(request)
+
+    def test_rulemaking_document_redirect_no_doc_id(self):
+        request = self.factory.get('/legal/search/rulemakings/documents/')
+
+        with self.assertRaises(Http404):
+            views.rulemaking_document_redirect(request)
+
+    def test_rulemaking_document_redirect_invalid_doc_id(self):
+        request = self.factory.get('/legal/search/rulemakings/documents/?doc_id=abc')
+
+        with self.assertRaises(Http404):
+            views.rulemaking_document_redirect(request)
+
+    @mock.patch('data.api_caller.find_rulemaking_document_by_doc_id')
+    def test_rulemaking_document_redirect_url_routing(self, mock_find_document):
+        mock_find_document.return_value = 'https://www.fec.gov/files/legal/rulemakings/2011-02/420899/test.pdf'
+
+        response = self.client.get('/legal/search/rulemakings/documents/?doc_id=420899')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, 'https://www.fec.gov/files/legal/rulemakings/2011-02/420899/test.pdf')
+        mock_find_document.assert_called_once_with(420899)
+
+    @mock.patch('data.api_caller.find_rulemaking_document_by_doc_id')
+    def test_rulemaking_document_redirect_uses_canonical_base(self, mock_find_document):
+        mock_find_document.return_value = 'https://env.fec.gov/files/legal/rulemakings/2011-02/420899/test.pdf'
+
+        request = self.factory.get('/legal/search/rulemakings/documents/?doc_id=420899')
+        response = views.rulemaking_document_redirect(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, 'https://env.fec.gov/files/legal/rulemakings/2011-02/420899/test.pdf')
+        mock_find_document.assert_called_once_with(420899)

--- a/fec/legal/urls.py
+++ b/fec/legal/urls.py
@@ -104,4 +104,6 @@ if settings.FEATURES['rulemakings_commenting'] and settings.FEATURES['rulemaking
 # Legal document redirect endpoint
 urlpatterns += [
     re_path(r'^legal/search/documents/$', views.legal_document_redirect, name='legal_document_redirect'),
+    re_path(r'^legal/search/rulemakings/documents/$', views.rulemaking_document_redirect,
+            name='rulemaking_document_redirect'),
 ]

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -1430,3 +1430,34 @@ def legal_document_redirect(request):
     except Exception as e:
         logger.error(f"Error searching for filename {filename}: {e}")
         raise Http404("Unable to retrieve document information")
+
+
+def rulemaking_document_redirect(request):
+    """
+    Redirects to the appropriate rulemaking document on the main website based on doc_id.
+    This endpoint is designed to work with proxy redirects from legacy domains.
+
+    Query parameter:
+    - doc_id: The rulemaking document ID
+
+    Example:
+    - /legal/search/rulemakings/documents/?doc_id=420899
+    """
+    doc_id = request.GET.get('doc_id', '').strip()
+    if not doc_id:
+        raise Http404("doc_id parameter is required")
+
+    try:
+        doc_id = int(doc_id)
+    except ValueError:
+        raise Http404("doc_id parameter must be an integer")
+
+    try:
+        document_url = api_caller.find_rulemaking_document_by_doc_id(doc_id)
+        if document_url:
+            return HttpResponseRedirect(document_url)
+        else:
+            raise Http404(f"Rulemaking document with doc_id '{doc_id}' not found")
+    except Exception as e:
+        logger.error(f"Error searching for rulemaking doc_id {doc_id}: {e}")
+        raise Http404("Unable to retrieve rulemaking document information")


### PR DESCRIPTION
## Summary (required)

- Resolves #7069 

Creates new redirect endpoint `/legal/search/rulemakings/documents/` to look up document `doc_id` redirect paths.

This PR should be merged along with the proxy PR https://github.com/fecgov/fec-proxy/pull/439, so that the legacy rulemaking documents paths will redirect to this new endpoint to look up the `doc_id`.

### Required reviewers

1 engineer

## Impacted areas of the application

-  Rulemaking documents path `/legal/search/rulemakings/documents/`

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
feature/438-add-sers-fec-gov | [link](https://github.com/fecgov/fec-proxy/pull/439/)

## How to test

- Pass a doc_id to query the endpoint to see if it will redirect. Examples: 
   - http://localhost:8000/legal/search/rulemakings/documents/?doc_id=400008
   - http://localhost:8000/legal/search/rulemakings/documents/?doc_id=516
   - http://localhost:8000/legal/search/rulemakings/documents/?doc_id=349376