### PR TITLE
Handle special characters in eCFR legal search queries

### DIFF
--- a/fec/data/ecfr_caller.py
+++ b/fec/data/ecfr_caller.py
@@ -6,25 +6,50 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _empty_response(page):
+    try:
+        current_page = int(page)
+    except (TypeError, ValueError):
+        current_page = 1
+
+    return {
+        "results": [],
+        "meta": {
+            "current_page": current_page,
+            "total_pages": 0,
+            "total_count": 0,
+        },
+    }
+
+
 def fetch_ecfr_data(query, date="current", limit=20, page=1):
     order = "hierarchy"
     if query:
         order = "relevance"
-    url = (f"https://www.ecfr.gov/api/search/v1/results?query={query}&"
-           f"agency_slugs%5B%5D=federal-election-commission&"
-           f"date={date}&"
-           f"per_page={limit}&"
-           f"page={page}&"
-           f"order={order}&"
-           f"paginate_by=results")
-    response = requests.get(url)
+    url = "https://www.ecfr.gov/api/search/v1/results"
+    params = {
+        "query": query,
+        "agency_slugs[]": "federal-election-commission",
+        "date": date,
+        "per_page": limit,
+        "page": page,
+        "order": order,
+        "paginate_by": "results",
+    }
+
+    response = requests.get(url, params=params)
 
     # Log the caller function and API endpoint
     current_frame = inspect.currentframe()
     caller_frame = inspect.getouterframes(current_frame, 2)
-    logger.info("{0}: {1}".format(caller_frame[1][3], url))
+    logger.info("{0}: {1}".format(caller_frame[1][3], response.url))
 
     if response.status_code == 200:
         return response.json()
     else:
-        return None
+        logger.error(
+            "eCFR API ERROR with status {0} for {1} with params: {2}".format(
+                response.status_code, url, params
+            )
+        )
+        return _empty_response(page)

--- a/fec/data/tests/test_ecfr_caller.py
+++ b/fec/data/tests/test_ecfr_caller.py
@@ -1,0 +1,51 @@
+from unittest import TestCase
+from unittest import mock
+
+from data import ecfr_caller
+
+
+class TestEcfrCaller(TestCase):
+    @mock.patch.object(ecfr_caller.requests, "get")
+    def test_fetch_ecfr_data_uses_encoded_query_params(self, mock_get):
+        response = mock.Mock()
+        response.status_code = 200
+        response.url = "https://www.ecfr.gov/api/search/v1/results?query=95%25+%236535"
+        response.json.return_value = {"results": []}
+        mock_get.return_value = response
+
+        result = ecfr_caller.fetch_ecfr_data("95% #6535")
+
+        self.assertEqual(result, {"results": []})
+        mock_get.assert_called_once_with(
+            "https://www.ecfr.gov/api/search/v1/results",
+            params={
+                "query": "95% #6535",
+                "agency_slugs[]": "federal-election-commission",
+                "date": "current",
+                "per_page": 20,
+                "page": 1,
+                "order": "relevance",
+                "paginate_by": "results",
+            },
+        )
+
+    @mock.patch.object(ecfr_caller.requests, "get")
+    def test_fetch_ecfr_data_returns_empty_payload_for_non_200(self, mock_get):
+        response = mock.Mock()
+        response.status_code = 500
+        response.url = "https://www.ecfr.gov/api/search/v1/results?query=95%25"
+        mock_get.return_value = response
+
+        result = ecfr_caller.fetch_ecfr_data("95%", page="3")
+
+        self.assertEqual(
+            result,
+            {
+                "results": [],
+                "meta": {
+                    "current_page": 3,
+                    "total_pages": 0,
+                    "total_count": 0,
+                },
+            },
+        )


### PR DESCRIPTION
Fixes #6339

Queries like 95% and #6535 were being passed into the eCFR URL as raw text, so special characters could break parsing and trigger a server error in legal search.

This change switches fetch_ecfr_data to requests.get with params, so query terms are encoded safely. It also adds a fallback empty payload when eCFR returns a non-200 response, so legal search pages render safely instead of crashing.

I also added focused tests in fec/data/tests/test_ecfr_caller.py for:
- special-character query params
- non-200 fallback payload

Verification:
- python3 -m pytest fec/data/tests/test_ecfr_caller.py
- python3 -m pytest fec/data/tests/test_legal_search.py -k transform_ecfr_query_string (fails in this environment: ModuleNotFoundError: No module named django)