### PR TITLE
[MERGE WITH GITFLOW] Add task_id to the query params

### DIFF
--- a/fec/fec/static/js/modules/download.js
+++ b/fec/fec/static/js/modules/download.js
@@ -93,6 +93,7 @@ export function DownloadItem(url, container, opts) {
   this.downloadUrl = payload.downloadUrl;
   this.isPending = !_isEmpty(payload);
   this.filename = this.resource + '-' + this.timestamp + '.csv';
+  this.task_id = '';
 }
 
 DownloadItem.prototype.init = function() {
@@ -119,7 +120,8 @@ DownloadItem.prototype.serialize = function() {
     url: this.url,
     apiUrl: this.apiUrl,
     downloadUrl: this.downloadUrl,
-    filename: this.filename
+    filename: this.filename,
+    task_id: this.task_id
   };
 };
 
@@ -141,7 +143,7 @@ DownloadItem.prototype.refresh = function() {
   this.promise = $.ajax({
     method: 'POST',
     url: this.apiUrl,
-    data: JSON.stringify({ filename: this.filename }),
+    data: JSON.stringify({ filename: this.filename, task_id: this.task_id }),
     contentType: 'application/json',
     dataType: 'json'
   });
@@ -156,6 +158,8 @@ DownloadItem.prototype.cancel = function() {
 };
 
 DownloadItem.prototype.handleSuccess = function(response) {
+  this.task_id = response.task_id || '';
+
   if (response && response.status === 'complete') {
     this.finish(response.url);
   } else {

--- a/fec/fec/tests/js/download.js
+++ b/fec/fec/tests/js/download.js
@@ -87,6 +87,7 @@ describe('DownloadItem', function() {
       expect(this.item.isPending).to.be.false;
       expect(this.item.timestamp.slice(0, 10)).to.equal('1985-10-01');
       expect(this.item.downloadUrl).not.to.be.ok;
+      expect(this.item.task_id).to.equal('');
     });
 
     it('parses localStorage', function() {
@@ -131,7 +132,7 @@ describe('DownloadItem', function() {
       expect($.ajax).to.have.been.calledWith({
         method: 'POST',
         url: this.item.apiUrl,
-        data: JSON.stringify({ filename: this.item.filename }),
+        data: JSON.stringify({ filename: this.item.filename, task_id: '' }),
         contentType: 'application/json',
         dataType: 'json'
       });


### PR DESCRIPTION
## Summary

- Resolves #7092 


### Required reviewers

- front-end for code
- back-end for integration with API

## Impacted areas of the application

- the downloads front-end:API interaction
- nothing should change if the back-end isn't providing the new `task_id`

## Screenshots

No visual changes

## Related PRs

Related PRs against other branches:
https://github.com/fecgov/openFEC/pull/6591
branch | PR
------ | ------
feature/6590-add-time-limit-downloads | https://github.com/fecgov/openFEC/pull/6591)

## How to test

- pull the branch
- start Chrome with no CORS security
- start a download