### PR TITLE
Enforce `sort_nulls_last=true` for schedule_a API calls when committee_id and two_year_transaction_period filter is used

### DIFF
--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -578,6 +578,15 @@ const defaultCallbacks = {
   afterRender: function() {} //eslint-disable-line no-empty-function
 };
 
+const hasQueryValue = function(value) {
+  return Array.isArray(value) ? value.length > 0 : value !== undefined && value !== null && value !== '';
+};
+
+// This query shape uses a faster API index when nulls sort last.
+const hasCommitteeTwoYearTransactionPeriod = function(query) {
+  return hasQueryValue(query.committee_id) && hasQueryValue(query.two_year_transaction_period);
+};
+
 /**
  * The FEC's class of DataTable (the `_FEC` suffix is to differentiate between this and
  * datatables v1's '.Datatable' jQuery plugin and
@@ -1025,9 +1034,17 @@ DataTable_FEC.prototype.buildUrl = function(data, paginate, download) {
       api_key: window.DOWNLOAD_API_KEY
     });
   }
+  query = _extend({}, query, this.opts.query || {});
+  // Keep broad searches unchanged; only target committee two-year lookups.
+  if (
+    this.opts.sortNullsLastForCommitteeTwoYearTransactionPeriod &&
+    hasCommitteeTwoYearTransactionPeriod(query)
+  ) {
+    query.sort_nulls_last = true;
+  }
   return buildUrl(
     this.opts.path,
-    _extend({}, query, this.opts.query || {})
+    query
   );
 };
 

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -88,6 +88,18 @@ const renderNullStringText = function(data, columnName) {
   }
 };
 
+// Committee page itemized tables use the optimized null-sort query shape.
+const committeeTwoYearTransactionPeriodQuery = function(committeeId, cycle, params = {}) {
+  return _extend(
+    {
+      committee_id: committeeId,
+      two_year_transaction_period: cycle,
+      sort_nulls_last: true
+    },
+    params
+  );
+};
+
 const employerColumns = [
   {
     data: 'employer',
@@ -599,11 +611,9 @@ $(function() {
           $table,
           _extend({}, tableOpts, {
             path: path,
-            query: {
-              committee_id: committeeId,
-              two_year_transaction_period: cycle,
+            query: committeeTwoYearTransactionPeriodQuery(committeeId, cycle, {
               is_individual: true
-            },
+            }),
             columns: individualContributionsColumns,
             callbacks: aggregateCallbacks,
             order: [[2, 'desc']],
@@ -627,11 +637,7 @@ $(function() {
           $table,
           _extend({}, tableOpts, {
             path: path,
-            query: {
-              committee_id: committeeId,
-              two_year_transaction_period: cycle
-              // is_individual: true
-            },
+            query: committeeTwoYearTransactionPeriodQuery(committeeId, cycle),
             columns: individualContributionsColumns,
             callbacks: aggregateCallbacks,
             order: [[3, 'desc']],
@@ -703,10 +709,7 @@ $(function() {
           $table,
           _extend({}, tableOpts, {
             path: path,
-            query: {
-              committee_id: committeeId,
-              two_year_transaction_period: cycle
-            },
+            query: committeeTwoYearTransactionPeriodQuery(committeeId, cycle),
             columns: itemizedDisbursementColumns,
             callbacks: aggregateCallbacks,
             order: [[3, 'desc']],
@@ -730,10 +733,7 @@ $(function() {
           $table,
           _extend({}, tableOpts, {
             path: path,
-            query: {
-              committee_id: committeeId,
-              two_year_transaction_period: cycle
-            },
+            query: committeeTwoYearTransactionPeriodQuery(committeeId, cycle),
             columns: ecItemizedDisbursementColumns,
             callbacks: aggregateCallbacks,
             order: [[3, 'desc']],
@@ -757,10 +757,7 @@ $(function() {
           $table,
           _extend({}, tableOpts, {
             path: path,
-            query: {
-              committee_id: committeeId,
-              two_year_transaction_period: cycle
-            },
+            query: committeeTwoYearTransactionPeriodQuery(committeeId, cycle),
             columns: nationalPartyRaisingColumns,
             callbacks: aggregateCallbacks,
             order: [[2, 'desc']],
@@ -784,10 +781,7 @@ $(function() {
           $table,
           _extend({}, tableOpts, {
             path: path,
-            query: {
-              committee_id: committeeId,
-              two_year_transaction_period: cycle
-            },
+            query: committeeTwoYearTransactionPeriodQuery(committeeId, cycle),
             columns: nationalPartySpendingColumns,
             callbacks: aggregateCallbacks,
             order: [[3, 'desc']],

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -88,7 +88,7 @@ const renderNullStringText = function(data, columnName) {
   }
 };
 
-// Committee page itemized tables use the optimized null-sort query shape.
+// Committee page Schedule A tables use the optimized null-sort query shape.
 const committeeTwoYearTransactionPeriodQuery = function(committeeId, cycle, params = {}) {
   return _extend(
     {
@@ -709,7 +709,10 @@ $(function() {
           $table,
           _extend({}, tableOpts, {
             path: path,
-            query: committeeTwoYearTransactionPeriodQuery(committeeId, cycle),
+            query: {
+              committee_id: committeeId,
+              two_year_transaction_period: cycle
+            },
             columns: itemizedDisbursementColumns,
             callbacks: aggregateCallbacks,
             order: [[3, 'desc']],
@@ -733,7 +736,10 @@ $(function() {
           $table,
           _extend({}, tableOpts, {
             path: path,
-            query: committeeTwoYearTransactionPeriodQuery(committeeId, cycle),
+            query: {
+              committee_id: committeeId,
+              two_year_transaction_period: cycle
+            },
             columns: ecItemizedDisbursementColumns,
             callbacks: aggregateCallbacks,
             order: [[3, 'desc']],
@@ -757,7 +763,10 @@ $(function() {
           $table,
           _extend({}, tableOpts, {
             path: path,
-            query: committeeTwoYearTransactionPeriodQuery(committeeId, cycle),
+            query: {
+              committee_id: committeeId,
+              two_year_transaction_period: cycle
+            },
             columns: nationalPartyRaisingColumns,
             callbacks: aggregateCallbacks,
             order: [[2, 'desc']],
@@ -781,7 +790,10 @@ $(function() {
           $table,
           _extend({}, tableOpts, {
             path: path,
-            query: committeeTwoYearTransactionPeriodQuery(committeeId, cycle),
+            query: {
+              committee_id: committeeId,
+              two_year_transaction_period: cycle
+            },
             columns: nationalPartySpendingColumns,
             callbacks: aggregateCallbacks,
             order: [[3, 'desc']],

--- a/fec/fec/static/js/pages/datatable-individual-contributions.js
+++ b/fec/fec/static/js/pages/datatable-individual-contributions.js
@@ -12,6 +12,8 @@ $(function() {
     title: 'Individual contributions',
     path: ['schedules', 'schedule_a'],
     query: { is_individual: true, sort_nulls_last: false },
+    // Override only when committee_id and two_year_transaction_period are set.
+    sortNullsLastForCommitteeTwoYearTransactionPeriod: true,
     columns: cols_indivContribs,
     paginator: SeekPaginator,
     order: [[4, 'desc']],

--- a/fec/fec/static/js/pages/datatable-receipts.js
+++ b/fec/fec/static/js/pages/datatable-receipts.js
@@ -15,6 +15,8 @@ $(function() {
     path: ['schedules', 'schedule_a'],
     columns: cols_receipts,
     query: { sort_nulls_last: false },
+    // Override only when committee_id and two_year_transaction_period are set.
+    sortNullsLastForCommitteeTwoYearTransactionPeriod: true,
     paginator: SeekPaginator,
     order: [[4, 'desc']],
     useFilters: true,


### PR DESCRIPTION
## Summary (required)

- Resolves #7118

Enforces `sort_nulls_last=true` for API requests for `schedule_a` that include both `committee_id` and `two_year_transaction_period`.

This applies to:

- Committee profile itemized schedule tables on `/data/committee/{committee_id}/`
- `/data/receipts/` when filtered by committee and two-year transaction period
- `/data/individual-contributions/` when filtered by committee and two-year transaction period

Broad receipts and individual contribution searches keep their existing `sort_nulls_last=false` behavior unless both targeted filters are present. This will be the case until we make other decisions in the API regarding the sort null filters.

### Required reviewers

One front-end developer review is required prior to merge.

## Impacted areas of the application

General components of the application that this PR will affect:

- Committee profile raising data tables
- Receipts datatable request parameters
- Individual contributions datatable request parameters

## Screenshots

Not applicable. This change updates API request parameters and does not change the UI.

## How to test

- Run `npm run build-js`
- Visit a committee profile page, such as `/data/committee/C00950584/?cycle=2026`, and confirm itemized receipt requests include `sort_nulls_last=true`.
- Visit `/data/receipts/?committee_id=C00950584&two_year_transaction_period=2026` and confirm the API request includes `sort_nulls_last=true`.
- Visit `/data/individual-contributions/?committee_id=C00950584&two_year_transaction_period=2026` and confirm the API request includes `sort_nulls_last=true`.
- Visit `/data/receipts/` without both filters and confirm broad searches continue to send `sort_nulls_last=false`.