### PR TITLE
Improve committee page load

### DIFF
--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -59,6 +59,7 @@
   <div class="data-container__wrapper">
     <nav class="sidebar side-nav-alt">
       <ul class="tablist" role="tablist" data-name="tab">
+        {# href keeps full page ?tab= URLs shareable; data-tab-url loads the partial on click. #}
         {% if committee_type not in ['C', 'E'] %}
         <li class="side-nav__item" role="presentation">
           <a
@@ -85,7 +86,8 @@
             data-name="about-committee"
             tabindex="0"
             aria-controls="panel2"
-            href="#section-2">About this committee</a>
+            data-tab-url="/data/committee/{{ committee_id }}/tab/about-committee/?cycle={{ cycle }}"
+            href="?cycle={{ cycle }}&tab=about-committee#section-2">About this committee</a>
         </li>
         {% elif committee_type == 'E' %}
         <li class="side-nav__item" role="presentation">
@@ -95,7 +97,8 @@
             data-name="about-committee"
             tabindex="0"
             aria-controls="panel2"
-            href="#section-2">About this filer</a>
+            data-tab-url="/data/committee/{{ committee_id }}/tab/about-committee/?cycle={{ cycle }}"
+            href="?cycle={{ cycle }}&tab=about-committee#section-2">About this filer</a>
         </li>
         {% else %}
         <li class="side-nav__item" role="presentation">
@@ -105,7 +108,8 @@
             data-name="about-committee"
             tabindex="0"
             aria-controls="panel1"
-            href="#section-2">About this committee</a>
+            data-tab-url="/data/committee/{{ committee_id }}/tab/about-committee/?cycle={{ cycle }}"
+            href="?cycle={{ cycle }}&tab=about-committee#section-2">About this committee</a>
         </li>
         {% endif %}
         {% if committee_type not in ['C', 'E'] %}
@@ -181,7 +185,8 @@
             data-name="filings"
             tabindex="0"
             aria-controls="panel5"
-            href="#section-5">Filings</a>
+            data-tab-url="/data/committee/{{ committee_id }}/tab/filings/?cycle={{ cycle }}"
+            href="?cycle={{ cycle }}&tab=filings#section-5">Filings</a>
             <ul>
               {% if has_raw_filings %}
               <li><a href="#raw-filings">Raw electronic filings</a></li>
@@ -215,7 +220,16 @@
     </nav>
 
     {% include 'partials/loading-tab.jinja' %}
-    {% include 'partials/committee/about-committee.jinja' %}
+    {# Inactive server-rendered tabs start as placeholders and load on tab click. #}
+    {% if active_tab == 'about-committee' %}
+      {% include 'partials/committee/about-committee.jinja' %}
+    {% else %}
+      <section id="section-2" role="tabpanel" aria-hidden="true" data-deferred-panel="about-committee">
+        <div class="container overlay__container">
+          <div class="overlay overlay--neutral is-loading"></div>
+        </div>
+      </section>
+    {% endif %}
  
     {% if committee_type not in ['C', 'E'] %}
       {% include 'partials/committee/financial-summary.jinja' %}
@@ -224,7 +238,15 @@
       {% include 'partials/committee/raising.jinja' %}
     {% endif %}
     {% include 'partials/committee/spending.jinja' %}
-    {% include 'partials/committee/filings.jinja' %}
+    {% if active_tab == 'filings' %}
+      {% include 'partials/committee/filings.jinja' %}
+    {% else %}
+      <section id="section-5" role="tabpanel" aria-hidden="true" data-deferred-panel="filings">
+        <div class="container overlay__container">
+          <div class="overlay overlay--neutral is-loading"></div>
+        </div>
+      </section>
+    {% endif %}
   </div>
 
 {% endblock %}

--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -2,6 +2,9 @@ from unittest import TestCase
 from unittest import mock
 import copy
 
+from django.http import Http404
+from django.test import RequestFactory
+
 from data import views, api_caller
 
 
@@ -666,6 +669,88 @@ class TestCommittee(TestCase):
             committee_id="C001",
             min_receipt_date=template_variables["min_receipt_date"],
         )
+        load_committee_statement_of_organization_mock.assert_not_called()
+
+    def test_committee_about_tab_view_renders_partial(
+        self,
+        load_committee_history_mock,
+        load_cycle_data_mock,
+        load_reports_and_totals_mock,
+        load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
+    ):
+        cycle = 2018
+
+        test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
+        load_committee_history_mock.return_value = (test_committee, [], cycle)
+        load_cycle_data_mock.return_value = (False, 2018, [2018])
+        load_committee_statement_of_organization_mock.return_value = {
+            "pdf_url": "https://docquery.fec.gov/pdf/123/123.pdf",
+            "receipt_date": "2019-11-30T00:00:00",
+        }
+        request = RequestFactory().get(
+            "/data/committee/C001/tab/about-committee/",
+            {"cycle": cycle},
+        )
+
+        response = views.committee_tab(request, "C001", "about-committee")
+
+        assert response.status_code == 200
+        assert b"About this committee" in response.content
+        assert b"Statement of organization" in response.content
+        load_reports_and_totals_mock.assert_not_called()
+        load_committee_statement_of_organization_mock.assert_called_once_with("C001")
+        load_endpoint_results_mock.assert_not_called()
+
+    def test_committee_filings_tab_view_renders_partial(
+        self,
+        load_committee_history_mock,
+        load_cycle_data_mock,
+        load_reports_and_totals_mock,
+        load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
+    ):
+        cycle = views.constants.DEFAULT_TIME_PERIOD
+
+        test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
+        test_committee["cycles_has_activity"] = [cycle]
+        load_committee_history_mock.return_value = (test_committee, [], cycle)
+        load_cycle_data_mock.return_value = (False, cycle, [cycle])
+        load_endpoint_results_mock.return_value = [{"file_number": 123}]
+        request = RequestFactory().get(
+            "/data/committee/C001/tab/filings/",
+            {"cycle": cycle},
+        )
+
+        response = views.committee_tab(request, "C001", "filings")
+
+        assert response.status_code == 200
+        assert b"Committee filings" in response.content
+        assert b"Raw electronic filings" in response.content
+        load_reports_and_totals_mock.assert_not_called()
+        load_endpoint_results_mock.assert_called_once()
+        load_committee_statement_of_organization_mock.assert_not_called()
+
+    def test_committee_tab_view_rejects_invalid_tab(
+        self,
+        load_committee_history_mock,
+        load_cycle_data_mock,
+        load_reports_and_totals_mock,
+        load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
+    ):
+        request = RequestFactory().get(
+            "/data/committee/C001/tab/not-a-tab/",
+            {"cycle": 2018},
+        )
+
+        with self.assertRaises(Http404):
+            views.committee_tab(request, "C001", "not-a-tab")
+
+        load_committee_history_mock.assert_not_called()
+        load_cycle_data_mock.assert_not_called()
+        load_reports_and_totals_mock.assert_not_called()
+        load_endpoint_results_mock.assert_not_called()
         load_committee_statement_of_organization_mock.assert_not_called()
 
 

--- a/fec/data/tests/test_committee.py
+++ b/fec/data/tests/test_committee.py
@@ -192,10 +192,6 @@ class TestCommittee(TestCase):
             self.STOCK_TOTALS,
             False
         )
