### PR TITLE
[MERGE WITH GIT FLOW] Fix datatables pagination buttons + audit search broken

### DIFF
--- a/fec/data/templates/datatable.jinja
+++ b/fec/data/templates/datatable.jinja
@@ -44,7 +44,7 @@
           <noscript>
           {% if query %}
             <div class="results-info">
-              <div class="dataTables_paginate paging_simple">
+              <div class="dt-paging paging_simple">
                 {% if query['page']|int > 1 %}
                   <a href="?page={{query['page']|int - 1}}" class="button button--previous button--standard"></a>
                 {% endif %}

--- a/fec/data/templates/datatable.jinja
+++ b/fec/data/templates/datatable.jinja
@@ -29,7 +29,7 @@
               {% for column in columns %}
                 <th scope="col" role="columnheader">{{ column }}</th>
               {% endfor %}
-              {% if slug != 'rulemakings' %}
+              {% if slug not in ['rulemakings', 'audit'] %}
               <th scope="col"></th>
               {% endif %}
             </tr>

--- a/fec/fec/static/scss/components/_pagination.scss
+++ b/fec/fec/static/scss/components/_pagination.scss
@@ -22,7 +22,16 @@
 //  </div>
 //
 
-.paginate_button {
+// .paging_simple for datatables.net-dt: ^2.3.7 and datatables.net-responsive-dt: ^3.0.8:
+
+//<div class="dt-paging paging_simple">
+//  <nav aria-label="pagination">
+//   <button class="dt-paging-button disabled previous" role="link" type="button" aria-controls="results" aria-disabled="true" aria-label="Previous" data-dt-idx="previous" tabindex="-1"></button>
+//   <button class="dt-paging-button next" role="link" type="button" aria-controls="results" aria-label="Next" data-dt-idx="next"></button>
+//  </nav>
+//</div>
+
+.paginate_button, button.dt-paging-button {
   @extend .button--standard;
   @extend .button--sm;
 
@@ -59,7 +68,7 @@
   }
 }
 
-.paginate_button + span.ellipsis {
+.paginate_button + span.ellipsis, button.dt-paging-button + span.ellipsis {
   display: inline-block;
   height: 24px;
   line-height: 36px;

--- a/fec/fec/static/scss/components/_results-info.scss
+++ b/fec/fec/static/scss/components/_results-info.scss
@@ -70,6 +70,33 @@
   }
 }
 
+// Styles for datatables datatables.net-dt: ^2.3.7 and datatables.net-responsive-dt: ^3.0.8
+.results-info {
+  font-family: $sans-serif;
+
+  div.dt-paging  {
+    float: right;
+    padding: u(0.5rem 0);
+  }
+
+  .dt-length {
+    float: left;
+    line-height: u(2rem);
+    margin-bottom: u(2rem);
+
+    label, select {
+      display: inline;
+    }
+  }
+
+  .dt-info {
+    padding-top: u(1rem);
+    clear: both;
+    float: right;
+  }
+}
+
+
 @include media($med) {
   .results-info {
     padding: u(1rem 1rem);
@@ -107,6 +134,31 @@
       padding: u(0 1rem 0 0);
     }
   }
+  
+  // media($med) styles for datatables datatables.net-dt: ^2.3.7 and datatables.net-responsive-dt: ^3.0.8
+  .results-info {
+      .dt-length {
+        float: left;
+        margin-bottom: 0;
+        margin-left: 0;
+      }
+
+
+      div.dt-paging {
+        padding: u(0.5rem 0 0.5rem 0.5rem);
+      }
+
+      .dt-info {
+        margin-left: 1.5em;
+        padding-top: u(0.75rem);
+        clear: none;
+      }
+    }
+
+    .dt-length {
+      padding: u(0 1rem 0 0);
+    }
+
 }
 
 @include media($lg) {
@@ -114,3 +166,4 @@
     padding: u(1rem);
   }
 }
+


### PR DESCRIPTION
## Summary (required)

- Resolves #7088

- [Recent datatables update](https://github.com/fecgov/fec-cms/pull/6528/changes#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) has new class names for built-in pagination which broke the styling on `data/` datatables and `rulemaking`

- Add support for new classes while maintaining existing classes used by legal datatables

- Also extra column on audit search breaking datatable
https://www.fec.gov/legal-resources/enforcement/audit-search/

### Required reviewers

two devs

## Impacted areas of the application

Pagination buttons and display on datatables using jQuery datatables
audit search

## Screenshots


## Related PRs

https://github.com/fecgov/fec-cms/pull/6528/


## How to test

- `npm i`
- `npm run build`
- Test pagination buttons on `/data` datatables and rulemaking
- Test audit search datatable (currently broken on production)
