### PR TITLE
Fix AO loading when AO issue date is empty or null

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -510,12 +510,12 @@ def _get_sorted_documents(ao):
     sorted_documents = sorted(
         ao["documents"], key=itemgetter("description", "document_id"), reverse=False
     )
-    sorted_documents = sorted(sorted_documents, key=itemgetter("date"), reverse=True)
+    sorted_documents = sorted(sorted_documents, key=lambda doc: doc.get("date") or "", reverse=True)
 
     # Sort by document date unless it's a final opinion. Final opinion uses issue date.
     sorted_documents = sorted(
         sorted_documents,
-        key=lambda doc: doc.get("date") if doc.get("ao_doc_category_id") != 'F' else ao.get("issue_date"),
+        key=lambda doc: (ao.get("issue_date") if doc.get("ao_doc_category_id") == 'F' else doc.get("date")) or "",
         reverse=True
     )
 

--- a/fec/data/tests/test_legal_search.py
+++ b/fec/data/tests/test_legal_search.py
@@ -1,5 +1,6 @@
 
 import datetime
+import unittest
 from unittest import mock
 import io
 import logging
@@ -13,6 +14,34 @@ from legal import views
 from legal.views import parse_query
 
 client = Client()
+
+
+class TestLegalSearchUtils(unittest.TestCase):
+    def test_sort_ao_documents_handles_missing_issue_date(self):
+        ao = {
+            'issue_date': None,
+            'documents': [
+                {
+                    'ao_doc_category_id': 'F',
+                    'date': '2024-01-15',
+                    'description': 'Final Opinion',
+                    'document_id': 2,
+                },
+                {
+                    'ao_doc_category_id': 'R',
+                    'date': '2024-02-01',
+                    'description': 'Request',
+                    'document_id': 1,
+                },
+            ],
+        }
+
+        sorted_documents = api_caller._get_sorted_documents(ao)
+
+        self.assertEqual(
+            [doc['description'] for doc in sorted_documents],
+            ['Request', 'Final Opinion']
+        )
 
 
 class TestLegalSearch(TestCase):

--- a/fec/fec/static/js/legal-search-ao.js
+++ b/fec/fec/static/js/legal-search-ao.js
@@ -368,7 +368,7 @@ LegalSearchAo.prototype.refreshTable = function(response) {
     newRow += `
           <td class="simple-table__cell">
             <div class="t-sans">
-              ${['Pending','Withdrawn'].includes(advisory_opinion.status) ? advisory_opinion.status : new Date(advisory_opinion.issue_date).toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })}
+              ${['Pending','Withdrawn'].includes(advisory_opinion.status) ? advisory_opinion.status : advisory_opinion.issue_date ? new Date(advisory_opinion.issue_date).toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' }) : 'Not dated'}
             </div>
           </td>`;
     newRow += `

--- a/fec/legal/templates/legal-advisory-opinion.jinja
+++ b/fec/legal/templates/legal-advisory-opinion.jinja
@@ -43,7 +43,14 @@
           <h2>Documents</h2>
           {% if final_opinion %}
             <div class="content__section">
-              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final opinion</a> <span class="t-sans u-padding--left">{{ final_opinion.date | date(fmt='%B %d, %Y') }}</span>
+              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final opinion</a>
+              <span class="t-sans u-padding--left">
+                {% if advisory_opinion.issue_date %}
+                  {{ advisory_opinion.issue_date | date(fmt='%B %d, %Y') }}
+                {% else %}
+                  Not dated
+                {% endif %}
+              </span>
             </div>
           {% endif %}
           <table class="data-table simple-table" style="table-layout: auto;">

--- a/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
+++ b/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
@@ -30,8 +30,10 @@
               Pending
             {% elif advisory_opinion.status == "Withdrawn"%}
               Withdrawn
-            {% elif advisory_opinion.issue_date != undefined %}
+            {% elif advisory_opinion.issue_date %}
               {{ advisory_opinion.issue_date | date(fmt='%m/%d/%Y') }}
+            {% else %}
+              Not dated
             {% endif %}
           </div> 
         </td>

--- a/fec/legal/tests/test_legal.py
+++ b/fec/legal/tests/test_legal.py
@@ -59,6 +59,42 @@ class TestLegal(unittest.TestCase):
         ])
 
 
+class TestAdvisoryOpinionPage(unittest.TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @mock.patch.object(api_caller, 'load_legal_advisory_opinion')
+    def test_advisory_opinion_page_handles_missing_issue_date(self, mock_load_ao):
+        final_opinion = {
+            'ao_doc_category_id': 'F',
+            'category': 'Final Opinion',
+            'date': '2024-01-15',
+            'description': 'Final Opinion',
+            'document_id': 2,
+            'url': '/files/legal/aos/2024-01/final.pdf',
+        }
+        mock_load_ao.return_value = {
+            'no': '2024-01',
+            'name': 'Test AO',
+            'summary': 'Test summary',
+            'issue_date': '',
+            'documents': [final_opinion],
+            'sorted_documents': [final_opinion],
+            'entities': [],
+            'statutory_citations': [],
+            'regulatory_citations': [],
+            'ao_citations': [],
+            'aos_cited_by': [],
+        }
+
+        request = self.factory.get('/data/legal/advisory-opinions/2024-01/')
+        response = views.advisory_opinion_page(request, '2024-01')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Final opinion', response.content)
+        self.assertIn(b'Not dated', response.content)
+
+
 class TestLegalDocumentRedirect(TestCase):
     def setUp(self):
         self.factory = RequestFactory()


### PR DESCRIPTION
## Summary

- Resolves #6601

Handles advisory opinions when `issue_date` is empty or null.

This updates AO document sorting and date display so pages do not fail when a final opinion has no `issue_date`. In those cases, the AO page and AO search results display `Not dated`.

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

- Advisory opinion individual pages
- Advisory opinion search results
- Advisory opinion table sorting

## How to test

- Run `pytest`
  - `test_sort_ao_documents_handles_missing_issue_date` covers an AO with `issue_date: None` and a final opinion document, confirming document sorting does not fail.
  - `test_advisory_opinion_page_handles_missing_issue_date` covers an AO with `issue_date: ''` and a final opinion document, confirming the AO page renders and displays `Not dated`.
- Run `npm run build-js`

There does not appear to be an example in the current data of a final opinion with no `issue_date`. The new legal tests covers that case directly, including the document sorting in the AO table and final opinion date display on the individual AO page.

