### PR TITLE
fix api_caller logs

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -60,14 +60,19 @@ def _call_api(*path_parts, **filters):
     # Log the caller function and API endpoint
     current_frame = inspect.currentframe()
     caller_frame = inspect.getouterframes(current_frame, 2)
-    logger.info("{0}: {1} ({2}ms)".format(caller_frame[1][3], results.url, elapsed_ms))
+    parsed = parse.urlparse(results.url)
+    params = parse.parse_qs(parsed.query, keep_blank_values=True)
+    params.pop("api_key", None)
+    safe_url = parsed._replace(query=parse.urlencode(params, doseq=True)).geturl()
+    logger.info("{0}: {1} ({2}ms)".format(caller_frame[1][3], safe_url, elapsed_ms))
 
     if results.ok:
         return results.json()
     else:
+        safe_filters = {k: v for k, v in filters.items() if k != "api_key"}
         logger.error(
             "API ERROR with status {0} for {1} with filters: {2}".format(
-                results.status_code, url, filters
+                results.status_code, safe_url, safe_filters
             )
         )
 

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -359,6 +359,7 @@ LOGGING = {
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
+            'stream': 'ext://sys.stdout',
             'level': 'INFO',
             'formatter': 'console',
         },


### PR DESCRIPTION
## Summary (required)

- Resolves #7167 

This switches the api_caller logs to INFO

### Required reviewers

2 devs

## Impacted areas of the application

-  CMS logs


## How to test

- rebuild https://app.circleci.com/pipelines/github/fecgov/fec-cms/4992/workflows/81ed0f45-cbd1-4ec3-99a9-c53df4f8c851/jobs/8610
- see api_caller logs level