-        load_endpoint_results_mock.return_value = mock.MagicMock()
-        load_committee_statement_of_organization_mock.return_value = {
-            "receipt_date": "2019-11-30T00:00:00"
-        }
         template_variables = views.get_committee("C001", 2018)
 
         committee = template_variables.get("committee")
@@ -232,9 +228,10 @@ class TestCommittee(TestCase):
         assert template_variables["result_type"] == "committees"
         assert template_variables["report_type"] == "pac-party"
         assert template_variables["reports"] == self.STOCK_REPORTS
-        assert template_variables["statement_of_organization"] == {
-            "receipt_date": "11/30/2019"
-        }
+        assert template_variables["has_raw_filings"] is False
+        assert template_variables["statement_of_organization"] is None
+        load_endpoint_results_mock.assert_not_called()
+        load_committee_statement_of_organization_mock.assert_not_called()
 
     def test_ie_summary(
         self,
@@ -540,6 +537,136 @@ class TestCommittee(TestCase):
         # JS and Python cycle should equal fallback cycle
         assert template_variables["context_vars"]["cycle"] == 2018
         assert template_variables["cycle"] == 2018
+
+    def test_about_tab_loads_statement_of_organization(
+        self,
+        load_committee_history_mock,
+        load_cycle_data_mock,
+        load_reports_and_totals_mock,
+        load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
+    ):
+        cycle = 2018
+
+        test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
+        load_committee_history_mock.return_value = (test_committee, [], cycle)
+        load_cycle_data_mock.return_value = (False, 2018, [2018])
+        load_reports_and_totals_mock.return_value = (
+            self.STOCK_REPORTS,
+            self.STOCK_TOTALS,
+            False
+        )
+        load_committee_statement_of_organization_mock.return_value = {
+            "receipt_date": "2019-11-30T00:00:00"
+        }
+
+        template_variables = views.get_committee(
+            "C001",
+            cycle,
+            requested_tab="about-committee",
+        )
+
+        assert template_variables["statement_of_organization"] == {
+            "receipt_date": "11/30/2019"
+        }
+        load_committee_statement_of_organization_mock.assert_called_once_with("C001")
+        load_endpoint_results_mock.assert_not_called()
+
+    def test_filings_tab_checks_raw_filings(
+        self,
+        load_committee_history_mock,
+        load_cycle_data_mock,
+        load_reports_and_totals_mock,
+        load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
+    ):
+        cycle = views.constants.DEFAULT_TIME_PERIOD
+
+        test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
+        test_committee["cycles_has_activity"] = [cycle]
+        load_committee_history_mock.return_value = (test_committee, [], cycle)
+        load_cycle_data_mock.return_value = (False, cycle, [cycle])
+        load_reports_and_totals_mock.return_value = (
+            self.STOCK_REPORTS,
+            self.STOCK_TOTALS,
+            False
+        )
+        load_endpoint_results_mock.return_value = [{"file_number": 123}]
+
+        template_variables = views.get_committee(
+            "C001",
+            cycle,
+            requested_tab="filings",
+        )
+
+        assert template_variables["has_raw_filings"] is True
+        load_endpoint_results_mock.assert_called_once_with(
+            "/efile/filings/",
+            committee_id="C001",
+            min_receipt_date=template_variables["min_receipt_date"],
+        )
+        load_committee_statement_of_organization_mock.assert_not_called()
+
+    def test_about_partial_skips_full_page_financial_calls(
+        self,
+        load_committee_history_mock,
+        load_cycle_data_mock,
+        load_reports_and_totals_mock,
+        load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
+    ):
+        cycle = 2018
+
+        test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
+        load_committee_history_mock.return_value = (test_committee, [], cycle)
+        load_cycle_data_mock.return_value = (False, 2018, [2018])
+        load_committee_statement_of_organization_mock.return_value = {
+            "receipt_date": "2019-11-30T00:00:00"
+        }
+
+        template_variables = views.get_committee_tab(
+            "C001",
+            cycle,
+            "about-committee",
+        )
+
+        assert template_variables["statement_of_organization"] == {
+            "receipt_date": "11/30/2019"
+        }
+        load_reports_and_totals_mock.assert_not_called()
+        load_committee_statement_of_organization_mock.assert_called_once_with("C001")
+        load_endpoint_results_mock.assert_not_called()
+
+    def test_filings_partial_skips_full_page_financial_calls(
+        self,
+        load_committee_history_mock,
+        load_cycle_data_mock,
+        load_reports_and_totals_mock,
+        load_endpoint_results_mock,
+        load_committee_statement_of_organization_mock,
+    ):
+        cycle = views.constants.DEFAULT_TIME_PERIOD
+
+        test_committee = copy.deepcopy(self.STOCK_COMMITTEE)
+        test_committee["cycles_has_activity"] = [cycle]
+        load_committee_history_mock.return_value = (test_committee, [], cycle)
+        load_cycle_data_mock.return_value = (False, cycle, [cycle])
+        load_endpoint_results_mock.return_value = [{"file_number": 123}]
+
+        template_variables = views.get_committee_tab(
+            "C001",
+            cycle,
+            "filings",
+        )
+
+        assert template_variables["has_raw_filings"] is True
+        load_reports_and_totals_mock.assert_not_called()
+        load_endpoint_results_mock.assert_called_once_with(
+            "/efile/filings/",
+            committee_id="C001",
+            min_receipt_date=template_variables["min_receipt_date"],
+        )
+        load_committee_statement_of_organization_mock.assert_not_called()
 
 
 @mock.patch.object(api_caller, "load_endpoint_results")

--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -9,6 +9,8 @@ urlpatterns = [
     re_path(r'^data/search/$', views.search),
     re_path(r'^data/browse-data/$', views.browse_data, name='browse-data'),
     re_path(r'^data/candidate/(?P<candidate_id>\w+)/$', views.candidate),
+    re_path(r'^data/committee/(?P<committee_id>\w+)/tab/(?P<tab_name>[\w-]+)/$',
+            views.committee_tab, name='committee-tab'),
     re_path(r'^data/committee/(?P<committee_id>\w+)/$',
             views.committee, name='committee-by-id'),
     re_path(r'^data/elections/(?P<office>\w+)/(?P<state>\w+)/(?P<district>\w+)/(?P<cycle>[0-9]+)/$',
@@ -58,7 +60,7 @@ urlpatterns = [
     re_path(r'^data/national-party-account-receipts/$',
             views_datatables.national_party_account_receipts),
     re_path(r'^data/national-party-account-disbursements/$',
-                views_datatables.national_party_account_disbursements)
+            views_datatables.national_party_account_disbursements)
 ]
 
 if settings.FEATURES.get('presidential_map'):

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -35,6 +35,12 @@ validListUrlParamValues = ["P", "S", "H"]
 # INITIALLY USED BY raising() AND spending() FOR VALIDATING URL PARAMETERS,
 # THE list URL PARAM
 
+# Only tabs with server side data are requested as partial renders.
+COMMITTEE_TAB_PARTIALS = {
+    "about-committee": "partials/committee/about-committee.jinja",
+    "filings": "partials/committee/filings.jinja",
+}
+
 
 def to_date(committee, cycle):
     if committee["committee_type"] in ["H", "S", "P"]:
@@ -353,10 +359,11 @@ def candidate(request, candidate_id):
     return render(request, "candidates-single.jinja", candidate)
 
 
-def get_committee(committee_id, cycle):
+def get_committee_base_context(committee_id, cycle, requested_tab=None):
     """
-    Given a committee_id and cycle, call the API and get the committee
-    and committee financial data needed to render the committee profile page
+    Load committee context shared by full page and tab partial renders.
+    Full page financial reports/totals are added separately so tab partials
+    can avoid those API calls.
     """
     committee, all_candidates, cycle = load_committee_history(committee_id, cycle)
     # When there are multiple candidate records of various offices (H, S, P)
@@ -389,6 +396,7 @@ def get_committee(committee_id, cycle):
         candidate["related_cycle"] = cycle if election_years else None
 
     report_type = report_types.get(committee["committee_type"], "pac-party")
+    active_tab = requested_tab or get_default_committee_tab(committee["committee_type"])
 
     cycle_out_of_range, fallback_cycle, cycles = load_cycle_data(committee, cycle)
 
@@ -398,9 +406,7 @@ def get_committee(committee_id, cycle):
     # we set cycle = fallback_cycle
     cycle = fallback_cycle if cycle_out_of_range else cycle
 
-    reports, totals, totals_national_party = load_reports_and_totals(
-        committee_id, cycle, cycle_out_of_range, fallback_cycle
-    )
+    min_receipt_date = utils.three_days_ago()
 
     # Check organization types to determine SSF status
     is_ssf = committee.get("organization_type") in ["W", "C", "L", "V", "M", "T"]
@@ -436,30 +442,6 @@ def get_committee(committee_id, cycle):
         "cycleOutOfRange": cycle_out_of_range,
         "lastCycleHasFinancial": fallback_cycle,
     }
-
-    # sponsor_candidates saves a sponsor candidate list.
-    sponsors_candidate_ids = committee.get("sponsor_candidate_ids")
-    sponsor_candidates = []
-    if sponsors_candidate_ids:
-        path = "/candidate/{}/history/"
-        filters = {"per_page": 1}
-        for sponsor_id in sponsors_candidate_ids:
-            election_years = []
-            sponsor_candidate = load_most_recent_candidate(sponsor_id)
-            # Handle API returning no results
-            if sponsor_candidate:
-                for election_year in sponsor_candidate["election_years"]:
-                    start_of_election_period = (
-                        election_year - election_durations[sponsor_candidate["office"]]
-                    )
-                    if start_of_election_period < cycle and cycle <= election_year:
-                        election_years.append(election_year)
-
-                # For each sponsor_candidate, set related_cycle
-                # to the candidate's time period
-                # relative to the selected cycle.
-                sponsor_candidate["related_cycle"] = cycle if election_years else None
-                sponsor_candidates.append(sponsor_candidate)
 
     # Human-friendly text and glossary links for the front-end
     com_org_type = committee.get('organization_type')
@@ -557,20 +539,61 @@ def get_committee(committee_id, cycle):
         "is_inaugural": is_inaugural,
         "current_committee_status": current_committee_status,
         "cycle_out_of_range": cycle_out_of_range,
+        "active_tab": active_tab,
         "parent": parent,
         "result_type": result_type,
         "report_type": report_type,
-        "reports": reports,
-        "totals": totals,
-        "totals_national_party": totals_national_party,
-        "min_receipt_date": utils.three_days_ago(),
-        "context_vars": context_vars,
+        "min_receipt_date": min_receipt_date,
         "party_full": committee["party_full"],
         "social_image_identifier": "data",
         "year": year,
         "timePeriod": time_period_js,
-        "sponsor_candidates": sponsor_candidates,
+        "sponsor_candidates": [],
+        "has_raw_filings": False,
+        "filings_lookup": {
+            "reports": ["F3", "F3X", "F3P", "F3L", "F4", "F5", "F7", "F13"],
+            "notices": ["F5", "F24", "F6", "F9", "F10", "F11"],
+            "statements": ["F1"],
+            "other": ["F1M", "F8", "F99", "F12"],
+        },
+        "statement_of_organization": None,
     }
