### PR TITLE
New sorting classNames for datatables

### DIFF
--- a/fec/fec/static/scss/components/_datatables.scss
+++ b/fec/fec/static/scss/components/_datatables.scss
@@ -74,25 +74,33 @@
 
     &.sorting,
     &.sorting_asc,
-    &.sorting_desc {
+    &.sorting_desc,
+    &.dt-ordering-asc,
+    &.dt-ordering-desc,
+    &.dt-orderable-asc,
+    &.dt-orderable-desc {
       background-position: calc(100% - 1rem) 50%;
       background-repeat: no-repeat;
       cursor: pointer;
       padding-right: u(3rem);
     }
 
-    &.sorting {
+    &.sorting,
+    &.dt-orderable-asc,
+    &.dt-orderable-desc {
       background-size: u(1rem);
       @include u-icon-bg($dash, $gray);
     }
 
-    &.sorting_asc {
+    &.sorting_asc,
+    &.dt-ordering-asc {
       background-size: u(1rem);
       background-color: $gray-lightest;
       @include u-icon-bg($arrow-up-border, $primary);
     }
 
-    &.sorting_desc {
+    &.sorting_desc,
+    &.dt-ordering-desc {
       background-size: u(1rem);
       background-color: $gray-lightest;
       @include u-icon-bg($arrow-down-border, $primary);


### PR DESCRIPTION
## Summary (required)

- Resolves #7152
- Sort icons currently missing on production
- Datatables changed sort name classes in latest version, breaking our sort icons
- Add new classNames to SCSS and keep old ones for places where we hardcode those.

Related issue:
https://github.com/fecgov/fec-cms/issues/7088


### Required reviewers

one dev

## Impacted areas of the application

jQ Datatables (includes rulemakings)

## Screenshots

<img width="1426" height="712" alt="sort-icons" src="https://github.com/user-attachments/assets/d32afee5-bf6b-45bb-af7a-a04dcd28085e" />


## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

## How to test

- `npm run build`
- Test sort  /data datatables and rulemakings which uses JQ datatables too

