### PR TITLE
Rulemakings - show first doc if no key doc and restore active-doc indicator  

### DIFF
--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -1116,31 +1116,37 @@ export const rulemakings = [
     render: function (data, type, row) {
       // Array to keep track of documents already shown
       let doc_ids = [];
-
       let html = `<p><strong>${row.rm_name}</strong>`;
+      let first_doc;
       if (row.key_documents && row.key_documents.length ) {
+        first_doc = row.key_documents[0];
+      }
+      else {
+        first_doc = row.documents[0];
+      }
+      const firstDocUrl = first_doc.url ? first_doc.url.replace(/#/g, '%23') : '';
+
         html += `<br><span class="icon icon--inline--left i-document"></span>`;
-        const keyDocUrl = row.key_documents[0].url ? row.key_documents[0].url.replace(/#/g, '%23') : '';
         html +=
           buildEntityLink(
-            row.key_documents[0].doc_type_label, keyDocUrl, row.key_documents[0].doc_type_label);
-            if (row.key_documents[0].doc_date !== null) {
-                const doc_date = moment(row.key_documents[0].doc_date).format('MM/DD/YYYY');
+            first_doc.doc_type_label, firstDocUrl, first_doc.doc_type_label);
+            if (first_doc.doc_date !== null) {
+                const doc_date = moment(first_doc.doc_date).format('MM/DD/YYYY');
                 html += ` | ${doc_date}`;
             }
             else {
               html += ' | Undated';
             }
-      }
+
         html += `</p>`;
 
-    const filters = new URLSearchParams(window.location.search);
-    const filters_category_type = filters.has('doc_category_id');
-    const filters_keyword = filters.has('q'); //getAll('q').length;
-    const filters_proximity = filters.has('q_proximity') && filters.getAll('q_proximity').length == 2;
-    const proximity_only = filters_proximity && !filters_keyword;
+      const filters = new URLSearchParams(window.location.search);
+      const filters_category_type = filters.has('doc_category_id');
+      const filters_keyword = filters.has('q'); //getAll('q').length;
+      const filters_proximity = filters.has('q_proximity') && filters.getAll('q_proximity').length == 2;
+      const proximity_only = filters_proximity && !filters_keyword;
 
-    const current_doc_ids = filters.getAll('doc_category_id') || [];
+      const current_doc_ids = filters.getAll('doc_category_id') || [];
 
     // Note: Opening div tags are lined up with their closing divs below
        html +=

--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -1117,27 +1117,29 @@ export const rulemakings = [
       // Array to keep track of documents already shown
       let doc_ids = [];
       let html = `<p><strong>${row.rm_name}</strong>`;
-      let first_doc;
-      if (row.key_documents && row.key_documents.length ) {
-        first_doc = row.key_documents[0];
-      }
-      else {
-        first_doc = row.documents[0];
-      }
-      const firstDocUrl = first_doc.url ? first_doc.url.replace(/#/g, '%23') : '';
+      // Make sure there is one or the other of key_documents or documents
+      if (row.key_documents?.length || row.documents?.length) {
+        let first_doc;
+        if (row.key_documents && row.key_documents.length ) {
+          first_doc = row.key_documents[0];
+        }
+        else {
+          first_doc = row.documents[0];
+        }
+        const firstDocUrl = first_doc.url ? first_doc.url.replace(/#/g, '%23') : '';
 
-        html += `<br><span class="icon icon--inline--left i-document"></span>`;
-        html +=
-          buildEntityLink(
-            first_doc.doc_type_label, firstDocUrl, first_doc.doc_type_label);
-            if (first_doc.doc_date !== null) {
-                const doc_date = moment(first_doc.doc_date).format('MM/DD/YYYY');
-                html += ` | ${doc_date}`;
-            }
-            else {
-              html += ' | Undated';
-            }
-
+          html += `<br><span class="icon icon--inline--left i-document"></span>`;
+          html +=
+            buildEntityLink(
+              first_doc.doc_type_label, firstDocUrl, first_doc.doc_type_label);
+              if (first_doc.doc_date !== null) {
+                  const doc_date = moment(first_doc.doc_date).format('MM/DD/YYYY');
+                  html += ` | ${doc_date}`;
+              }
+              else {
+                html += ' | Undated';
+              }
+        }
         html += `</p>`;
 
       const filters = new URLSearchParams(window.location.search);

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -26,6 +26,10 @@
   border-width: 2px 0;
   font-family: $sans-serif;
   margin: u(2rem 0);
+
+  tr.row-active {
+    border-left: 0.5rem solid $primary;
+  }
 }
 
 .simple-table__header {

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -28,7 +28,7 @@
   margin: u(2rem 0);
 
   tr.row-active {
-    border-left: 0.5rem solid $primary;
+    box-shadow: inset 3px 0px 0px 0px $primary;
   }
 }
 

--- a/fec/fec/static/scss/components/_table-styles.scss
+++ b/fec/fec/static/scss/components/_table-styles.scss
@@ -28,7 +28,7 @@
   margin: u(2rem 0);
 
   tr.row-active {
-    box-shadow: inset 3px 0px 0px 0px $primary;
+    box-shadow: inset .5rem 0px 0px 0px $primary;
   }
 }
 

--- a/fec/legal/templates/rulemaking.jinja
+++ b/fec/legal/templates/rulemaking.jinja
@@ -68,7 +68,7 @@
     {%- endif %}{# end: if docL1.url -#}
 
     {#- If its doc_description includes 'pdf', add doc_description under the label/link -#}
-    {%- if docL1.doc_description and 'pdf' not in docL1.doc_description.lower() and docL1.doc_description|compare(doc.label) -%}
+    {%- if docL1.doc_description and 'pdf' not in docL1.doc_description.lower() and docL1.doc_description|compare(docL1.label) -%}
             <br><span id="a-desc-{{ docL1.doc_id }}" aria-label="{{ docL1.doc_description|replace('FEC', 'F.E.C.') }}" tabindex="0">{{ docL1.doc_description }}</span>
     {%- endif -%}
 


### PR DESCRIPTION
## Summary (required)

- Resolves #7112

- Default to show the first level-1 document if there is no key document on Rulemakings search page
- Restore active-document indicator on Rulemaking single page
- Typo introduced in last changes to `rulemaking.jinja` causing server errors on dev (2024-08, 2024-01, 2023-02 and others)

### Required reviewers
one or two devs

## Impacted areas of the application

Rulemakings search and Rulemakings single pages

## Screenshots

### Restored active-doc  indicator:
<img width="453" height="236" alt="Screenshot 2026-06-24 at 8 46 54 PM" src="https://github.com/user-attachments/assets/277c6d8e-6109-45db-9ee3-f37912450a41" />

### Server error caused by typo in last develop changes to `rulemaking.jinja`:
<img width="1098" height="611" alt="Screenshot 2026-06-24 at 8 43 05 PM" src="https://github.com/user-attachments/assets/b68dd1ec-2547-46e0-aec0-f1035ff54835" />



## How to test
- `npm run build`
- Confirm that RMs without key docs show the first level-1 doc instead (2024-06 is an example)
- Test the active-document indicator on rulemaking single page (see screenshot above)
- Confirm server error does not happen on single page for 2024-08, 2024-01, 2023-02 and others.
 