### PR TITLE
Download message for commitee filing PDFs that are 100K or more pages

### DIFF
--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -491,7 +491,7 @@ export const filings = {
       return reportType({
         doc_description: doc_description,
         amendment_version: amendment_version,
-        safe_size: row.pages < 100000,
+        large_pdf: row.pages >= 100000,
         fec_url: fec_url,
         pdf_url: pdf_url,
         csv_url: csv_url,

--- a/fec/fec/static/js/modules/columns.js
+++ b/fec/fec/static/js/modules/columns.js
@@ -491,6 +491,7 @@ export const filings = {
       return reportType({
         doc_description: doc_description,
         amendment_version: amendment_version,
+        safe_size: row.pages < 100000,
         fec_url: fec_url,
         pdf_url: pdf_url,
         csv_url: csv_url,

--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -110,7 +110,8 @@ Dropdown.prototype.handleFocusAway = function(e) {
     this.isOpen &&
     !this.$panel.has($target).length &&
     !this.$panel.is($target) &&
-    !$target.is(this.$button)
+    !$target.is(this.$button) &&
+    !this.$panel.has('p.dropdown-msg')
   ) {
     this.hide();
   }

--- a/fec/fec/static/js/modules/dropdowns.js
+++ b/fec/fec/static/js/modules/dropdowns.js
@@ -111,7 +111,7 @@ Dropdown.prototype.handleFocusAway = function(e) {
     !this.$panel.has($target).length &&
     !this.$panel.is($target) &&
     !$target.is(this.$button) &&
-    !this.$panel.has('p.dropdown-msg')
+    !this.$panel.has('p.dropdown-msg').length
   ) {
     this.hide();
   }

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -249,7 +249,6 @@ export function modalRenderFactory(template, fetch) {
         if ($target.is('a')) return true;
         if ($target.is('.dropdown-msg')) return true;
 
-
         // Hide any other open rows
         // For each row
         let toggledSelfClosed = false;

--- a/fec/fec/static/js/modules/tables.js
+++ b/fec/fec/static/js/modules/tables.js
@@ -247,6 +247,8 @@ export function modalRenderFactory(template, fetch) {
 
         // If the click target is a link, stop here. Don't toggle any rows
         if ($target.is('a')) return true;
+        if ($target.is('.dropdown-msg')) return true;
+
 
         // Hide any other open rows
         // For each row

--- a/fec/fec/static/js/templates/reports/reportType.hbs
+++ b/fec/fec/static/js/templates/reports/reportType.hbs
@@ -32,16 +32,9 @@
       <li class="dropdown__item">
         {{#if large_pdf }}
           <p class="dropdown-msg">
-          .pdf not available for reports 100,000 pages or more. Request data at
+           .pdf not available for reports 100,000 pages or more. Request data at
            <a href="mailto:efiletechsupport@fec.gov" aria-label="Request data at efiletechsupport@fec.gov">efiletechsupport@fec.gov</a>
-           </p>
-          {{!-- <a class="dropdown-msg"
-          aria-label=".pdf not available for reports 100,000 pages or more. Request data at efiletechsupport@fec.gov, email technical support."
-          href="mailto:efiletechsupport@fec.gov">
-          .pdf not available for reports 100,000 pages or more. Request data at
-           <span>efiletechsupport@fec.gov</span>
-           </a> --}}
-
+          </p>
         {{else}}
           <a class="dropdown__value" target="_blank" href="{{ pdf_url }}">.pdf</a>
         {{/if}}

--- a/fec/fec/static/js/templates/reports/reportType.hbs
+++ b/fec/fec/static/js/templates/reports/reportType.hbs
@@ -30,10 +30,10 @@
       {{/if}}
       {{#if pdf_url}}
       <li class="dropdown__item">
-        {{#if safe_size}}
-        <a class="dropdown__value" target="_blank" href="{{ pdf_url }}">.pdf</a>
+        {{#if large_pdf }}
+          <p class="dropdown-msg">.pdf not available for reports 100,000 pages or more. Request data at <a href="mailto:efiletechsupport@fec.gov">efiletechsupport@fec.gov</a></p>
         {{else}}
-        <p class="dropdown-msg">.pdf not available for reports 100,000 pages or more. Request data at <a href="mailto:efiletechsupport@fec.gov">efiletechsupport@fec.gov</a></p>
+          <a class="dropdown__value" target="_blank" href="{{ pdf_url }}">.pdf</a>
         {{/if}}
       </li>
       {{/if}}

--- a/fec/fec/static/js/templates/reports/reportType.hbs
+++ b/fec/fec/static/js/templates/reports/reportType.hbs
@@ -31,7 +31,17 @@
       {{#if pdf_url}}
       <li class="dropdown__item">
         {{#if large_pdf }}
-          <p class="dropdown-msg">.pdf not available for reports 100,000 pages or more. Request data at <a href="mailto:efiletechsupport@fec.gov">efiletechsupport@fec.gov</a></p>
+          <p class="dropdown-msg">
+          .pdf not available for reports 100,000 pages or more. Request data at
+           <a href="mailto:efiletechsupport@fec.gov" aria-label="Request data at efiletechsupport@fec.gov">efiletechsupport@fec.gov</a>
+           </p>
+          {{!-- <a class="dropdown-msg"
+          aria-label=".pdf not available for reports 100,000 pages or more. Request data at efiletechsupport@fec.gov, email technical support."
+          href="mailto:efiletechsupport@fec.gov">
+          .pdf not available for reports 100,000 pages or more. Request data at
+           <span>efiletechsupport@fec.gov</span>
+           </a> --}}
+
         {{else}}
           <a class="dropdown__value" target="_blank" href="{{ pdf_url }}">.pdf</a>
         {{/if}}

--- a/fec/fec/static/js/templates/reports/reportType.hbs
+++ b/fec/fec/static/js/templates/reports/reportType.hbs
@@ -30,7 +30,11 @@
       {{/if}}
       {{#if pdf_url}}
       <li class="dropdown__item">
+        {{#if safe_size}}
         <a class="dropdown__value" target="_blank" href="{{ pdf_url }}">.pdf</a>
+        {{else}}
+        <p class="dropdown-msg">.pdf not available for reports 100,000 pages or more. Request data at <a href="mailto:efiletechsupport@fec.gov">efiletechsupport@fec.gov</a></p>
+        {{/if}}
       </li>
       {{/if}}
     </ul>

--- a/fec/fec/static/js/templates/reports/reportType.hbs
+++ b/fec/fec/static/js/templates/reports/reportType.hbs
@@ -30,7 +30,7 @@
       {{/if}}
       {{#if pdf_url}}
       <li class="dropdown__item">
-        {{#if large_pdf }}
+        {{#if large_pdf}}
           <p class="dropdown-msg">
            .pdf not available for reports 100,000 pages or more. Request data at
            <a href="mailto:efiletechsupport@fec.gov" aria-label="Request data at efiletechsupport@fec.gov">efiletechsupport@fec.gov</a>

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -91,6 +91,16 @@
     width: 100%;
   }
 
+   .dropdown-msg {
+    padding: u(1rem);
+    line-height: u(2rem);
+    color: $neutral-base;
+
+      a {
+        color: $base;
+      }
+   }
+
   // For scrolling dropdowns, force the scrollbars to appear,
   // flip its x to move the scroll to the left, then flip its content back
   &.dropdown-scrolling {

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -91,16 +91,44 @@
     width: 100%;
   }
 
-   .dropdown-msg {
-    padding: u(1rem);
-    line-height: u(2rem);
-    color: $neutral-base;
+  .dropdown-msg {
+    color: $neutral-base !important;;
+    display: block;
+    line-height: 1.7rem;
+    padding: u(.5rem 1rem .5rem .7rem);
+    cursor: default;
 
-      a {
-        color: $base;
+    &:hover {
+      background-color: $gray-light;
+    }
+
+    a {
+      color: $base !important;
+      border-bottom: 1px dotted $primary;
+      &:hover {
+        border-bottom: 1px dotted $primary-contrast;
       }
-   }
+    }
+  }
 
+  /* .dropdown-msg {
+    color: $neutral-base !important;;
+    display: block;
+    line-height: 1.7rem;
+    padding: u(.5rem 1rem .5rem .7rem);
+
+    &:hover {
+      background-color: $gray-light;
+    }
+
+    span {
+      color: $base !important;
+      border-bottom: 1px dotted $primary;
+      &:hover {
+        border-bottom: 1px dotted $primary-contrast;
+      }
+    }
+  } */
   // For scrolling dropdowns, force the scrollbars to appear,
   // flip its x to move the scroll to the left, then flip its content back
   &.dropdown-scrolling {
@@ -134,7 +162,7 @@
     color: $base;
     display: block;
     margin: 0;
-    padding: u(0.5rem 1rem 0.5rem 1.5rem);
+    padding: u(.5rem .75rem);
     max-width: 100%;
     white-space: nowrap;
 

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -91,7 +91,6 @@
     width: 100%;
   }
 
-  // For conditional message inside report-type download dropdowns,
   .dropdown-msg {
     color: $neutral-base !important;;
     display: block;

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -102,8 +102,12 @@
     &:hover {
       background-color: $gray-light;
     }
+    
     a {
       color: $base !important;
+      &:hover {
+        border-bottom: 1px dotted $aqua !important;
+      }
     }
   }
 

--- a/fec/fec/static/scss/components/_dropdowns.scss
+++ b/fec/fec/static/scss/components/_dropdowns.scss
@@ -91,44 +91,23 @@
     width: 100%;
   }
 
+  // For conditional message inside report-type download dropdowns,
   .dropdown-msg {
     color: $neutral-base !important;;
     display: block;
-    line-height: 1.7rem;
+    font-size: inherit;
+    line-height: u(1.7rem);
     padding: u(.5rem 1rem .5rem .7rem);
     cursor: default;
 
     &:hover {
       background-color: $gray-light;
     }
-
     a {
       color: $base !important;
-      border-bottom: 1px dotted $primary;
-      &:hover {
-        border-bottom: 1px dotted $primary-contrast;
-      }
     }
   }
 
-  /* .dropdown-msg {
-    color: $neutral-base !important;;
-    display: block;
-    line-height: 1.7rem;
-    padding: u(.5rem 1rem .5rem .7rem);
-
-    &:hover {
-      background-color: $gray-light;
-    }
-
-    span {
-      color: $base !important;
-      border-bottom: 1px dotted $primary;
-      &:hover {
-        border-bottom: 1px dotted $primary-contrast;
-      }
-    }
-  } */
   // For scrolling dropdowns, force the scrollbars to appear,
   // flip its x to move the scroll to the left, then flip its content back
   &.dropdown-scrolling {

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
+    ('feature', lambda _, branch: branch == 'feature/7195-large-pdf-dwnld-msg'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,7 @@ DEPLOY_RULES = (
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
-    ('feature', lambda _, branch: branch == 'feature/7195-large-pdf-dwnld-msg'),
+    # ('feature', lambda _, branch: branch == '[BRANCH NAME]'),
 )
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #7195

- For committee filings downloads, adds an "email tech support" message for PDFs that are over 100,000 pages
- Make sure reports datatables that use the same `download panel template` are not affected


### Required reviewers

one dev. one UX

## Impacted areas of the application
PDF file download options on:
https://www.fec.gov/data/filings/?data_type=processed

## Screenshots

<img width="974" height="688" alt="dropdown-click-select-copy" src="https://github.com/user-attachments/assets/02ac25f3-4c5e-44fe-b3d7-83f7c841aef0" />

<hr>

## How to test

*** **REMOVE TEMP FEATURE DEPLOY TASK BEFORE MERGE!** ***
- `npm run build`
- `npm run test-single`
- Test filings datatable with committee with big data like ActBlue:
    - http://127.0.0.1:8000/data/filings/?data_type=processed&q_filer=C00401224
- Test single committee page for commitee with  big data like ActBlue:
    - http://127.0.0.1:8000//data/committee/C00401224/?tab=filings
- Confirm that the PDF option in the downloads panel shows the message when pages are >= 100,000
- Make sure you can select and copy the email address instead of clicking the link



