### PR TITLE
Display 24–48 hour reports under filings-notices section

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -988,7 +988,16 @@ $(function() {
                 cycle: cycle,
                 committee_id: committeeId,
                 form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11', 'RFAI'],
-                report_type: ['-Q1', '-Q2', '-Q3', '-YE'],
+                report_type: [
+                  '-M1', '-M2', '-M3', '-M4', '-M5', '-M6',
+                  '-M7', '-M8', '-M9', '-M10', '-M11', '-M12',
+                  '-MY', '-ADJ', '-CA', '-Q1', '-Q2', '-Q3',
+                  '-YE', '-TER', '-10D', '-10G', '-10P', '-10R',
+                  '-10S', '-12C', '-12G', '-12P', '-12R', '-12S',
+                  '-30D', '-30G', '-30P', '-30R', '-30S', '-60D',
+                  '-90S', '-90D', '-M7S', '-MSA', '-MYS', '-Q2S',
+                  '-QSA', '-QYS', '-QYE', '-QMS', '-MSY'
+                ],
                 /* Performing an include would only show RFAI form types.
                 For this reason, excludes need to be used for request_type
 


### PR DESCRIPTION
## Summary (required)

- Resolves #7060 

This PR excludes the following **_Report Types_** values from appearing in the 24–48 hour filings notices section. Forms that include 24–48 hour reports will appear only in the 24–48 hour reports section. There are no changes to the regularly filed reports section, Statements of Organization section, or Other documents section.

_**Report Types:**_
 
```
    - 10D Pre-Election
    - 10G Pre-General
    - 10P Pre-Primary
    - 10R Pre-Run-Off
    - 10S Pre-Special
    - 12C Pre-Convention
    - 12G Pre-General
    - 12P Pre-Primary
    - 12R Pre-Run-Off
    - 12S Pre-Special
    - 30D Post-Election
    - 30G Post-General
    - 30P Post-Primary
    - 30R Post-Run-Off
    - 30S Post-Special
    - 60D Post-Convention
    - M1  January Monthly
    - M2  February Monthly
    - M3  March Monthly
    - M4  April Monthly
    - M5  May Monthly
    - M6  June Monthly
    - M7  July Monthly
    - M8  August Monthly
    - M9  September Monthly
    - M10 October Monthly
    - M11 November Monthly
    - M12 December Monthly
    - MY  Mid-Year Report
    - Q1  April Quarterly
    - Q2  July Quarterly
    - Q3  October Quarterly
    - TER Termination Report
    - YE  Year-End
    - ADJ COMP ADJUST AMEND
    - CA  COMPREHENSIVE AMEND
    -  90S Post Inaugural Supplement
    - 90D Post Inaugural
    - M7S July Monthly/Semi-Annual
    - MSA Monthly Semi-Annual (MY)
    - MYS Monthly Year End/Semi-Annual
    - Q2S July Quarterly/Semi-Annual
    - QSA Quarterly Semi-Annual (MY)
    - QYS Quarterly Year End/Semi-Annual
    - QYE Quarterly Semi-Annual (YE)
    - QMS Quarterly Mid-Year/ Semi-Annual
    - MSY Monthly Semi-Annual (YE)
```

### Required reviewers

1-2 developers

## Impacted areas of the application

-  committee filings notices

## How to test

- run: `git checkout feature/7060-display-rfai-24-48-reports-under-filings-notices-section`
- run: `npm run build-js`
- run: `cd fec`
- run: `./manage.py runserver` 
**Note**: In the 24–48 hour filings-notices section, only 24–48 hour reports will be displayed (see the comparison between the production and local URLs provided below)

prod: https://www.fec.gov/data/committee/C00434563/?tab=filings&cycle=2024
local: http://localhost:8000/data/committee/C00434563/?tab=filings&cycle=2024

prod: https://www.fec.gov/data/committee/C00869750/?tab=filings&cycle=2024
local: http://localhost:8000/data/committee/C00869750/?tab=filings&cycle=2024

RQ-4 (appearing in the 24–48hour section as intended):
RFAI: 24 HOUR NOTIFICATION 2012
prod: https://www.fec.gov/data/committee/C90012774/?tab=filings#notices
local: http://localhost:8000/data/committee/C90012774/?tab=filings#notices

prod: https://www.fec.gov/data/committee/C00784983/?tab=filings&cycle=2024
local: http://localhost:8000/data/committee/C00784983/?tab=filings&cycle=2024

RFAI: 24 HOUR NOTIFICATION 2024 (appearing in the 24–48hour section as intended)
prod: https://www.fec.gov/data/committee/C00207944/?cycle=2024&tab=filings#notices
local: http://localhost:8000/data/committee/C00207944/?cycle=2024&tab=filings#notices

RFAI: 48 HOUR NOTIFICATION 2010, 24 HOUR Reports (appearing in the 24–48hour section as intended):
prod: https://www.fec.gov/data/committee/C90010604/?cycle=2010&tab=filings#notices
local: http://localhost:8000/data/committee/C90010604/?cycle=2010&tab=filings#notices

RFAI: 48 HOUR NOTIFICATION 2024 (appearing in the 24–48hour section as intended)
prod: https://www.fec.gov/data/committee/C00540203/?cycle=2024&tab=filings#notices
local: http://localhost:8000/data/committee/C00540203/?cycle=2024&tab=filings#notices

12C - RQ2
prod: https://www.fec.gov/data/committee/C00768689/?cycle=2024&tab=filings#notices
local: http://localhost:8000/data/committee/C00768689/?cycle=2024&tab=filings#notices

30S and 12S - RQ2
prod: https://www.fec.gov/data/committee/C00839894/?tab=filings#notices
local: http://localhost:8000/data/committee/C00839894/?tab=filings#notices

60D - RQ2
prod: https://www.fec.gov/data/committee/C00344267/?cycle=2000&tab=filings#notices
local: http://localhost:8000/data/committee/C00344267/?cycle=2000&tab=filings#notices

