### PR TITLE
Upgrade to Node 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            nvm install 22.1.0
-            nvm use 22.1.0
-            nvm alias default 22.1.0
+            nvm install 24.15.0
+            nvm use 24.15.0
+            nvm alias default 24.15.0
             sudo npm install -g npm
             npm install
             npm rebuild sass

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            nvm install 24.15.0
-            nvm use 24.15.0
-            nvm alias default 24.15.0
+            nvm install 24.16.0
+            nvm use 24.16.0
+            nvm alias default 24.16.0
             sudo npm install -g npm
             npm install
             npm rebuild sass

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,8 +122,8 @@
         "webpack-manifest-plugin": "^5.0.0"
       },
       "engines": {
-        "node": "22.1.0",
-        "npm": "10.7.0"
+        "node": "24.16.0",
+        "npm": "11.16.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -150,8 +150,8 @@
   },
   "browserslist": "last 2 versions, > 1%, IE 10",
   "engines": {
-    "node": "24.15.0",
-    "npm": "11.14.1"
+    "node": "24.16.0",
+    "npm": "11.16.0"
   },
   "license": "CC0-1.0"
 }

--- a/package.json
+++ b/package.json
@@ -150,8 +150,8 @@
   },
   "browserslist": "last 2 versions, > 1%, IE 10",
   "engines": {
-    "node": "22.1.0",
-    "npm": "10.7.0"
+    "node": "24.15.0",
+    "npm": "11.14.1"
   },
   "license": "CC0-1.0"
 }


### PR DESCRIPTION
## Summary

- Resolves #7117 

Upgrading Node from 22 to 24 LTS

### Required reviewers

- dev
- dev 2?
- dev 3?

## Impacted areas of the application

General components of the application that this PR will affect:

- Mostly the npm commands but maybe running the site generally

## Screenshots

No visual changes

## Related PRs

Node

## How to test

- Pull the branch
- `nvm install 24`
- `npm i -g npm@latest`
- [ ] `npm i` throws no errors
- Run the npm scripts without errors
  - [ ] `npm run build`
  - [ ] `npm run build-icons`
  - [ ] `npm run build-webp`
  - [ ] `npm run build-sass`
  - [ ] `npm run build-widgets-sass`
  - [ ] `npm run build-homepage-css`
  - [ ] `npm run build-js`
  - [ ] `npm run build-production`
  - [ ] `npm run format`
  - [ ] `npm run format-sass`
  - [ ] `npm run format-sass-fix`
  - [ ] `npm run lint`
  - [ ] `npm run format-lint`
  - [ ] `npm run test`
  - [ ] `npm run test-single`
  - [ ] `npm run watch-js`
  - [ ] `npm run watch-css`
  - [ ] `npm run watch`
- [ ] Site works as expected
- Deploys work as expected
  - [ ] dev
  - [ ] feature
  - [ ] stage?