### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Temporarily add NRSC v. FEC snippet reference to specific guide pages

### DIFF
--- a/fec/home/templates/home/candidate-and-committee-services/guides.html
+++ b/fec/home/templates/home/candidate-and-committee-services/guides.html
@@ -69,6 +69,9 @@
     <div class="main__content--right-full">
       <section id="cand-comm-guides-candidates-and-their-authorized-committees" role="tabpanel" aria-hidden="false" aria-labelledby="candidates-and-their-authorized-committees">
         <h2>Candidates and their authorized committees</h2>
+        {% if guides_info_message %}
+          {% include "blocks/embed-info-message.html" with self=guides_info_message only %}
+        {% endif %}
         <p>An individual running for a seat in the Senate or the House of Representatives or for President of the United States becomes a candidate when he or she raises or spends more than $5,000 in contributions or expenditures.</p>
         <p>Presidential, House and Senate candidates must designate a campaign committee. This "authorized committee" takes in contributions and make expenditures on behalf of the campaign.</p>
         <div class="grid grid--2-wide">
@@ -95,6 +98,9 @@
 
       <section id="cand-comm-guides-political-party-committees" role="tabpanel" aria-hidden="true" aria-labelledby="political-party-committees">
         <h2>Political party committees</h2>
+        {% if guides_info_message %}
+          {% include "blocks/embed-info-message.html" with self=guides_info_message only %}
+        {% endif %}
         <p>Political party committees represent a political party at a local, state or national level. Examples of political party committees include the Democratic National Committee, the Green Party of the United States, the Libertarian National Committee and the Republican National Committee.</p>
         <p>Political party committees can take in contributions and make expenditures to influence federal elections.</p>
         <div class="grid grid--2-wide">

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -12,8 +12,9 @@ from django.shortcuts import get_object_or_404, render
 from wagtail.documents.models import Document
 
 from fec.forms import ContactRAD, fetch_categories  # form_categories
-from home.models import (CommissionerPage, DigestPage, MeetingPage,
-                         PressReleasePage, RecordPage, TipsForTreasurersPage)
+from home.models import (CommissionerPage, DigestPage, EmbedSnippet,
+                         MeetingPage, PressReleasePage, RecordPage,
+                         TipsForTreasurersPage)
 
 
 logging.basicConfig(level=logging.INFO)
@@ -454,11 +455,13 @@ def index_meetings(request):
 
 
 def guides(request):
+    # Temporary until guide pages can be templatized in Wagtail.
+    guides_info_message = EmbedSnippet.objects.filter(title="NRSC v. FEC").first()
     page_context = {"content_section": "help", "title": "Guides"}
     return render(
         request,
         "home/candidate-and-committee-services/guides.html",
-        {"self": page_context},
+        {"self": page_context, "guides_info_message": guides_info_message},
     )
 
 


### PR DESCRIPTION
## Summary (required)

Adds the existing Wagtail `EmbedSnippet` titled `NRSC v. FEC` as an informational message box at the top of two guides tabs:

- `/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees`
- `/help-candidates-and-committees/guides/?tab=political-party-committees`

This reuses the existing `blocks/embed-info-message.html` snippet template so the markup and rich text rendering match other pages that already use informational-message snippets. This snippet implementation is intentionally temporary until guide pages can be templatized.

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

- Help for candidates and committees guides landing page
- Candidates and their authorized committees guide tab
- Political party committees guide tab
- Wagtail `EmbedSnippet` rendering for the `NRSC v. FEC` informational message

## Screenshots

<img width="1511" height="737" alt="Screenshot 2026-07-21 at 2 10 32 PM" src="https://github.com/user-attachments/assets/af302c7f-bdf0-408d-a102-de4f72329b29" />

<img width="1512" height="746" alt="Screenshot 2026-07-21 at 2 10 21 PM" src="https://github.com/user-attachments/assets/6dfbebcb-f2e4-4ef5-a336-7b4e480aca8a" />

## How to test

- On your local, add the `NRSC v. FEC` snippet in Wagtail as an informational message.
- Visit `/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees` and confirm the info message appears under the tab heading.
- Visit `/help-candidates-and-committees/guides/?tab=political-party-committees` and confirm the same info message appears under the tab heading.
- Visit the other guides tabs and confirm the message does not appear there.
- On your local, add the informational snippet to the forms page under this heading here: `/help-candidates-and-committees/forms/#political-parties-and-political-action-committees-pacs`. This is using the normal method of adding a snippet. Ensure that it renders ok.
- Test changing the snippet content to ensure that the snippet text changes across the different pages it was applied accordingly. Note, you cannot change the `NRSC v. FEC` snippet title. Doing so, will make the snippet disappear from the guide pages, since we're hardcoding that for now. The forms page will remain uneffected if the title changes since we are using the normal method of adding snippets there.