+
+    # Add message for a committee that was formerly an authorized candidate committee.
+    if committee['former_candidate_id']:
+        template_variables["former_committee_name"] = committee['former_committee_name']
+        template_variables["former_authorized_candidate_name"] = committee['former_candidate_name']
+        template_variables["former_authorized_candidate_id"] = committee['former_candidate_id']
+
+    return template_variables
+
+
+def get_committee(committee_id, cycle, requested_tab=None):
+    """
+    Given a committee_id and cycle, call the API and get the committee
+    and committee financial data needed to render the committee profile page
+    """
+    template_variables = get_committee_base_context(
+        committee_id,
+        cycle,
+        requested_tab,
+    )
+    committee = template_variables["committee"]
+    cycle = template_variables["cycle"]
+    cycle_out_of_range = template_variables["cycle_out_of_range"]
+    fallback_cycle = template_variables["context_vars"]["lastCycleHasFinancial"]
+
+    reports, totals, totals_national_party = load_reports_and_totals(
+        committee_id, cycle, cycle_out_of_range, fallback_cycle
+    )
+    template_variables.update({
+        "reports": reports,
+        "totals": totals,
+        "totals_national_party": totals_national_party,
+    })
+
+    add_committee_tab_context(template_variables)
+
     # Format the current two-year-period's totals
     if reports and totals:
         # IE-only committees
