### PR TITLE
7079 - Main Nav Layout Shift

### DIFF
--- a/fec/fec/static/scss/components/_mega-menu.scss
+++ b/fec/fec/static/scss/components/_mega-menu.scss
@@ -4,7 +4,7 @@
 //
 .mega-container {
   a:not(.mega__page-link, .button) {
-    border-bottom: none;
+    border-bottom: 1px dotted #fff0; // Add a clear border to avoid layout shift when hovering
 
     &:hover {
       border-bottom: 1px dotted $inverse;
@@ -13,6 +13,7 @@
 
   ul {
     margin-left: 0;
+    position: relative;
   }
 }
 
@@ -88,7 +89,6 @@
 
 .mega__item {
   break-inside: avoid;
-  float: left;
   line-height: 1.2;
   margin-bottom: u(1.5rem);
   position: relative;


### PR DESCRIPTION
## Summary

- Resolves #7079 
- Resolves #7080 
- Resolves #6898 

Tweaking the css to fix some layout shifts on rollover in some browsers

### Required reviewers

- UX?
- dev

## Impacted areas of the application

- Main-nav on every page of every site and every repo

## Screenshots

www, Firefox:
<img width="970" height="573" alt="image" src="https://github.com/user-attachments/assets/a727e9c7-2647-4b05-9119-8c4cb8690212" />

www, Firefox, hover over "Committees"
<img width="970" height="551" alt="image" src="https://github.com/user-attachments/assets/d69d5e20-9fea-43e3-a84d-a76cbd92a8ac" />

This PR, Firefox:
<img width="970" height="502" alt="image" src="https://github.com/user-attachments/assets/fc29eeed-0dfe-4cae-ba97-52dc7348eb1e" />

This PR, Chrome:
<img width="969" height="503" alt="image" src="https://github.com/user-attachments/assets/1e483e1d-934c-42d8-a1a7-0078d3b2cdb7" />

This PR, Safari:
<img width="969" height="500" alt="image" src="https://github.com/user-attachments/assets/0a0c3024-14d9-41a8-bc97-e1b5f92283c9" />


## Related PRs

None

## How to test

- Pull the branch
- `npm i`
- `npm run build`
- `./manage.py runserver`
- Load any page and check the main nav elements
  - [ ] Main nav link columns are balanced for medium+
  - [ ] Main nav link columns don't shift on rollover for medium+
  - [ ] Main nav is unaffected for smallest widths
  - [ ] across browsers (at least Chrome, Firefox, Safari)