### PR TITLE
HOTFIX - MERGE WITH GITFLOW - 7094 datatables childrows fixes

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -1420,12 +1420,14 @@ function drawContributionsByStateTable(selected, pageContext) {
  * @returns {string} a string to be used as the innerHTML of the child/details row
  */
 function childRow(contents, pdf_url) {
-  return `<div class="dt-details">
-    <div class="dt-details__nav">
-      <a href="${pdf_url}" class="dt-details__link button--small button--standard js-pdf_url" target="_blank">Open image</a>
-    </div>
-    <div class="dt-details__content">
-      ${contents}
-    </div>
-  </div>`;
+  let toReturn ='<div class="dt-details">';
+  if (pdf_url) {
+    toReturn += '<div class="dt-details__nav">';
+    toReturn += `<a href="${pdf_url}" class="dt-details__link button--small button--standard js-pdf_url" target="_blank">Open image</a>`;
+    toReturn += '</div>';
+  }
+  toReturn += `<div class="dt-details__content">${contents}</div>`;
+  toReturn += '</div>';
+
+  return toReturn;
 }

--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -130,7 +130,7 @@
         background-color: $navy;
         color: $inverse;
 
-        a {
+        a:not(.dropdown__value) {
           border-bottom-color: $inverse;
           color: $inverse;
         }


### PR DESCRIPTION
## Summary

- Resolves #7094 

(Include a summary of proposed changes and connect issue below)

### Required reviewers

- front-end?
- another dev?

## Impacted areas of the application
Datatables rows with children will still be blue but their dropdown text won't change to white.


## Screenshots

"Open image" no longer appears if no pdf_url is returned
http://127.0.0.1:8000/data/committees/pac-party/?cycle=2026


## Related PRs

Related PRs against other branches:

None

## How to test

- Committees (e.g. http://127.0.0.1:8000/data/committees/pac-party/) should no longer offer the Open image button:
- [Filings](http://127.0.0.1:8000/data/filings/?data_type=processed)
  - dropdowns should be readable on rows that can have child rows
  - child rows should offer the "Open image" button as needed