### PR TITLE
[PR TO 05/05/26 RELEASE] Restore legal pagination for datatables

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -152,12 +152,15 @@ let pagination_legal;
  */
 let legal_type;
 export function getCount(response) {
-  let pagination_count = response.pagination.count; // eslint-disable-line camelcase
+  let pagination_count;
   if (!response.pagination) {
      pagination_legal = true;
      legal_type = Object.keys(response)[0];
      const legal_type_count = `total_${legal_type}`;
      pagination_count = response[legal_type_count];
+  }
+  else {
+    pagination_count = response.pagination.count; // eslint-disable-line camelcase
   }
 
   if (pagination_count > 500000)


### PR DESCRIPTION
## Summary 

- Resolves **"Type error"** when loading rulemakings datatable page

<img width="1493" height="737" alt="Screenshot 2026-05-05 at 2 01 37 PM" src="https://github.com/user-attachments/assets/81f62241-8867-4f02-8471-44fc347854c2" />


Restores legal pagination for Rulemakings in jq Datatables

### Required reviewers

one or two devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  Rulemakings datatable page

## Screenshots

Rulemakings datatable page loads OK.  "Type error" no longer shows on browser console.


After: 

<img width="1495" height="729" alt="Screenshot 2026-05-05 at 2 04 04 PM" src="https://github.com/user-attachments/assets/b4995d4c-597c-4977-b583-b06c07042043" />


## How to test

- `npm run build`
- check http://127.0.0.1:8000/legal/search/rulemakings/ to make sure it works and you do not get a console error
- check new datatables details panels for any issues

