### PR TITLE
Remove Coordinated party expenditure from glossary

### DIFF
--- a/fec/fec/static/js/data/terms.json
+++ b/fec/fec/static/js/data/terms.json
@@ -124,10 +124,6 @@
     "definition": "A communication that satisfies a three-pronged test: <ol class='list-bulleted'><li>The communication must be paid for by a person other than a federal candidate, authorized committee, or a political party committee, or any agents of the aforementioned entities with whom the communication is coordinated.</li><li>One or more of the five content standards set forth in <a href=\"https://www.fec.gov/regulations/109-21/CURRENT#109-21-c\">11 CFR 109.21(c)</a> must be satisfied; and</li><li>One or more of the five conduct standards set forth in <a href=\"https://www.fec.gov/regulations/109-21/CURRENT#109-21-d\">11 CFR 109.21(d)</a> must be satisfied.</li></ol>A payment for a communication satisfying all three prongs is an in-kind contribution to the candidate or political party committee with which it was coordinated. 11 CFR <a href=\"https://www.fec.gov/regulations/109-21/CURRENT#109-21\">109.21</a>."
   },
   {
-    "term": "Coordinated party expenditure",
-    "definition": "A special type of expenditure that can be made only by a national or state political party committee in connection with the general election of a candidate. These expenditures are subject to a separate set of limits and do not count against the party’s normal contribution limits with respect to each candidate. 11 CFR <a href=\"https://www.fec.gov/regulations/109-30/CURRENT#109-30\">109.30</a> and <a href=\"https://www.fec.gov/regulations/109-32/CURRENT#109-32\">109.32-37</a>."
-  },
-  {
     "term": "Corporation",
     "definition": "Any separately incorporated entity (other than a political committee that has incorporated for liability purposes only). 11 CFR <a href=\"https://www.fec.gov/regulations/100-134/CURRENT#100-134-l\">100.134(l)</a> and <a href=\"https://www.fec.gov/regulations/114-12/CURRENT#114-12\">114.12(a)</a>. The term corporation covers both for-profit and nonprofit corporations and includes nonstock corporations, incorporated membership organizations, incorporated cooperatives, incorporated trade associations, professional corporations and, under certain circumstances, limited liability companies."
   },


### PR DESCRIPTION
## Summary (required)

- Resolves #7194

- Remove Coordinated party expenditure from glossary

### Required reviewers

one content or dev

## Impacted areas of the application

- Glossary


## Screenshots

<img width="369" height="662" alt="Screenshot 2026-07-31 at 12 29 22 PM" src="https://github.com/user-attachments/assets/2c6e0d8a-662f-4431-a9ac-5a21c46e2cfd" />

## How to test

- `npm run build-js`
- Confirm that Coordinated party expenditure is no longer in Glossary

