### PR TITLE
Upgrade wagtail to v7.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psycopg[pool]==3.1.20
 requests==2.32.4
 urllib3==2.7.0
 whitenoise==5.2.0
-wagtail==6.3.8
+wagtail==7.0.7
 Jinja2==3.1.6
 django_jinja==2.11.0
 CacheControl==0.11.5


### PR DESCRIPTION
## Summary 

Security fixes are available in wagtail v7.0 and later versions. See release notes [here](https://docs.wagtail.org/en/7.0/releases/7.0.7.html).  

This PR upgrades wagtail to 7.0.7 to remediate snyk vulnerabilities.

Wagtail user guide for 7.0 release: https://guide.wagtail.org/en-7.0.x/releases/new-in-wagtail-7-0/

- Resolves #7103

### Required reviewers

2 or more

## How to test

- run: `git checkout feature/7103-upgrade-wagtail`
- run: `pyenv virtualenv <new virtualenv>`
- run: `pyenv activate <new virutalenv>`
- run: `pip install -r requirements.txt`
- run: `pip install -r requirements-dev.txt`
- run: `snyk test --file=requirements.txt` (snyk no longer flags wagtail as vulnerable package)
- run: `rm -rf node_modules`
- run: `npm i`
- run: `npm run build`
- run: `pytest`
- run: `./manage.py runserver` and test website
- `http://127.0.0.1:8000/admin` (wagtail version shown as 7.0.7). Verify the layouts, page creation, editing etc...
<img width="400" height="747" alt="Screenshot 2026-06-04 at 10 07 40 AM" src="https://github.com/user-attachments/assets/8f9a68ac-b025-4294-a5b1-db7b0dbe1fe3" />

