### PR TITLE
Feature/optimize circleci after node 24 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             nvm install 24.16.0
             nvm use 24.16.0
             nvm alias default 24.16.0
-            sudo npm install -g npm
+            sudo npm install -g npm@11.13.0
             npm ci
             npm run build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,9 @@ jobs:
 
       - restore_cache:
           keys:
-          - v2-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+          - v3-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
           # fallback to using the latest cache if no exact match is found
-          - v2-fec-cms-dependencies-
+          - v3-fec-cms-dependencies-
 
       - run:
           name: Install python dependencies
@@ -61,15 +61,14 @@ jobs:
             nvm use 24.16.0
             nvm alias default 24.16.0
             sudo npm install -g npm
-            npm install
-            npm rebuild sass
+            npm ci
             npm run build
 
       - save_cache:
           paths:
             - ./.env
-            - ./node_modules
-          key: v2-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+            - ~/.npm
+          key: v3-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
 
       - run:
           name: Ensure database is available

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - save_cache:
           paths:
             - ./.env
-            - ~/.npm
+            - ./node_modules
           key: v3-fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
 
       - run:

--- a/fec/fec/static/scss/components/_hero.scss
+++ b/fec/fec/static/scss/components/_hero.scss
@@ -44,11 +44,7 @@
 }
 
 .hero--home {
-  background-image: url('../img/Homepage-hero-image-flag.jpg'); /* TODO: remove when image-set is more widely supported */
-  background-image: image-set( /* Add the webp and a backup */
-    url('../img/Homepage-hero-image-flag.webp') type('image/webp'),
-    url('../img/Homepage-hero-image-flag.jpg') type('image/jpeg')
-  );
+  background-image: url('../img/Homepage-hero-image-flag.jpg');
   background-repeat: no-repeat;
   background-position: 50% 70%;
   background-size: cover;
@@ -87,44 +83,28 @@
 // Hero panel for the campaign finance data section
 .hero--data {
   .hero__image {
-    background-image: url('../img/hero-data.jpg'); /* TODO: remove when image-set is more widely supported */
-    background-image: image-set( /* Add the webp and a backup */
-      url('../img/hero-data.webp') type('image/webp'),
-      url('../img/hero-data.jpg') type('image/jpg')
-    );
+    background-image: url('../img/hero-data.jpg');
   }
 }
 
 .hero--registration,
 .hero--services {
   .hero__image {
-    background-image: url('../img/hero-registration.jpg'); /* TODO: remove when image-set is more widely supported */
-    background-image: image-set( /* Add the webp and a backup */
-      url('../img/hero-registration.webp') type('image/webp'),
-      url('../img/hero-registration.jpg') type('image/jpg')
-    );
+    background-image: url('../img/hero-registration.jpg');
   }
 }
 
 // Hero panel for the legal resources section.
 .hero--legal {
   .hero__image {
-    background-image: url('../img/hero-legal.jpg'); /* TODO: remove when image-set is more widely supported */
-    background-image: image-set( /* Add the webp and a backup */
-      url('../img/hero-legal.webp') type('image/webp'),
-      url('../img/hero-legal.jpg') type('image/jpg')
-    );
+    background-image: url('../img/hero-legal.jpg');
   }
 }
 
 // Hero panel for the OIG landing page.
 .hero--oig {
   .hero__image {
-    background-image: url('../img/hero-oig.png'); /* TODO: remove when image-set is more widely supported */
-    background-image: image-set( /* Add the webp and a backup */
-      url('../img/hero-oig.webp') type('image/webp'),
-      url('../img/hero-oig.png') type('image/png')
-    );
+    background-image: url('../img/hero-oig.png');
   }
   .container a {
     // TODO: Should we make this available outside of only OIG? (add to pattern library?)
@@ -172,21 +152,13 @@
 // Hero panel for the press section.
 .hero--press {
   .hero__image {
-    background-image: url('../img/hero-press.jpg'); /* TODO: remove when image-set is more widely supported */
-    background-image: image-set( /* Add the webp and a backup */
-      url('../img/hero-press.webp') type('image/webp'),
-      url('../img/hero-press.jpg') type('image/jpg')
-    );
+    background-image: url('../img/hero-press.jpg');
   }
 }
 
 .hero--about {
   .hero__image {
-    background-image: url('../img/hero-about.jpg'); /* TODO: remove when image-set is more widely supported */
-    background-image: image-set( /* Add the webp and a backup */
-      url('../img/hero-about.webp') type('image/webp'),
-      url('../img/hero-about.jpg') type('image/jpg')
-    );
+    background-image: url('../img/hero-about.jpg');
   }
 }
 
@@ -237,11 +209,7 @@
 
   @include media($med) {
     display: block;
-    background-image: url('../img/fec-office.jpg'); /* TODO: remove when image-set is more widely supported */
-    background-image: image-set( /* Add the webp and a backup */
-      url('../img/fec-office.webp') type('image/webp'),
-      url('../img/fec-office.jpg') type('image/jpg')
-    );
+    background-image: url('../img/fec-office.jpg');
     background-position: right center;
     background-repeat: no-repeat;
     background-size: cover;

--- a/fec/fec/static/scss/components/_maps.scss
+++ b/fec/fec/static/scss/components/_maps.scss
@@ -151,10 +151,6 @@ path.shape {
 .election-map.dormant,
 .election-map--home.dormant {
   background-image: url('/static/img/map-election-search-default.png');
-  background-image: image-set(
-    url('../img/map-election-search-default.webp') type('image/webp'),
-    url('../img/map-election-search-default.png') type('image/png')
-  );
   background-position: center;
   background-size: 1200px auto;
   background-repeat: no-repeat;

--- a/fec/webpack.config.cjs
+++ b/fec/webpack.config.cjs
@@ -3,6 +3,7 @@ const path = require('path');
 
 const webpack = require('webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const TerserPlugin = require('terser-webpack-plugin');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 
 // mode comes from the package.json's definition for `npm run build…` but defaults to 'development'
@@ -24,6 +25,12 @@ const sourceMapType_prod = undefined; // For when mode == 'production'
 // Pauses the Webpack bundling near the end and opens a browser window with an interactive graph of the bundles.
 // (Will need to control-c the terminal to do anything else after running this)
 const analyzerBundlesDuringDevelopment = false;
+
+const productionMinimizer = [
+  new TerserPlugin({
+    parallel: false
+  })
+];
 
 // Abbreviation for use throughout this file
 const js = './fec/static/js';
@@ -171,6 +178,7 @@ module.exports = [
     optimization: {
       emitOnErrors: true,
       innerGraph: true,
+      minimizer: mode === 'production' ? productionMinimizer : undefined,
       moduleIds: 'named',
       // chunkIds: 'named', // shared chunks default to numbered names. 'named' makes it easier to debug
       // removeAvailableModules: true,
@@ -240,6 +248,9 @@ module.exports = [
       path: path.resolve(__dirname, './dist/fec/static/js')
     },
     devtool: mode === 'production' ? sourceMapType_prod : sourceMapType,
+    optimization: {
+      minimizer: mode === 'production' ? productionMinimizer : undefined
+    },
     plugins: [
       new webpack.ProvidePlugin({
         $: 'jquery',

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
       },
       "engines": {
         "node": "24.16.0",
-        "npm": "11.16.0"
+        "npm": "11.13.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
     "url": "git+https://github.com/fecgov/fec-cms.git"
   },
   "scripts": {
-    "build": "cd fec && webpack --mode development && gulp build-sass && gulp build-widgets-sass && gulp purgecss && gulp build-webp-files",
+    "build": "cd fec && webpack --mode development && gulp build-sass && gulp build-widgets-sass && gulp purgecss",
     "build-icons": "cd fec && gulp build-icons && gulp build-sass",
     "build-webp": "cd fec && gulp build-webp-files",
     "build-sass": "cd fec && gulp build-sass && gulp build-widgets-sass && gulp purgecss",
     "build-widgets-sass": "cd fec && gulp build-widgets-sass",
     "build-homepage-css": "cd fec && gulp purgecss",
     "build-js": "cd fec && webpack --mode development",
-    "build-production": "cd fec && webpack --mode production && gulp build-sass && gulp build-widgets-sass && gulp purgecss && gulp build-webp-files",
+    "build-production": "cd fec && webpack --mode production && gulp build-sass && gulp build-widgets-sass && gulp purgecss",
     "format": "eslint --fix ./fec/fec/static/js/**/*.js",
     "format-sass": "prettier './fec/fec/static/scss/**/*.scss' --check",
     "format-sass-fix": "prettier './fec/fec/static/scss/**/*.scss' --write",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
   "browserslist": "last 2 versions, > 1%, IE 10",
   "engines": {
     "node": "24.16.0",
-    "npm": "11.16.0"
+    "npm": "11.13.0"
   },
   "license": "CC0-1.0"
 }


### PR DESCRIPTION
## Summary

Fix circleci build after node 24 upgrade by:
- Not running parallel for webpack minify
- pin npm 11.13.0
- update circleci config to do npm clean install and cache package-lock.json 
- remove webp gulp process since it's currently not working for hero images 

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

-  circleCI builds

## How to test

- This PR is built to the dev environment, check that to make sure everything is running as expected