### PR TITLE
remove lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ invoke==2.2.0
 GitPython==3.1.47
 requests-mock==1.3.0
 pdbpp==0.11.7
-lxml==6.0.0
 
 # Data import
 unicode-slugify==0.1.3


### PR DESCRIPTION
## Summary (required)

- Resolves #7076

This removes lxml as I don't think we are currently using it. Wagtail used to use it a long time ago, and it was brought in [here](https://github.com/fecgov/fec-cms/commit/d87dbfc3ef8e6b451fd372556edb94cd2feb03f8) to support scrapers which I don't think we use anymore: 
fec-cms/fec/search/management/commands/scrape_cms_pages.py
fec-cms/fec/search/management/commands/scrape_transition_pages.py
fec-cms/fec/search/management/commands/scrape_web_app_pages.py
fec-cms/fec/search/utils/search_indexing.py

### Required reviewers

1-2 dev

## How to test

- activate your current CMS virtualenv and confirm snyk vulnerability
- snyk test --file=requirements.txt

- pull this branch: `gh pr checkout 7090`
- pip install -r requirements.txt
- pip install -r requirements.txt
- rm -rf node_modules
- npm i &&  run build
- run snyk test --file=requirements.txt (confirm vulnerability is removed)
- pytest
- cd fec && ./manage.py runserver

Or rebuild this on stage and double check searching: 
https://app.circleci.com/pipelines/github/fecgov/fec-cms/4806/workflows/3576821e-07da-4379-9abb-969e0918e7df/jobs/8392