### PR TITLE
increase gunicorn workers

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -11,4 +11,4 @@ cd fec
 ./manage.py migrate --noinput
 
 # Run application
-gunicorn -k gevent -w 5 fec.wsgi:application
+gunicorn -k gevent -w 6 fec.wsgi:application


### PR DESCRIPTION
## Summary (required)

- Resolves #7108

Increases gunicorn workers

### Required reviewers

1 dev

## How to test
Increasing gunicorn workers increases our memory consumption, before pushing an increase we need to make sure that our memory is not running too hot in Kibana and the cloud.gov UI
- https://logs.fr.cloud.gov/goto/d1bdd041b60987456253ae043ce63bc8?security_tenant=fec-beta-fec
- login to cloud.gov, look at the CMS prod instances and check memory and disk percentages (if above 80, increase) 
If it is too high and we need more due to outages, here's the memory spreadsheet (might be more efficient to increase workers and lower instances, Do not get within several G's of the org limit our tests have shown issues with deploying builds when we are even just near the limit) 
- https://docs.google.com/spreadsheets/d/1Y7j5Qd0h7PCEpdfTbnmrpk2-eILsLhqT7GkiiC-86cs/edit?gid=241025863#gid=241025863

NOTE: disk usage has become higher, if we start getting close to the limit we will need to lower CMS instances to increase disk space per instance (6G is the limit per application) 
 
