### PR TITLE
Decrease org chart to 3+1 columns (from 4+1)

### DIFF
--- a/fec/fec/static/scss/components/_fec-org-chart.scss
+++ b/fec/fec/static/scss/components/_fec-org-chart.scss
@@ -264,9 +264,9 @@ $orgChart_lineSolidDark: thin solid $orgChart_colorStandard;
   #fec-orgchart {
     display: grid;
     grid-template-areas:
-      'comms comms comms comms ig'
-      '1fr 1fr 1fr 1fr ig';
-    grid-template-columns: repeat(5, 1fr);
+      'comms comms comms ig'
+      '1fr 1fr 1fr ig';
+    grid-template-columns: repeat(4, 1fr);
     grid-template-rows: auto;
     grid-row-gap: 0;
     grid-column-gap: 0;


### PR DESCRIPTION
## Summary

- Resolves #7165 

### Required reviewers

- UX or
- dev

## Impacted areas of the application

The css for the org chart

## Screenshots

Fixed, 3+1 columns instead of 4+1
<img width="732" height="269" alt="image" src="https://github.com/user-attachments/assets/a2a46979-a511-4e40-b708-a0bb0c920ebd" />

www looking broken:
<img width="964" height="446" alt="image" src="https://github.com/user-attachments/assets/240c29f9-98e2-4616-a5d0-e03ea79c3e5b" />


## Related PRs

None

## How to test

- Pull the branch
- `npm run build-sass`
- `./manage.py runserver`
- Check the layout of [FEC Offices](http://127.0.0.1:8000/about/leadership-and-structure/fec-offices/)
