### PR TITLE
Don't raise 404 for committee profile page when committee exists

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -717,12 +717,12 @@ def load_committee_history(committee_id, cycle=None):
     path = "/committee/" + committee_id + "/history/" + str(cycle)
     committee = api_caller.load_first_row_data(path, **filters)
     if committee is None:
-        # If commitee has no dara for cycle data but commitee_id exists, call /history/ endpoint without cycle
+        # If commitee has no data for cycle data but commitee_id exists, call /history/ endpoint without /cycle/
         path = "/committee/" + committee_id + "/history/"
         committee = api_caller.load_first_row_data(path, **filters)
-        # Raise 404 instead of server error for urls with non-existent comm-id and cycle query (data/committee/C0000000/?cycle=2026)
-        if committee is None:
-            raise Http404()
+        # Raise 404 instead of server error for urls with non-existent comm-id and cycle query (data/committee/C00123456/?cycle=2026)
+        # if committee is None:
+        #     raise Http404()
 
     # (3)call endpoint: committee/{committee_id}/candidates/history/{cycle}
     # --under tag: candidate, get all candidates associated with that commitee

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -717,7 +717,7 @@ def load_committee_history(committee_id, cycle=None):
     path = "/committee/" + committee_id + "/history/" + str(cycle)
     committee = api_caller.load_first_row_data(path, **filters)
     if committee is None:
-        # If commitee has no data for cycle but commitee_id exists, call /history/ endpoint without /cycle/
+        # If committee has no data for cycle but commitee_id exists, call /history/ endpoint without /cycle/
         path = "/committee/" + committee_id + "/history/"
         committee = api_caller.load_first_row_data(path, **filters)
         # Raise 404 instead of server error for urls with non-existent comm-id and cycle query (data/committee/C00123456/?cycle=2026)

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -717,12 +717,12 @@ def load_committee_history(committee_id, cycle=None):
     path = "/committee/" + committee_id + "/history/" + str(cycle)
     committee = api_caller.load_first_row_data(path, **filters)
     if committee is None:
-        # If commitee has no data for cycle data but commitee_id exists, call /history/ endpoint without /cycle/
+        # If commitee has no data for cycle but commitee_id exists, call /history/ endpoint without /cycle/
         path = "/committee/" + committee_id + "/history/"
         committee = api_caller.load_first_row_data(path, **filters)
         # Raise 404 instead of server error for urls with non-existent comm-id and cycle query (data/committee/C00123456/?cycle=2026)
-        # if committee is None:
-        #     raise Http404()
+        if committee is None:
+            raise Http404()
 
     # (3)call endpoint: committee/{committee_id}/candidates/history/{cycle}
     # --under tag: candidate, get all candidates associated with that commitee

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -717,7 +717,12 @@ def load_committee_history(committee_id, cycle=None):
     path = "/committee/" + committee_id + "/history/" + str(cycle)
     committee = api_caller.load_first_row_data(path, **filters)
     if committee is None:
-        raise Http404()
+        # If commitee has no dara for cycle data but commitee_id exists, call /history/ endpoint without cycle
+        path = "/committee/" + committee_id + "/history/"
+        committee = api_caller.load_first_row_data(path, **filters)
+        # Raise 404 instead of server error for urls with non-existent comm-id and cycle query (data/committee/C0000000/?cycle=2026)
+        if committee is None:
+            raise Http404()
 
     # (3)call endpoint: committee/{committee_id}/candidates/history/{cycle}
     # --under tag: candidate, get all candidates associated with that commitee


### PR DESCRIPTION
## Summary 
- Resolves #7059
- A committee profile page URL with no cycle query (Example: `/data/committee/C00944777/`) will call `/committee/<committee_id>/history/<cycle>` using `last_cycle_has_activity` or `last_cycle_has_financial`. The api will return `None` if this cycle has no financial data.
- Do not raise a 404 in this case, instead fallback to calling `/committee/<committee_id>/history` (without /cycle) which will render the page with `last_cycle_has_financial/activity` selected , showing  missing financials messaging

### Required reviewers

two devs

## Impacted areas of the application

Committee profile pages where the `last_cycle_has_financial` or `last_cycle_has_activity` has no data 

## How to test

- Run branch locally: `feature/7059-commitee-profile-page-404`

- Test these committee profile  on production and local:
    - https://api.open.fec.gov/v1/committee/C30003594/history/?api_key=DEMO_KEY
    - https://www.fec.gov/data/committee/C30003594
    - http://127.0.0.1:8000/data/committee/C30003594
      <br>
    - https://api.open.fec.gov/v1/committee/C00944777/history/?api_key=DEMO_KEY
    - https://www.fec.gov/data/committee/C00944777
    - http://127.0.0.1:8000/data/committee/C00944777
      <br>
    - https://api.open.fec.gov/v1/committee/C00867507/history/?api_key=DEMO_KEY
    - https://www.fec.gov/data/committee/C00867507
    - http://127.0.0.1:8000/data/committee/C00867507
      <br>
    - https://api.open.fec.gov/v1/committee/C00758730/history/?api_key=DEMO_KEY
    - https://www.fec.gov/data/committee/C00758730
    - http://127.0.0.1:8000/data/committee/C00758730
      <br> 
    - https://api.open.fec.gov/v1/committee/C00703165/history/?api_key=DEMO_KEY
    - https://www.fec.gov/data/committee/C00703165
    - http://127.0.0.1:8000/data/committee/C00703165
      <br>
    - https://api.open.fec.gov/v1/committee/C00635912/history/?api_key=DEMO_KEY
    - https://www.fec.gov/data/committee/C00635912  
    - http://127.0.0.1:8000/data/committee/C00635912
     
- run `pytest` from both `/fec-cms` and `/fec-cms/fec` directories