@@ -596,49 +619,43 @@ def get_committee(committee_id, cycle):
             template_variables["spending_summary"] = utils.process_spending_data(totals)
             template_variables["cash_summary"] = utils.process_cash_data(totals)
 
-    # When cycle >= constants.DEFAULT_TIME_PERIOD, check for raw filings in the last three days
-    if cycle >= constants.DEFAULT_TIME_PERIOD:
-        # (4)call efile/filings under tag: efiling
-        path = "/efile/filings/"
-        filters = {
-            "committee_id": committee["committee_id"],
-            "min_receipt_date": template_variables["min_receipt_date"]
-        }
-        raw_filings = api_caller.load_endpoint_results(path, **filters)
+    return template_variables
 
-        template_variables["has_raw_filings"] = True if raw_filings else False
-    else:
-        template_variables["has_raw_filings"] = False
 
-    # Needed for filings tab
-    template_variables["filings_lookup"] = {
-        "reports": ["F3", "F3X", "F3P", "F3L", "F4", "F5", "F7", "F13"],
-        "notices": ["F5", "F24", "F6", "F9", "F10", "F11"],
-        "statements": ["F1"],
-        "other": ["F1M", "F8", "F99", "F12"],
-    }
-
-    # Call /filings?committee_id=C00693234&form_type=F1
-    # Get the statements of organization
-    statement_of_organization = api_caller.load_committee_statement_of_organization(
-        committee_id
+def get_committee_tab(committee_id, cycle, requested_tab):
+    # Partial tab renders use the shared page context plus only tab specific data.
+    template_variables = get_committee_base_context(
+        committee_id,
+        cycle,
+        requested_tab,
     )
+    add_committee_tab_context(template_variables)
+    return template_variables
 
-    if statement_of_organization:
-        statement_of_organization["receipt_date"] = format_receipt_date(
-            statement_of_organization["receipt_date"]
+
+def add_committee_tab_context(template_variables):
+    # Full page ?tab= URLs and partial tab endpoints share this tab specific data.
+    active_tab = template_variables["active_tab"]
+    committee = template_variables["committee"]
+    cycle = template_variables["cycle"]
+
+    # Defer About tab only API calls until the About tab is requested.
+    if active_tab == "about-committee":
+        template_variables["statement_of_organization"] = (
+            load_committee_statement_of_organization(committee["committee_id"])
+        )
+        template_variables["sponsor_candidates"] = load_sponsor_candidates(
+            committee,
+            cycle,
         )
 
-    template_variables["statement_of_organization"] = statement_of_organization
-
-    # Add message for a committee that was formerly an authorized candidate committee.
-    # These committees are now unauthorized committees.
-    if committee['former_candidate_id']:
-        template_variables["former_committee_name"] = committee['former_committee_name']
-        template_variables["former_authorized_candidate_name"] = committee['former_candidate_name']
-        template_variables["former_authorized_candidate_id"] = committee['former_candidate_id']
-
-    return template_variables
+    # Defer the raw filings availability check until the Filings tab is requested.
+    template_variables["has_raw_filings"] = should_show_raw_filings(
+        active_tab,
+        committee["committee_id"],
+        cycle,
+        template_variables["min_receipt_date"],
+    )
 
 
 def committee(request, committee_id):
@@ -648,9 +665,92 @@ def committee(request, committee_id):
     """
 
     cycle = request.GET.get("cycle", None)
-    committee = get_committee(committee_id, cycle)
+    requested_tab = request.GET.get("tab", None)
+    committee = get_committee(committee_id, cycle, requested_tab)
 
     return render(request, "committees-single.jinja", committee)
+
+
+def committee_tab(request, committee_id, tab_name):
+    # Used by in page tab clicks, direct ?tab= URLs still render the full page.
+    if tab_name not in COMMITTEE_TAB_PARTIALS:
+        raise Http404()
+
+    cycle = request.GET.get("cycle", None)
+    committee = get_committee_tab(committee_id, cycle, tab_name)
+
+    return render(request, COMMITTEE_TAB_PARTIALS[tab_name], committee)
+
+
+def get_default_committee_tab(committee_type):
+    if committee_type not in ["C", "E"]:
+        return "summary"
+    return "about-committee"
+
+
+def should_show_raw_filings(active_tab, committee_id, cycle, min_receipt_date):
+    if active_tab != "filings" or cycle < constants.DEFAULT_TIME_PERIOD:
+        return False
+
+    path = "/efile/filings/"
+    filters = {
+        "committee_id": committee_id,
+        "min_receipt_date": min_receipt_date,
+    }
+    raw_filings = api_caller.load_endpoint_results(path, **filters)
+
+    return True if raw_filings else False
+
+
+def load_committee_statement_of_organization(committee_id):
+    # Call /filings?committee_id=C00693234&form_type=F1
+    # Get the statements of organization
+    statement_of_organization = api_caller.load_committee_statement_of_organization(
+        committee_id
+    )
+
+    if statement_of_organization:
+        statement_of_organization = statement_of_organization.copy()
+        statement_of_organization["receipt_date"] = format_receipt_date(
+            statement_of_organization["receipt_date"]
+        )
+
+    return statement_of_organization
+
+
+def load_sponsor_candidates(committee, cycle):
+    sponsors_candidate_ids = committee.get("sponsor_candidate_ids")
+    if not sponsors_candidate_ids:
+        return []
+
+    sponsor_candidates = [
+        load_sponsor_candidate(sponsor_id, cycle)
+        for sponsor_id in sponsors_candidate_ids
+    ]
+
+    return [candidate for candidate in sponsor_candidates if candidate]
+
+
+def load_sponsor_candidate(sponsor_id, cycle):
+    election_years = []
+    sponsor_candidate = load_most_recent_candidate(sponsor_id)
+    # Handle API returning no results
+    if not sponsor_candidate:
+        return None
+
+    sponsor_candidate = sponsor_candidate.copy()
+    for election_year in sponsor_candidate["election_years"]:
+        start_of_election_period = (
+            election_year - election_durations[sponsor_candidate["office"]]
+        )
+        if start_of_election_period < cycle and cycle <= election_year:
+            election_years.append(election_year)
+
+    # For each sponsor_candidate, set related_cycle
+    # to the candidate's time period relative to the selected cycle.
+    sponsor_candidate["related_cycle"] = cycle if election_years else None
+
+    return sponsor_candidate
 
 
 def load_most_recent_candidate(candidate_id):

--- a/fec/fec/static/js/data-init.js
+++ b/fec/fec/static/js/data-init.js
@@ -46,9 +46,7 @@ $(function() {
   });
 
   // Initialize cycle selects
-  $('.js-cycle').each(function(idx, elm) {
-    CycleSelect.build($(elm));
-  });
+  CycleSelect.init($(document));
 
   initToggles();
   downloadHydrate();

--- a/fec/fec/static/js/modules/cycle-select.js
+++ b/fec/fec/static/js/modules/cycle-select.js
@@ -88,12 +88,30 @@ CycleSelect.prototype.setTimePeriod = function(min, max) {
 };
 
 CycleSelect.build = function($elm) {
-  var location = $elm.data('cycle-location');
-  if (location === 'query') {
-    return new QueryCycleSelect($elm);
-  } else if (location === 'path') {
-    return new PathCycleSelect($elm);
+  // Deferred committee tabs can re-run cycle initialization after the page load.
+  // Store the instance on the select so change handlers are only bound once.
+  if ($elm.data('cycle-select-init')) {
+    return;
   }
+
+  var location = $elm.data('cycle-location');
+  var cycleSelect;
+  if (location === 'query') {
+    cycleSelect = new QueryCycleSelect($elm);
+  } else if (location === 'path') {
+    cycleSelect = new PathCycleSelect($elm);
+  }
+
+  if (cycleSelect) {
+    $elm.data('cycle-select-init', cycleSelect);
+  }
+  return cycleSelect;
+};
+
+CycleSelect.init = function($context) {
+  $context.find('.js-cycle').each(function(idx, elm) {
+    CycleSelect.build($(elm));
+  });
 };
 
 CycleSelect.prototype.handleChange = function(e) {

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -7,6 +7,7 @@ import { default as URI } from 'urijs';
 
 import { buildEntityLink, buildTotalLink, getColumns, getSizeParams, sizeInfo } from '../modules/column-helpers.js';
 import { candidateColumn, currencyColumn, dateColumn, filings, supportOpposeColumn } from '../modules/columns.js';
+import CycleSelect from '../modules/cycle-select.js';
 import Dropdown from '../modules/dropdowns.js';
 import initEvents from '../modules/events.js';
 import { renderModal, renderRow } from '../modules/filings.js';
@@ -98,6 +99,30 @@ const committeeTwoYearTransactionPeriodQuery = function(committeeId, cycle, para
     },
     params
   );
+};
+
+// Deferred tab links are rendered before client-side cycle changes. Preserve the
+// active cycle when requesting a tab partial so its tables and selects stay in sync.
+const currentTabUrl = function($tab) {
+  const tabUrl = URI($tab.attr('data-tab-url'));
+  const query = URI.parseQuery(window.location.search);
+
+  if (query.cycle) {
+    tabUrl.removeQuery('cycle').addQuery('cycle', query.cycle);
+  }
+
+  return tabUrl.toString();
+};
+
+const currentTabHref = function($tab) {
+  const tabHref = URI($tab.attr('href'));
+  const query = URI.parseQuery(window.location.search);
+
+  if (query.cycle) {
+    tabHref.removeQuery('cycle').addQuery('cycle', query.cycle);
+  }
+
+  return tabHref.toString();
 };
 
 const employerColumns = [
@@ -1109,16 +1134,19 @@ $(function() {
     }
 
     $panel.attr('data-loading', 'true');
-    $.get($tab.attr('data-tab-url'))
+    const tabUrl = currentTabUrl($tab);
+
+    $.get(tabUrl)
       .done(function(html) {
         const $html = $(html);
         $html.attr('aria-hidden', null);
         $html.attr('data-loaded-panel', tabName);
         $panel.replaceWith($html);
+        CycleSelect.init($html);
         initCommitteeTables($html.find('.data-table'));
       })
       .fail(function() {
-        window.location.href = $tab.attr('href');
+        window.location.href = currentTabHref($tab);
       });
   }
 

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -469,7 +469,6 @@ const filingsReportsColumns = getColumns(filings, [
 ]);
 
 $(function() {
-  let $mapTable;
   // Reset time period to the fallback_cycle, which is the LAST_CYCLE_HAS_FINANCIAL.
   if (window.context.cycleOutOfRange == 'true') {
     const lastCycle = Number(window.context.lastCycleHasFinancial);
@@ -478,8 +477,9 @@ $(function() {
     window.context.cycle = lastCycle;
   }
 
-  // Set up data tables
-  $('.data-table').each(function(index, table) {
+  function initCommitteeTables($tables) {
+    let $mapTable;
+    $tables.each(function(index, table) {
     const $table = $(table);
     const committeeId = $table.attr('data-committee');
     const query = {
@@ -1092,7 +1092,46 @@ $(function() {
         DataTable_FEC.defer($table, opts);
         break;
     }
+    });
+    return $mapTable;
+  }
+
+  function loadCommitteeTab($tab) {
+    const tabName = $tab.attr('data-name');
+    const $panel = $('#' + URI($tab.attr('href')).fragment());
+
+    // Replace only deferred tab placeholders with server rendered partials.
+    if (
+      $panel.attr('data-deferred-panel') !== tabName ||
+      $panel.attr('data-loading')
+    ) {
+      return;
+    }
+
+    $panel.attr('data-loading', 'true');
+    $.get($tab.attr('data-tab-url'))
+      .done(function(html) {
+        const $html = $(html);
+        $html.attr('aria-hidden', null);
+        $html.attr('data-loaded-panel', tabName);
+        $panel.replaceWith($html);
+        initCommitteeTables($html.find('.data-table'));
+      })
+      .fail(function() {
+        window.location.href = $tab.attr('href');
+      });
+  }
+
+  $('[role="tab"][data-tab-url]').each(function(index, tab) {
+    const $tab = $(tab);
+    // The tablist opens the panel first; this then fills its placeholder.
+    events.on('tabs.show.' + $tab.attr('data-name'), function() {
+      loadCommitteeTab($tab);
+    });
   });
+
+  // Set up data tables
+  const $mapTable = initCommitteeTables($('.data-table'));
 
   // Set up state map
   const $map = $('.state-map');

--- a/fec/fec/static/js/vendor/tablist.js
+++ b/fec/fec/static/js/vendor/tablist.js
@@ -28,7 +28,8 @@ function show($target, push) {
   });
   // Toggle panels
   $($container + ' [role="tabpanel"]').attr('aria-hidden', 'true');
-  const $panel = $('#' + $target.attr('href').substring(1));
+  // Tab hrefs may include query params before the panel fragment.
+  const $panel = $('#' + URI($target.attr('href')).fragment());
   $panel.attr('aria-hidden', null);
   const name = $target.closest('[role="tablist"]').attr('data-name');
   const value = $target.attr('data-name');
@@ -67,7 +68,7 @@ export function onShow($elm, callback) {
   if ($panel.is(':visible')) {
     callback();
   } else {
-    const $trigger = $('[href="#' + $panel.attr('id') + '"]');
+    const $trigger = $('[role="tab"][href$="#' + $panel.attr('id') + '"]');
     const event = 'tabs.show.' + $trigger.attr('data-name');
     events.once(event, callback);
   }

--- a/fec/fec/tests/js/cycle-select.js
+++ b/fec/fec/tests/js/cycle-select.js
@@ -134,4 +134,30 @@ describe('cycle select', function() {
       expect(CycleSelect.prototype.setUrl).to.have.been.calledWith(url.toString());
     });
   });
+
+  describe('scoped initialization', function() {
+    beforeEach(function() {
+      this.$fixture.empty().append(
+        '<div class="loaded-tab">' +
+          '<select class="js-cycle" data-cycle-location="query">' +
+            '<option value="2012"></option>' +
+            '<option value="2014"></option>' +
+          '</select>' +
+        '</div>'
+      );
+    });
+
+    it('initializes cycle selects inside a context', function() {
+      CycleSelect.init(this.$fixture.find('.loaded-tab'));
+      this.$fixture.find('.js-cycle').val('2014').trigger('change');
+      expect(CycleSelect.prototype.setUrl).to.have.been.calledWith(window.location.href + '?cycle=2014');
+    });
+
+    it('does not bind the same cycle select twice', function() {
+      CycleSelect.init(this.$fixture);
+      CycleSelect.init(this.$fixture);
+      this.$fixture.find('.js-cycle').val('2014').trigger('change');
+      expect(CycleSelect.prototype.setUrl).to.have.been.calledOnce;
+    });
+  });
 });


### PR DESCRIPTION
## Summary (required)

- Resolves #7107

Defers committee `About` and `Filings` API calls until those tabs are requested. Adds server rendered tab partials while keeping direct `?tab=` URLs working.

**Note:** `views.py` changes looks larger than it is because much of the diff moves existing committee context building code into shared helpers. That lets the full committee page and the deferred tab partials reuse the same context while keeping reports/totals and tab specific API calls out of partial renders.

### Required reviewers

1 frontend engineer

## Impacted areas of the application

General components of the application that this PR will affect:

- Committee profile pages
- About and Filings tab loading
- Committee page tab navigation

## How to test

- Run `npm run build-js`.
- Load any committee page such as `/data/committee/C00003418/?cycle=2026`.
- Confirm initial load skips `About` F1/sponsor calls and raw efiling server data calls.
- Click `About` tab and confirm `/data/committee/C00003418/tab/about-committee/?cycle=2026` loads the tab content.
- Click `Filings` tab and confirm `/data/committee/C00003418/tab/filings/?cycle=2026` loads the tab content.
- Confirm direct URLs still work:
  - `/data/committee/C00003418/?cycle=2026&tab=about-committee`
  - `/data/committee/C00003418/?cycle=2026&tab=filings`
 - Test the cycle dropdowns to make sure you can switch cycles on the `about-committee` and  `filings` tabs 
- Run `pytest`.
