### PR TITLE
Update hearings intro paragraph

### DIFF
--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -110,7 +110,7 @@
           </section>
           <section id="meetings-hearings" role="tabpanel" aria-hidden="true" aria-labelledby="hearings">
             <h2>Public hearings</h2>
-            <p>The Commission periodically holds public hearings at FEC headquarters, 1050 First Street NE, Washington, DC. These hearings offer interested persons an opportunity to testify concerning proposed regulations and other matters that come before the Commission. This page lists upcoming public hearings as well as those held from 2005 through the present. Use the <a href="https://sers.fec.gov/fosers/" title="Searchable Electronic Rulemaking System">Searchable Electronic Rulemaking System (SERS)</a> to search for all archived rulemaking hearings.</p>
+            <p>The Commission periodically holds public hearings at FEC headquarters, 1050 First Street NE, Washington, DC. These hearings offer interested persons an opportunity to testify concerning proposed regulations and other matters that come before the Commission. This page lists upcoming public hearings as well as those held from 2000 through the present. Use the <a href="/legal/search/rulemakings/" title="Rulemakings Search">Rulemakings search</a> to search for all archived rulemaking hearings.</p>
             <div class="filters--horizontal">
               <form action="" id="hearings_form" method="get" class="js-form-nav container">
                 <div class="filter">


### PR DESCRIPTION
## Summary (required)

- Resolves #7218 

- [x] Changed " This page lists upcoming public hearings as well as those held from 2005 through the present." to read" "This page lists upcoming public hearings as well as those held from 2000 through the present." 
- [x] Changed "Use the [Searchable Electronic Rulemaking System (SERS)](https://sers.fec.gov/fosers/) to search for all archived rulemaking hearings." to read "“Use the [Rulemakings search](https://www.fec.gov/legal/search/rulemakings/) to search for all archived rulemaking hearings.” 

### Required reviewers

1 content

## Impacted areas of the application

General components of the application that this PR will affect:

-  hearings page

## Screenshots
<img width="1172" height="791" alt="Screenshot 2026-08-24 at 2 25 10 PM" src="https://github.com/user-attachments/assets/1bdd5cc3-a9b1-4f01-a943-08c6fe75dde8" />

## How to test

- See screenshot for hearings page intro paragraph.
