### PR TITLE
upgrade urllib3 to remediate snyk vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gunicorn==23.0.0
 gevent==25.5.1
 psycopg[pool]==3.1.20
 requests==2.32.4
-urllib3==2.6.3
+urllib3==2.7.0
 whitenoise==5.2.0
 wagtail==6.3.8
 Jinja2==3.1.6


### PR DESCRIPTION
## Summary 

Upgrade urllib3 to 2.7.0 in requirements.txt, to remediate snyk vulnerability

- Resolves #https://github.com/fecgov/fec-cms/issues/7102


### Required reviewers

 1 developer

## How to test

-  run: `git checkout develop`
- run: `git pull`
- run: `snyk test --all-projects` (snyk flags urllib3 as vulnerable pkg)
- run: `git checkout feature/7102-upgrade-urllib3`
- run: `git pull`
- run: `snyk test --all-projects` (snyk NO longer flags urllib3 as vulnerable pkg)
- run: `rm -rn node_modules` (optional)
- run: `npm i` (optional)
- run: `npm run build` (optional)
- run:  `cd fec` 
- run:  `python manage.py migrate` 
- run: `./manage.py runserver`
- Test CMS:  http://localhost:8000/

